### PR TITLE
Add internal API to add custom resource values

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSource.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSource.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
 /**
  * Creates a [EnvelopeResource] object.
  */
-fun interface EnvelopeResourceSource {
+interface EnvelopeResourceSource {
     fun getEnvelopeResource(): EnvelopeResource
+    fun add(key: String, value: String)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImpl.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.internal.envelope.CpuAbi
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
+import java.util.concurrent.ConcurrentHashMap
 
 internal class EnvelopeResourceSourceImpl(
     private val hosted: HostedSdkVersionInfo,
@@ -18,6 +19,8 @@ internal class EnvelopeResourceSourceImpl(
     private val device: Device,
     private val rnBundleIdTracker: RnBundleIdTracker,
 ) : EnvelopeResourceSource {
+
+    private val extras = ConcurrentHashMap<String, String>()
 
     override fun getEnvelopeResource(): EnvelopeResource {
         return EnvelopeResource(
@@ -46,7 +49,12 @@ internal class EnvelopeResourceSourceImpl(
             osVersion = device.systemInfo.osVersion,
             osCode = device.systemInfo.androidOsApiLevel,
             screenResolution = device.screenResolution,
-            numCores = device.numberOfCores
+            numCores = device.numberOfCores,
+            extras = extras.toMap()
         )
+    }
+
+    override fun add(key: String, value: String) {
+        extras[key] = value
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModule.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.internal.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.internal.capture.metadata.RnBundleIdTracker
 import io.embrace.android.embracesdk.internal.envelope.log.LogEnvelopeSource
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
+import io.embrace.android.embracesdk.internal.envelope.resource.EnvelopeResourceSource
 import io.embrace.android.embracesdk.internal.envelope.session.SessionEnvelopeSource
 import io.embrace.android.embracesdk.internal.resurrection.PayloadResurrectionService
 
@@ -17,4 +18,5 @@ interface PayloadSourceModule {
     val hostedSdkVersionInfo: HostedSdkVersionInfo
     val rnBundleIdTracker: RnBundleIdTracker
     val payloadResurrectionService: PayloadResurrectionService?
+    val resourceSource: EnvelopeResourceSource
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
@@ -17,6 +17,7 @@ import io.embrace.android.embracesdk.internal.envelope.metadata.NativeSdkVersion
 import io.embrace.android.embracesdk.internal.envelope.metadata.ReactNativeSdkVersionInfo
 import io.embrace.android.embracesdk.internal.envelope.metadata.UnitySdkVersionInfo
 import io.embrace.android.embracesdk.internal.envelope.resource.DeviceImpl
+import io.embrace.android.embracesdk.internal.envelope.resource.EnvelopeResourceSource
 import io.embrace.android.embracesdk.internal.envelope.resource.EnvelopeResourceSourceImpl
 import io.embrace.android.embracesdk.internal.envelope.session.OtelPayloadMapper
 import io.embrace.android.embracesdk.internal.envelope.session.SessionEnvelopeSource
@@ -97,7 +98,7 @@ class PayloadSourceModuleImpl(
         }
     }
 
-    private val resourceSource by singleton {
+    override val resourceSource: EnvelopeResourceSource by singleton {
         EmbTrace.trace("resource-source") {
             EnvelopeResourceSourceImpl(
                 hostedSdkVersionInfo,

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeResource.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeResource.kt
@@ -69,6 +69,9 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class EnvelopeResource(
 
+    /**** WARNING: when altering fields, please keep JSON keys in sync with
+     * [io.embrace.android.embracesdk.internal.serialization.EnvelopeResourceAdapter]. ****/
+
     /* The app's publicly displayed version name. Previous name: a.v */
     @Json(name = "app_version")
     val appVersion: String? = null,
@@ -176,5 +179,8 @@ data class EnvelopeResource(
 
     /* (Android) The number of CPU cores the device has. Previous name: d.nc */
     @Json(name = "num_cores")
-    val numCores: Int? = null
+    val numCores: Int? = null,
+
+    @Transient
+    val extras: Map<String, String> = emptyMap(),
 )

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/serialization/EmbraceSerializer.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/serialization/EmbraceSerializer.kt
@@ -16,6 +16,7 @@ class EmbraceSerializer : PlatformSerializer {
     private val ref = object : ThreadLocal<Moshi>() {
         override fun initialValue(): Moshi = Moshi.Builder()
             .add(AppFrameworkAdapter())
+            .add(EnvelopeResourceAdapter())
             .build()
     }
 

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/serialization/EnvelopeResourceAdapter.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/serialization/EnvelopeResourceAdapter.kt
@@ -1,0 +1,83 @@
+package io.embrace.android.embracesdk.internal.serialization
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.ToJson
+import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
+
+@Suppress("UNCHECKED_CAST")
+class EnvelopeResourceAdapter {
+
+    @FromJson
+    fun fromJson(
+        reader: JsonReader,
+        delegate: JsonAdapter<EnvelopeResource>,
+    ): EnvelopeResource? {
+        val raw = reader.readJsonValue() as? Map<String, Any?> ?: return null
+        val value = delegate.fromJsonValue(raw) ?: return null
+
+        /**** WARNING: when altering fields, please keep JSON keys in sync with [EnvelopeResource] ****/
+        val knownKeys = setOf(
+            "app_version",
+            "app_build_number",
+            "app_framework",
+            "build_id",
+            "app_ecosystem_id",
+            "build_type",
+            "build_flavor",
+            "environment",
+            "bundle_version",
+            "sdk_version",
+            "sdk_simple_version",
+            "react_native_bundle_id",
+            "react_native_version",
+            "javascript_patch_number",
+            "hosted_platform_version",
+            "hosted_sdk_version",
+            "unity_build_id",
+            "device_manufacturer",
+            "device_model",
+            "device_architecture",
+            "jailbroken",
+            "disk_total_capacity",
+            "os_type",
+            "os_name",
+            "os_version",
+            "os_code",
+            "screen_resolution",
+            "num_cores",
+        )
+        val extras = (raw - knownKeys).mapValues { it.value.toString() }
+        return value.copy(extras = extras)
+    }
+
+    @ToJson
+    fun toJson(
+        writer: JsonWriter,
+        value: EnvelopeResource?,
+        delegate: JsonAdapter<EnvelopeResource>,
+    ) {
+        if (value == null) {
+            writer.nullValue()
+            return
+        }
+
+        val json = delegate.toJsonValue(value) as MutableMap<String, Any?>
+        json.putAll(value.extras)
+
+        writer.beginObject()
+        for ((k, v) in json) {
+            writer.name(k)
+
+            when (v) {
+                is Long -> writer.value(v)
+                is Int -> writer.value(v)
+                is Boolean -> writer.value(v)
+                else -> writer.value(v.toString())
+            }
+        }
+        writer.endObject()
+    }
+}

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.internal.EmbraceInternalApi
 import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Rule
 import org.junit.Test
@@ -50,9 +51,19 @@ internal class EmbraceInternalInterfaceTest {
                 )
             ),
             testCaseAction = {
+                EmbraceInternalApi.internalInterface.addEnvelopeResource("foo", "bar")
                 recordSession {
+                    embrace.logInfo("Hi")
                     assertFalse(EmbraceInternalApi.internalInterface.isNetworkSpanForwardingEnabled())
                 }
+            },
+            assertAction = {
+                val expected = mapOf("foo" to "bar")
+                val sessionResource = checkNotNull(getSingleSessionEnvelope().resource)
+                assertEquals(expected, sessionResource.extras)
+
+                val logResource = checkNotNull(getSingleLogEnvelope().resource)
+                assertEquals(expected, logResource.extras)
             }
         )
     }

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/EmbraceInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/EmbraceInternalInterfaceImpl.kt
@@ -2,11 +2,17 @@ package io.embrace.android.embracesdk.internal.api.delegate
 
 import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
 import io.embrace.android.embracesdk.internal.config.ConfigService
+import io.embrace.android.embracesdk.internal.envelope.resource.EnvelopeResourceSource
 
 internal class EmbraceInternalInterfaceImpl(
     private val configService: ConfigService,
+    private val resourceSource: EnvelopeResourceSource,
 ) : EmbraceInternalInterface {
 
     override fun isNetworkSpanForwardingEnabled(): Boolean =
         configService.networkSpanForwardingBehavior.isNetworkSpanForwardingEnabled()
+
+    override fun addEnvelopeResource(key: String, value: String) {
+        resourceSource.add(key, value)
+    }
 }

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InternalInterfaceModuleImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InternalInterfaceModuleImpl.kt
@@ -19,7 +19,10 @@ internal class InternalInterfaceModuleImpl(
 ) : InternalInterfaceModule {
 
     override val embraceInternalInterface: EmbraceInternalInterface by singleton {
-        EmbraceInternalInterfaceImpl(configModule.configService)
+        EmbraceInternalInterfaceImpl(
+            configModule.configService,
+            payloadSourceModule.resourceSource
+        )
     }
 
     override val reactNativeInternalInterface: ReactNativeInternalInterface by singleton {

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/EmbraceInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/EmbraceInternalInterfaceImplTest.kt
@@ -4,10 +4,12 @@ import io.embrace.android.embracesdk.EmbraceImpl
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
 import io.embrace.android.embracesdk.fakes.behavior.FakeNetworkSpanForwardingBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.api.delegate.EmbraceInternalInterfaceImpl
 import io.mockk.mockk
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -20,6 +22,7 @@ internal class EmbraceInternalInterfaceImplTest {
     private lateinit var fakeClock: FakeClock
     private lateinit var initModule: FakeInitModule
     private lateinit var fakeConfigService: FakeConfigService
+    private lateinit var resourceSource: FakeEnvelopeResourceSource
 
     @Before
     fun setUp() {
@@ -27,7 +30,8 @@ internal class EmbraceInternalInterfaceImplTest {
         fakeClock = FakeClock(currentTime = beforeObjectInitTime)
         initModule = FakeInitModule(clock = fakeClock, logger = FakeEmbLogger(false))
         fakeConfigService = FakeConfigService()
-        internalImpl = EmbraceInternalInterfaceImpl(fakeConfigService)
+        resourceSource = FakeEnvelopeResourceSource()
+        internalImpl = EmbraceInternalInterfaceImpl(fakeConfigService, resourceSource)
     }
 
     @Test
@@ -35,6 +39,12 @@ internal class EmbraceInternalInterfaceImplTest {
         assertFalse(internalImpl.isNetworkSpanForwardingEnabled())
         fakeConfigService.networkSpanForwardingBehavior = FakeNetworkSpanForwardingBehavior(true)
         assertTrue(internalImpl.isNetworkSpanForwardingEnabled())
+    }
+
+    @Test
+    fun `check resource source addition`() {
+        internalImpl.addEnvelopeResource("foo", "bar")
+        assertEquals("bar", resourceSource.customValues["foo"])
     }
 
     companion object {

--- a/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/EmbraceInternalInterface.kt
+++ b/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/EmbraceInternalInterface.kt
@@ -10,4 +10,13 @@ interface EmbraceInternalInterface {
      * Whether the Network Span Forwarding feature is enabled
      */
     fun isNetworkSpanForwardingEnabled(): Boolean
+
+    /**
+     * Adds a key-value-pair to the 'resource' object on session and log envelopes.
+     *
+     * This can be used to add arbitrary values such as the hybrid SDK's versioning for example.
+     * It should be used sparingly and a schema must be agreed with the backend before
+     * setting values here.
+     */
+    fun addEnvelopeResource(key: String, value: String)
 }

--- a/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/NoopEmbraceInternalInterface.kt
+++ b/embrace-internal-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/NoopEmbraceInternalInterface.kt
@@ -5,4 +5,7 @@ import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
 internal object NoopEmbraceInternalInterface : EmbraceInternalInterface {
 
     override fun isNetworkSpanForwardingEnabled(): Boolean = false
+
+    override fun addEnvelopeResource(key: String, value: String) {
+    }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceInternalInterface.kt
@@ -10,4 +10,7 @@ class FakeEmbraceInternalInterface(
     var networkRequests: MutableList<EmbraceNetworkRequest> = mutableListOf()
 
     override fun isNetworkSpanForwardingEnabled(): Boolean = networkSpanForwardingEnabled
+
+    override fun addEnvelopeResource(key: String, value: String) {
+    }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEnvelopeResourceSource.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEnvelopeResourceSource.kt
@@ -6,6 +6,11 @@ import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
 class FakeEnvelopeResourceSource : EnvelopeResourceSource {
 
     var resource: EnvelopeResource = EnvelopeResource()
+    var customValues = mutableMapOf<String, String>()
 
     override fun getEnvelopeResource(): EnvelopeResource = resource
+
+    override fun add(key: String, value: String) {
+        customValues[key] = value
+    }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakePayloadSourceModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakePayloadSourceModule.kt
@@ -32,18 +32,18 @@ class FakePayloadSourceModule(
     logPayloadSource: LogPayloadSource = FakeLogPayloadSource(),
 ) : PayloadSourceModule {
 
-    private val envelopeResourceSource = FakeEnvelopeResourceSource()
+    override val resourceSource = FakeEnvelopeResourceSource()
     private val envelopeMetadataSource = FakeEnvelopeMetadataSource()
 
     override val sessionEnvelopeSource: SessionEnvelopeSource = FakeSessionEnvelopeSource(
         envelopeMetadataSource,
-        envelopeResourceSource,
+        resourceSource,
         sessionPayloadSource
     )
 
     override val logEnvelopeSource: FakeLogEnvelopeSource = FakeLogEnvelopeSource(
         envelopeMetadataSource,
-        envelopeResourceSource,
+        resourceSource,
         logPayloadSource
     )
 }


### PR DESCRIPTION
## Goal

Adds an internal API to add custom values to the 'resource' object in the `Envelope` type. This requires a custom Moshi serializer that delegates to the default `EnvelopeResourceJsonAdapter` implementation generated by Moshi - additional fields are appended at the end.

This is only intended for internal use and only adds values to the HTTP payload, not OTLP.

## Testing

Added tests.

