### PR TITLE
Simplify ANR threading model

### DIFF
--- a/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceSupplier.kt
+++ b/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceSupplier.kt
@@ -22,7 +22,6 @@ fun createAnrService(args: InstrumentationArgs): AnrService? {
         AnrStacktraceSampler(
             clock = args.clock,
             targetThread = looper.thread,
-            watchdogWorker = anrMonitorWorker,
             maxIntervalsPerSession = args.configService.anrBehavior.getMaxAnrIntervalsPerSession(),
             maxStacktracesPerInterval = args.configService.anrBehavior.getMaxStacktracesPerInterval(),
             stacktraceFrameLimit = args.configService.anrBehavior.getStacktraceFrameLimit(),

--- a/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrStacktraceSampler.kt
+++ b/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrStacktraceSampler.kt
@@ -11,7 +11,6 @@ import io.embrace.android.embracesdk.internal.instrumentation.anr.detection.Thre
 import io.embrace.android.embracesdk.internal.instrumentation.anr.payload.ThreadBlockageInterval
 import io.embrace.android.embracesdk.internal.instrumentation.anr.payload.ThreadBlockageSample
 import io.embrace.android.embracesdk.internal.session.MemoryCleanerListener
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
@@ -23,7 +22,6 @@ import java.util.concurrent.atomic.AtomicReference
 internal class AnrStacktraceSampler(
     private val clock: Clock,
     private val targetThread: Thread,
-    private val watchdogWorker: BackgroundWorker,
     private val maxIntervalsPerSession: Int,
     private val maxStacktracesPerInterval: Int,
     private val stacktraceFrameLimit: Int,
@@ -69,7 +67,7 @@ internal class AnrStacktraceSampler(
     }
 
     override fun cleanCollections() {
-        watchdogWorker.submit {
+        synchronized(intervals) {
             intervals.removeAll { it.endTime != null }
         }
     }

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceRule.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceRule.kt
@@ -53,7 +53,6 @@ internal class AnrServiceRule<T : ScheduledExecutorService>(
         stacktraceSampler = AnrStacktraceSampler(
             clock = clock,
             targetThread = looper.thread,
-            watchdogWorker = worker,
             maxIntervalsPerSession = fakeConfigService.anrBehavior.getMaxAnrIntervalsPerSession(),
             maxStacktracesPerInterval = fakeConfigService.anrBehavior.getMaxStacktracesPerInterval(),
             stacktraceFrameLimit = fakeConfigService.anrBehavior.getStacktraceFrameLimit(),

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrStacktraceSamplerTest.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrStacktraceSamplerTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.instrumentation.anr
 
-import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.behavior.FakeAnrBehavior
@@ -9,7 +8,6 @@ import io.embrace.android.embracesdk.internal.instrumentation.anr.detection.Thre
 import io.embrace.android.embracesdk.internal.instrumentation.anr.detection.ThreadBlockageEvent.UNBLOCKED
 import io.embrace.android.embracesdk.internal.instrumentation.anr.payload.ThreadBlockageInterval
 import io.embrace.android.embracesdk.internal.instrumentation.anr.payload.ThreadBlockageSample
-import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -23,16 +21,12 @@ internal class AnrStacktraceSamplerTest {
     private val thread = Thread.currentThread()
     private val clock = FakeClock()
     private val configService = FakeConfigService()
-    private val worker = BackgroundWorker(
-        BlockingScheduledExecutorService()
-    )
 
     @Test
     fun testLeastValuableInterval() {
         val sampler = AnrStacktraceSampler(
             clock,
             thread,
-            worker,
             configService.anrBehavior.getMaxAnrIntervalsPerSession(),
             configService.anrBehavior.getMaxStacktracesPerInterval(),
             configService.anrBehavior.getStacktraceFrameLimit(),
@@ -65,7 +59,6 @@ internal class AnrStacktraceSamplerTest {
         val sampler = AnrStacktraceSampler(
             clock,
             thread,
-            worker,
             configService.anrBehavior.getMaxAnrIntervalsPerSession(),
             configService.anrBehavior.getMaxStacktracesPerInterval(),
             configService.anrBehavior.getStacktraceFrameLimit(),
@@ -120,7 +113,6 @@ internal class AnrStacktraceSamplerTest {
         val sampler = AnrStacktraceSampler(
             clock,
             thread,
-            worker,
             configService.anrBehavior.getMaxAnrIntervalsPerSession(),
             configService.anrBehavior.getMaxStacktracesPerInterval(),
             configService.anrBehavior.getStacktraceFrameLimit(),
@@ -169,7 +161,6 @@ internal class AnrStacktraceSamplerTest {
         val sampler = AnrStacktraceSampler(
             clock,
             thread,
-            worker,
             configService.anrBehavior.getMaxAnrIntervalsPerSession(),
             configService.anrBehavior.getMaxStacktracesPerInterval(),
             configService.anrBehavior.getStacktraceFrameLimit(),
@@ -195,7 +186,6 @@ internal class AnrStacktraceSamplerTest {
         val sampler = AnrStacktraceSampler(
             clock,
             thread,
-            worker,
             configService.anrBehavior.getMaxAnrIntervalsPerSession(),
             configService.anrBehavior.getMaxStacktracesPerInterval(),
             configService.anrBehavior.getStacktraceFrameLimit(),

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AnrFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AnrFeatureTest.kt
@@ -10,7 +10,6 @@ import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
-import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -202,11 +201,12 @@ internal class AnrFeatureTest {
      * Triggers an ANR by simulating the main thread getting blocked & unblocked. Time is controlled
      * with a fake Clock instance & a blockable executor that runs the blockage checks.
      */
-    private fun EmbraceActionInterface.triggerAnr(
+    private fun triggerAnr(
         sampleCount: Int,
         intervalMs: Long = INTERVAL_MS,
         incomplete: Boolean = false,
     ) {
+        testRule.bootstrapper.anrService?.simulateTargetThreadResponse()
         with(anrMonitorExecutor) {
             blockingMode = true
 


### PR DESCRIPTION
## Goal

Simplifies the threading model used for ANRs as now that concurrent collections + synchronisation are used by `AnrStacktraceSampler` there's no need to run on a specific worker thread.

