### PR TITLE
Make startup trace use TelemetryDestination

### DIFF
--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImpl.kt
@@ -19,7 +19,6 @@ import io.embrace.android.embracesdk.internal.utils.VersionChecker
 
 class DataCaptureServiceModuleImpl(
     initModule: InitModule,
-    openTelemetryModule: OpenTelemetryModule,
     instrumentationModule: InstrumentationModule,
     configService: ConfigService,
     versionChecker: VersionChecker = BuildVersionChecker,
@@ -35,7 +34,7 @@ class DataCaptureServiceModuleImpl(
         AppStartupTraceEmitter(
             clock = initModule.clock,
             startupServiceProvider = { startupService },
-            spanService = openTelemetryModule.spanService,
+            destination = instrumentationModule.instrumentationArgs.destination,
             versionChecker = versionChecker,
             logger = initModule.logger,
             manualEnd = configService.autoDataCaptureBehavior.isEndStartupWithAppReadyEnabled(),
@@ -57,7 +56,7 @@ class DataCaptureServiceModuleImpl(
     override val uiLoadDataListener: UiLoadDataListener? by singleton {
         if (configService.autoDataCaptureBehavior.isUiLoadTracingEnabled()) {
             UiLoadTraceEmitter(
-                spanService = openTelemetryModule.spanService,
+                destination = instrumentationModule.instrumentationArgs.destination,
                 versionChecker = versionChecker,
             )
         } else {

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleSupplier.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleSupplier.kt
@@ -9,7 +9,6 @@ import io.embrace.android.embracesdk.internal.utils.VersionChecker
  */
 typealias DataCaptureServiceModuleSupplier = (
     initModule: InitModule,
-    openTelemetryModule: OpenTelemetryModule,
     instrumentationModule: InstrumentationModule,
     configService: ConfigService,
     versionChecker: VersionChecker,

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/AppStartupDataCollector.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/AppStartupDataCollector.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.instrumentation.startup
 
-import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
-import io.embrace.android.embracesdk.spans.ErrorCode
+import io.embrace.android.embracesdk.internal.arch.datasource.SpanEvent
+import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 
 /**
  * Collects relevant information during app startup to be used to produce telemetry about the startup workflow.
@@ -74,8 +74,8 @@ interface AppStartupDataCollector {
         startTimeMs: Long,
         endTimeMs: Long,
         attributes: Map<String, String> = emptyMap(),
-        events: List<EmbraceSpanEvent> = emptyList(),
-        errorCode: ErrorCode? = null,
+        events: List<SpanEvent> = emptyList(),
+        errorCode: ErrorCodeAttribute? = null,
     )
 
     /**

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/activity/UiLoadTraceModifier.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/activity/UiLoadTraceModifier.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.instrumentation.startup.activity
 
-import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
-import io.embrace.android.embracesdk.spans.ErrorCode
+import io.embrace.android.embracesdk.internal.arch.datasource.SpanEvent
+import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 
 /**
  * Interface containing methods that will add more data to any on-going UI Load trace
@@ -22,7 +22,7 @@ interface UiLoadTraceModifier {
         startTimeMs: Long,
         endTimeMs: Long,
         attributes: Map<String, String> = emptyMap(),
-        events: List<EmbraceSpanEvent> = emptyList(),
-        errorCode: ErrorCode? = null,
+        events: List<SpanEvent> = emptyList(),
+        errorCode: ErrorCodeAttribute? = null,
     )
 }

--- a/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImplTest.kt
+++ b/embrace-android-features/src/test/java/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImplTest.kt
@@ -13,14 +13,12 @@ import org.junit.Test
 internal class DataCaptureServiceModuleImplTest {
 
     private val initModule = FakeInitModule()
-    private val openTelemetryModule = initModule.openTelemetryModule
     private val instrumentationModule = FakeInstrumentationModule(mockk())
 
     @Test
     fun testDefaultImplementations() {
         val module = DataCaptureServiceModuleImpl(
             initModule,
-            openTelemetryModule,
             instrumentationModule,
             FakeConfigService(),
             FakeVersionChecker(false)
@@ -36,7 +34,6 @@ internal class DataCaptureServiceModuleImplTest {
     fun `disable ui load performance capture`() {
         val module = DataCaptureServiceModuleImpl(
             initModule,
-            openTelemetryModule,
             instrumentationModule,
             FakeConfigService(
                 autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(uiLoadTracingEnabled = false)
@@ -52,7 +49,6 @@ internal class DataCaptureServiceModuleImplTest {
     fun `enable only selected ui load performance capture`() {
         val module = DataCaptureServiceModuleImpl(
             initModule,
-            openTelemetryModule,
             instrumentationModule,
             FakeConfigService(
                 autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(uiLoadTracingTraceAll = false)

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
@@ -109,7 +109,6 @@ internal class InitializedModuleGraph(
     override val dataCaptureServiceModule: DataCaptureServiceModule = init {
         dataCaptureServiceModuleSupplier(
             initModule,
-            openTelemetryModule,
             instrumentationModule,
             configModule.configService,
             versionChecker,

--- a/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/java/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -117,14 +117,12 @@ internal class ModuleInitBootstrapper(
     },
     private val dataCaptureServiceModuleSupplier: DataCaptureServiceModuleSupplier = {
             initModule: InitModule,
-            openTelemetryModule: OpenTelemetryModule,
             instrumentationModule: InstrumentationModule,
             configService: ConfigService,
             versionChecker: VersionChecker,
         ->
         DataCaptureServiceModuleImpl(
             initModule,
-            openTelemetryModule,
             instrumentationModule,
             configService,
             versionChecker

--- a/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleGraph.kt
+++ b/embrace-android-sdk/src/test/java/io/embrace/android/embracesdk/fakes/FakeModuleGraph.kt
@@ -41,7 +41,7 @@ internal fun fakeModuleInitBootstrapper(
             fakeCoreModule.application
         )
     },
-    dataCaptureServiceModuleSupplier: DataCaptureServiceModuleSupplier = { _, _, _, _, _ -> FakeDataCaptureServiceModule() },
+    dataCaptureServiceModuleSupplier: DataCaptureServiceModuleSupplier = { _, _, _, _ -> FakeDataCaptureServiceModule() },
     deliveryModuleSupplier: DeliveryModuleSupplier = { _, _, _, _, _, _, _, _, _, _ -> FakeDeliveryModule() },
     anrModuleSupplier: AnrModuleSupplier = { _, _ -> FakeAnrModule() },
     logModuleSupplier: LogModuleSupplier = { _, _, _, _, _, _, _ -> FakeLogModule() },

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAppStartupDataCollector.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeAppStartupDataCollector.kt
@@ -1,11 +1,11 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.internal.arch.datasource.SpanEvent
+import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.instrumentation.startup.AppStartupDataCollector
 import io.embrace.android.embracesdk.internal.otel.sdk.DataValidator
 import io.embrace.android.embracesdk.internal.toOtelJava
-import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
-import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaEventData
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaSpanData
 import io.embrace.opentelemetry.kotlin.aliases.OtelJavaStatusData
@@ -88,11 +88,11 @@ class FakeAppStartupDataCollector(
         startTimeMs: Long,
         endTimeMs: Long,
         attributes: Map<String, String>,
-        events: List<EmbraceSpanEvent>,
-        errorCode: ErrorCode?,
+        events: List<SpanEvent>,
+        errorCode: ErrorCodeAttribute?,
     ) {
         val map = if (errorCode != null) {
-            val errorCodeAttr = errorCode.fromErrorCode()
+            val errorCodeAttr = errorCode
             mutableMapOf(errorCodeAttr.key.name to errorCodeAttr.value)
         } else {
             mutableMapOf()

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeUiLoadDataListener.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeUiLoadDataListener.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.internal.arch.datasource.SpanEvent
+import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.instrumentation.startup.activity.UiLoadDataListener
-import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
-import io.embrace.android.embracesdk.spans.ErrorCode
 
 class FakeUiLoadDataListener : UiLoadDataListener {
     override fun create(instanceId: Int, activityName: String, timestampMs: Long, manualEnd: Boolean) {
@@ -44,8 +44,8 @@ class FakeUiLoadDataListener : UiLoadDataListener {
         startTimeMs: Long,
         endTimeMs: Long,
         attributes: Map<String, String>,
-        events: List<EmbraceSpanEvent>,
-        errorCode: ErrorCode?,
+        events: List<SpanEvent>,
+        errorCode: ErrorCodeAttribute?,
     ) {
     }
 }


### PR DESCRIPTION
## Goal

Updates the startup tracing instrumentation to use `TelemetryDestination` instead of `SpanService`.

## Testing

Updated existing test assertions.

