### PR TITLE
Use app version and package name for OTel service attributes

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
@@ -50,6 +50,8 @@ class OpenTelemetryModuleImpl(
             logSink = logSink,
             sdkName = BuildConfig.LIBRARY_PACKAGE_NAME,
             sdkVersion = BuildConfig.VERSION_NAME,
+            appVersion = initModule.instrumentedConfig.project.getVersionName() ?: "UNKNOWN",
+            packageName = initModule.instrumentedConfig.project.getPackageName() ?: "UNKNOWN",
             systemInfo = initModule.systemInfo,
             sessionIdProvider = { currentSessionSpan.getSessionId() },
             processIdentifierProvider = processIdentifierProvider,

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/OTelAssertions.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/OTelAssertions.kt
@@ -16,11 +16,13 @@ fun Resource.assertExpectedAttributes(
     expectedServiceName: String,
     expectedServiceVersion: String,
     systemInfo: SystemInfo,
+    expectedDistroName: String = expectedServiceName,
+    expectedDistroVersion: String = expectedServiceVersion,
 ) {
     assertEquals(expectedServiceName, attributes[ServiceAttributes.SERVICE_NAME])
     assertEquals(expectedServiceVersion, attributes[ServiceAttributes.SERVICE_VERSION])
-    assertEquals(expectedServiceName, attributes[TelemetryAttributes.TELEMETRY_DISTRO_NAME])
-    assertEquals(expectedServiceVersion, attributes[TelemetryAttributes.TELEMETRY_DISTRO_VERSION])
+    assertEquals(expectedDistroName, attributes[TelemetryAttributes.TELEMETRY_DISTRO_NAME])
+    assertEquals(expectedDistroVersion, attributes[TelemetryAttributes.TELEMETRY_DISTRO_VERSION])
     assertEquals(systemInfo.osName, attributes[OsAttributes.OS_NAME])
     assertEquals(systemInfo.osVersion, attributes[OsAttributes.OS_VERSION])
     assertEquals(systemInfo.osType, attributes[OsAttributes.OS_TYPE])

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
@@ -27,6 +27,8 @@ class OtelSdkConfig(
     logSink: LogSink,
     val sdkName: String,
     val sdkVersion: String,
+    val appVersion: String,
+    val packageName: String,
     private val systemInfo: SystemInfo,
     private val sessionIdProvider: () -> String? = { null },
     private val processIdentifierProvider: () -> String = IdGenerator.Companion::generateLaunchInstanceId
@@ -37,8 +39,8 @@ class OtelSdkConfig(
     @OptIn(IncubatingApi::class)
     val resourceAction: MutableAttributeContainer.() -> Unit
         get() = {
-            setStringAttribute(ServiceAttributes.SERVICE_NAME, sdkName)
-            setStringAttribute(ServiceAttributes.SERVICE_VERSION, sdkVersion)
+            setStringAttribute(ServiceAttributes.SERVICE_NAME, packageName)
+            setStringAttribute(ServiceAttributes.SERVICE_VERSION, appVersion)
             setStringAttribute(OsAttributes.OS_NAME, systemInfo.osName)
             setStringAttribute(OsAttributes.OS_VERSION, systemInfo.osVersion)
             setStringAttribute(OsAttributes.OS_TYPE, systemInfo.osType)

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfigTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfigTest.kt
@@ -34,13 +34,15 @@ internal class OtelSdkConfigTest {
             logSink = LogSinkImpl(),
             sdkName = "sdk",
             sdkVersion = "1.0",
+            appVersion = "2.5.1",
+            packageName = "com.test.app",
             systemInfo = systemInfo
         )
 
         val attrs = FakeMutableAttributeContainer().apply(configuration.resourceAction).attributes
         val expected = mapOf(
-            ServiceAttributes.SERVICE_NAME to configuration.sdkName,
-            ServiceAttributes.SERVICE_VERSION to configuration.sdkVersion,
+            ServiceAttributes.SERVICE_NAME to configuration.packageName,
+            ServiceAttributes.SERVICE_VERSION to configuration.appVersion,
             TelemetryAttributes.TELEMETRY_DISTRO_NAME to configuration.sdkName,
             TelemetryAttributes.TELEMETRY_DISTRO_VERSION to configuration.sdkVersion,
             OsAttributes.OS_NAME to systemInfo.osName,

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OpenTelemetrySdkTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OpenTelemetrySdkTest.kt
@@ -41,9 +41,11 @@ internal class OpenTelemetrySdkTest {
     fun `check resource added by sdk tracer`() {
         sdk.sdkTracer.createSpan("test").end()
         spanExporter.exportedSpans.single().resource.assertExpectedAttributes(
-            expectedServiceName = configuration.sdkName,
-            expectedServiceVersion = configuration.sdkVersion,
-            systemInfo = systemInfo
+            expectedServiceName = configuration.packageName,
+            expectedServiceVersion = configuration.appVersion,
+            systemInfo = systemInfo,
+            expectedDistroName = configuration.sdkName,
+            expectedDistroVersion = configuration.sdkVersion
         )
     }
 
@@ -51,9 +53,11 @@ internal class OpenTelemetrySdkTest {
     fun `check resource added by default logger`() {
         sdk.openTelemetryKotlin.loggerProvider.getLogger("my_logger").log()
         checkNotNull(logExporter.exportedLogs).single().resource.assertExpectedAttributes(
-            expectedServiceName = configuration.sdkName,
-            expectedServiceVersion = configuration.sdkVersion,
-            systemInfo = systemInfo
+            expectedServiceName = configuration.packageName,
+            expectedServiceVersion = configuration.appVersion,
+            systemInfo = systemInfo,
+            expectedDistroName = configuration.sdkName,
+            expectedDistroVersion = configuration.sdkVersion
         )
     }
 
@@ -96,6 +100,8 @@ internal class OpenTelemetrySdkTest {
             logSink = logSink,
             sdkName = "sdk",
             sdkVersion = "1.0",
+            appVersion = "2.5.1",
+            packageName = "com.test.app",
             systemInfo = systemInfo,
         )
         spanExporter = FakeSpanExporter()

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanServiceTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanServiceTest.kt
@@ -46,6 +46,8 @@ internal class EmbraceSpanServiceTest {
             logSink = LogSinkImpl(),
             sdkName = "test-sdk",
             sdkVersion = "1.0",
+            appVersion = "1.0.0",
+            packageName = "com.test.app",
             systemInfo = SystemInfo(),
             sessionIdProvider = { "fake-session-id" },
             processIdentifierProvider = { "fake-pid" }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
@@ -619,6 +619,8 @@ internal class SpanServiceImplTest {
             logSink = LogSinkImpl(),
             sdkName = "test-sdk",
             sdkVersion = "1.0",
+            appVersion = "1.0.0",
+            packageName = "com.test.app",
             systemInfo = SystemInfo(),
             sessionIdProvider = { "fake-session-id" },
             processIdentifierProvider = { "fake-pid" }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
@@ -35,6 +35,8 @@ class FakeOpenTelemetryModule(
             logSink = logSink,
             sdkName = sdkName,
             sdkVersion = sdkVersion,
+            appVersion = "1.0.0",
+            packageName = "com.test.app",
             systemInfo = systemInfo,
         )
 


### PR DESCRIPTION
## Goal

Fix issue #2223 by using the mobile app's version and package name for OTel service attributes instead of the SDK version.

## Changes

- Updated `OtelSdkConfig` to accept `appVersion` and `packageName` parameters
- Modified resource attributes mapping:
  - `service.name` now uses the app package name (e.g., "com.example.app")
  - `service.version` now uses the app version name (e.g., "1.0.0")
  - `telemetry.distro.name` and `telemetry.distro.version` remain unchanged (SDK name/version)
- Wired `getPackageName()` and `getVersionName()` from build-time injected config through `OpenTelemetryModuleImpl`
- Updated all tests to provide the new parameters

Closes #2223 