### PR TITLE
Avoid unnecessary config checks

### DIFF
--- a/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/EmbraceAnrService.kt
+++ b/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/EmbraceAnrService.kt
@@ -34,7 +34,6 @@ internal class EmbraceAnrService(
     private val random: Random = Random.Default,
 ) : AnrService {
 
-    private val configService = args.configService
     private val logger = args.logger
     private val clock = args.clock
     private val appStateTracker = args.appStateTracker
@@ -133,12 +132,6 @@ internal class EmbraceAnrService(
     }
 
     private fun processAnrTick(timestamp: Long) {
-        // Check if ANR capture is enabled
-        if (!configService.anrBehavior.isAnrCaptureEnabled()) {
-            return
-        }
-
-        // Invoke callbacks
         for (listener in listeners) {
             listener.onThreadBlockedInterval(looper.thread, timestamp)
         }

--- a/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/ThreadInfoCollector.kt
+++ b/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/ThreadInfoCollector.kt
@@ -1,11 +1,11 @@
 package io.embrace.android.embracesdk.internal.instrumentation.anr
 
 import io.embrace.android.embracesdk.internal.arch.stacktrace.getThreadInfo
-import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.payload.ThreadInfo
 
 internal class ThreadInfoCollector(
     private val targetThread: Thread,
+    private val stacktraceFrameLimit: Int,
 ) {
 
     private val currentStacktraceStates: MutableMap<Long, ThreadInfo> = HashMap()
@@ -18,8 +18,8 @@ internal class ThreadInfoCollector(
     /**
      * Captures the thread traces required for the given sample.
      */
-    fun captureSample(configService: ConfigService): List<ThreadInfo> {
-        val threadInfo = getMainThread(configService)
+    fun captureSample(): List<ThreadInfo> {
+        val threadInfo = getMainThread()
         val sanitizedThreads = mutableListOf<ThreadInfo>()
 
         // Compares main thread with the last known thread state via hashcode. If hashcode changed
@@ -40,9 +40,9 @@ internal class ThreadInfoCollector(
      *
      * @return filtered threads
      */
-    fun getMainThread(configService: ConfigService): ThreadInfo = getThreadInfo(
+    fun getMainThread(): ThreadInfo = getThreadInfo(
         targetThread,
         targetThread.stackTrace,
-        configService.anrBehavior.getStacktraceFrameLimit()
+        stacktraceFrameLimit
     )
 }

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrStacktraceSamplerTest.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrStacktraceSamplerTest.kt
@@ -27,7 +27,14 @@ internal class AnrStacktraceSamplerTest {
 
     @Test
     fun testLeastValuableInterval() {
-        val sampler = AnrStacktraceSampler(configService, clock, thread, worker)
+        val sampler = AnrStacktraceSampler(
+            clock,
+            thread,
+            worker,
+            configService.anrBehavior.getMaxAnrIntervalsPerSession(),
+            configService.anrBehavior.getMaxStacktracesPerInterval(),
+            configService.anrBehavior.getStacktraceFrameLimit(),
+        )
         assertNull(sampler.findLeastValuableIntervalWithSamples())
         val interval1 = AnrInterval(
             startTime = BASELINE_MS,
@@ -78,7 +85,14 @@ internal class AnrStacktraceSamplerTest {
         clock.setCurrentTime(BASELINE_MS)
         val repeatCount = 100
         val intervalMs: Long = 100
-        val sampler = AnrStacktraceSampler(configService, clock, thread, worker)
+        val sampler = AnrStacktraceSampler(
+            clock,
+            thread,
+            worker,
+            configService.anrBehavior.getMaxAnrIntervalsPerSession(),
+            configService.anrBehavior.getMaxStacktracesPerInterval(),
+            configService.anrBehavior.getStacktraceFrameLimit(),
+        )
 
         // simulate one ANR with 100 intervals
         sampler.onThreadBlocked(thread, clock.now())
@@ -126,7 +140,14 @@ internal class AnrStacktraceSamplerTest {
         val anrRepeatCount = 15
         val intervalRepeatCount = 100
         val intervalMs: Long = 100
-        val sampler = AnrStacktraceSampler(configService, clock, thread, worker)
+        val sampler = AnrStacktraceSampler(
+            clock,
+            thread,
+            worker,
+            configService.anrBehavior.getMaxAnrIntervalsPerSession(),
+            configService.anrBehavior.getMaxStacktracesPerInterval(),
+            configService.anrBehavior.getStacktraceFrameLimit(),
+        )
 
         // simulate multiple ANRs with intervals
         repeat(anrRepeatCount) { index ->
@@ -169,7 +190,14 @@ internal class AnrStacktraceSamplerTest {
         clock.setCurrentTime(BASELINE_MS)
         val anrRepeatCount = 110
         val intervalMs: Long = 100
-        val sampler = AnrStacktraceSampler(configService, clock, thread, worker)
+        val sampler = AnrStacktraceSampler(
+            clock,
+            thread,
+            worker,
+            configService.anrBehavior.getMaxAnrIntervalsPerSession(),
+            configService.anrBehavior.getMaxStacktracesPerInterval(),
+            configService.anrBehavior.getStacktraceFrameLimit(),
+        )
 
         // simulate 110 ANRs with intervals
         repeat(anrRepeatCount) {

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/EmbraceAnrServiceRule.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/EmbraceAnrServiceRule.kt
@@ -62,25 +62,28 @@ internal class EmbraceAnrServiceRule<T : ScheduledExecutorService>(
             clock = clock
         )
         blockedThreadDetector = BlockedThreadDetector(
-            configService = fakeConfigService,
             clock = clock,
             state = state,
-            targetThread = Thread.currentThread()
+            targetThread = Thread.currentThread(),
+            blockedDurationThreshold = fakeConfigService.anrBehavior.getMinDuration(),
+            samplingIntervalMs = fakeConfigService.anrBehavior.getSamplingIntervalMs()
         )
         livenessCheckScheduler = LivenessCheckScheduler(
-            configService = fakeConfigService,
             anrMonitorWorker = worker,
             clock = clock,
             state = state,
             targetThreadHandler = targetThreadHandler,
             blockedThreadDetector = blockedThreadDetector,
-            logger = logger
+            logger = logger,
+            intervalMs = fakeConfigService.anrBehavior.getSamplingIntervalMs(),
         )
         stacktraceSampler = AnrStacktraceSampler(
-            configService = fakeConfigService,
             clock = clock,
             targetThread = looper.thread,
-            anrMonitorWorker = worker
+            anrMonitorWorker = worker,
+            maxIntervalsPerSession = fakeConfigService.anrBehavior.getMaxAnrIntervalsPerSession(),
+            maxStacktracesPerInterval = fakeConfigService.anrBehavior.getMaxStacktracesPerInterval(),
+            stacktraceFrameLimit = fakeConfigService.anrBehavior.getStacktraceFrameLimit(),
         )
         args = FakeInstrumentationArgs(
             mockk(),

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/EmbraceAnrServiceTest.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/EmbraceAnrServiceTest.kt
@@ -284,30 +284,12 @@ internal class EmbraceAnrServiceTest {
     }
 
     @Test
-    fun testProcessAnrTickDisabled() {
-        with(rule) {
-            // create an ANR service with config that disables ANR capture
-            rule.anrBehavior.anrCaptureEnabled = false
-            clock.setCurrentTime(15020000L)
-            anrService.onThreadBlockedInterval(currentThread(), clock.now())
-            assertEquals(0, stacktraceSampler.size())
-
-            // assert no anr intervals were added
-            val anrIntervals = anrService.getCapturedData()
-            assertTrue(anrIntervals.isEmpty())
-        }
-    }
-
-    @Test
     fun testReachedAnrCaptureLimit() {
         with(rule) {
-            rule.anrBehavior.anrPerSessionImpl = 3
-            assertFalse(stacktraceSampler.reachedAnrStacktraceCaptureLimit())
-
-            stacktraceSampler.anrIntervals.add(AnrInterval(0, anrSampleList = AnrSampleList(listOf())))
-            stacktraceSampler.anrIntervals.add(AnrInterval(0, anrSampleList = AnrSampleList(listOf())))
-            stacktraceSampler.anrIntervals.add(AnrInterval(0, anrSampleList = AnrSampleList(listOf())))
-            assertFalse(stacktraceSampler.reachedAnrStacktraceCaptureLimit())
+            repeat(rule.anrBehavior.anrPerSessionImpl) {
+                stacktraceSampler.anrIntervals.add(AnrInterval(0, anrSampleList = AnrSampleList(listOf())))
+                assertFalse(stacktraceSampler.reachedAnrStacktraceCaptureLimit())
+            }
 
             stacktraceSampler.anrIntervals.add(AnrInterval(0, anrSampleList = AnrSampleList(listOf())))
             assertTrue(stacktraceSampler.reachedAnrStacktraceCaptureLimit())

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/ThreadInfoCollectorTest.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/ThreadInfoCollectorTest.kt
@@ -19,12 +19,12 @@ internal class ThreadInfoCollectorTest {
         configService = FakeConfigService(
             anrBehavior = FakeAnrBehavior(frameLimit = 5)
         )
-        threadInfoCollector = ThreadInfoCollector(currentThread())
+        threadInfoCollector = ThreadInfoCollector(currentThread(), configService.anrBehavior.getStacktraceFrameLimit())
     }
 
     @Test
     fun `verify truncation of ANR stacktrace respects the config`() {
-        val thread = threadInfoCollector.getMainThread(configService)
+        val thread = threadInfoCollector.getMainThread()
         val frames = checkNotNull(thread.lines)
         assertEquals(5, frames.size)
         assertTrue(thread.frameCount > frames.size)

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/detection/BlockedThreadDetectorTest.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/detection/BlockedThreadDetectorTest.kt
@@ -30,11 +30,12 @@ internal class BlockedThreadDetectorTest {
         state = ThreadMonitoringState(clock)
         anrMonitorThread = AtomicReference(Thread.currentThread())
         detector = BlockedThreadDetector(
-            configService,
             clock,
             listener,
             state,
-            Thread.currentThread()
+            Thread.currentThread(),
+            configService.anrBehavior.getMinDuration(),
+            configService.anrBehavior.getSamplingIntervalMs()
         )
     }
 

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeAnrModule.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeAnrModule.kt
@@ -11,10 +11,10 @@ import io.embrace.android.embracesdk.testframework.NoopAnrService
 class FakeAnrModule(
     override val anrService: AnrService = NoopAnrService,
     override val blockedThreadDetector: BlockedThreadDetector = BlockedThreadDetector(
-        FakeConfigService(),
         FakeClock(),
-        null,
-        ThreadMonitoringState(FakeClock()),
-        Thread.currentThread()
+        state = ThreadMonitoringState(FakeClock()),
+        targetThread = Thread.currentThread(),
+        blockedDurationThreshold = FakeConfigService().anrBehavior.getMinDuration(),
+        samplingIntervalMs = FakeConfigService().anrBehavior.getSamplingIntervalMs()
     ),
 ) : AnrModule


### PR DESCRIPTION
## Goal

`ConfigService` return values used to be mutable across a process. As they can no longer change there are lots of unnecessary checks in the ANR instrumentation that I've simplified in this PR.

## Testing

Relied on existing test coverage.
