### PR TITLE
Fix proguard rules for 8.0.0

### DIFF
--- a/embrace-android-sdk/embrace-proguard.cfg
+++ b/embrace-android-sdk/embrace-proguard.cfg
@@ -5,7 +5,6 @@
 -keep class io.embrace.android.embracesdk.network.http.HttpMethod { *; }
 -keep class io.embrace.android.embracesdk.network.EmbraceNetworkRequest { *; }
 -keep class io.embrace.android.embracesdk.Severity { *; }
--keep class io.embrace.android.embracesdk.LogType { *; }
 -keep class io.embrace.android.embracesdk.LogExceptionType { *; }
 -keep class io.embrace.android.embracesdk.spans.ErrorCode { *; }
 
@@ -13,19 +12,11 @@
 -keep class io.embrace.android.embracesdk.instrumentation.huc.HttpUrlConnectionTracker {*; }
 
 ## Keep classes used by hosted SDKs
--keep class io.embrace.android.embracesdk.Embrace$AppFramework { *; }
--keep class io.embrace.android.embracesdk.Embrace$LastRunEndState { *; }
+-keep class io.embrace.android.embracesdk.LastRunEndState { *; }
 -keep public class * implements io.embrace.android.embracesdk.internal.EmbraceInternalInterface { *; }
 
-## Keep classes used from native code
--keep class io.embrace.android.embracesdk.internal.payload.NativeThreadAnrSample { *; }
--keep class io.embrace.android.embracesdk.internal.payload.NativeThreadAnrStackframe { *; }
--keep class io.embrace.android.embracesdk.internal.anr.sigquit.SigquitDataSource { *; }
--keep class io.embrace.android.embracesdk.internal.anr.sigquit.SigquitDataSourceImpl { *; }
-
 ## Keep classes with JNI calls to native code
--keep class io.embrace.android.embracesdk.internal.anr.ndk.NativeThreadSamplerNdkDelegate { *; }
--keep class io.embrace.android.embracesdk.internal.ndk.jni.JniDelegateImpl { *; }
+-keep class io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.jni.JniDelegateImpl { *; }
 
 ## Keep internal instrumentation API
 -keep class io.embrace.android.embracesdk.internal.arch.InstrumentationProvider


### PR DESCRIPTION
## Goal

Backport of #2831 to fix an incorrect package for `JniDelegateImpl` and remove obsolete keep rules.
