### PR TITLE
Move device start time calculation

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModule.kt
@@ -1,7 +1,5 @@
 package io.embrace.android.embracesdk.internal.injection
 
-import android.os.SystemClock
-import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.config.behavior.OtelBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehavior
 import io.embrace.android.embracesdk.internal.otel.config.OtelSdkConfig
@@ -78,8 +76,6 @@ interface OpenTelemetryModule {
     fun applyConfiguration(
         sensitiveKeysBehavior: SensitiveKeysBehavior,
         bypassValidation: Boolean,
-        otelBehavior: OtelBehavior
+        otelBehavior: OtelBehavior,
     )
-
-    fun deviceStartTimeMs(): Long = openTelemetryClock.run { now() - SystemClock.elapsedRealtimeNanos() }.nanosToMillis()
 }

--- a/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImpl.kt
+++ b/embrace-android-features/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DataCaptureServiceModuleImpl.kt
@@ -1,7 +1,9 @@
 package io.embrace.android.embracesdk.internal.injection
 
+import android.os.SystemClock
 import io.embrace.android.embracesdk.internal.capture.startup.StartupService
 import io.embrace.android.embracesdk.internal.capture.startup.StartupServiceImpl
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.instrumentation.startup.AppStartupDataCollector
 import io.embrace.android.embracesdk.internal.instrumentation.startup.AppStartupTraceEmitter
@@ -29,6 +31,8 @@ class DataCaptureServiceModuleImpl(
     }
 
     override val appStartupDataCollector: AppStartupDataCollector by singleton {
+        val deviceStartTimeMs = (initModule.clock.now().millisToNanos() - SystemClock.elapsedRealtimeNanos()).millisToNanos()
+
         AppStartupTraceEmitter(
             clock = initModule.clock,
             startupServiceProvider = { startupService },
@@ -37,7 +41,7 @@ class DataCaptureServiceModuleImpl(
             logger = initModule.logger,
             manualEnd = configService.autoDataCaptureBehavior.isEndStartupWithAppReadyEnabled(),
             processInfo = ProcessInfoImpl(
-                deviceStartTimeMs = openTelemetryModule.deviceStartTimeMs(),
+                deviceStartTimeMs = deviceStartTimeMs,
                 versionChecker = versionChecker,
             )
         )


### PR DESCRIPTION
## Goal

Moves the calculation of device start time as it wasn't used outside of `AppStartupDataCollector`. An OpenTelemetry clock wasn't required either given that is just wrapping Embrace's clock.