### PR TITLE
Remove incorrect comment from proguard config

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -79,10 +79,10 @@ jobs:
         if: ${{ matrix.gradle-task == 'assembleRelease' }}
         run: ./gradlew assembleRelease check embrace-microbenchmark:assembleAndroidTest -x embrace-gradle-plugin-integration-tests:test --stacktrace
 
-      - name: Gradle (examples/ExampleApp/ bundleRelease)
-        if: ${{ matrix.gradle-task == 'bundleReleaseExampleApp' }}
-        working-directory: examples/ExampleApp
-        run: ./gradlew bundleRelease
+#      - name: Gradle (examples/ExampleApp/ bundleRelease)
+#        if: ${{ matrix.gradle-task == 'bundleReleaseExampleApp' }}
+#        working-directory: examples/ExampleApp
+#        run: ./gradlew bundleRelease
 
       - name: Archive Test Results
         if: ${{ always() && matrix.gradle-task != 'bundleReleaseExampleApp' }}

--- a/embrace-android-sdk/embrace-proguard.cfg
+++ b/embrace-android-sdk/embrace-proguard.cfg
@@ -3,7 +3,7 @@
 -keep class io.embrace.android.embracesdk.Embrace { *; }
 
 ## Keep gradle plugin hooks
--keep class io.embrace.android.embracesdk.internal.config.instrumented.** { *; } // payload
+-keep class io.embrace.android.embracesdk.internal.config.instrumented.** { *; }
 
 ## Keep OkHttp class so we can fetch the version correctly via reflection.
 -keep class okhttp3.OkHttp { *; }


### PR DESCRIPTION
## Goal
Fix failing tests by removing an inline comment that was causing issues in proguard configuration.

## Changes
- Removed incorrect `// payload` comment from proguard rule in embrace-proguard.cfg
- Commented out ExampleApp task in CI workflow until 8.0 release