### PR TITLE
Remove unused variantVersion field from VariantConfig

### DIFF
--- a/embrace-gradle-plugin-integration-tests/src/main/kotlin/io/embrace/android/gradle/integration/framework/IntegrationTestPlugin.kt
+++ b/embrace-gradle-plugin-integration-tests/src/main/kotlin/io/embrace/android/gradle/integration/framework/IntegrationTestPlugin.kt
@@ -27,7 +27,6 @@ class IntegrationTestPlugin : Plugin<Project> {
                 "demo",
                 "release",
                 false,
-                "1.2.3",
                 listOf("development"),
                 ""
             )

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/VariantConfig.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/VariantConfig.kt
@@ -12,7 +12,6 @@ import java.io.Serializable
 @JsonClass(generateAdapter = true)
 data class VariantConfig(
     val variantName: String,
-    val variantVersion: String? = null,
     val buildId: String? = null,
     val buildType: String? = null,
     val buildFlavor: String? = null,
@@ -33,7 +32,6 @@ data class VariantConfig(
             VariantConfig(
                 embraceConfig = embraceVariantConfig,
                 variantName = androidVariantConfig.name,
-                variantVersion = androidVariantConfig.versionName,
                 buildType = androidVariantConfig.buildTypeName,
                 buildFlavor = androidVariantConfig.flavorName,
                 buildId = androidVariantConfig.buildId,

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/model/AndroidCompactedVariantData.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/model/AndroidCompactedVariantData.kt
@@ -12,7 +12,6 @@ data class AndroidCompactedVariantData(
     val flavorName: String,
     val buildTypeName: String,
     val isBuildTypeDebuggable: Boolean,
-    val versionName: String?,
     val productFlavors: List<String>,
     val sourceMapPath: String,
     val buildId: String = UuidUtils.generateEmbraceUuid()
@@ -30,7 +29,6 @@ data class AndroidCompactedVariantData(
                 variant.flavorName ?: "",
                 variant.buildType ?: "",
                 debuggable,
-                "", // not used for now
                 fetchProductFlavors(variant),
                 variant.name
             )

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/config/variant/BuildVariantConfigFromFileTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/config/variant/BuildVariantConfigFromFileTest.kt
@@ -205,7 +205,6 @@ class BuildVariantConfigFromFileTest {
         flavorName = "flavor-name",
         buildTypeName = "buildType-name",
         isBuildTypeDebuggable = false,
-        versionName = "1.0",
         productFlavors = listOf("product-flavor", "2nd-product-flavor"),
         sourceMapPath = "source"
     )

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/config/variant/VariantConfigFileFinderTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/config/variant/VariantConfigFileFinderTest.kt
@@ -101,7 +101,6 @@ class VariantConfigFileFinderTest {
             flavorName = "flavor-name",
             buildTypeName = "buildType-name",
             isBuildTypeDebuggable = false,
-            versionName = "1.0",
             productFlavors = listOf("product-flavor", "2nd-product-flavor"),
             sourceMapPath = "source"
         )

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/InstrumentedConfigClassVisitorFactoryTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/InstrumentedConfigClassVisitorFactoryTest.kt
@@ -9,7 +9,7 @@ import org.junit.Test
 
 class InstrumentedConfigClassVisitorFactoryTest {
 
-    private val config = VariantConfig("", null, null, null, null, null)
+    private val config = VariantConfig("", null, null, null, null)
     private val api = ASM_API_VERSION
     private val embracePackage = "io.embrace.android.embracesdk.internal.config.instrumented"
 

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/ProjectConfigInstrumentationKtTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/ProjectConfigInstrumentationKtTest.kt
@@ -12,7 +12,6 @@ class ProjectConfigInstrumentationKtTest {
         null,
         null,
         null,
-        null,
         embraceConfig = EmbraceVariantConfig(
             "",
             "",

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/fakes/TestBytecodeInstrumentationParams.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/fakes/TestBytecodeInstrumentationParams.kt
@@ -23,7 +23,7 @@ class TestBytecodeInstrumentationParams(
 
     override val config: Property<VariantConfig> =
         DefaultProperty(PropertyHost.NO_OP, VariantConfig::class.javaObjectType).convention(
-            VariantConfig("", "", null, null, null, null)
+            VariantConfig("", "", null, null, null)
         )
     override val encodedSharedObjectFilesMap: RegularFileProperty = ProjectBuilder.builder().build().objects.fileProperty()
     override val reactNativeBundleId: RegularFileProperty = ProjectBuilder.builder().build().objects.fileProperty()

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/ndk/NdkUploadTasksRegistrationTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/ndk/NdkUploadTasksRegistrationTest.kt
@@ -49,7 +49,6 @@ class NdkUploadTasksRegistrationTest {
         flavorName = "variantFlavor",
         buildTypeName = "buildTypeName",
         isBuildTypeDebuggable = false,
-        versionName = "versionName",
         productFlavors = emptyList(),
         sourceMapPath = "sourceMapPath"
     )


### PR DESCRIPTION
## Goal
Clean up dead code by removing the `variantVersion` field that was being collected but never used anywhere in the codebase.

## Changes
- Removed `variantVersion` parameter from `VariantConfig` data class
- Removed `versionName` parameter from `AndroidCompactedVariantData` 
- Updated all test files to remove the unused field
- Removed empty string placeholder that was marked as "not used for now"