### PR TITLE
Alter unity/flutter logging

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/PayloadStoreImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/PayloadStoreImpl.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.internal.session.orchestrator
 
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType.System.Crash
-import io.embrace.android.embracesdk.internal.arch.schema.EmbType.System.FlutterException
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType.System.NativeCrash
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType.System.NetworkCapturedRequest
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType.System.ReactNativeCrash
@@ -79,7 +78,6 @@ internal class PayloadStoreImpl(
             Crash.value -> SupportedEnvelopeType.CRASH
             NativeCrash.value -> SupportedEnvelopeType.CRASH
             ReactNativeCrash.value -> SupportedEnvelopeType.CRASH
-            FlutterException.value -> SupportedEnvelopeType.CRASH
             NetworkCapturedRequest.value -> SupportedEnvelopeType.BLOB
             else -> SupportedEnvelopeType.LOG
         }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStoreTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStoreTest.kt
@@ -86,7 +86,6 @@ class V2PayloadStoreTest {
             System.Crash,
             System.NativeCrash,
             System.ReactNativeCrash,
-            System.FlutterException
         ).forEach { type ->
             storeLogWithType(type)
             assertEquals(SupportedEnvelopeType.CRASH, getLastLogMetadata().envelopeType)

--- a/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/EmbType.kt
+++ b/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/EmbType.kt
@@ -62,18 +62,6 @@ sealed class EmbType(type: String, subtype: String?) : EmbraceAttribute {
 
         object InternalError : System("internal")
 
-        object FlutterException : System("flutter_exception", SendMode.IMMEDIATE) {
-            /**
-             * Attribute name for the exception context in a log representing an exception
-             */
-            val embFlutterExceptionContext: EmbraceAttributeKey = EmbraceAttributeKey.create("exception.context")
-
-            /**
-             * Attribute name for the exception library in a log representing an exception
-             */
-            val embFlutterExceptionLibrary: EmbraceAttributeKey = EmbraceAttributeKey.create("exception.library")
-        }
-
         object Exit : System("exit", SendMode.IMMEDIATE)
 
         object PushNotification : System("push_notification")
@@ -118,4 +106,13 @@ sealed class EmbType(type: String, subtype: String?) : EmbraceAttribute {
 
         object WebViewInfo : System("webview_info")
     }
+
+    /**
+     * Custom type for hybrid SDKs.
+     */
+    class Custom(
+        type: String,
+        subtype: String?,
+        override val sendMode: SendMode = SendMode.DEFAULT,
+    ) : EmbType(type, subtype)
 }

--- a/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
+++ b/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
@@ -9,7 +9,6 @@ import io.embrace.opentelemetry.kotlin.semconv.HttpAttributes
 import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
 import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes
 import io.embrace.opentelemetry.kotlin.semconv.UrlAttributes
-import kotlin.Suppress
 
 /**
  * The collections of attribute schemas used by the associated telemetry types.
@@ -152,11 +151,6 @@ sealed class SchemaType(
         override val schemaAttributes: Map<String, String> = attributes.snapshot()
     }
 
-    class FlutterException(attributes: TelemetryAttributes) :
-        SchemaType(EmbType.System.FlutterException) {
-        override val schemaAttributes: Map<String, String> = attributes.snapshot()
-    }
-
     class JvmCrash(attributes: TelemetryAttributes) : SchemaType(EmbType.System.Crash) {
         override val schemaAttributes: Map<String, String> = attributes.snapshot()
     }
@@ -281,6 +275,21 @@ sealed class SchemaType(
             ),
             ExceptionAttributes.EXCEPTION_MESSAGE to (throwable.message ?: "")
         )
+    }
+
+    /**
+     * A custom telemetry type. This allows the hybrid SDKs (and others) to pass in custom
+     * telemetry schemas if required.
+     */
+    class Custom(
+        type: String,
+        subType: String,
+        attributes: TelemetryAttributes,
+        sendMode: SendMode,
+    ) : SchemaType(
+        telemetryType = EmbType.Custom(type, subType, sendMode)
+    ) {
+        override val schemaAttributes: Map<String, String> = attributes.snapshot()
     }
 }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/FlutterInternalInterfaceTest.kt
@@ -1,14 +1,17 @@
 package io.embrace.android.embracesdk.testcases
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.internal.logs.LogExceptionType
 import io.embrace.android.embracesdk.assertions.assertMatches
 import io.embrace.android.embracesdk.assertions.assertOtelLogReceived
 import io.embrace.android.embracesdk.assertions.getLogOfType
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.config.FakeProjectConfig
 import io.embrace.android.embracesdk.internal.EmbraceInternalApi
+import io.embrace.android.embracesdk.internal.arch.attrs.embSendMode
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.arch.schema.SendMode
+import io.embrace.android.embracesdk.internal.logs.LogExceptionType
+import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
@@ -27,6 +30,8 @@ import org.junit.runner.RunWith
 @OptIn(ExperimentalApi::class)
 @RunWith(AndroidJUnit4::class)
 internal class FlutterInternalInterfaceTest {
+
+    private val flutterExceptionType = EmbType.Custom("sys", "flutter_exception")
 
     private val instrumentedConfig = FakeInstrumentedConfig(
         project = FakeProjectConfig(
@@ -176,7 +181,7 @@ internal class FlutterInternalInterfaceTest {
                 }.actionTimeMs
             },
             assertAction = {
-                val log = getSingleLogEnvelope().getLogOfType(EmbType.System.FlutterException)
+                val log = getSingleLogEnvelope().getLogOfType(flutterExceptionType)
 
                 assertOtelLogReceived(
                     logReceived = log,
@@ -196,6 +201,8 @@ internal class FlutterInternalInterfaceTest {
                         "emb.exception.library" to expectedLibrary,
                     )
                 )
+                val sendMode = log.attributes?.findAttributeValue(embSendMode.name)
+                assertEquals(SendMode.IMMEDIATE, SendMode.fromString(sendMode))
             }
         )
     }
@@ -222,7 +229,7 @@ internal class FlutterInternalInterfaceTest {
                 }.actionTimeMs
             },
             assertAction = {
-                val log = getSingleLogEnvelope().getLogOfType(EmbType.System.FlutterException)
+                val log = getSingleLogEnvelope().getLogOfType(flutterExceptionType)
 
                 assertOtelLogReceived(
                     logReceived = log,
@@ -242,6 +249,8 @@ internal class FlutterInternalInterfaceTest {
                         "emb.exception.library" to expectedLibrary,
                     )
                 )
+                val sendMode = log.attributes?.findAttributeValue(embSendMode.name)
+                assertEquals(SendMode.IMMEDIATE, SendMode.fromString(sendMode))
             }
         )
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UnityInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UnityInternalInterfaceTest.kt
@@ -1,11 +1,20 @@
 package io.embrace.android.embracesdk.testcases
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.assertions.assertOtelLogReceived
+import io.embrace.android.embracesdk.assertions.getLogOfType
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.config.FakeProjectConfig
 import io.embrace.android.embracesdk.internal.EmbraceInternalApi
+import io.embrace.android.embracesdk.internal.arch.attrs.embSendMode
+import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.arch.schema.SendMode
+import io.embrace.android.embracesdk.internal.logs.LogExceptionType
+import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Rule
@@ -15,13 +24,16 @@ import org.junit.runner.RunWith
 /**
  * Validation of the internal API
  */
+@OptIn(ExperimentalApi::class)
 @RunWith(AndroidJUnit4::class)
 internal class UnityInternalInterfaceTest {
 
-    private val instrumentedConfig = FakeInstrumentedConfig(project = FakeProjectConfig(
-        appId = "abcde",
-        appFramework = "unity"
-    ))
+    private val instrumentedConfig = FakeInstrumentedConfig(
+        project = FakeProjectConfig(
+            appId = "abcde",
+            appFramework = "unity"
+        )
+    )
 
     @Rule
     @JvmField
@@ -121,6 +133,83 @@ internal class UnityInternalInterfaceTest {
                 assertEquals("28.9.2", res.hostedPlatformVersion)
                 assertEquals("1.2.4", res.hostedSdkVersion)
                 assertEquals("new unity build id", res.unityBuildId)
+            }
+        )
+    }
+
+    @Test
+    fun `log unity handled exception generates an OTel log`() {
+        val expectedName = "Exception name"
+        val expectedMessage = "Handled exception: name: message"
+        val expectedStacktrace = "stacktrace"
+        var sessionStartTimeMs: Long = 0
+
+        testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
+            testCaseAction = {
+                sessionStartTimeMs = recordSession {
+                    EmbraceInternalApi.unityInternalInterface.logHandledUnityException(
+                        name = expectedName,
+                        message = expectedMessage,
+                        stacktrace = expectedStacktrace,
+                    )
+                }.actionTimeMs
+            },
+            assertAction = {
+                val singleLogEnvelope = getSingleLogEnvelope()
+                val log = singleLogEnvelope.getLogOfType(EmbType.System.Exception)
+
+                assertOtelLogReceived(
+                    logReceived = log,
+                    expectedMessage = "Unity exception",
+                    expectedSeverityNumber = SeverityNumber.ERROR,
+                    expectedTimeMs = sessionStartTimeMs,
+                    expectedType = LogExceptionType.HANDLED.value,
+                    expectedExceptionName = expectedName,
+                    expectedExceptionMessage = expectedMessage,
+                    expectedEmbType = "sys.exception",
+                    expectedState = "foreground",
+                )
+                val sendMode = log.attributes?.findAttributeValue(embSendMode.name)
+                assertEquals(SendMode.IMMEDIATE, SendMode.fromString(sendMode))
+            }
+        )
+    }
+
+    @Test
+    fun `log unity unhandled exception generates an OTel log`() {
+        val expectedName = "Exception name"
+        val expectedMessage = "Handled exception: name: message"
+        val expectedStacktrace = "stacktrace"
+        var sessionStartTimeMs: Long = 0
+
+        testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
+            testCaseAction = {
+                sessionStartTimeMs = recordSession {
+                    EmbraceInternalApi.unityInternalInterface.logUnhandledUnityException(
+                        name = expectedName,
+                        message = expectedMessage,
+                        stacktrace = expectedStacktrace,
+                    )
+                }.actionTimeMs
+            },
+            assertAction = {
+                val log = getSingleLogEnvelope().getLogOfType(EmbType.System.Exception)
+
+                assertOtelLogReceived(
+                    logReceived = log,
+                    expectedMessage = "Unity exception",
+                    expectedSeverityNumber = SeverityNumber.ERROR,
+                    expectedTimeMs = sessionStartTimeMs,
+                    expectedType = LogExceptionType.UNHANDLED.value,
+                    expectedExceptionName = expectedName,
+                    expectedExceptionMessage = expectedMessage,
+                    expectedEmbType = "sys.exception",
+                    expectedState = "foreground",
+                )
+                val sendMode = log.attributes?.findAttributeValue(embSendMode.name)
+                assertEquals(SendMode.IMMEDIATE, SendMode.fromString(sendMode))
             }
         )
     }

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -20,7 +20,6 @@ import io.embrace.android.embracesdk.internal.api.SessionApi
 import io.embrace.android.embracesdk.internal.api.UserApi
 import io.embrace.android.embracesdk.internal.api.ViewTrackingApi
 import io.embrace.android.embracesdk.internal.api.delegate.BreadcrumbApiDelegate
-import io.embrace.android.embracesdk.internal.api.delegate.ExceptionData
 import io.embrace.android.embracesdk.internal.api.delegate.InstrumentationApiDelegate
 import io.embrace.android.embracesdk.internal.api.delegate.LogsApiDelegate
 import io.embrace.android.embracesdk.internal.api.delegate.NetworkRequestApiDelegate
@@ -186,20 +185,6 @@ internal class EmbraceImpl(
                 }
             }
         }
-    }
-
-    fun logMessage(
-        severity: Severity,
-        message: String,
-        attributes: Map<String, Any> = emptyMap(),
-        exceptionData: ExceptionData? = null,
-    ) {
-        logsApiDelegate.logMessageImpl(
-            severity = severity,
-            message = message,
-            attributes = attributes,
-            exceptionData = exceptionData,
-        )
     }
 
     /**

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/UnityInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/UnityInternalInterfaceImpl.kt
@@ -55,15 +55,24 @@ internal class UnityInternalInterfaceImpl(
         exceptionType: LogExceptionType,
     ) {
         if (embrace.isStarted) {
+            val attrs = mutableMapOf(
+                "emb.type" to "sys.exception",
+                "emb.private.send_mode" to "immediate",
+                "exception.message" to message,
+            )
+
+            // add exception name + message attrs
+            name?.let { attrs["exception.type"] = it }
+            stacktrace?.let { attrs["exception.stacktrace"] = it }
+
+            if (exceptionType != LogExceptionType.NONE) {
+                attrs["emb.exception_handling"] = exceptionType.value
+            }
+
             embrace.logMessage(
                 severity = Severity.ERROR,
                 message = "Unity exception",
-                exceptionData = ExceptionData(
-                    name = name,
-                    message = message,
-                    stacktrace = stacktrace,
-                    logExceptionType = exceptionType,
-                )
+                properties = attrs,
             )
         } else {
             logger.logSdkNotInitialized("log Unity exception")

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/FlutterInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/FlutterInternalInterfaceImplTest.kt
@@ -1,15 +1,11 @@
 package io.embrace.android.embracesdk.internal.api
 
 import io.embrace.android.embracesdk.EmbraceImpl
-import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.fakes.FakeKeyValueStore
 import io.embrace.android.embracesdk.internal.api.delegate.FlutterInternalInterfaceImpl
-import io.embrace.android.embracesdk.internal.arch.schema.EmbType.System.FlutterException.embFlutterExceptionContext
-import io.embrace.android.embracesdk.internal.arch.schema.EmbType.System.FlutterException.embFlutterExceptionLibrary
 import io.embrace.android.embracesdk.internal.envelope.metadata.FlutterSdkVersionInfo
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.logs.LogExceptionType
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -48,51 +44,6 @@ internal class FlutterInternalInterfaceImplTest {
         impl.setDartVersion("2.12")
         verify(exactly = 1) {
             logger.logSdkNotInitialized(any())
-        }
-    }
-
-    @Test
-    fun testLogUnhandledDartException() {
-        every { embrace.isStarted } returns true
-        impl.logUnhandledDartException("stack", "exception name", "message", "ctx", "lib")
-        verify(exactly = 1) {
-            embrace.logMessage(
-                severity = Severity.ERROR,
-                message = "Dart error",
-                attributes = mapOf(
-                    embFlutterExceptionContext.name to "ctx",
-                    embFlutterExceptionLibrary.name to "lib"
-                ),
-                exceptionData = match {
-                    it.name == "exception name" &&
-                        it.message == "message" &&
-                        it.stacktrace == "stack" &&
-                        it.logExceptionType == LogExceptionType.UNHANDLED
-                }
-            )
-        }
-    }
-
-    @Test
-    fun testLogHandledDartException() {
-        every { embrace.isStarted } returns true
-        impl.logHandledDartException("stack", "exception name", "message", "ctx", "lib")
-
-        verify(exactly = 1) {
-            embrace.logMessage(
-                severity = Severity.ERROR,
-                message = "Dart error",
-                attributes = mapOf(
-                    embFlutterExceptionContext.name to "ctx",
-                    embFlutterExceptionLibrary.name to "lib"
-                ),
-                exceptionData = match {
-                    it.name == "exception name" &&
-                        it.message == "message" &&
-                        it.stacktrace == "stack" &&
-                        it.logExceptionType == LogExceptionType.HANDLED
-                }
-            )
         }
     }
 }

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/UnityInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/UnityInternalInterfaceImplTest.kt
@@ -1,13 +1,11 @@
 package io.embrace.android.embracesdk.internal.api
 
 import io.embrace.android.embracesdk.EmbraceImpl
-import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.fakes.FakeKeyValueStore
 import io.embrace.android.embracesdk.internal.api.delegate.UnityInternalInterfaceImpl
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.envelope.metadata.UnitySdkVersionInfo
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.logs.LogExceptionType
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -46,41 +44,5 @@ internal class UnityInternalInterfaceImplTest {
         every { embrace.isStarted } returns true
         impl.setUnityMetaData(null, null, "unitySdkVersion")
         assertEquals(emptyMap<String, Any?>(), store.values())
-    }
-
-    @Test
-    fun testLogUnhandledUnityException() {
-        every { embrace.isStarted } returns true
-        impl.logUnhandledUnityException("name", "msg", "stack")
-        verify(exactly = 1) {
-            embrace.logMessage(
-                severity = Severity.ERROR,
-                message = "Unity exception",
-                exceptionData = match {
-                    it.name == "name" &&
-                        it.message == "msg" &&
-                        it.stacktrace == "stack" &&
-                        it.logExceptionType == LogExceptionType.UNHANDLED
-                }
-            )
-        }
-    }
-
-    @Test
-    fun testLogHandledUnityException() {
-        every { embrace.isStarted } returns true
-        impl.logHandledUnityException("name", "msg", "stack")
-        verify(exactly = 1) {
-            embrace.logMessage(
-                severity = Severity.ERROR,
-                message = "Unity exception",
-                exceptionData = match {
-                    it.name == "name" &&
-                        it.message == "msg" &&
-                        it.stacktrace == "stack" &&
-                        it.logExceptionType == LogExceptionType.HANDLED
-                }
-            )
-        }
     }
 }


### PR DESCRIPTION
## Goal

Alters the implementation of the Unity/Flutter internal logging APIs so that they use Embrace's public Log API only. For backwards compatibility I've altered the existing functions to use the public API for now - see `FlutterInternalInterfaceImpl`. This demonstrates what the invocation should look like from the relevant hybrid SDK.

I've achieved this by creating a `Custom` class on `SchemaType` and inspecting the `attributes` that are passed in. If `emb.type` is set we construct the schema appropriately. All other attributes such as stacktrace etc are just treated as a normal key-value-pair - it's only necessary to know the semantic convention.

## Testing

Updated unit/integration tests.

