### PR TITLE
Extract thread sampling

### DIFF
--- a/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceSupplier.kt
+++ b/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceSupplier.kt
@@ -24,7 +24,7 @@ fun createAnrService(args: InstrumentationArgs): AnrService? {
             clock = args.clock,
             targetThread = looper.thread,
             maxIntervalsPerSession = anrBehavior.getMaxAnrIntervalsPerSession(),
-            maxStacktracesPerInterval = anrBehavior.getMaxStacktracesPerInterval(),
+            maxSamplesPerInterval = anrBehavior.getMaxStacktracesPerInterval(),
             stacktraceFrameLimit = anrBehavior.getStacktraceFrameLimit(),
         )
     }

--- a/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadSampleMetadata.kt
+++ b/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadSampleMetadata.kt
@@ -1,0 +1,9 @@
+package io.embrace.android.embracesdk.internal.instrumentation.thread.blockage
+
+import io.embrace.android.embracesdk.internal.arch.stacktrace.ThreadSample
+
+internal class ThreadSampleMetadata(
+    val sample: ThreadSample?,
+    val sampleTimeMs: Long,
+    val sampleOverheadMs: Long,
+)

--- a/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadStacktraceSampler.kt
+++ b/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadStacktraceSampler.kt
@@ -1,0 +1,48 @@
+package io.embrace.android.embracesdk.internal.instrumentation.thread.blockage
+
+import io.embrace.android.embracesdk.internal.arch.stacktrace.truncateStacktrace
+import io.embrace.android.embracesdk.internal.clock.Clock
+
+internal class ThreadStacktraceSampler(
+    private val clock: Clock,
+    private val targetThread: Thread,
+    private val sampleLimit: Int,
+    private val stacktraceFrameLimit: Int,
+) {
+
+    private val samples: MutableList<ThreadSampleMetadata> = mutableListOf()
+
+    fun captureSample() {
+        if (samples.size < MAX_SAMPLE_COUNT) {
+            val sampleTimeMs = clock.now()
+            val withinSampleLimit = samples.size < sampleLimit
+            val trace = if (withinSampleLimit) {
+                truncateStacktrace(
+                    targetThread,
+                    targetThread.stackTrace,
+                    stacktraceFrameLimit
+                )
+            } else {
+                null
+            }
+            samples.add(
+                ThreadSampleMetadata(
+                    sample = trace,
+                    sampleTimeMs = sampleTimeMs,
+                    sampleOverheadMs = sampleTimeMs - clock.now(),
+                )
+            )
+        }
+    }
+
+    fun retrieveSampleMetadata() = samples.toList()
+
+    private companion object {
+
+        /**
+         * Hard limit for the maximum number of samples to track in one instantiation,
+         * even if there's not a stacktrace associated with each sample.
+         */
+        private const val MAX_SAMPLE_COUNT = 1000
+    }
+}

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceImplTest.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceImplTest.kt
@@ -213,6 +213,8 @@ internal class AnrServiceImplTest {
                 val extra = 10
                 val count = defaultLimit + extra
 
+                stacktraceSampler.onThreadBlockageEvent(BLOCKED, clock.now())
+
                 repeat(count) {
                     stacktraceSampler.onThreadBlockageEvent(BLOCKED_INTERVAL, clock.now())
                 }
@@ -274,15 +276,22 @@ internal class AnrServiceImplTest {
                 val now = 100L
                 recreateService()
 
+                clock.setCurrentTime(now + 500)
                 blockedThreadDetector.onMonitorThreadInterval(now + 500)
+
+                clock.setCurrentTime(now + 1000)
                 blockedThreadDetector.onMonitorThreadInterval(now + 1000)
-                blockedThreadDetector.onMonitorThreadInterval(now + 1001)
+
+                clock.setCurrentTime(now + 2001)
+                blockedThreadDetector.onMonitorThreadInterval(now + 2001)
+
+                clock.setCurrentTime(now + 10000)
                 blockedThreadDetector.onMonitorThreadInterval(now + 10000)
 
                 val samples = checkNotNull(stacktraceSampler.getThreadBlockageIntervals().single().samples)
                 assertEquals(3, samples.size)
                 assertEquals(now + 1000, samples[0].timestamp)
-                assertEquals(now + 1001, samples[1].timestamp)
+                assertEquals(now + 2001, samples[1].timestamp)
                 assertEquals(now + 10000, samples[2].timestamp)
             }
         }

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceRule.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/anr/AnrServiceRule.kt
@@ -54,7 +54,7 @@ internal class AnrServiceRule<T : ScheduledExecutorService>(
             clock = clock,
             targetThread = looper.thread,
             maxIntervalsPerSession = fakeConfigService.anrBehavior.getMaxAnrIntervalsPerSession(),
-            maxStacktracesPerInterval = fakeConfigService.anrBehavior.getMaxStacktracesPerInterval(),
+            maxSamplesPerInterval = fakeConfigService.anrBehavior.getMaxStacktracesPerInterval(),
             stacktraceFrameLimit = fakeConfigService.anrBehavior.getStacktraceFrameLimit(),
         )
         blockedThreadDetector = BlockedThreadDetector(

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadStacktraceSamplerTest.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadStacktraceSamplerTest.kt
@@ -1,0 +1,54 @@
+package io.embrace.android.embracesdk.internal.instrumentation.thread.blockage
+
+import io.embrace.android.embracesdk.fakes.FakeClock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ThreadStacktraceSamplerTest {
+
+    private val sampleLimit = 100
+    private lateinit var clock: FakeClock
+    private lateinit var sampler: ThreadStacktraceSampler
+
+    @Before
+    fun setUp() {
+        clock = FakeClock()
+        sampler = ThreadStacktraceSampler(
+            clock,
+            Thread.currentThread(),
+            sampleLimit,
+            200
+        )
+    }
+
+    @Test
+    fun `test empty`() {
+        assertTrue(sampler.retrieveSampleMetadata().isEmpty())
+        assertFalse(sampler.retrieveSampleMetadata() is MutableList)
+    }
+
+    @Test
+    fun `test sample max limit`() {
+        repeat(1050) {
+            sampler.captureSample()
+        }
+        val metadata = sampler.retrieveSampleMetadata()
+        assertEquals(1000, metadata.size)
+        metadata.forEachIndexed { index, metadata ->
+            if (index < sampleLimit) {
+                assertNotNull(metadata.sample)
+                assertNotNull(metadata.sampleTimeMs)
+                assertNotNull(metadata.sampleOverheadMs)
+            } else {
+                assertNull(metadata.sample)
+                assertNotNull(metadata.sampleTimeMs)
+                assertNotNull(metadata.sampleOverheadMs)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Extracts the actual sampling to `ThreadStacktraceSampler` and confines all the logic around setting interval codes etc to the ANR-specific class.

## Testing

Relied on existing test coverage.
