### PR TITLE
Simplify ANR listeners

### DIFF
--- a/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrService.kt
+++ b/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrService.kt
@@ -19,9 +19,4 @@ interface AnrService :
      * Initializes capture of ANRs
      */
     fun startAnrCapture()
-
-    /**
-     * Adds a listener which is invoked when the thread becomes blocked/unblocked.
-     */
-    fun addBlockedThreadListener(listener: BlockedThreadListener)
 }

--- a/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/EmbraceAnrService.kt
+++ b/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/EmbraceAnrService.kt
@@ -57,10 +57,6 @@ internal class EmbraceAnrService(
         }
     }
 
-    override fun addBlockedThreadListener(listener: BlockedThreadListener) {
-        listeners.add(listener)
-    }
-
     /**
      * Gets the intervals during which the application was not responding (ANR).
      *

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/EmbraceAnrServiceTest.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/EmbraceAnrServiceTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.internal.instrumentation.anr
 
 import io.embrace.android.embracesdk.concurrency.SingleThreadTestScheduledExecutor
-import io.embrace.android.embracesdk.fakes.FakeBlockedThreadListener
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.internal.instrumentation.anr.payload.AnrInterval
 import io.embrace.android.embracesdk.internal.instrumentation.anr.payload.AnrSample
@@ -54,21 +53,6 @@ internal class EmbraceAnrServiceTest {
             }.get(1L, TimeUnit.SECONDS)
             // verify the config service was changed from the bootstrapped early version
             assertNotSame(this.fakeConfigService, configService)
-        }
-    }
-
-    @Test
-    fun testListener() {
-        with(rule) {
-            val listener = FakeBlockedThreadListener()
-            anrService.addBlockedThreadListener(listener)
-
-            // Test that the listener actually gets notified when thread blocking events occur
-            anrService.onThreadBlocked(currentThread(), 1000L)
-            assertEquals(1, listener.blockedCount)
-
-            anrService.onThreadUnblocked(currentThread(), 2000L)
-            assertEquals(1, listener.unblockedCount)
         }
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/NoopAnrService.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/NoopAnrService.kt
@@ -1,15 +1,11 @@
 package io.embrace.android.embracesdk.testframework
 
 import io.embrace.android.embracesdk.internal.instrumentation.anr.AnrService
-import io.embrace.android.embracesdk.internal.instrumentation.anr.BlockedThreadListener
 import io.embrace.android.embracesdk.internal.payload.Span
 
 internal object NoopAnrService : AnrService {
 
     override fun startAnrCapture() {
-    }
-
-    override fun addBlockedThreadListener(listener: BlockedThreadListener) {
     }
 
     override fun cleanCollections() {


### PR DESCRIPTION
## Goal

Removes the ability to add a `BlockedThreadListener` to `AnrService` as this functionality wasn't used outside of tests.

## Testing

Relied on existing test coverage

