### PR TITLE
Track package info on build time

### DIFF
--- a/embrace-bytecode-instrumentation-tests/src/test/java/io/embrace/gradle/plugin/instrumentation/FakeBytecodeInstrumentationParams.kt
+++ b/embrace-bytecode-instrumentation-tests/src/test/java/io/embrace/gradle/plugin/instrumentation/FakeBytecodeInstrumentationParams.kt
@@ -3,6 +3,7 @@ package io.embrace.gradle.plugin.instrumentation
 import io.embrace.android.gradle.plugin.instrumentation.BytecodeInstrumentationParams
 import io.embrace.android.gradle.plugin.instrumentation.ClassInstrumentationFilter
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
+import io.embrace.android.gradle.plugin.model.VariantOutputInfo
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 
@@ -17,6 +18,8 @@ class FakeBytecodeInstrumentationParams(
     override val applicationInitTimingEnabled: Property<Boolean> = fakeProperty(true),
 ) : BytecodeInstrumentationParams {
     override val config: Property<VariantConfig>
+        get() = TODO("Not yet implemented")
+    override val variantOutputInfo: Property<VariantOutputInfo>
         get() = TODO("Not yet implemented")
     override val encodedSharedObjectFilesMap: RegularFileProperty
         get() = TODO("Not yet implemented")

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/AsmTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/AsmTaskRegistration.kt
@@ -5,6 +5,7 @@ import com.android.build.api.instrumentation.InstrumentationScope
 import io.embrace.android.gradle.plugin.EmbraceLogger
 import io.embrace.android.gradle.plugin.gradle.lazyTaskLookup
 import io.embrace.android.gradle.plugin.gradle.safeFlatMap
+import io.embrace.android.gradle.plugin.model.toVariantOutputInfoProvider
 import io.embrace.android.gradle.plugin.tasks.ndk.EncodeFileToBase64Task
 import io.embrace.android.gradle.plugin.tasks.reactnative.GenerateRnSourcemapTask
 import io.embrace.android.gradle.plugin.tasks.registration.EmbraceTaskRegistration
@@ -47,6 +48,7 @@ class AsmTaskRegistration : EmbraceTaskRegistration {
                 params.shouldInstrumentOnLongClick.set(behavior.instrumentation.onLongClickEnabled)
                 params.shouldInstrumentOnClick.set(behavior.instrumentation.onClickEnabled)
                 params.applicationInitTimingEnabled.set(behavior.instrumentation.applicationInitTimingEnabled)
+                params.variantOutputInfo.set(variant.toVariantOutputInfoProvider(project))
 
                 val encodeFileToBase64Task = project.lazyTaskLookup<EncodeFileToBase64Task>(
                     "${EncodeFileToBase64Task.NAME}${data.name.capitalizedString()}"

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/BytecodeInstrumentationParams.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/BytecodeInstrumentationParams.kt
@@ -2,6 +2,7 @@ package io.embrace.android.gradle.plugin.instrumentation
 
 import com.android.build.api.instrumentation.InstrumentationParameters
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
+import io.embrace.android.gradle.plugin.model.VariantOutputInfo
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
@@ -24,6 +25,12 @@ interface BytecodeInstrumentationParams : InstrumentationParameters {
      */
     @get:Input
     val config: Property<VariantConfig>
+
+    /**
+     * Variant output information including version name, version code, and application ID.
+     */
+    @get:Input
+    val variantOutputInfo: Property<VariantOutputInfo>
 
     /**
      * Base64 encoded string of the shared object files map to be injected in the SDK.

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/EmbraceClassVisitorFactory.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/EmbraceClassVisitorFactory.kt
@@ -30,8 +30,17 @@ abstract class EmbraceClassVisitorFactory : AsmClassVisitorFactory<BytecodeInstr
         val params = parameters.get()
         val cfg = params.config.get()
         val reactNativeBundleId = readTextFromFile(params.reactNativeBundleId)
+        val variantOutputInfo = params.variantOutputInfo.get()
         val encodedSharedObjectFilesMap = readTextFromFile(params.encodedSharedObjectFilesMap)
-        ConfigClassVisitorFactory.createClassVisitor(className, cfg, encodedSharedObjectFilesMap, reactNativeBundleId, api, visitor)?.let {
+        ConfigClassVisitorFactory.createClassVisitor(
+            className,
+            cfg,
+            encodedSharedObjectFilesMap,
+            variantOutputInfo,
+            reactNativeBundleId,
+            api,
+            visitor
+        )?.let {
             visitor = it
         }
 

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/ConfigClassVisitorFactory.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/ConfigClassVisitorFactory.kt
@@ -8,6 +8,7 @@ import io.embrace.android.gradle.plugin.instrumentation.config.arch.sdk.createRe
 import io.embrace.android.gradle.plugin.instrumentation.config.arch.sdk.createSharedObjectFilesMapInstrumentation
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
 import io.embrace.android.gradle.plugin.instrumentation.config.visitor.ConfigInstrumentationClassVisitor
+import io.embrace.android.gradle.plugin.model.VariantOutputInfo
 import org.objectweb.asm.ClassVisitor
 
 object ConfigClassVisitorFactory {
@@ -25,6 +26,7 @@ object ConfigClassVisitorFactory {
             cfg: VariantConfig,
             encodedSharedObjectFilesMap: String?,
             reactNativeBundleId: String?,
+            variantOutputInfo: VariantOutputInfo,
             api: Int,
             cv: ClassVisitor?,
         ): ClassVisitor {
@@ -32,7 +34,7 @@ object ConfigClassVisitorFactory {
                 BaseUrlConfig -> createBaseUrlConfigInstrumentation(cfg)
                 EnabledFeatureConfig -> createEnabledFeatureConfigInstrumentation(cfg)
                 NetworkCaptureConfig -> createNetworkCaptureConfigInstrumentation(cfg)
-                ProjectConfig -> createProjectConfigInstrumentation(cfg, reactNativeBundleId)
+                ProjectConfig -> createProjectConfigInstrumentation(cfg, reactNativeBundleId, variantOutputInfo)
                 RedactionConfig -> createRedactionConfigInstrumentation(cfg)
                 Base64SharedObjectFilesMap -> createSharedObjectFilesMapInstrumentation(encodedSharedObjectFilesMap)
             }
@@ -48,11 +50,12 @@ object ConfigClassVisitorFactory {
         className: String,
         cfg: VariantConfig,
         encodedSharedObjectFilesMap: String?,
+        variantOutputInfo: VariantOutputInfo,
         reactNativeBundleId: String?,
         api: Int,
         cv: ClassVisitor?,
     ): ClassVisitor? {
         val type = ConfigClassType.entries.singleOrNull { it.className == className }
-        return type?.createClassVisitor(cfg, encodedSharedObjectFilesMap, reactNativeBundleId, api, cv)
+        return type?.createClassVisitor(cfg, encodedSharedObjectFilesMap, reactNativeBundleId, variantOutputInfo, api, cv)
     }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/ProjectConfigInstrumentation.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/ProjectConfigInstrumentation.kt
@@ -3,12 +3,17 @@ package io.embrace.android.gradle.plugin.instrumentation.config.arch.sdk
 import io.embrace.android.gradle.plugin.instrumentation.config.arch.modelSdkConfigClass
 import io.embrace.android.gradle.plugin.instrumentation.config.arch.stringMethod
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
+import io.embrace.android.gradle.plugin.model.VariantOutputInfo
 
-fun createProjectConfigInstrumentation(cfg: VariantConfig, reactNativeBundleId: String?) = modelSdkConfigClass {
-    stringMethod("getAppId") { cfg.embraceConfig?.appId }
-    stringMethod("getAppFramework") { cfg.embraceConfig?.sdkConfig?.appFramework }
-    stringMethod("getBuildId") { cfg.buildId }
-    stringMethod("getBuildFlavor") { cfg.buildFlavor }
-    stringMethod("getBuildType") { cfg.buildType }
-    stringMethod("getReactNativeBundleId") { reactNativeBundleId }
-}
+fun createProjectConfigInstrumentation(cfg: VariantConfig, reactNativeBundleId: String?, variantOutputInfo: VariantOutputInfo) =
+    modelSdkConfigClass {
+        stringMethod("getAppId") { cfg.embraceConfig?.appId }
+        stringMethod("getAppFramework") { cfg.embraceConfig?.sdkConfig?.appFramework }
+        stringMethod("getBuildId") { cfg.buildId }
+        stringMethod("getBuildFlavor") { cfg.buildFlavor }
+        stringMethod("getBuildType") { cfg.buildType }
+        stringMethod("getReactNativeBundleId") { reactNativeBundleId }
+        stringMethod("getVersionName") { variantOutputInfo.versionName }
+        stringMethod("getVersionCode") { variantOutputInfo.versionCode }
+        stringMethod("getPackageName") { variantOutputInfo.packageName }
+    }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/model/VariantOutputInfo.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/model/VariantOutputInfo.kt
@@ -1,0 +1,67 @@
+package io.embrace.android.gradle.plugin.model
+
+import com.android.build.api.variant.ApplicationVariant
+import com.android.build.api.variant.Variant
+import com.android.build.api.variant.VariantOutput
+import com.android.build.api.variant.VariantOutputConfiguration
+import org.gradle.api.Project
+import org.gradle.api.provider.Provider
+import java.io.Serializable
+
+data class VariantOutputInfo(
+    val versionName: String,
+    val versionCode: String,
+    val packageName: String,
+) : Serializable {
+    private companion object {
+        @Suppress("ConstPropertyName")
+        private const val serialVersionUID = 1L
+    }
+}
+
+private const val UNKNOWN = "UNKNOWN"
+
+/**
+ * Creates a Provider of VariantOutputInfo from a Variant by selecting the main output.
+ *
+ * Selection priority:
+ * 1. SINGLE - for non-split builds
+ * 2. UNIVERSAL - for split builds (contains base version code)
+ * 3. First output - defensive fallback
+ *
+ * For non-application variants or when no output is found, returns a provider with UNKNOWN values.
+ */
+fun Variant.toVariantOutputInfoProvider(project: Project): Provider<VariantOutputInfo> {
+    val unknownProvider = project.provider {
+        VariantOutputInfo(
+            versionName = UNKNOWN,
+            versionCode = UNKNOWN,
+            packageName = UNKNOWN
+        )
+    }
+
+    val appVariant = this as? ApplicationVariant ?: return unknownProvider
+    val mainOutput = appVariant.getMainOutput() ?: return unknownProvider
+
+    val versionName = mainOutput.versionName.map { it ?: UNKNOWN }
+    val versionCode = mainOutput.versionCode.map { it?.toString() ?: UNKNOWN }
+    val packageName = appVariant.applicationId.map { it ?: UNKNOWN }
+
+    return versionName
+        .zip(versionCode) { name, code -> name to code }
+        .zip(packageName) { versionPair, pkg ->
+            VariantOutputInfo(
+                versionName = versionPair.first,
+                versionCode = versionPair.second,
+                packageName = pkg
+            )
+        }
+}
+
+private fun ApplicationVariant.getMainOutput(): VariantOutput? {
+    return outputs.firstOrNull {
+        it.outputType == VariantOutputConfiguration.OutputType.SINGLE
+    } ?: outputs.firstOrNull {
+        it.outputType == VariantOutputConfiguration.OutputType.UNIVERSAL
+    } ?: outputs.firstOrNull()
+}

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/InstrumentedConfigClassVisitorFactoryTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/InstrumentedConfigClassVisitorFactoryTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.gradle.plugin.instrumentation.config
 import io.embrace.android.gradle.plugin.instrumentation.ASM_API_VERSION
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
 import io.embrace.android.gradle.plugin.instrumentation.config.visitor.ConfigInstrumentationClassVisitor
+import io.embrace.android.gradle.plugin.model.VariantOutputInfo
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -10,6 +11,7 @@ import org.junit.Test
 class InstrumentedConfigClassVisitorFactoryTest {
 
     private val config = VariantConfig("", null, null, null, null)
+    private val variantOutputInfo = VariantOutputInfo("", "", "")
     private val api = ASM_API_VERSION
     private val embracePackage = "io.embrace.android.embracesdk.internal.config.instrumented"
 
@@ -65,5 +67,5 @@ class InstrumentedConfigClassVisitorFactoryTest {
     }
 
     private fun createVisitor(className: String) =
-        ConfigClassVisitorFactory.createClassVisitor(className, config, null, null, api, null)
+        ConfigClassVisitorFactory.createClassVisitor(className, config, null, variantOutputInfo, null, api, null)
 }

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/ProjectConfigInstrumentationKtTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/ProjectConfigInstrumentationKtTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.gradle.plugin.instrumentation.config.arch.sdk
 import io.embrace.android.gradle.plugin.instrumentation.config.model.EmbraceVariantConfig
 import io.embrace.android.gradle.plugin.instrumentation.config.model.SdkLocalConfig
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
+import io.embrace.android.gradle.plugin.model.VariantOutputInfo
 import org.junit.Test
 
 class ProjectConfigInstrumentationKtTest {
@@ -21,6 +22,8 @@ class ProjectConfigInstrumentationKtTest {
         )
     )
 
+    private val variantOutputInfo = VariantOutputInfo("", "", "")
+
     private val methods = listOf(
         ConfigMethod("getAppFramework", "()Ljava/lang/String;", "native"),
         ConfigMethod("getBuildId", "()Ljava/lang/String;", "my_id"),
@@ -30,7 +33,7 @@ class ProjectConfigInstrumentationKtTest {
 
     @Test
     fun `test empty cfg`() {
-        val instrumentation = createProjectConfigInstrumentation(cfg, null)
+        val instrumentation = createProjectConfigInstrumentation(cfg, null, variantOutputInfo)
         verifyConfigMethodVisitor(instrumentation, ConfigMethod("getAppId", "()Ljava/lang/String;", ""))
 
         methods.map { it.copy(result = null) }.forEach { method ->
@@ -53,7 +56,8 @@ class ProjectConfigInstrumentationKtTest {
                 buildType = "build_type",
                 buildFlavor = "build_flavor"
             ),
-            reactNativeBundleId = "a1B2c3"
+            reactNativeBundleId = "a1B2c3",
+            variantOutputInfo
         )
         verifyConfigMethodVisitor(instrumentation, ConfigMethod("getAppId", "()Ljava/lang/String;", "abcde"))
         methods.forEach { method ->

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/fakes/TestBytecodeInstrumentationParams.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/fakes/TestBytecodeInstrumentationParams.kt
@@ -3,6 +3,7 @@ package io.embrace.android.gradle.plugin.instrumentation.fakes
 import io.embrace.android.gradle.plugin.instrumentation.BytecodeInstrumentationParams
 import io.embrace.android.gradle.plugin.instrumentation.ClassInstrumentationFilter
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
+import io.embrace.android.gradle.plugin.model.VariantOutputInfo
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.internal.provider.DefaultProperty
 import org.gradle.api.internal.provider.PropertyHost
@@ -24,6 +25,10 @@ class TestBytecodeInstrumentationParams(
     override val config: Property<VariantConfig> =
         DefaultProperty(PropertyHost.NO_OP, VariantConfig::class.javaObjectType).convention(
             VariantConfig("", "", null, null, null)
+        )
+    override val variantOutputInfo: Property<VariantOutputInfo> =
+        DefaultProperty(PropertyHost.NO_OP, VariantOutputInfo::class.javaObjectType).convention(
+            VariantOutputInfo("", "", "")
         )
     override val encodedSharedObjectFilesMap: RegularFileProperty = ProjectBuilder.builder().build().objects.fileProperty()
     override val reactNativeBundleId: RegularFileProperty = ProjectBuilder.builder().build().objects.fileProperty()


### PR DESCRIPTION
## Goal
Enable tracking of package information (version name, version code, and package name) during build time by making it available to the SDK through bytecode instrumentation.

## Changes
- Add `VariantOutputInfo` data class to hold version name, version code, and package name
- Update bytecode instrumentation pipeline to pass variant output info through `BytecodeInstrumentationParams`
- Enhance `ProjectConfigInstrumentation` to inject three new getter methods: `getVersionName()`, `getVersionCode()`, and `getPackageName()`
- Update all test files and fakes to handle the new parameter
- Handle non-application variants gracefully by returning "UNKNOWN" values