### PR TITLE
Tweaks to span capture on TelemetryDestination

### DIFF
--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanToken.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanToken.kt
@@ -10,13 +10,31 @@ class FakeSpanToken(
     val startTimeMs: Long,
     var endTimeMs: Long?,
     var errorCode: ErrorCodeAttribute?,
+    var parent: SpanToken?,
     val type: EmbType,
-    val attributes: Map<String, String>,
-    val events: List<SpanEvent>
+    val internal: Boolean,
+    initialAttrs: Map<String, String>,
+    val events: List<SpanEvent>,
 ) : SpanToken {
-    override fun stop(endTimeMs: Long?) {
+
+    val attributes: Map<String, String>
+        get() = attrs.toMap()
+
+    private val attrs: MutableMap<String, String> = initialAttrs.toMutableMap()
+
+    override fun stop(endTimeMs: Long?, errorCode: ErrorCodeAttribute?) {
         this.endTimeMs = endTimeMs ?: 0
+        this.errorCode = errorCode
     }
 
-    fun isRecording(): Boolean = endTimeMs == null
+    override fun isRecording(): Boolean = endTimeMs == null
+
+    override fun addAttribute(key: String, value: String) {
+        attrs[key] = value
+    }
+
+    override fun setSystemAttribute(key: String, value: String) {
+    }
+
+    override fun getStartTimeMs(): Long? = startTimeMs
 }

--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTelemetryDestination.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTelemetryDestination.kt
@@ -54,8 +54,32 @@ class FakeTelemetryDestination : TelemetryDestination {
             startTimeMs,
             null,
             null,
+            null,
             schemaType.telemetryType,
+            true,
             schemaType.attributes() + mapOf(schemaType.telemetryType.asPair()),
+            emptyList(),
+        )
+
+        createdSpans.add(token)
+        return token
+    }
+
+    override fun startSpanCapture(
+        name: String,
+        startTimeMs: Long,
+        parent: SpanToken?,
+        type: EmbType,
+    ): SpanToken? {
+        val token = FakeSpanToken(
+            name,
+            startTimeMs,
+            null,
+            null,
+            parent,
+            type,
+            true,
+            emptyMap(),
             emptyList(),
         )
 
@@ -68,7 +92,9 @@ class FakeTelemetryDestination : TelemetryDestination {
         startTimeMs: Long,
         endTimeMs: Long,
         errorCode: ErrorCodeAttribute?,
+        parent: SpanToken?,
         type: EmbType,
+        internal: Boolean,
         attributes: Map<String, String>,
         events: List<SpanEvent>,
     ) {
@@ -77,7 +103,9 @@ class FakeTelemetryDestination : TelemetryDestination {
             startTimeMs,
             endTimeMs,
             errorCode,
+            parent,
             type,
+            internal,
             attributes,
             events,
         )

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/SpanToken.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/SpanToken.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.internal.arch.datasource
 
+import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
+
 /**
  * A token that represents a span.
  */
@@ -8,5 +10,25 @@ interface SpanToken {
     /**
      * Stops the span with an optional explicit end time
      */
-    fun stop(endTimeMs: Long? = null)
+    fun stop(endTimeMs: Long? = null, errorCode: ErrorCodeAttribute? = null)
+
+    /**
+     * Returns true if the span is currently recording
+     */
+    fun isRecording(): Boolean
+
+    /**
+     * Adds an attribute to the span
+     */
+    fun addAttribute(key: String, value: String)
+
+    /**
+     * Gets the start time in ms or null if the span has not started
+     */
+    fun getStartTimeMs(): Long?
+
+    /**
+     * Set the value of the attribute with the given key, overwriting the original value if it's already set
+     */
+    fun setSystemAttribute(key: String, value: String)
 }

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/TelemetryDestination.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/TelemetryDestination.kt
@@ -52,6 +52,16 @@ interface TelemetryDestination {
     ): SpanToken?
 
     /**
+     * Starts a new span with the given [name] and [startTimeMs].
+     */
+    fun startSpanCapture(
+        name: String,
+        startTimeMs: Long,
+        parent: SpanToken? = null,
+        type: EmbType = EmbType.Performance.Default,
+    ): SpanToken?
+
+    /**
      * Records a span that has already completed.
      */
     fun recordCompletedSpan(
@@ -59,7 +69,9 @@ interface TelemetryDestination {
         startTimeMs: Long,
         endTimeMs: Long,
         errorCode: ErrorCodeAttribute? = null,
+        parent: SpanToken? = null,
         type: EmbType = EmbType.Performance.Default,
+        internal: Boolean = true,
         attributes: Map<String, String> = emptyMap(),
         events: List<SpanEvent> = emptyList(),
     )

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
@@ -87,7 +87,7 @@ class FakeSpanService : SpanService {
                 parentContext = fakeOpenTelemetry().contextFactory.root(),
                 type = type,
                 internal = internal,
-                private = private
+                private = private,
             ).apply {
                 start(startTimeMs)
                 attributes.forEach { (key, value) -> addAttribute(key, value) }


### PR DESCRIPTION
## Goal

Adds the ability to specify parent/name/type and access other information when capturing spans from `TelemetryDestination`. In future I think we'll want to refactor this API to consolidate all these different functions, but that should probably happen as part of the data modelling work.
