### PR TITLE
Reduce internal details of stacktrace sampler

### DIFF
--- a/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceImpl.kt
+++ b/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceImpl.kt
@@ -58,7 +58,7 @@ internal class AnrServiceImpl(
     internal fun getCapturedData(): List<ThreadBlockageInterval> {
         return try {
             val callable = Callable {
-                checkNotNull(stacktraceSampler.getAnrIntervals(state, clock)) {
+                checkNotNull(stacktraceSampler.getAnrIntervals()) {
                     "ANR samples to be cached is null"
                 }
             }

--- a/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceSupplier.kt
+++ b/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceSupplier.kt
@@ -23,6 +23,7 @@ fun createAnrService(args: InstrumentationArgs): AnrService? {
     val stacktraceSampler by lazy {
         AnrStacktraceSampler(
             clock = args.clock,
+            state = state,
             targetThread = looper.thread,
             watchdogWorker = anrMonitorWorker,
             maxIntervalsPerSession = args.configService.anrBehavior.getMaxAnrIntervalsPerSession(),

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceRule.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceRule.kt
@@ -55,6 +55,7 @@ internal class AnrServiceRule<T : ScheduledExecutorService>(
         worker = BackgroundWorker(watchdogExecutorService)
         stacktraceSampler = AnrStacktraceSampler(
             clock = clock,
+            state = state,
             targetThread = looper.thread,
             watchdogWorker = worker,
             maxIntervalsPerSession = fakeConfigService.anrBehavior.getMaxAnrIntervalsPerSession(),


### PR DESCRIPTION
## Goal

Reduces the amount of introspection the tests do into the stacktrace sampler internals.

