### PR TITLE
Add test case where no data is exported to embrace

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/OTelExportTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/OTelExportTest.kt
@@ -4,6 +4,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.fakes.FakeLogRecordExporter
 import io.embrace.android.embracesdk.fakes.FakeSpanExporter
+import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
+import io.embrace.android.embracesdk.fakes.config.FakeProjectConfig
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.toStringMap
@@ -17,6 +19,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@Suppress("DEPRECATION")
 @OptIn(ExperimentalApi::class)
 @RunWith(AndroidJUnit4::class)
 internal class OTelExportTest {
@@ -72,7 +75,6 @@ internal class OTelExportTest {
         )
     }
 
-    @Suppress("deprecation")
     @Test
     fun `SDK can receive a LogRecordExporter`() {
         var logTimestampNanos = 0L
@@ -103,8 +105,6 @@ internal class OTelExportTest {
         )
     }
 
-    @Suppress("DEPRECATION")
-    @OptIn(ExperimentalApi::class)
     @Test
     fun `add opentelemetry-kotlin exporters`() {
         val logRecordExporter = FakeLogRecordExporter()
@@ -130,5 +130,37 @@ internal class OTelExportTest {
         )
         spanExporter.exportedSpans.single { it.name == spanName }
         logRecordExporter.exportedLogs.single { it.body == logMessage }
+    }
+
+    @Test
+    fun `test otel export without sending data to embrace`() {
+        val logRecordExporter = FakeLogRecordExporter()
+        val spanExporter = FakeSpanExporter()
+        val spanName = "test"
+        val logMessage = "Hello, World!"
+
+        testRule.runTest(
+            instrumentedConfig = FakeInstrumentedConfig(
+                project = FakeProjectConfig(appId = null)
+            ),
+            preSdkStartAction = {
+                embrace.addLogRecordExporter(logRecordExporter)
+                embrace.addSpanExporter(spanExporter)
+            },
+            testCaseAction = {
+                recordSession {
+                    embrace.startSpan(spanName)?.stop()
+                    embrace.logMessage(logMessage, Severity.INFO)
+                }
+            },
+            assertAction = {
+                assertEquals(0, getSessionEnvelopes(0).size)
+                assertEquals(0, getLogEnvelopes(0).size)
+            },
+            otelExportAssertion = {
+                awaitSpans(1) { it.name == spanName }
+                awaitLogs(1) { it.body.asString() == logMessage }
+            }
+        )
     }
 }


### PR DESCRIPTION
## Goal

Adds an integration test case where data export to Embrace via our HTTP API is disabled, but OTLP export is enabled.