### PR TITLE
Reduce thread monitoring state

### DIFF
--- a/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/detection/ThreadMonitoringState.kt
+++ b/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/detection/ThreadMonitoringState.kt
@@ -23,24 +23,10 @@ internal class ThreadMonitoringState(
     var lastMonitorThreadResponseMs: Long = clock.now()
 
     /**
-     * The last sample attempt in ms.
-     */
-    @Volatile
-    var lastSampleAttemptMs: Long = 0
-
-    /**
-     * Whether the thread blockage is in progress or not.
-     */
-    @Volatile
-    var threadBlockageInProgress: Boolean = false
-
-    /**
      * Resets state properties to the initial values
      */
     fun resetState() {
-        threadBlockageInProgress = false
         lastTargetThreadResponseMs = clock.now()
         lastMonitorThreadResponseMs = clock.now()
-        lastSampleAttemptMs = 0
     }
 }

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceImplTimingTest.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceImplTimingTest.kt
@@ -4,8 +4,6 @@ import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorServic
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.internal.arch.state.AppState
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -36,28 +34,6 @@ internal class AnrServiceImplTimingTest {
             rule.watchdogMonitorThread = AtomicReference(currentThread())
         }
         watchdogExecutorService.runCurrentlyBlocked()
-    }
-
-    @Test
-    fun `check ANR recovery`() {
-        with(rule) {
-            clock.setCurrentTime(100000L)
-            anrService.startCapture()
-            watchdogExecutorService.runCurrentlyBlocked()
-            simulateAnrRecovery()
-            watchdogExecutorService.runCurrentlyBlocked()
-            repeat(20) {
-                watchdogExecutorService.moveForwardAndRunBlocked(100L)
-            }
-            assertTrue(state.threadBlockageInProgress)
-            simulateAnrRecovery()
-            watchdogExecutorService.runCurrentlyBlocked()
-            assertFalse(state.threadBlockageInProgress)
-        }
-    }
-
-    private fun AnrServiceRule<*>.simulateAnrRecovery() {
-        blockedThreadDetector.onTargetThreadProcessedMessage(clock.now())
     }
 
     @Test

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/detection/BlockedThreadDetectorTest.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/detection/BlockedThreadDetectorTest.kt
@@ -63,7 +63,6 @@ internal class BlockedThreadDetectorTest {
 
     @Test
     fun testShouldSampleBlockedThread() {
-        state.threadBlockageInProgress = true
         detector.onMonitorThreadInterval(-23409)
         assertEquals(0, listener.intervalCount)
 
@@ -79,10 +78,10 @@ internal class BlockedThreadDetectorTest {
         detector.onMonitorThreadInterval(BASELINE_MS + 50)
         assertEquals(0, listener.intervalCount)
 
-        detector.onMonitorThreadInterval(BASELINE_MS + 51)
+        detector.onMonitorThreadInterval(BASELINE_MS + 1001)
         assertEquals(1, listener.intervalCount)
 
-        detector.onMonitorThreadInterval(BASELINE_MS + 100)
+        detector.onMonitorThreadInterval(BASELINE_MS + 5000)
         assertEquals(2, listener.intervalCount)
 
         detector.onMonitorThreadInterval(BASELINE_MS + 30000)
@@ -96,7 +95,6 @@ internal class BlockedThreadDetectorTest {
         detector.onMonitorThreadInterval(BASELINE_MS + 2000)
         assertEquals(1, listener.intervalCount)
         assertEquals(now, state.lastMonitorThreadResponseMs)
-        assertEquals(now, state.lastSampleAttemptMs)
     }
 
     @Test
@@ -104,12 +102,10 @@ internal class BlockedThreadDetectorTest {
         val now = BASELINE_MS + 2000
         clock.setCurrentTime(now)
         state.lastMonitorThreadResponseMs = now - 10
-        state.lastSampleAttemptMs = now - 10
 
         detector.onMonitorThreadInterval(now)
         assertEquals(0, listener.intervalCount)
         assertEquals(now, state.lastMonitorThreadResponseMs)
-        assertEquals(now - 10, state.lastSampleAttemptMs)
     }
 
     @Test


### PR DESCRIPTION
## Goal

Moves `threadBlockageInProgress` out of `ThreadMonitoringState` and stops accessing this internal detail in the tests.

