### PR TITLE
Simplify log service attributes

### DIFF
--- a/embrace-android-core/config/detekt/baseline.xml
+++ b/embrace-android-core/config/detekt/baseline.xml
@@ -1,7 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <SmellBaseline>
   <ManuallySuppressedIssues/>
-  <CurrentIssues>
-    <ID>CyclomaticComplexMethod:EmbraceLogService.kt$EmbraceLogService$override fun log( message: String, severity: Severity, logExceptionType: LogExceptionType, attributes: Map&lt;String, Any>, embraceAttributes: Map&lt;String, String>, attachment: Attachment?, stackTraceElements: Array&lt;StackTraceElement>?, customStackTrace: String?, exceptionName: String?, exceptionMessage: String?, )</ID>
-  </CurrentIssues>
+  <CurrentIssues/>
 </SmellBaseline>

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogService.kt
@@ -17,7 +17,6 @@ interface LogService : SessionChangeListener {
         severity: LogSeverity,
         logExceptionType: LogExceptionType,
         attributes: Map<String, Any> = emptyMap(),
-        embraceAttributes: Map<String, String> = emptyMap(),
         stackTraceElements: Array<StackTraceElement>? = null,
         customStackTrace: String? = null,
     )

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -196,7 +196,6 @@ internal class EmbraceImpl(
         logExceptionType: LogExceptionType = LogExceptionType.NONE,
         exceptionName: String? = null,
         exceptionMessage: String? = null,
-        embraceAttributes: Map<String, String> = emptyMap(),
     ) {
         logsApiDelegate.logMessageImpl(
             severity = severity,
@@ -207,7 +206,6 @@ internal class EmbraceImpl(
             logExceptionType = logExceptionType,
             exceptionName = exceptionName,
             exceptionMessage = exceptionMessage,
-            embraceAttributes = embraceAttributes,
         )
     }
 

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/FlutterInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/FlutterInternalInterfaceImpl.kt
@@ -77,7 +77,7 @@ internal class FlutterInternalInterfaceImpl(
                 logExceptionType = exceptionType,
                 exceptionName = name,
                 exceptionMessage = message,
-                embraceAttributes = attrs,
+                attributes = attrs,
             )
         } else {
             logger.logSdkNotInitialized("logDartError")

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/LogsApiDelegate.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/LogsApiDelegate.kt
@@ -136,7 +136,6 @@ internal class LogsApiDelegate(
         logExceptionType: LogExceptionType = LogExceptionType.NONE,
         exceptionName: String? = null,
         exceptionMessage: String? = null,
-        embraceAttributes: Map<String, String> = emptyMap(),
         attachment: Attachment? = null,
     ) {
         if (sdkCallChecker.check("log_message")) {
@@ -171,7 +170,6 @@ internal class LogsApiDelegate(
                     severity = logSeverity,
                     logExceptionType = logExceptionType,
                     attributes = attrs,
-                    embraceAttributes = embraceAttributes,
                     stackTraceElements = stackTraceElements,
                     customStackTrace = customStackTrace,
                 )

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/FlutterInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/FlutterInternalInterfaceImplTest.kt
@@ -57,18 +57,16 @@ internal class FlutterInternalInterfaceImplTest {
         impl.logUnhandledDartException("stack", "exception name", "message", "ctx", "lib")
         verify(exactly = 1) {
             embrace.logMessage(
-                Severity.ERROR,
-                "Dart error",
-                emptyMap(),
-                null,
-                "stack",
-                LogExceptionType.UNHANDLED,
-                "exception name",
-                "message",
-                mapOf(
+                severity = Severity.ERROR,
+                message = "Dart error",
+                attributes = mapOf(
                     embFlutterExceptionContext.name to "ctx",
                     embFlutterExceptionLibrary.name to "lib"
                 ),
+                customStackTrace = "stack",
+                logExceptionType = LogExceptionType.UNHANDLED,
+                exceptionName = "exception name",
+                exceptionMessage = "message",
             )
         }
     }
@@ -86,7 +84,7 @@ internal class FlutterInternalInterfaceImplTest {
                 logExceptionType = LogExceptionType.HANDLED,
                 exceptionName = "exception name",
                 exceptionMessage = "message",
-                embraceAttributes = mapOf(
+                attributes = mapOf(
                     embFlutterExceptionContext.name to "ctx",
                     embFlutterExceptionLibrary.name to "lib"
                 ),

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogService.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.LogExceptionType
-import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.internal.arch.datasource.LogSeverity
 import io.embrace.android.embracesdk.internal.logs.LogService
 
@@ -22,7 +21,6 @@ class FakeLogService : LogService {
         severity: LogSeverity,
         logExceptionType: LogExceptionType,
         attributes: Map<String, Any>,
-        embraceAttributes: Map<String, String>,
         stackTraceElements: Array<StackTraceElement>?,
         customStackTrace: String?,
     ) {


### PR DESCRIPTION
## Goal

Consolidates the potential ways in which log service attributes are set, ultimately attempting to unify to only one parameter.

## Testing

Relied on existing test coverage.
