### PR TITLE
Test native crash metadata after session change

### DIFF
--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeJniDelegate.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeJniDelegate.kt
@@ -6,6 +6,7 @@ class FakeJniDelegate : JniDelegate {
 
     private val rawCrashes: MutableMap<String, String?> = mutableMapOf()
     var culprit: String? = "testCulprit"
+    var sessionId: String? = null
     var reportPath: String? = null
     var signalHandlerInstalled: Boolean = false
     var signalHandlerReinstalled = false
@@ -19,6 +20,7 @@ class FakeJniDelegate : JniDelegate {
     }
 
     override fun onSessionChange(sessionId: String, reportPath: String) {
+        this.sessionId = sessionId
         this.reportPath = reportPath
     }
 


### PR DESCRIPTION
## Goal

Test the installation of the native crash handling bits and verify what we can, specifically calls into the native layer during session transitions.