### PR TITLE
Remove ANR module

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SupplierTypealiases.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SupplierTypealiases.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.delivery.debug.DeliveryTracer
 import io.embrace.android.embracesdk.internal.delivery.execution.RequestExecutionService
 import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageService
-import io.embrace.android.embracesdk.internal.instrumentation.anr.AnrModule
+import io.embrace.android.embracesdk.internal.envelope.session.OtelPayloadMapper
 import io.embrace.android.embracesdk.internal.utils.Provider
 
 typealias ConfigModuleSupplier = (
@@ -78,7 +78,7 @@ typealias PayloadSourceModuleSupplier = (
     essentialServiceModule: EssentialServiceModule,
     configModule: ConfigModule,
     otelModule: OpenTelemetryModule,
-    anrModule: AnrModule,
+    otelPayloadMapper: OtelPayloadMapper?,
     deliveryModule: DeliveryModule,
 ) -> PayloadSourceModule
 

--- a/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrModule.kt
+++ b/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrModule.kt
@@ -1,5 +1,0 @@
-package io.embrace.android.embracesdk.internal.instrumentation.anr
-
-interface AnrModule {
-    val anrService: AnrService?
-}

--- a/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrModuleSupplier.kt
+++ b/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrModuleSupplier.kt
@@ -1,8 +1,0 @@
-package io.embrace.android.embracesdk.internal.instrumentation.anr
-
-import io.embrace.android.embracesdk.internal.arch.InstrumentationArgs
-
-/**
- * Function that returns an instance of [AnrModule]. Matches the signature of the constructor for [AnrModuleImpl]
- */
-typealias AnrModuleSupplier = (args: InstrumentationArgs) -> AnrModule

--- a/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/detection/BlockedThreadDetector.kt
+++ b/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/detection/BlockedThreadDetector.kt
@@ -184,15 +184,11 @@ internal class BlockedThreadDetector(
         override fun handleMessage(msg: Message) {
             runCatching {
                 if (msg.what == HEARTBEAT_REQUEST) {
-                    onIdleThread()
+                    val timestamp = clock.now()
+                    anrMonitorWorker.submit {
+                        action(timestamp)
+                    }
                 }
-            }
-        }
-
-        fun onIdleThread() {
-            val timestamp = clock.now()
-            anrMonitorWorker.submit {
-                action(timestamp)
             }
         }
     }

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceSupplierTest.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceSupplierTest.kt
@@ -12,24 +12,24 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-internal class AnrModuleImplTest {
+internal class AnrServiceSupplierTest {
 
     @Test
     fun testDefaultImplementations() {
         val application = ApplicationProvider.getApplicationContext<Application>()
-        val module = AnrModuleImpl(
+        val service = createAnrService(
             FakeInstrumentationArgs(
                 application,
                 configService = FakeConfigService()
             ),
         )
-        assertNotNull(module.anrService)
+        assertNotNull(service)
     }
 
     @Test
     fun testBehaviorDisabled() {
         val application = ApplicationProvider.getApplicationContext<Application>()
-        val module = AnrModuleImpl(
+        val service = createAnrService(
             FakeInstrumentationArgs(
                 application,
                 configService = FakeConfigService(
@@ -37,6 +37,6 @@ internal class AnrModuleImplTest {
                 )
             ),
         )
-        assertNull(module.anrService)
+        assertNull(service)
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AnrFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AnrFeatureTest.kt
@@ -221,7 +221,7 @@ internal class AnrFeatureTest {
 
             if (!incomplete) {
                 // simulate the main thread becoming responsive again, ending the ANR interval
-                testRule.bootstrapper.anrModule.anrService?.simulateTargetThreadResponse()
+                testRule.bootstrapper.anrService?.simulateTargetThreadResponse()
             }
 
             // AnrService#getCapturedData() currently gets a Callable with a timeout, so we

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -11,7 +11,6 @@ import io.embrace.android.embracesdk.fakes.FakeNetworkConnectivityService
 import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
 import io.embrace.android.embracesdk.fakes.FakeSharedObjectLoader
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
-import io.embrace.android.embracesdk.fakes.injection.FakeAnrModule
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakeWorkerThreadModule
@@ -33,7 +32,7 @@ import io.embrace.android.embracesdk.internal.injection.InstrumentationModuleImp
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.injection.WorkerThreadModule
 import io.embrace.android.embracesdk.internal.injection.WorkerThreadModuleImpl
-import io.embrace.android.embracesdk.internal.instrumentation.anr.AnrModuleImpl
+import io.embrace.android.embracesdk.internal.instrumentation.anr.createAnrService
 import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.jniDelegateTestOverride
 import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.sharedObjectLoaderTestOverride
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
@@ -133,11 +132,11 @@ internal class EmbraceSetupInterface(
                 deliveryTracer = deliveryTracer
             )
         },
-        anrModuleSupplier = { instrumentationModule ->
+        anrServiceSupplier = { args ->
             if (anrMonitoringThread != null) {
-                AnrModuleImpl(instrumentationModule)
+                createAnrService(args)
             } else {
-                FakeAnrModule()
+                null
             }
         },
         instrumentationModuleSupplier = {

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.internal.injection
 
 import android.content.Context
-import io.embrace.android.embracesdk.internal.instrumentation.anr.AnrModule
-import io.embrace.android.embracesdk.internal.instrumentation.anr.AnrModuleSupplier
+import io.embrace.android.embracesdk.internal.instrumentation.anr.AnrService
+import io.embrace.android.embracesdk.internal.instrumentation.anr.AnrServiceSupplier
 import io.embrace.android.embracesdk.internal.instrumentation.startup.DataCaptureServiceModule
 import io.embrace.android.embracesdk.internal.instrumentation.startup.DataCaptureServiceModuleSupplier
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
@@ -27,7 +27,7 @@ internal class InitializedModuleGraph(
     private val instrumentationModuleSupplier: InstrumentationModuleSupplier,
     private val dataCaptureServiceModuleSupplier: DataCaptureServiceModuleSupplier,
     private val deliveryModuleSupplier: DeliveryModuleSupplier,
-    private val anrModuleSupplier: AnrModuleSupplier,
+    private val anrServiceSupplier: AnrServiceSupplier,
     private val logModuleSupplier: LogModuleSupplier,
     private val sessionOrchestrationModuleSupplier: SessionOrchestrationModuleSupplier,
     private val payloadSourceModuleSupplier: PayloadSourceModuleSupplier,
@@ -129,10 +129,8 @@ internal class InitializedModuleGraph(
         )
     }
 
-    override val anrModule: AnrModule = init {
-        anrModuleSupplier(
-            instrumentationModule.instrumentationArgs,
-        )
+    override val anrService: AnrService? = init {
+        anrServiceSupplier(instrumentationModule.instrumentationArgs)
     }
 
     override val payloadSourceModule: PayloadSourceModule = init {
@@ -143,7 +141,7 @@ internal class InitializedModuleGraph(
             essentialServiceModule,
             configModule,
             openTelemetryModule,
-            anrModule,
+            anrService,
             deliveryModule
         )
     }

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleGraph.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleGraph.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.injection
 
-import io.embrace.android.embracesdk.internal.instrumentation.anr.AnrModule
+import io.embrace.android.embracesdk.internal.instrumentation.anr.AnrService
 import io.embrace.android.embracesdk.internal.instrumentation.startup.DataCaptureServiceModule
 
 /**
@@ -16,7 +16,7 @@ internal interface ModuleGraph {
     val essentialServiceModule: EssentialServiceModule
     val dataCaptureServiceModule: DataCaptureServiceModule
     val deliveryModule: DeliveryModule
-    val anrModule: AnrModule
+    val anrService: AnrService?
     val logModule: LogModule
     val instrumentationModule: InstrumentationModule
     val featureModule: FeatureModule

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -10,9 +10,10 @@ import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.delivery.debug.DeliveryTracer
 import io.embrace.android.embracesdk.internal.delivery.execution.RequestExecutionService
 import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageService
-import io.embrace.android.embracesdk.internal.instrumentation.anr.AnrModule
-import io.embrace.android.embracesdk.internal.instrumentation.anr.AnrModuleImpl
-import io.embrace.android.embracesdk.internal.instrumentation.anr.AnrModuleSupplier
+import io.embrace.android.embracesdk.internal.envelope.session.OtelPayloadMapper
+import io.embrace.android.embracesdk.internal.instrumentation.anr.AnrService
+import io.embrace.android.embracesdk.internal.instrumentation.anr.AnrServiceSupplier
+import io.embrace.android.embracesdk.internal.instrumentation.anr.createAnrService
 import io.embrace.android.embracesdk.internal.instrumentation.startup.DataCaptureServiceModule
 import io.embrace.android.embracesdk.internal.instrumentation.startup.DataCaptureServiceModuleImpl
 import io.embrace.android.embracesdk.internal.instrumentation.startup.DataCaptureServiceModuleSupplier
@@ -153,8 +154,8 @@ internal class ModuleInitBootstrapper(
             deliveryTracer
         )
     },
-    private val anrModuleSupplier: AnrModuleSupplier = { args: InstrumentationArgs ->
-        AnrModuleImpl(args)
+    private val anrServiceSupplier: AnrServiceSupplier = { args: InstrumentationArgs ->
+        createAnrService(args)
     },
     private val logModuleSupplier: LogModuleSupplier = {
             initModule: InitModule,
@@ -207,7 +208,7 @@ internal class ModuleInitBootstrapper(
             essentialServiceModule: EssentialServiceModule,
             configModule: ConfigModule,
             otelModule: OpenTelemetryModule,
-            anrModule: AnrModule,
+            otelPayloadMapper: OtelPayloadMapper?,
             deliveryModule: DeliveryModule,
         ->
         PayloadSourceModuleImpl(
@@ -217,7 +218,7 @@ internal class ModuleInitBootstrapper(
             essentialServiceModule,
             configModule,
             otelModule,
-            anrModule.anrService,
+            otelPayloadMapper,
             deliveryModule,
         )
     },
@@ -232,7 +233,7 @@ internal class ModuleInitBootstrapper(
     override val essentialServiceModule: EssentialServiceModule get() = delegate.essentialServiceModule
     override val dataCaptureServiceModule: DataCaptureServiceModule get() = delegate.dataCaptureServiceModule
     override val deliveryModule: DeliveryModule get() = delegate.deliveryModule
-    override val anrModule: AnrModule get() = delegate.anrModule
+    override val anrService: AnrService? get() = delegate.anrService
     override val logModule: LogModule get() = delegate.logModule
     override val instrumentationModule: InstrumentationModule get() = delegate.instrumentationModule
     override val featureModule: FeatureModule get() = delegate.featureModule
@@ -269,7 +270,7 @@ internal class ModuleInitBootstrapper(
                     instrumentationModuleSupplier,
                     dataCaptureServiceModuleSupplier,
                     deliveryModuleSupplier,
-                    anrModuleSupplier,
+                    anrServiceSupplier,
                     logModuleSupplier,
                     sessionOrchestrationModuleSupplier,
                     payloadSourceModuleSupplier

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
@@ -62,7 +62,7 @@ internal fun ModuleGraph.registerListeners() {
                 lazy { dataCaptureServiceModule.appStartupDataCollector },
             )
             registerServices(
-                lazy { anrModule.anrService }
+                lazy { anrService }
             )
             registerService(lazy { logModule.attachmentService })
             registerService(lazy { logModule.logService })
@@ -82,7 +82,7 @@ internal fun ModuleGraph.loadInstrumentation() {
     val instrumentationProviders = ServiceLoader.load(InstrumentationProvider::class.java)
     registry.loadInstrumentations(instrumentationProviders, instrumentationModule.instrumentationArgs)
 
-    anrModule.anrService?.startAnrCapture()
+    anrService?.startAnrCapture()
 
     featureModule.lastRunCrashVerifier.readAndCleanMarkerAsync(
         workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker)
@@ -96,7 +96,7 @@ internal fun ModuleGraph.postLoadInstrumentation() {
     // setup crash teardown handlers
     val registry = instrumentationModule.instrumentationRegistry
     registry.findByType(JvmCrashDataSource::class)?.apply {
-        anrModule.anrService?.let(::addCrashTeardownHandler)
+        anrService?.let(::addCrashTeardownHandler)
         addCrashTeardownHandler(logModule.logOrchestrator)
         addCrashTeardownHandler(sessionOrchestrationModule.sessionOrchestrator)
         addCrashTeardownHandler(featureModule.crashMarker)

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UninitializedModuleGraph.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UninitializedModuleGraph.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.injection
 
-import io.embrace.android.embracesdk.internal.instrumentation.anr.AnrModule
+import io.embrace.android.embracesdk.internal.instrumentation.anr.AnrService
 import io.embrace.android.embracesdk.internal.instrumentation.startup.DataCaptureServiceModule
 
 internal class SdkDisabledException : IllegalStateException()
@@ -18,7 +18,7 @@ internal object UninitializedModuleGraph : ModuleGraph {
     override val essentialServiceModule: EssentialServiceModule get() = throwSdkNotInitialized()
     override val dataCaptureServiceModule: DataCaptureServiceModule get() = throwSdkNotInitialized()
     override val deliveryModule: DeliveryModule get() = throwSdkNotInitialized()
-    override val anrModule: AnrModule get() = throwSdkNotInitialized()
+    override val anrService: AnrService get() = throwSdkNotInitialized()
     override val logModule: LogModule get() = throwSdkNotInitialized()
     override val instrumentationModule: InstrumentationModule get() = throwSdkNotInitialized()
     override val featureModule: FeatureModule get() = throwSdkNotInitialized()

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeAnrModule.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeAnrModule.kt
@@ -1,8 +1,0 @@
-package io.embrace.android.embracesdk.fakes.injection
-
-import io.embrace.android.embracesdk.internal.instrumentation.anr.AnrModule
-import io.embrace.android.embracesdk.internal.instrumentation.anr.AnrService
-
-class FakeAnrModule(
-    override val anrService: AnrService? = null
-) : AnrModule

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
@@ -110,7 +110,7 @@ internal class ModuleInitBootstrapperTest {
 
         val handlers = dataSource.handlers
         val expected = listOf(
-            moduleInitBootstrapper.anrModule.anrService,
+            moduleInitBootstrapper.anrService,
             moduleInitBootstrapper.logModule.logOrchestrator,
             moduleInitBootstrapper.sessionOrchestrationModule.sessionOrchestrator,
             moduleInitBootstrapper.featureModule.crashMarker,


### PR DESCRIPTION
## Goal

Removes the `AnrModule` interface as it was only exposing one property - let's use that directly.

## Testing

Relied on existing test coverage
