### PR TITLE
Alter ANR capture to avoid using ThreadInfo class

### DIFF
--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/utils/ThreadExtKtTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/utils/ThreadExtKtTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.utils
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.internal.arch.stacktrace.compatThreadId
-import io.embrace.android.embracesdk.internal.arch.stacktrace.getThreadInfo
+import io.embrace.android.embracesdk.internal.arch.stacktrace.truncateStacktrace
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -19,7 +19,7 @@ class ThreadExtKtTest {
     @Test
     fun `correct threadInfo created`() {
         val targetThread = currentThread()
-        val threadInfo = getThreadInfo(
+        val threadInfo = truncateStacktrace(
             thread = targetThread,
             stackTraceElements = targetThread.stackTrace,
             maxStacktraceSize = 4
@@ -35,7 +35,7 @@ class ThreadExtKtTest {
 
     @Test
     fun `verify default stacktrace size is 200`() {
-        val threadInfo = getThreadInfo(
+        val threadInfo = truncateStacktrace(
             thread = currentThread(),
             stackTraceElements = fakeBigStackTrace
         )
@@ -44,7 +44,7 @@ class ThreadExtKtTest {
 
     @Test
     fun `verify max stacktrace size capped at 500`() {
-        val threadInfo = getThreadInfo(
+        val threadInfo = truncateStacktrace(
             thread = currentThread(),
             stackTraceElements = fakeBigStackTrace,
             maxStacktraceSize = 600

--- a/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/ThreadBlockageOtelMapper.kt
+++ b/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/ThreadBlockageOtelMapper.kt
@@ -56,12 +56,12 @@ internal fun mapSampleToSpanEvent(sample: ThreadBlockageSample): SpanEvent {
     sample.code?.let {
         attrs.add(Attribute("sample_code", it.toString()))
     }
-    sample.threads?.singleOrNull()?.let { thread ->
-        attrs.add(Attribute(JvmAttributes.JVM_THREAD_STATE, thread.state.toString()))
-        attrs.add(Attribute("thread_priority", thread.priority.toString()))
-        attrs.add(Attribute("frame_count", thread.frameCount.toString()))
+    sample.threadSample?.let { threadTrace ->
+        attrs.add(Attribute(JvmAttributes.JVM_THREAD_STATE, threadTrace.state.toString()))
+        attrs.add(Attribute("thread_priority", threadTrace.priority.toString()))
+        attrs.add(Attribute("frame_count", threadTrace.frameCount.toString()))
 
-        thread.lines?.let { lines ->
+        threadTrace.lines?.let { lines ->
             attrs.add(
                 Attribute(
                     ExceptionAttributes.EXCEPTION_STACKTRACE,

--- a/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/payload/ThreadBlockageSample.kt
+++ b/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/payload/ThreadBlockageSample.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.instrumentation.anr.payload
 
-import io.embrace.android.embracesdk.internal.payload.ThreadInfo
+import io.embrace.android.embracesdk.internal.arch.stacktrace.ThreadSample
 
 /**
  * Holds thread data taken during an [ThreadBlockageInterval].
@@ -15,7 +15,7 @@ internal data class ThreadBlockageSample(
     /**
      * All the information for threads that were captured during a sample
      */
-    val threads: List<ThreadInfo>?,
+    val threadSample: ThreadSample?,
 
     /**
      * The overhead in milliseconds associated with capturing thread traces for this sample

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceImplTest.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceImplTest.kt
@@ -255,13 +255,13 @@ internal class AnrServiceImplTest {
                 assertEquals(
                     extra,
                     samples.count { sample ->
-                        sample.threads == null && sample.code == ThreadBlockageSample.CODE_SAMPLE_LIMIT_REACHED
+                        sample.threadSample == null && sample.code == ThreadBlockageSample.CODE_SAMPLE_LIMIT_REACHED
                     }
                 )
                 assertEquals(
                     defaultLimit,
                     samples.count { sample ->
-                        sample.threads != null && sample.code == ThreadBlockageSample.CODE_DEFAULT
+                        sample.threadSample != null && sample.code == ThreadBlockageSample.CODE_DEFAULT
                     }
                 )
             }

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrStacktraceSamplerTest.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrStacktraceSamplerTest.kt
@@ -215,7 +215,7 @@ internal class AnrStacktraceSamplerTest {
         val intervals = sampler.getAnrIntervals()
         val interval = intervals.single()
         interval.samples?.forEach { sample ->
-            sample.threads?.forEach { thread ->
+            sample.threadSample?.let { thread ->
                 val lines = checkNotNull(thread.lines)
                 assertEquals(5, lines.size)
                 assertTrue(thread.frameCount > lines.size)

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/ThreadBlockageIntervalTest.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/ThreadBlockageIntervalTest.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.internal.instrumentation.anr
 
+import io.embrace.android.embracesdk.internal.arch.stacktrace.ThreadSample
 import io.embrace.android.embracesdk.internal.instrumentation.anr.payload.ThreadBlockageInterval
 import io.embrace.android.embracesdk.internal.instrumentation.anr.payload.ThreadBlockageSample
-import io.embrace.android.embracesdk.internal.payload.ThreadInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNull
@@ -10,7 +10,7 @@ import org.junit.Test
 
 internal class ThreadBlockageIntervalTest {
 
-    private val threadInfo = ThreadInfo(
+    private val threadSample = ThreadSample(
         13,
         Thread.State.RUNNABLE,
         "my-thread",
@@ -22,7 +22,7 @@ internal class ThreadBlockageIntervalTest {
         2
     )
 
-    private val threadBlockageSample = ThreadBlockageSample(150980980980, listOf(threadInfo), 0)
+    private val threadBlockageSample = ThreadBlockageSample(150980980980, threadSample, 0)
 
     private val sampleList = listOf(threadBlockageSample)
 

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/stacktrace/ThreadExt.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/stacktrace/ThreadExt.kt
@@ -5,16 +5,31 @@ import io.embrace.android.embracesdk.internal.config.behavior.DEFAULT_STACKTRACE
 import io.embrace.android.embracesdk.internal.payload.ThreadInfo
 import kotlin.math.min
 
-fun getThreadInfo(
+fun truncateStacktrace(
     thread: Thread,
     stackTraceElements: Array<StackTraceElement>,
     maxStacktraceSize: Int = DEFAULT_STACKTRACE_SIZE_LIMIT,
-): ThreadInfo {
+): ThreadSample {
     val name = thread.name
     val priority = thread.priority
     val frameCount = stackTraceElements.size
     val lines = stackTraceElements.take(min(MAX_STACKTRACE_SIZE, maxStacktraceSize)).map(StackTraceElement::toString)
-    return ThreadInfo(thread.compatThreadId(), thread.state, name, priority, lines, frameCount)
+    return ThreadSample(thread.compatThreadId(), thread.state, name, priority, lines, frameCount)
+}
+
+fun truncateStacktrace(
+    thread: Thread,
+    stackTraceElements: Array<StackTraceElement>,
+): ThreadInfo {
+    val stacktrace = truncateStacktrace(thread, stackTraceElements, DEFAULT_STACKTRACE_SIZE_LIMIT)
+    return ThreadInfo(
+        stacktrace.threadId,
+        stacktrace.state,
+        stacktrace.name,
+        stacktrace.priority,
+        stacktrace.lines,
+        stacktrace.frameCount,
+    )
 }
 
 @Suppress("DEPRECATION")

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/stacktrace/ThreadSample.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/stacktrace/ThreadSample.kt
@@ -1,0 +1,10 @@
+package io.embrace.android.embracesdk.internal.arch.stacktrace
+
+class ThreadSample(
+    val threadId: Long,
+    val state: Thread.State?,
+    val name: String?,
+    val priority: Int,
+    val lines: List<String>?,
+    val frameCount: Int,
+)

--- a/embrace-android-instrumentation-crash-jvm/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/JvmCrashDataSourceImpl.kt
+++ b/embrace-android-instrumentation-crash-jvm/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/JvmCrashDataSourceImpl.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.internal.arch.limits.NoopLimitStrategy
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.arch.schema.TelemetryAttributes
-import io.embrace.android.embracesdk.internal.arch.stacktrace.getThreadInfo
+import io.embrace.android.embracesdk.internal.arch.stacktrace.truncateStacktrace
 import io.embrace.android.embracesdk.internal.payload.LegacyExceptionInfo
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.store.Ordinal
@@ -126,7 +126,7 @@ class JvmCrashDataSourceImpl(
      * @return a String representation of the current thread list.
      */
     private fun getThreadsInfo(): String {
-        val threadsList = Thread.getAllStackTraces().map { getThreadInfo(it.key, it.value) }
+        val threadsList = Thread.getAllStackTraces().map { truncateStacktrace(it.key, it.value) }
         return serializer.toJson(threadsList, List::class.java)
     }
 


### PR DESCRIPTION
## Goal

Uses a class that doesn't have JSON annotations & also avoids creating an unnecessary list when only one thread is captured for a given sample at a time.

## Testing

Updated existing test coverage

