### PR TITLE
Tweak config assertion

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/RemoteConfigTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/RemoteConfigTest.kt
@@ -66,11 +66,13 @@ internal class RemoteConfigTest {
         assertConfigRequested(1)
         returnIfConditionMet(
             desiredValueSupplier = {},
-            condition = {
-                expectedThreshold == it.cfg?.threshold && "server_etag_value" == it.etag
+            condition = { response ->
+                response != null && expectedThreshold == response.cfg?.threshold && "server_etag_value" == response.etag
             },
             dataProvider = {
-                readPersistedConfigResponse()
+                runCatching {
+                    readPersistedConfigResponse()
+                }.getOrNull()
             }
         )
     }


### PR DESCRIPTION
## Goal

Tweaks an assertion in the remote config tests so that the test won't fail if the remote config is present on disk but doesn't contain valid JSON. I believe sporadic failures on CI and locally have been down to a race between the test assertion and the HTTP request where the config file is present on disk but empty. I've fixed this by returning null if valid JSON isn't present and waiting for another iteration in `returnIfConditionMet`.

