### PR TITLE
Alter log function signatures

### DIFF
--- a/embrace-android-sdk/config/detekt/baseline.xml
+++ b/embrace-android-sdk/config/detekt/baseline.xml
@@ -2,6 +2,6 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>CyclomaticComplexMethod:LogsApiDelegate.kt$LogsApiDelegate$fun logMessageImpl( severity: Severity, message: String, attributes: Map&lt;String, Any> = emptyMap(), stackTraceElements: Array&lt;StackTraceElement>? = null, customStackTrace: String? = null, logExceptionType: LogExceptionType = LogExceptionType.NONE, exceptionName: String? = null, exceptionMessage: String? = null, attachment: Attachment? = null, )</ID>
+    <ID>CyclomaticComplexMethod:LogsApiDelegate.kt$LogsApiDelegate$private fun sendLog( attributes: Map&lt;String, Any>, exceptionData: ExceptionData?, attachment: Attachment?, severity: Severity, dst: LogService, message: String, )</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.testcases
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.LogExceptionType
+import io.embrace.android.embracesdk.internal.logs.LogExceptionType
 import io.embrace.android.embracesdk.assertions.assertMatches
 import io.embrace.android.embracesdk.assertions.assertOtelLogReceived
 import io.embrace.android.embracesdk.assertions.getLogOfType

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LogFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LogFeatureTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.testcases.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.LogExceptionType
+import io.embrace.android.embracesdk.internal.logs.LogExceptionType
 import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.assertions.assertOtelLogReceived
 import io.embrace.android.embracesdk.assertions.getLogOfType

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -20,6 +20,7 @@ import io.embrace.android.embracesdk.internal.api.SessionApi
 import io.embrace.android.embracesdk.internal.api.UserApi
 import io.embrace.android.embracesdk.internal.api.ViewTrackingApi
 import io.embrace.android.embracesdk.internal.api.delegate.BreadcrumbApiDelegate
+import io.embrace.android.embracesdk.internal.api.delegate.ExceptionData
 import io.embrace.android.embracesdk.internal.api.delegate.InstrumentationApiDelegate
 import io.embrace.android.embracesdk.internal.api.delegate.LogsApiDelegate
 import io.embrace.android.embracesdk.internal.api.delegate.NetworkRequestApiDelegate
@@ -191,19 +192,13 @@ internal class EmbraceImpl(
         severity: Severity,
         message: String,
         attributes: Map<String, Any> = emptyMap(),
-        customStackTrace: String? = null,
-        logExceptionType: LogExceptionType = LogExceptionType.NONE,
-        exceptionName: String? = null,
-        exceptionMessage: String? = null,
+        exceptionData: ExceptionData? = null,
     ) {
         logsApiDelegate.logMessageImpl(
             severity = severity,
             message = message,
             attributes = attributes,
-            customStackTrace = customStackTrace,
-            logExceptionType = logExceptionType,
-            exceptionName = exceptionName,
-            exceptionMessage = exceptionMessage,
+            exceptionData = exceptionData,
         )
     }
 

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExceptionData.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExceptionData.kt
@@ -1,0 +1,10 @@
+package io.embrace.android.embracesdk.internal.api.delegate
+
+import io.embrace.android.embracesdk.internal.logs.LogExceptionType
+
+internal class ExceptionData(
+    val name: String?,
+    val message: String?,
+    val stacktrace: String?,
+    val logExceptionType: LogExceptionType? = null
+)

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/FlutterInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/FlutterInternalInterfaceImpl.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.internal.api.delegate
 
 import io.embrace.android.embracesdk.EmbraceImpl
-import io.embrace.android.embracesdk.LogExceptionType
 import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
 import io.embrace.android.embracesdk.internal.FlutterInternalInterface
@@ -9,6 +8,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.EmbType.System.Flutter
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType.System.FlutterException.embFlutterExceptionLibrary
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logs.LogExceptionType
 
 internal class FlutterInternalInterfaceImpl(
     private val embrace: EmbraceImpl,
@@ -73,11 +73,13 @@ internal class FlutterInternalInterfaceImpl(
             embrace.logMessage(
                 severity = Severity.ERROR,
                 message = "Dart error",
-                customStackTrace = stack,
-                logExceptionType = exceptionType,
-                exceptionName = name,
-                exceptionMessage = message,
                 attributes = attrs,
+                exceptionData = ExceptionData(
+                    name = name,
+                    message = message,
+                    stacktrace = stack,
+                    logExceptionType = exceptionType,
+                )
             )
         } else {
             logger.logSdkNotInitialized("logDartError")

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/UnityInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/UnityInternalInterfaceImpl.kt
@@ -1,12 +1,12 @@
 package io.embrace.android.embracesdk.internal.api.delegate
 
 import io.embrace.android.embracesdk.EmbraceImpl
-import io.embrace.android.embracesdk.LogExceptionType
 import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
 import io.embrace.android.embracesdk.internal.UnityInternalInterface
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logs.LogExceptionType
 
 internal class UnityInternalInterfaceImpl(
     private val embrace: EmbraceImpl,
@@ -58,10 +58,12 @@ internal class UnityInternalInterfaceImpl(
             embrace.logMessage(
                 severity = Severity.ERROR,
                 message = "Unity exception",
-                customStackTrace = stacktrace,
-                logExceptionType = exceptionType,
-                exceptionName = name,
-                exceptionMessage = message
+                exceptionData = ExceptionData(
+                    name = name,
+                    message = message,
+                    stacktrace = stacktrace,
+                    logExceptionType = exceptionType,
+                )
             )
         } else {
             logger.logSdkNotInitialized("log Unity exception")

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogExceptionType.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogExceptionType.kt
@@ -1,13 +1,11 @@
-package io.embrace.android.embracesdk
+package io.embrace.android.embracesdk.internal.logs
 
 /**
  * Enum representing the type of exception that occurred.
  * NONE is for a native android log, whether have or not an exception.
  * HANDLED or UNHANDLED are ONLY for Unity and Flutter handled and unhandled exceptions.
- *
- * @suppress
  */
-enum class LogExceptionType(val value: String) {
+internal enum class LogExceptionType(val value: String) {
     NONE("none"),
     HANDLED("handled"),
     UNHANDLED("unhandled")

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/FlutterInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/FlutterInternalInterfaceImplTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.internal.api
 
 import io.embrace.android.embracesdk.EmbraceImpl
-import io.embrace.android.embracesdk.LogExceptionType
 import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.fakes.FakeKeyValueStore
 import io.embrace.android.embracesdk.internal.api.delegate.FlutterInternalInterfaceImpl
@@ -10,6 +9,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.EmbType.System.Flutter
 import io.embrace.android.embracesdk.internal.envelope.metadata.FlutterSdkVersionInfo
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logs.LogExceptionType
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -63,10 +63,12 @@ internal class FlutterInternalInterfaceImplTest {
                     embFlutterExceptionContext.name to "ctx",
                     embFlutterExceptionLibrary.name to "lib"
                 ),
-                customStackTrace = "stack",
-                logExceptionType = LogExceptionType.UNHANDLED,
-                exceptionName = "exception name",
-                exceptionMessage = "message",
+                exceptionData = match {
+                    it.name == "exception name" &&
+                        it.message == "message" &&
+                        it.stacktrace == "stack" &&
+                        it.logExceptionType == LogExceptionType.UNHANDLED
+                }
             )
         }
     }
@@ -80,14 +82,16 @@ internal class FlutterInternalInterfaceImplTest {
             embrace.logMessage(
                 severity = Severity.ERROR,
                 message = "Dart error",
-                customStackTrace = "stack",
-                logExceptionType = LogExceptionType.HANDLED,
-                exceptionName = "exception name",
-                exceptionMessage = "message",
                 attributes = mapOf(
                     embFlutterExceptionContext.name to "ctx",
                     embFlutterExceptionLibrary.name to "lib"
                 ),
+                exceptionData = match {
+                    it.name == "exception name" &&
+                        it.message == "message" &&
+                        it.stacktrace == "stack" &&
+                        it.logExceptionType == LogExceptionType.HANDLED
+                }
             )
         }
     }

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/UnityInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/UnityInternalInterfaceImplTest.kt
@@ -1,13 +1,13 @@
 package io.embrace.android.embracesdk.internal.api
 
 import io.embrace.android.embracesdk.EmbraceImpl
-import io.embrace.android.embracesdk.LogExceptionType
 import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.fakes.FakeKeyValueStore
 import io.embrace.android.embracesdk.internal.api.delegate.UnityInternalInterfaceImpl
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.envelope.metadata.UnitySdkVersionInfo
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logs.LogExceptionType
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -56,10 +56,12 @@ internal class UnityInternalInterfaceImplTest {
             embrace.logMessage(
                 severity = Severity.ERROR,
                 message = "Unity exception",
-                customStackTrace = "stack",
-                logExceptionType = LogExceptionType.UNHANDLED,
-                exceptionName = "name",
-                exceptionMessage = "msg"
+                exceptionData = match {
+                    it.name == "name" &&
+                        it.message == "msg" &&
+                        it.stacktrace == "stack" &&
+                        it.logExceptionType == LogExceptionType.UNHANDLED
+                }
             )
         }
     }
@@ -72,10 +74,12 @@ internal class UnityInternalInterfaceImplTest {
             embrace.logMessage(
                 severity = Severity.ERROR,
                 message = "Unity exception",
-                customStackTrace = "stack",
-                logExceptionType = LogExceptionType.HANDLED,
-                exceptionName = "name",
-                exceptionMessage = "msg"
+                exceptionData = match {
+                    it.name == "name" &&
+                        it.message == "msg" &&
+                        it.stacktrace == "stack" &&
+                        it.logExceptionType == LogExceptionType.HANDLED
+                }
             )
         }
     }


### PR DESCRIPTION
## Goal

Simplified the function signature required for `logMessageImpl` by creating an optional `LogExceptionType` parameter that holds data about an error/exception. 

## Testing

Relied on existing test coverage.
