### PR TITLE
Move sdk init code

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CoreModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CoreModule.kt
@@ -18,6 +18,11 @@ import io.embrace.android.embracesdk.internal.store.OrdinalStore
 interface CoreModule {
 
     /**
+     * Start time in milliseconds at which SDK initialization started
+     */
+    val sdkStartTime: Long
+
+    /**
      * Reference to the context. This will always return the application context so won't leak.
      */
     val context: Context

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CoreModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CoreModuleImpl.kt
@@ -26,6 +26,8 @@ class CoreModuleImpl(
     versionChecker: VersionChecker = BuildVersionChecker,
 ) : CoreModule {
 
+    override val sdkStartTime: Long = initModule.clock.now()
+
     override val context: Context by singleton {
         when (ctx) {
             is Application -> ctx

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitModule.kt
@@ -11,6 +11,7 @@ import io.embrace.android.embracesdk.internal.telemetry.TelemetryService
  * A module of components and services required at SDK instantiation time, i.e. before the SDK has fully started
  */
 interface InitModule {
+
     /**
      * Clock instance locked to the time of creation used by the SDK throughout its lifetime
      */

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
@@ -302,7 +302,8 @@ internal class AppStartupTraceTest {
             },
             otelExportAssertion = {
                 with(awaitSpansWithType(5, EmbType.Performance.Default).associateBy { it.name }) {
-                    assertEquals(sdkStartTime, coldAppStartupRootSpan().startEpochNanos.nanosToMillis())
+                    val observed = coldAppStartupRootSpan().startEpochNanos.nanosToMillis()
+                    assertEquals(sdkStartTime, observed)
                 }
             }
         )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
@@ -150,12 +150,12 @@ internal class BackgroundActivityDisabledTest {
 
         testRule.runTest(
             testCaseAction = {
-                with(recordSession()) {
+                with(recordSession(isBackgroundActivityEnabled = false)) {
                     session1StartMs = startTimeMs
                     session1EndMs = endTimeMs
                 }
                 clock.tick(15000)
-                with(recordSession()) {
+                with(recordSession(isBackgroundActivityEnabled = false)) {
                     session2StartMs = startTimeMs
                     session2EndMs = endTimeMs
                 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
@@ -41,6 +41,7 @@ internal class EmbraceActionInterface(
      * are guaranteed not to change in the start/end message.
      */
     internal fun recordSession(
+        isBackgroundActivityEnabled: Boolean = true,
         action: EmbraceActionInterface.() -> Unit = {},
     ): SessionTimestamps {
         val sessionAction: () -> Unit = {
@@ -58,12 +59,6 @@ internal class EmbraceActionInterface(
                 startInBackground = true,
                 activitiesAndActions = activityAndAction
             ).let { executionTimestamps ->
-                val isBackgroundActivityEnabled = if (bootstrapper.isInitialized()) {
-                    bootstrapper.configModule.configService.backgroundActivityBehavior.isBackgroundActivityCaptureEnabled()
-                } else {
-                    false
-                }
-
                 SessionTimestamps(
                     startTimeMs = if (isBackgroundActivityEnabled) {
                         executionTimestamps.firstForegroundTimeMs

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -90,7 +90,7 @@ internal class EmbraceSetupInterface(
     )
 
     private val fakeCoreModule: CoreModule = FakeCoreModule()
-    private val coreModule: CoreModule = CoreModuleImpl(fakeCoreModule.context, fakeInitModule)
+    private val coreModule: CoreModule by lazy { CoreModuleImpl(fakeCoreModule.context, fakeInitModule) }
 
     @OptIn(ExperimentalApi::class)
     fun createBootstrapper(
@@ -240,7 +240,7 @@ internal class EmbraceSetupInterface(
             }
     }
 
-    private class DecoratedConfigModule(private val impl: ConfigModule): ConfigModule by impl {
+    private class DecoratedConfigModule(private val impl: ConfigModule) : ConfigModule by impl {
         override val appEnvironment: AppEnvironment = AppEnvironment(true)
         override val buildInfo: BuildInfo = BuildInfo(
             "fakeBuildId",

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
@@ -17,7 +17,6 @@ import io.embrace.android.embracesdk.internal.utils.VersionChecker
 @Suppress("UseCheckOrError")
 internal class InitializedModuleGraph(
     context: Context,
-    sdkStartTimeMs: Long,
     versionChecker: VersionChecker = BuildVersionChecker,
     override val initModule: InitModule,
     override val openTelemetryModule: OpenTelemetryModule,
@@ -46,7 +45,7 @@ internal class InitializedModuleGraph(
         workerThreadModuleSupplier()
     }.apply {
         EmbTrace.trace("span-service-init") {
-            openTelemetryModule.spanService.initializeService(sdkStartTimeMs)
+            openTelemetryModule.spanService.initializeService(coreModule.sdkStartTime)
         }
     }
 

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
@@ -1,0 +1,155 @@
+package io.embrace.android.embracesdk.internal.injection
+
+import io.embrace.android.embracesdk.core.BuildConfig
+import io.embrace.android.embracesdk.internal.arch.InstrumentationProvider
+import io.embrace.android.embracesdk.internal.capture.connectivity.NetworkStatusDataSource
+import io.embrace.android.embracesdk.internal.instrumentation.crash.jvm.JvmCrashDataSource
+import io.embrace.android.embracesdk.internal.utils.EmbTrace
+import io.embrace.android.embracesdk.internal.utils.EmbTrace.end
+import io.embrace.android.embracesdk.internal.utils.EmbTrace.start
+import io.embrace.android.embracesdk.internal.worker.Worker
+import java.util.ServiceLoader
+
+/**
+ * Performs bootstrapping by setting required values where there is an interdependency
+ * between modules.
+ */
+internal fun ModuleGraph.postInit() {
+    openTelemetryModule.applyConfiguration(
+        sensitiveKeysBehavior = configModule.configService.sensitiveKeysBehavior,
+        bypassValidation = configModule.configService.isOnlyUsingOtelExporters(),
+        otelBehavior = configModule.configService.otelBehavior
+    )
+
+    initModule.logger.errorHandlerProvider = { featureModule.internalErrorDataSource.dataSource }
+    deliveryModule.payloadCachingService?.run {
+        openTelemetryModule.spanRepository.setSpanUpdateNotifier {
+            reportBackgroundActivityStateChange()
+        }
+    }
+
+    payloadSourceModule.metadataService.precomputeValues()
+
+    // Start the log orchestrator
+    openTelemetryModule.logSink.registerLogStoredCallback {
+        logModule.logOrchestrator.onLogsAdded()
+    }
+
+    essentialServiceModule.telemetryDestination.sessionUpdateAction =
+        sessionOrchestrationModule.sessionOrchestrator::onSessionDataUpdate
+}
+
+/**
+ * Registers listeners for various lifecycle/system callbacks.
+ */
+internal fun ModuleGraph.registerListeners() {
+    EmbTrace.trace("service-registration") {
+        EmbTrace.trace("startup-tracker") {
+            coreModule.application.registerActivityLifecycleCallbacks(
+                dataCaptureServiceModule.startupTracker
+            )
+        }
+
+        workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker).submit {
+            EmbTrace.trace("network-connectivity-registration") {
+                essentialServiceModule.networkConnectivityService.register()
+            }
+        }
+        with(coreModule.serviceRegistry) {
+            registerService(lazy { configModule.configService })
+            registerService(lazy { configModule.remoteConfigSource })
+            registerService(lazy { configModule.configService.networkBehavior.domainCountLimiter })
+
+            registerServices(
+                lazy { essentialServiceModule.appStateTracker },
+                lazy { essentialServiceModule.activityLifecycleTracker },
+                lazy { essentialServiceModule.networkConnectivityService }
+            )
+            registerServices(
+                lazy { dataCaptureServiceModule.appStartupDataCollector },
+                lazy { dataCaptureServiceModule.uiLoadDataListener },
+            )
+            registerServices(
+                lazy { anrModule.anrService }
+            )
+            registerService(lazy { logModule.attachmentService })
+            registerService(lazy { logModule.logService })
+
+            // registration ignored after this point
+            registerAppStateListeners(essentialServiceModule.appStateTracker)
+            registerMemoryCleanerListeners(sessionOrchestrationModule.memoryCleanerService)
+            registerActivityLifecycleListeners(essentialServiceModule.activityLifecycleTracker)
+        }
+    }
+}
+
+/**
+ * Loads instrumentation via SPI and legacy methods.
+ */
+internal fun ModuleGraph.loadInstrumentation() {
+    val registry = instrumentationModule.instrumentationRegistry
+    val instrumentationProviders = ServiceLoader.load(InstrumentationProvider::class.java)
+    registry.loadInstrumentations(instrumentationProviders, instrumentationModule.instrumentationArgs)
+
+    anrModule.anrService?.startAnrCapture()
+    nativeCoreModule.sharedObjectLoader.loadEmbraceNative()
+    nativeCoreModule.nativeCrashHandlerInstaller?.install()
+
+    featureModule.lastRunCrashVerifier.readAndCleanMarkerAsync(
+        workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker)
+    )
+}
+
+/**
+ * Performs post-load instrumentation tasks such as setting listeners.
+ */
+internal fun ModuleGraph.postLoadInstrumentation() {
+    // setup crash teardown handlers
+    val registry = instrumentationModule.instrumentationRegistry
+    registry.findByType(JvmCrashDataSource::class)?.apply {
+        anrModule.anrService?.let(::addCrashTeardownHandler)
+        addCrashTeardownHandler(logModule.logOrchestrator)
+        addCrashTeardownHandler(sessionOrchestrationModule.sessionOrchestrator)
+        addCrashTeardownHandler(featureModule.crashMarker)
+        deliveryModule.payloadStore?.let(::addCrashTeardownHandler)
+    }
+    registry.findByType(NetworkStatusDataSource::class)?.let {
+        essentialServiceModule.networkConnectivityService.addNetworkConnectivityListener(it)
+    }
+}
+
+/**
+ * Trigger sending cached data on disk.
+ */
+internal fun ModuleGraph.triggerPayloadSend() {
+    val worker = workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker)
+    worker.submit {
+        payloadSourceModule.payloadResurrectionService?.resurrectOldPayloads(
+            nativeCrashServiceProvider = { nativeFeatureModule.nativeCrashService }
+        )
+    }
+    worker.submit { // potentially trigger first delivery attempt by firing network status callback
+        deliveryModule.schedulingService?.let(
+            essentialServiceModule.networkConnectivityService::addNetworkConnectivityListener
+        )
+        deliveryModule.schedulingService?.onPayloadIntake()
+    }
+}
+
+/**
+ * Mark SDK initialization as complete.
+ */
+internal fun ModuleGraph.markSdkInitComplete() {
+    start("startup-tracking")
+    val dataCaptureServiceModule = dataCaptureServiceModule
+    dataCaptureServiceModule.startupService.setSdkStartupInfo(
+        coreModule.sdkStartTime,
+        initModule.clock.now(),
+        essentialServiceModule.appStateTracker.getAppState(),
+        Thread.currentThread().name
+    )
+    end()
+    val appId = configModule.configService.appId
+    val startMsg = "Embrace SDK version ${BuildConfig.VERSION_NAME} started" + appId?.run { " for appId =  $this" }
+    initModule.logger.logInfo(startMsg)
+}

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
@@ -16,6 +16,7 @@ import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.injection.EssentialServiceModuleImpl
 import io.embrace.android.embracesdk.internal.injection.InitModuleImpl
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
+import io.embrace.android.embracesdk.internal.injection.postLoadInstrumentation
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -63,7 +64,6 @@ internal class ModuleInitBootstrapperTest {
             assertTrue(
                 moduleInitBootstrapper.init(
                     context = context,
-                    sdkStartTimeMs = 0L,
                 )
             )
             assertNotNull(initModule)
@@ -83,13 +83,11 @@ internal class ModuleInitBootstrapperTest {
         assertTrue(
             moduleInitBootstrapper.init(
                 context = context,
-                sdkStartTimeMs = 0L,
             )
         )
         assertFalse(
             moduleInitBootstrapper.init(
                 context = context,
-                sdkStartTimeMs = 0L,
             )
         )
     }
@@ -99,14 +97,13 @@ internal class ModuleInitBootstrapperTest {
         assertTrue(
             moduleInitBootstrapper.init(
                 context = context,
-                sdkStartTimeMs = 0L,
             )
         )
     }
 
     @Test
     fun `post load instrumentation hooks up listeners`() {
-        moduleInitBootstrapper.init(context, 0)
+        moduleInitBootstrapper.init(context)
         val registry = moduleInitBootstrapper.instrumentationModule.instrumentationRegistry
         val dataSource = CrashHandlerDataSource()
         registry.add(DataSourceState(factory = { dataSource }))
@@ -122,19 +119,5 @@ internal class ModuleInitBootstrapperTest {
             moduleInitBootstrapper.deliveryModule.payloadStore
         )
         assertEquals(expected, handlers)
-    }
-
-    @Test
-    fun `stopping services makes bootstrapper not initialized`() {
-        assertTrue(
-            moduleInitBootstrapper.init(
-                context = context,
-                sdkStartTimeMs = 0L,
-            )
-        )
-
-        assertTrue(moduleInitBootstrapper.isInitialized())
-        moduleInitBootstrapper.stopServices()
-        assertFalse(moduleInitBootstrapper.isInitialized())
     }
 }

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/ReactNativeInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/ReactNativeInternalInterfaceImplTest.kt
@@ -154,7 +154,7 @@ internal class ReactNativeInternalInterfaceImplTest {
     @Test
     fun `test RN crash by calling logUnhandledJsException() before handleCrash()`() {
         every { embrace.isStarted } returns true
-        bootstrapper.init(ApplicationProvider.getApplicationContext(), 0)
+        bootstrapper.init(ApplicationProvider.getApplicationContext())
 
         val registry = bootstrapper.instrumentationModule.instrumentationRegistry
         val args = bootstrapper.instrumentationModule.instrumentationArgs

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/LogsApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/LogsApiDelegateTest.kt
@@ -28,7 +28,7 @@ internal class LogsApiDelegateTest {
         val moduleInitBootstrapper = fakeModuleInitBootstrapper(
             logModuleSupplier = { _, _, _, _, _, _, _ -> FakeLogModule(logService = logService) }
         )
-        moduleInitBootstrapper.init(ApplicationProvider.getApplicationContext(), 0)
+        moduleInitBootstrapper.init(ApplicationProvider.getApplicationContext())
         orchestrator = moduleInitBootstrapper.sessionOrchestrationModule.sessionOrchestrator as FakeSessionOrchestrator
 
         val sdkCallChecker = SdkCallChecker(FakeEmbLogger(), FakeTelemetryService())

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/NetworkRequestApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/NetworkRequestApiDelegateTest.kt
@@ -22,7 +22,7 @@ internal class NetworkRequestApiDelegateTest {
     @Before
     fun setUp() {
         val moduleInitBootstrapper = fakeModuleInitBootstrapper()
-        moduleInitBootstrapper.init(ApplicationProvider.getApplicationContext(), 0)
+        moduleInitBootstrapper.init(ApplicationProvider.getApplicationContext())
         configService = moduleInitBootstrapper.configModule.configService as FakeConfigService
         val sdkCallChecker = SdkCallChecker(FakeEmbLogger(), FakeTelemetryService())
         sdkCallChecker.started.set(true)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegateTest.kt
@@ -34,7 +34,7 @@ internal class OTelApiDelegateTest {
     @Before
     fun setUp() {
         bootstrapper = fakeModuleInitBootstrapper()
-        bootstrapper.init(ApplicationProvider.getApplicationContext(), 0)
+        bootstrapper.init(ApplicationProvider.getApplicationContext())
         cfg = bootstrapper.openTelemetryModule.otelSdkConfig
 
         sdkCallChecker = SdkCallChecker(FakeEmbLogger(), FakeTelemetryService())

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegateTest.kt
@@ -36,7 +36,7 @@ internal class SdkStateApiDelegateTest {
         val moduleInitBootstrapper = fakeModuleInitBootstrapper(
             logModuleSupplier = { _, _, _, _, _, _, _ -> FakeLogModule(logService = logService) }
         )
-        moduleInitBootstrapper.init(ApplicationProvider.getApplicationContext(), 0)
+        moduleInitBootstrapper.init(ApplicationProvider.getApplicationContext())
         orchestrator = moduleInitBootstrapper.sessionOrchestrationModule.sessionOrchestrator as FakeSessionOrchestrator
         preferencesService = moduleInitBootstrapper.coreModule.preferencesService as FakePreferenceService
         sessionIdTracker = moduleInitBootstrapper.essentialServiceModule.sessionIdTracker as FakeSessionIdTracker

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/SessionApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/SessionApiDelegateTest.kt
@@ -26,7 +26,7 @@ internal class SessionApiDelegateTest {
     @Before
     fun setUp() {
         val moduleInitBootstrapper = fakeModuleInitBootstrapper()
-        moduleInitBootstrapper.init(ApplicationProvider.getApplicationContext(), 0)
+        moduleInitBootstrapper.init(ApplicationProvider.getApplicationContext())
         orchestrator = moduleInitBootstrapper.sessionOrchestrationModule.sessionOrchestrator as FakeSessionOrchestrator
         sessionPropertiesService =
             moduleInitBootstrapper.essentialServiceModule.sessionPropertiesService as FakeSessionPropertiesService

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/UserApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/UserApiDelegateTest.kt
@@ -31,10 +31,7 @@ internal class UserApiDelegateTest {
                 }
             }
         )
-        moduleInitBootstrapper.init(
-            ApplicationProvider.getApplicationContext(),
-            0
-        )
+        moduleInitBootstrapper.init(ApplicationProvider.getApplicationContext())
         val sdkCallChecker = SdkCallChecker(FakeEmbLogger(), FakeTelemetryService())
         sdkCallChecker.started.set(true)
         delegate = UserApiDelegate(moduleInitBootstrapper, sdkCallChecker)

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/ViewTrackingApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/internal/api/delegate/ViewTrackingApiDelegateTest.kt
@@ -17,7 +17,7 @@ internal class ViewTrackingApiDelegateTest {
     @Before
     fun setUp() {
         val moduleInitBootstrapper = fakeModuleInitBootstrapper()
-        moduleInitBootstrapper.init(ApplicationProvider.getApplicationContext(), 0)
+        moduleInitBootstrapper.init(ApplicationProvider.getApplicationContext())
 
         val sdkCallChecker = SdkCallChecker(FakeEmbLogger(), FakeTelemetryService())
         sdkCallChecker.started.set(true)

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeCoreModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeCoreModule.kt
@@ -39,6 +39,7 @@ class FakeCoreModule(
     override val connectivityManager: ConnectivityManager? = null,
     override val storageManager: StorageStatsManager? = null,
     override val windowManager: WindowManager? = null,
+    override val sdkStartTime: Long = -1,
 ) : CoreModule {
 
     companion object {


### PR DESCRIPTION
## Goal

Moves SDK init code out of `ModuleInitBootstrapper` and `EmbraceImpl` into a separate file.

