### PR TITLE
[POC] Remote configuration access for Hybrid SDKs

### DIFF
--- a/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
+++ b/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.fakes.behavior.FakeBreadcrumbBehavior
 import io.embrace.android.embracesdk.internal.config.ConfigService
+import io.embrace.android.embracesdk.internal.config.HybridSdkConfigService
 import io.embrace.android.embracesdk.internal.config.behavior.AppExitInfoBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.AutoDataCaptureBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.BackgroundActivityBehavior
@@ -15,6 +16,7 @@ import io.embrace.android.embracesdk.internal.config.behavior.SdkModeBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.SessionBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.ThreadBlockageBehavior
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 
 /**
@@ -39,6 +41,8 @@ class FakeConfigService(
     override var networkSpanForwardingBehavior: NetworkSpanForwardingBehavior = createNetworkSpanForwardingBehavior(),
     override var sensitiveKeysBehavior: SensitiveKeysBehavior = createSensitiveKeysBehavior(),
     override val otelBehavior: OtelBehavior = createOtelBehavior(),
-) : ConfigService {
+    override var remoteConfig: RemoteConfig? = null
+) : ConfigService, HybridSdkConfigService {
     override fun isOnlyUsingOtelExporters(): Boolean = onlyUsingOtelExporters
+    override fun isBehaviorEnabled(pctEnabled: Float?): Boolean? = false
 }

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
@@ -23,10 +23,10 @@ import io.embrace.android.embracesdk.internal.payload.AppFramework
  */
 class ConfigServiceImpl(
     instrumentedConfig: InstrumentedConfig,
-    remoteConfig: RemoteConfig?,
+    override val remoteConfig: RemoteConfig?,
     deviceIdSupplier: () -> String,
     private val hasConfiguredOtelExporters: () -> Boolean,
-) : ConfigService {
+) : ConfigService, HybridSdkConfigService {
 
     private val thresholdCheck: BehaviorThresholdCheck = BehaviorThresholdCheck(deviceIdSupplier)
     override val backgroundActivityBehavior =
@@ -62,4 +62,6 @@ class ConfigServiceImpl(
     override val appFramework: AppFramework = instrumentedConfig.project.getAppFramework()?.let {
         AppFramework.fromString(it)
     } ?: AppFramework.NATIVE
+
+    override fun isBehaviorEnabled(pctEnabled: Float?): Boolean? = thresholdCheck.isBehaviorEnabled(pctEnabled)
 }

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/HybridSdkConfigService.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/HybridSdkConfigService.kt
@@ -1,0 +1,11 @@
+package io.embrace.android.embracesdk.internal.config
+
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+
+/**
+ * Accessors for the config service that should only be used by the hybrid SDKs.
+ */
+interface HybridSdkConfigService {
+    val remoteConfig: RemoteConfig?
+    fun isBehaviorEnabled(pctEnabled: Float?): Boolean?
+}

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/EmbraceInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/EmbraceInternalInterfaceImpl.kt
@@ -4,7 +4,9 @@ import android.annotation.SuppressLint
 import io.embrace.android.embracesdk.EmbraceImpl
 import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
 import io.embrace.android.embracesdk.internal.InternalTracingApi
+import io.embrace.android.embracesdk.internal.TypeUtils
 import io.embrace.android.embracesdk.internal.config.ConfigService
+import io.embrace.android.embracesdk.internal.config.HybridSdkConfigService
 import io.embrace.android.embracesdk.internal.injection.InitModule
 import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkCaptureDataSource
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
@@ -48,5 +50,17 @@ internal class EmbraceInternalInterfaceImpl(
 
     override fun logInternalError(error: Throwable) {
         initModule.logger.trackInternalError(InternalErrorType.INTERNAL_INTERFACE_FAIL, error)
+    }
+
+    override fun getRemoteConfig(): Map<String, Any>? {
+        val cfg = (configService as? HybridSdkConfigService)?.remoteConfig ?: return null
+        val serializer = initModule.jsonSerializer
+        val json = serializer.toJson(cfg)
+        val type = TypeUtils.typedMap(String::class.java, Any::class.java)
+        return serializer.fromJson(json, type)
+    }
+
+    override fun isConfigFeatureEnabled(pctEnabled: Float?): Boolean? {
+        return (configService as? HybridSdkConfigService)?.isBehaviorEnabled(pctEnabled)
     }
 }

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/EmbraceInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/EmbraceInternalInterfaceImplTest.kt
@@ -8,8 +8,13 @@ import io.embrace.android.embracesdk.fakes.FakeNetworkCaptureDataSource
 import io.embrace.android.embracesdk.fakes.behavior.FakeNetworkSpanForwardingBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.api.delegate.EmbraceInternalInterfaceImpl
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.ThreadBlockageRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.UiRemoteConfig
 import io.mockk.mockk
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -58,6 +63,53 @@ internal class EmbraceInternalInterfaceImplTest {
         internalImpl.logInternalError("err", "message")
         val logger = initModule.logger as FakeEmbLogger
         checkNotNull(logger.internalErrorMessages.single().throwable)
+    }
+
+    @Test
+    fun `test retrieve remote config null`() {
+        val cfg = internalImpl.getRemoteConfig()
+        assertNull(cfg)
+    }
+
+    @Test
+    fun `test retrieve remote config empty map`() {
+        fakeConfigService.remoteConfig = RemoteConfig()
+        val cfg = internalImpl.getRemoteConfig()
+        assertEquals(emptyMap<String, String>(), cfg)
+    }
+
+    @Test
+    fun `test retrieve remote config with values`() {
+        fakeConfigService.remoteConfig = RemoteConfig(
+            threshold = 50,
+            uiConfig = UiRemoteConfig(
+                taps = 25
+            ),
+            threadBlockageRemoteConfig = ThreadBlockageRemoteConfig(
+                sampleIntervalMs = 200
+            ),
+            internalExceptionCaptureEnabled = true,
+            disabledUrlPatterns = setOf("*.google.com")
+        )
+        val cfg = internalImpl.getRemoteConfig()
+        val expected = mapOf(
+            "threshold" to 50.0,
+            "ui" to mapOf(
+                "taps" to 25.0
+            ),
+            "anr" to mapOf(
+                "interval" to 200.0
+            ),
+            "internal_exception_capture_enabled" to true,
+            "disabled_url_patterns" to listOf("*.google.com")
+        )
+        assertEquals(expected, cfg)
+    }
+
+    @Test
+    fun `test is config feature enabled`() {
+        assertFalse(checkNotNull(internalImpl.isConfigFeatureEnabled(0.0f)))
+        assertTrue(checkNotNull(internalImpl.isConfigFeatureEnabled(100.0f)))
     }
 
     companion object {

--- a/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/EmbraceInternalInterface.kt
+++ b/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/EmbraceInternalInterface.kt
@@ -29,4 +29,26 @@ interface EmbraceInternalInterface : InternalTracingApi {
     fun logInternalError(error: Throwable)
 
     fun recordNetworkRequest(networkRequest: EmbraceNetworkRequest)
+
+    /**
+     * Retrieves the latest available remote config response from Embrace's server, or null if none is available.
+     *
+     * The return value is guaranteed to remain the same for the lifecycle of a process. Given this function is
+     * expensive, it should only be called once and the value should be safely cached by the hybrid SDK.
+     */
+    fun getRemoteConfig(): Map<String, Any>?
+
+    /**
+     * This function can be called by the hybrid SDks to check whether % based features are enabled via
+     * remote config. It does this by using the device ID and % threshold in the remote config response.
+     * The return value can be true/false/null. If null is returned, then the default behaviour should be used.
+     * true/false will only be returned if they were explicitly set in the config response.
+     *
+     * The return value for a given parameter is guaranteed to remain the same for the lifecycle of a process.
+     * It's preferred but not necessary for the hybrid SDK to cache the returned value.
+     *
+     * As an example, anr.pct_enabled could be obtained from the [getRemoteConfig] map and passed to this
+     * function to determine whether ANR capture should be enabled or not.
+     */
+    fun isConfigFeatureEnabled(pctEnabled: Float?): Boolean?
 }

--- a/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/NoopEmbraceInternalInterface.kt
+++ b/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/NoopEmbraceInternalInterface.kt
@@ -20,4 +20,7 @@ internal class NoopEmbraceInternalInterface(
 
     override fun recordNetworkRequest(networkRequest: EmbraceNetworkRequest) {
     }
+    override fun getRemoteConfig(): Map<String, Any>? = null
+
+    override fun isConfigFeatureEnabled(pctEnabled: Float?): Boolean? = false
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt
@@ -69,4 +69,8 @@ class FakeEmbraceInternalInterface(
     override fun recordNetworkRequest(networkRequest: EmbraceNetworkRequest) {
         networkRequests.add(networkRequest)
     }
+
+    override fun getRemoteConfig(): Map<String, Any>? = null
+
+    override fun isConfigFeatureEnabled(pctEnabled: Float?): Boolean? = null
 }


### PR DESCRIPTION
## Goal

This allows the hybrid SDks to access the remote configuration HTTP response as a `Map`. As an example, here is how the limit for tap breadcrumbs would be obtained:

```
val config: Map<String, Any>? = EmbraceInternalApi.flutterInternalInterface.getRemoteConfig()

if (config == null) {
    return // use the default behavior.
}

val uiConfig = config["ui"] as? Map<String, String>?

// enforce tap limit
val tapLimit = uiConfig["taps"] as? Int?

if (tapLimit != null) {
    // enforce limit
} else {
    // use default behavior
}
```

This broadly follows Option D in our internal documentation.

## Testing

Added unit tests.

