### PR TITLE
Move EmbraceCustomPathException back to original package

### DIFF
--- a/embrace-android-instrumentation-okhttp/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/InterceptorType.kt
+++ b/embrace-android-instrumentation-okhttp/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/InterceptorType.kt
@@ -13,7 +13,7 @@ internal enum class InterceptorType {
      * OkHttp network interceptors are added almost at the end of stack, they are closer to "the wire"
      * so they are not able to see network errors.
      *
-     * We use the [EmbraceCustomPathException] to capture the custom path added in the interceptor
+     * We use the [io.embrace.android.embracesdk.okhttp3.EmbraceCustomPathException] to capture the custom path added in the interceptor
      * chain process for client errors on requests to a generic URL like a GraphQL endpoint.
      */
     APPLICATION,

--- a/embrace-android-instrumentation-okhttp/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpDataSource.kt
+++ b/embrace-android-instrumentation-okhttp/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpDataSource.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkReq
 import io.embrace.android.embracesdk.internal.instrumentation.network.TraceparentGenerator
 import io.embrace.android.embracesdk.internal.instrumentation.network.getOverriddenURLString
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.okhttp3.EmbraceCustomPathException
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response

--- a/embrace-android-instrumentation-okhttp/src/main/kotlin/io/embrace/android/embracesdk/okhttp3/EmbraceCustomPathException.kt
+++ b/embrace-android-instrumentation-okhttp/src/main/kotlin/io/embrace/android/embracesdk/okhttp3/EmbraceCustomPathException.kt
@@ -1,4 +1,4 @@
-package io.embrace.android.embracesdk.internal.instrumentation.okhttp
+package io.embrace.android.embracesdk.okhttp3
 
 import java.io.IOException
 

--- a/embrace-android-instrumentation-okhttp/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpDataSourceTest.kt
+++ b/embrace-android-instrumentation-okhttp/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpDataSourceTest.kt
@@ -14,6 +14,7 @@ import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRe
 import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkCaptureDataSourceImpl
 import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkRequestDataSourceImpl
 import io.embrace.android.embracesdk.internal.utils.NetworkUtils.getValidTraceId
+import io.embrace.android.embracesdk.okhttp3.EmbraceCustomPathException
 import io.embrace.opentelemetry.kotlin.semconv.ErrorAttributes
 import io.embrace.opentelemetry.kotlin.semconv.ExceptionAttributes
 import io.embrace.opentelemetry.kotlin.semconv.HttpAttributes


### PR DESCRIPTION
## Goal

Restore the old package name of EmbraceCustomPathException since it's part of the public API  
