### PR TITLE
Make state value type non-null and formalize attribute names

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/EnvelopeExt.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/EnvelopeExt.kt
@@ -14,6 +14,10 @@ fun Envelope<SessionPayload>.getSessionSpan(): Span? {
         ?: data.spanSnapshots?.singleOrNull { it.hasEmbraceAttribute(EmbType.Ux.Session) }
 }
 
+fun Envelope<SessionPayload>.getStateSpan(spanName: String): Span? {
+    return data.spans?.singleOrNull { it.hasEmbraceAttribute(EmbType.State) && it.name == spanName }
+}
+
 @OptIn(IncubatingApi::class)
 fun Envelope<SessionPayload>.getSessionId(): String? {
     return getSessionSpan()?.attributes?.findAttributeValue(SessionAttributes.SESSION_ID)

--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTelemetryDestination.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTelemetryDestination.kt
@@ -118,7 +118,7 @@ class FakeTelemetryDestination : TelemetryDestination {
         createdSpans.add(token)
     }
 
-    override fun <T> startSessionStateCapture(state: SchemaType.State<T>): SessionStateToken<T> = FakeSessionStateToken()
+    override fun <T: Any> startSessionStateCapture(state: SchemaType.State<T>): SessionStateToken<T> = FakeSessionStateToken()
 
     override var sessionUpdateAction: (() -> Unit)? = null
 }

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/SpanToken.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/SpanToken.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.arch.datasource
 
+import io.embrace.android.embracesdk.internal.arch.attrs.EmbraceAttributeKey
 import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 
 /**
@@ -31,6 +32,12 @@ interface SpanToken {
      * Set the value of the attribute with the given key, overwriting the original value if it's already set
      */
     fun setSystemAttribute(key: String, value: String)
+
+    /**
+     * Set the value of the attribute with the given [EmbraceAttributeKey] to the result of [toString] on the value,
+     * overwriting the original value if it's already set
+     */
+    fun setSystemAttribute(key: EmbraceAttributeKey, value: Any) = setSystemAttribute(key.name, value.toString())
 
     /**
      * Add an event to the span

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/StateDataSource.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/StateDataSource.kt
@@ -13,7 +13,7 @@ import java.util.concurrent.atomic.AtomicReference
  * Base [DataSource] to handle State updates in a unified way. This will create the right objects to represent a state in the data model,
  * as well as track and put in the common metadata expected by the backend.
  */
-abstract class StateDataSource<T>(
+abstract class StateDataSource<T : Any>(
     private val args: InstrumentationArgs,
     private val stateValueFactory: (initialValue: T) -> SchemaType.State<T>,
     defaultValue: T,

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/StateInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/StateInstrumentationProvider.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.internal.arch.InstrumentationProvider
  *
  * It ensures the state feature flag is enabled as well as whatever configuration gate is required.
  */
-abstract class StateInstrumentationProvider<T : StateDataSource<S>, S>(
+abstract class StateInstrumentationProvider<T : StateDataSource<S>, S : Any>(
     private val configGate: InstrumentationArgs.() -> Boolean = { true },
 ) : InstrumentationProvider {
 

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/TelemetryDestination.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/TelemetryDestination.kt
@@ -64,7 +64,7 @@ interface TelemetryDestination {
     /**
      * Start a recording the given [SchemaType.State] for the current session
      */
-    fun <T> startSessionStateCapture(state: SchemaType.State<T>): SessionStateToken<T>
+    fun <T : Any> startSessionStateCapture(state: SchemaType.State<T>): SessionStateToken<T>
 
     /**
      * Records a span that has already completed.

--- a/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/attrs/EmbraceAttributeExt.kt
+++ b/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/attrs/EmbraceAttributeExt.kt
@@ -4,3 +4,8 @@ package io.embrace.android.embracesdk.internal.arch.attrs
  * Converts [EmbraceAttribute] to a [Pair]
  */
 fun EmbraceAttribute.asPair(): Pair<String, String> = Pair(key.name, value)
+
+/**
+ * Creates a new [Pair] based on the key and the passed-in value is coerced into a string via [toString]
+ */
+fun EmbraceAttributeKey.asPair(value: Any): Pair<String, String> = Pair(name, value.toString())

--- a/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/attrs/EmbraceAttributeKeys.kt
+++ b/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/attrs/EmbraceAttributeKeys.kt
@@ -119,3 +119,30 @@ val embAttachmentErrorCode: EmbraceAttributeKey = EmbraceAttributeKey.create("at
  * The name of the Activity that app startup completed in
  */
 val embStartupActivityName: EmbraceAttributeKey = EmbraceAttributeKey.create("startup_activity")
+
+/**
+ * The initial value a state began with
+ */
+val embStateInitialValue: EmbraceAttributeKey = createStateKey("initial_value")
+
+/**
+ * The value a state transitioned into in the given event
+ */
+val embStateNewValue: EmbraceAttributeKey = createStateKey("new_value")
+
+/**
+ * The total number of transitions recorded explicitly in the given state span
+ */
+val embStateTransitionCount: EmbraceAttributeKey = createStateKey("transition_count")
+
+/**
+ * The number of transitions dropped because they didn't occur during a session since the last time a transition event was recorded
+ */
+val embStateNotInSession: EmbraceAttributeKey = createStateKey("not_in_session")
+
+/**
+ * The number of transitions dropped by the instrumentation since the last time a transition event was recorded
+ */
+val embStateDroppedByInstrumentation: EmbraceAttributeKey = createStateKey("dropped_by_instrumentation")
+
+private fun createStateKey(id: String) = EmbraceAttributeKey.create("state.$id")

--- a/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
+++ b/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.arch.schema
 import io.embrace.android.embracesdk.internal.arch.attrs.embAeiNumber
 import io.embrace.android.embracesdk.internal.arch.attrs.embCrashNumber
 import io.embrace.android.embracesdk.internal.arch.attrs.embSendMode
+import io.embrace.android.embracesdk.internal.arch.attrs.embStateInitialValue
 import io.embrace.android.embracesdk.internal.arch.attrs.toEmbraceAttributeName
 import io.embrace.opentelemetry.kotlin.semconv.ExceptionAttributes
 import io.embrace.opentelemetry.kotlin.semconv.HttpAttributes
@@ -281,7 +282,7 @@ sealed class SchemaType(
      * Base [SchemaType] to handle common logic for States. This includes expecting the type [T] as the value of the State
      * whose value can be encoded uniquely as a string via [toString], which will be used to presented it in any serialized forms.
      */
-    abstract class State<T>(
+    abstract class State<T : Any>(
         initialValue: T,
         stateSpanName: String,
     ) : SchemaType(
@@ -289,7 +290,7 @@ sealed class SchemaType(
         fixedObjectName = "state-$stateSpanName"
     ) {
         override val schemaAttributes: Map<String, String> = mapOf(
-            "initial_value" to initialValue.toString()
+            embStateInitialValue.name to initialValue.toString()
         )
     }
 

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SpanEventAssertions.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SpanEventAssertions.kt
@@ -1,0 +1,36 @@
+package io.embrace.android.embracesdk.assertions
+
+import io.embrace.android.embracesdk.internal.arch.attrs.embStateDroppedByInstrumentation
+import io.embrace.android.embracesdk.internal.arch.attrs.embStateNewValue
+import io.embrace.android.embracesdk.internal.arch.attrs.embStateNotInSession
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
+import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttributeKey
+import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttributeValue
+import io.embrace.android.embracesdk.internal.payload.SpanEvent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+
+fun <T: Any> SpanEvent.assertStateTransition(
+    timestampMs: Long,
+    newStateValue: T,
+    notInSession: Int = 0,
+    droppedByInstrumentation: Int = 0,
+) {
+    assertEquals("transition", name)
+    assertEquals(timestampMs.millisToNanos(), timestampNanos)
+    with(checkNotNull(attributes)) {
+        assertTrue(hasEmbraceAttributeValue(embStateNewValue, newStateValue))
+        if (notInSession > 0) {
+            assertTrue(hasEmbraceAttributeValue(embStateNotInSession, notInSession.toString()))
+        } else {
+            assertFalse(hasEmbraceAttributeKey(embStateNotInSession))
+        }
+
+        if (droppedByInstrumentation > 0) {
+            assertTrue(hasEmbraceAttributeValue(embStateDroppedByInstrumentation, droppedByInstrumentation.toString()))
+        } else {
+            assertFalse(hasEmbraceAttributeKey(embStateDroppedByInstrumentation))
+        }
+    }
+}

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/EmbraceExt.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/EmbraceExt.kt
@@ -32,6 +32,10 @@ fun List<Attribute>.hasEmbraceAttributeKey(embraceAttributeKey: EmbraceAttribute
     it.key == embraceAttributeKey.name
 }
 
+fun List<Attribute>.hasEmbraceAttributeValue(embraceAttributeKey: EmbraceAttributeKey, value: Any): Boolean = any {
+    it.key == embraceAttributeKey.name && it.data == value.toString()
+}
+
 fun List<Attribute>.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean = any {
     it.key == embraceAttribute.key.name && it.data == embraceAttribute.value
 }
@@ -43,6 +47,11 @@ fun Map<String, String>.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute):
 
 fun MutableMap<String, String>.setEmbraceAttribute(embraceAttribute: EmbraceAttribute): Map<String, String> {
     this[embraceAttribute.key.name] = embraceAttribute.value
+    return this
+}
+
+fun MutableMap<String, String>.setEmbraceAttribute(key: EmbraceAttributeKey, value: Any): Map<String, String> {
+    this[key.name] = value.toString()
     return this
 }
 

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanExt.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanExt.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.otel.spans
 
 import io.embrace.android.embracesdk.internal.arch.attrs.EmbraceAttribute
+import io.embrace.android.embracesdk.internal.arch.attrs.EmbraceAttributeKey
 import io.embrace.android.embracesdk.internal.arch.schema.AppTerminationCause
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
@@ -13,6 +14,10 @@ import io.embrace.android.embracesdk.internal.payload.Span
 
 fun Span.hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean {
     return embraceAttribute.value == attributes?.singleOrNull { it.key == embraceAttribute.key.name }?.data
+}
+
+fun Span.hasEmbraceAttributeValue(key: EmbraceAttributeKey, value: Any): Boolean {
+    return attributes?.singleOrNull { it.key == key.name }?.data == value.toString()
 }
 
 fun Span.toFailedSpan(endTimeMs: Long): Span {


### PR DESCRIPTION
## Goal

Define and use the correct Embrace attributes when setting state attributes. Add a bunch of syntactic sugar for testing states as well. As part of that, make the type for the state values to be explicitly non-null, which I should've done earlier anyway.  
