### PR TITLE
Reduce blocked thread detector visibility

### DIFF
--- a/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceImpl.kt
+++ b/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceImpl.kt
@@ -45,17 +45,17 @@ internal class AnrServiceImpl(
 
     override fun startCapture() {
         this.watchdogWorker.submit {
-            blockedThreadDetector.startMonitoringThread()
+            blockedThreadDetector.start()
         }
     }
 
     override fun simulateTargetThreadResponse() {
-        blockedThreadDetector.onTargetThreadResponse(clock.now())
+        blockedThreadDetector.onTargetThreadProcessedMessage(clock.now())
     }
 
     override fun handleCrash(crashId: String) {
         this.watchdogWorker.submit {
-            blockedThreadDetector.stopMonitoringThread()
+            blockedThreadDetector.stop()
         }
     }
 
@@ -72,7 +72,7 @@ internal class AnrServiceImpl(
             // Cancel any pending delayed background check since we're now in foreground
             cancelDelayedBackgroundCheck()
             state.resetState()
-            blockedThreadDetector.startMonitoringThread()
+            blockedThreadDetector.start()
         }
     }
 
@@ -83,7 +83,7 @@ internal class AnrServiceImpl(
      */
     override fun onBackground() {
         this.watchdogWorker.submit {
-            blockedThreadDetector.stopMonitoringThread()
+            blockedThreadDetector.stop()
         }
     }
 
@@ -152,7 +152,7 @@ internal class AnrServiceImpl(
      */
     private fun stopMonitoringIfStillInBackground() {
         if (appStateTracker.getAppState() == AppState.BACKGROUND) {
-            blockedThreadDetector.stopMonitoringThread()
+            blockedThreadDetector.stop()
         }
         delayedBackgroundCheckTask = null
     }

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceImplTimingTest.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceImplTimingTest.kt
@@ -57,7 +57,7 @@ internal class AnrServiceImplTimingTest {
     }
 
     private fun AnrServiceRule<*>.simulateAnrRecovery() {
-        blockedThreadDetector.onTargetThreadResponse(clock.now())
+        blockedThreadDetector.onTargetThreadProcessedMessage(clock.now())
     }
 
     @Test


### PR DESCRIPTION
## Goal

Reduces the visibility of internal details of `BlockedThreadDetector`.

## Testing

Updated existing tests
