### PR TITLE
Track Kotlin JVM target in build telemetry

### DIFF
--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryCollector.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryCollector.kt
@@ -12,6 +12,7 @@ import org.gradle.api.Project
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 import org.jetbrains.kotlin.gradle.plugin.kotlinToolingVersion
 import java.util.UUID
 
@@ -62,6 +63,7 @@ class BuildTelemetryCollector {
                     )
                 },
                 kotlinVersion = getKotlinVersion(project),
+                kotlinJvmTarget = getKotlinJvmTarget(project),
             )
         }
     }
@@ -112,6 +114,19 @@ class BuildTelemetryCollector {
     private fun getKotlinVersion(project: Project): String? {
         return if (project.pluginManager.hasPlugin("org.jetbrains.kotlin.android")) {
             project.kotlinToolingVersion.toString()
+        } else {
+            null
+        }
+    }
+
+    private fun getKotlinJvmTarget(project: Project): String? {
+        return if (project.pluginManager.hasPlugin("org.jetbrains.kotlin.android")) {
+            try {
+                val kotlinExtension = project.extensions.findByType(KotlinAndroidProjectExtension::class.java)
+                kotlinExtension?.compilerOptions?.jvmTarget?.orNull?.target
+            } catch (_: Throwable) {
+                null
+            }
         } else {
             null
         }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryRequest.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryRequest.kt
@@ -21,6 +21,7 @@ data class BuildTelemetryRequest(
     @Json(name = "edm") val isEdmEnabled: Boolean? = null,
     @Json(name = "edmv") val edmVersion: String? = null,
     @Json(name = "kgpv") val kotlinVersion: String? = null,
+    @Json(name = "kjvm") val kotlinJvmTarget: String? = null,
     @Json(name = "sc") val sourceCompatibility: String? = null,
     @Json(name = "msdk") val minSdk: Int? = null,
     @Json(name = "csdk") val compileSdk: Int? = null,


### PR DESCRIPTION
## Goal
Track the Kotlin JVM target configuration in build telemetry to understand what JVM bytecode version customers are using. This helps answer questions like "Can we require JVM 17 in our SDK?"
