### PR TITLE
Modularise proguard keep rules

### DIFF
--- a/embrace-android-api/build.gradle.kts
+++ b/embrace-android-api/build.gradle.kts
@@ -6,6 +6,7 @@ description = "Embrace Android SDK: API"
 
 android {
     namespace = "io.embrace.android.embracesdk.api"
+    defaultConfig.consumerProguardFiles("embrace-proguard.cfg")
 }
 
 dependencies {

--- a/embrace-android-api/embrace-proguard.cfg
+++ b/embrace-android-api/embrace-proguard.cfg
@@ -1,0 +1,5 @@
+-keep class io.embrace.android.embracesdk.network.http.HttpMethod { *; }
+-keep class io.embrace.android.embracesdk.network.EmbraceNetworkRequest { *; }
+-keep class io.embrace.android.embracesdk.Severity { *; }
+-keep class io.embrace.android.embracesdk.spans.ErrorCode { *; }
+-keep class io.embrace.android.embracesdk.LastRunEndState { *; }

--- a/embrace-android-core/build.gradle.kts
+++ b/embrace-android-core/build.gradle.kts
@@ -16,6 +16,7 @@ android {
     buildFeatures {
         buildConfig = true
     }
+    defaultConfig.consumerProguardFiles("embrace-proguard.cfg")
 }
 
 dependencies {

--- a/embrace-android-core/embrace-proguard.cfg
+++ b/embrace-android-core/embrace-proguard.cfg
@@ -1,0 +1,1 @@
+-keep class io.embrace.android.embracesdk.LogExceptionType { *; }

--- a/embrace-android-instrumentation-api/build.gradle.kts
+++ b/embrace-android-instrumentation-api/build.gradle.kts
@@ -6,6 +6,7 @@ description = "Embrace Android SDK: Instrumentation API"
 
 android {
     namespace = "io.embrace.android.embracesdk.internal.instrumentation"
+    defaultConfig.consumerProguardFiles("embrace-proguard.cfg")
 }
 
 dependencies {

--- a/embrace-android-instrumentation-api/embrace-proguard.cfg
+++ b/embrace-android-instrumentation-api/embrace-proguard.cfg
@@ -1,0 +1,2 @@
+-keep class io.embrace.android.embracesdk.internal.arch.InstrumentationProvider
+-keep class * implements io.embrace.android.embracesdk.internal.arch.InstrumentationProvider

--- a/embrace-android-instrumentation-crash-ndk/build.gradle.kts
+++ b/embrace-android-instrumentation-crash-ndk/build.gradle.kts
@@ -16,6 +16,7 @@ android {
     packaging {
         jniLibs.pickFirsts.add("**/*.so")
     }
+    defaultConfig.consumerProguardFiles("embrace-proguard.cfg")
 }
 
 dependencies {

--- a/embrace-android-instrumentation-crash-ndk/embrace-proguard.cfg
+++ b/embrace-android-instrumentation-crash-ndk/embrace-proguard.cfg
@@ -1,0 +1,1 @@
+-keep class io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.jni.JniDelegateImpl { *; }

--- a/embrace-android-instrumentation-fcm/build.gradle.kts
+++ b/embrace-android-instrumentation-fcm/build.gradle.kts
@@ -6,6 +6,7 @@ description = "Embrace Android SDK: Firebase Cloud Messaging"
 
 android {
     namespace = "io.embrace.android.embracesdk.fcm"
+    defaultConfig.consumerProguardFiles("embrace-proguard.cfg")
 }
 
 dependencies {

--- a/embrace-android-instrumentation-fcm/embrace-proguard.cfg
+++ b/embrace-android-instrumentation-fcm/embrace-proguard.cfg
@@ -1,0 +1,4 @@
+## Annotations used by some dependencies (such as OTel, Protobuf and Moshi) and features (FCM capture) at compile time.
+## No need to keep them for runtime.
+-dontwarn com.google.firebase.messaging.RemoteMessage$Notification
+-dontwarn com.google.firebase.messaging.RemoteMessage

--- a/embrace-android-instrumentation-huc/build.gradle.kts
+++ b/embrace-android-instrumentation-huc/build.gradle.kts
@@ -6,6 +6,7 @@ description = "Embrace Android SDK: HttpUrlConnection instrumentation"
 
 android {
     namespace = "io.embrace.android.embracesdk.instrumentation.huc"
+    defaultConfig.consumerProguardFiles("embrace-proguard.cfg")
 }
 
 dependencies {

--- a/embrace-android-instrumentation-huc/embrace-proguard.cfg
+++ b/embrace-android-instrumentation-huc/embrace-proguard.cfg
@@ -1,0 +1,1 @@
+-keep class io.embrace.android.embracesdk.instrumentation.huc.HttpUrlConnectionTracker {*; }

--- a/embrace-android-otel/build.gradle.kts
+++ b/embrace-android-otel/build.gradle.kts
@@ -6,6 +6,7 @@ description = "Embrace Android SDK: OTel"
 
 android {
     namespace = "io.embrace.android.embracesdk.otel"
+    defaultConfig.consumerProguardFiles("embrace-proguard.cfg")
 }
 
 dependencies {

--- a/embrace-android-otel/embrace-proguard.cfg
+++ b/embrace-android-otel/embrace-proguard.cfg
@@ -1,0 +1,18 @@
+## OpenTelemetry Java SDK
+-keep class io.opentelemetry.api.trace.StatusCode { *; }
+-dontwarn com.google.auto.value.extension.memoized.Memoized
+-dontwarn io.opentelemetry.api.incubator.common.ExtendedAttributeKey
+-dontwarn io.opentelemetry.api.incubator.common.ExtendedAttributes
+-dontwarn io.opentelemetry.api.incubator.common.ExtendedAttributesBuilder
+-dontwarn io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder
+-dontwarn io.opentelemetry.api.incubator.logs.ExtendedLogger
+-dontwarn io.opentelemetry.api.incubator.trace.ExtendedSpanBuilder
+-dontwarn io.opentelemetry.api.incubator.trace.ExtendedTracer
+-dontwarn io.opentelemetry.api.incubator.metrics.ExtendedDoubleHistogram
+-dontwarn io.opentelemetry.api.incubator.metrics.ExtendedLongHistogram
+
+## Annotations used by some dependencies (such as OTel, Protobuf and Moshi) at compile time.
+## No need to keep them for runtime.
+-dontwarn com.google.auto.value.AutoValue
+-dontwarn com.google.auto.value.AutoValue$CopyAnnotations
+-dontwarn com.google.errorprone.annotations.MustBeClosed

--- a/embrace-android-sdk/embrace-proguard.cfg
+++ b/embrace-android-sdk/embrace-proguard.cfg
@@ -1,51 +1,10 @@
 -keepattributes LineNumberTable, SourceFile, RuntimeVisibleAnnotations
 
-## Keep public API including enums
 -keep class io.embrace.android.embracesdk.Embrace { *; }
--keep class io.embrace.android.embracesdk.network.http.HttpMethod { *; }
--keep class io.embrace.android.embracesdk.network.EmbraceNetworkRequest { *; }
--keep class io.embrace.android.embracesdk.Severity { *; }
--keep class io.embrace.android.embracesdk.LogExceptionType { *; }
--keep class io.embrace.android.embracesdk.spans.ErrorCode { *; }
-
-# Keep classes that will be looked up and used via reflection
--keep class io.embrace.android.embracesdk.instrumentation.huc.HttpUrlConnectionTracker {*; }
-
-## Keep classes used by hosted SDKs
--keep class io.embrace.android.embracesdk.LastRunEndState { *; }
--keep public class * implements io.embrace.android.embracesdk.internal.EmbraceInternalInterface { *; }
-
-## Keep classes with JNI calls to native code
--keep class io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.jni.JniDelegateImpl { *; }
-
-## Keep internal instrumentation API
--keep class io.embrace.android.embracesdk.internal.arch.InstrumentationProvider
--keep class * implements io.embrace.android.embracesdk.internal.arch.InstrumentationProvider
 
 ## Keep gradle plugin hooks
--keep class io.embrace.android.embracesdk.internal.config.instrumented.** { *; }
-
-## OpenTelemetry Java SDK
--keep class io.opentelemetry.api.trace.StatusCode { *; }
--dontwarn com.google.auto.value.extension.memoized.Memoized
--dontwarn io.opentelemetry.api.incubator.common.ExtendedAttributeKey
--dontwarn io.opentelemetry.api.incubator.common.ExtendedAttributes
--dontwarn io.opentelemetry.api.incubator.common.ExtendedAttributesBuilder
--dontwarn io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder
--dontwarn io.opentelemetry.api.incubator.logs.ExtendedLogger
--dontwarn io.opentelemetry.api.incubator.trace.ExtendedSpanBuilder
--dontwarn io.opentelemetry.api.incubator.trace.ExtendedTracer
--dontwarn io.opentelemetry.api.incubator.metrics.ExtendedDoubleHistogram
--dontwarn io.opentelemetry.api.incubator.metrics.ExtendedLongHistogram
+-keep class io.embrace.android.embracesdk.internal.config.instrumented.** { *; } // payload
 
 ## Keep OkHttp class so we can fetch the version correctly via reflection.
 -keep class okhttp3.OkHttp { *; }
 -keep class okhttp3.OkHttpClient { *; }
-
-## Annotations used by some dependencies (such as OTel, Protobuf and Moshi) and features (FCM capture) at compile time.
-## No need to keep them for runtime.
--dontwarn com.google.auto.value.AutoValue
--dontwarn com.google.auto.value.AutoValue$CopyAnnotations
--dontwarn com.google.errorprone.annotations.MustBeClosed
--dontwarn com.google.firebase.messaging.RemoteMessage$Notification
--dontwarn com.google.firebase.messaging.RemoteMessage

--- a/embrace-internal-api/build.gradle.kts
+++ b/embrace-internal-api/build.gradle.kts
@@ -6,6 +6,7 @@ description = "Embrace Android SDK: Internal API"
 
 android {
     namespace = "io.embrace.android.embracesdk.api.internal"
+    defaultConfig.consumerProguardFiles("embrace-proguard.cfg")
 }
 
 dependencies {

--- a/embrace-internal-api/embrace-proguard.cfg
+++ b/embrace-internal-api/embrace-proguard.cfg
@@ -1,0 +1,1 @@
+-keep public class * implements io.embrace.android.embracesdk.internal.EmbraceInternalInterface { *; }


### PR DESCRIPTION
## Goal

Splits the proguard keep rules by module so that it's easier to see where a rule is added. This will eventually mean rules are only included when certain instrumentation is enabled.

