### PR TITLE
Avoid obfuscating fragment class names

### DIFF
--- a/embrace-android-sdk/embrace-proguard.cfg
+++ b/embrace-android-sdk/embrace-proguard.cfg
@@ -8,3 +8,7 @@
 ## Keep OkHttp class so we can fetch the version correctly via reflection.
 -keep class okhttp3.OkHttp { *; }
 -keep class okhttp3.OkHttpClient { *; }
+
+# Keep fragment class names
+-keepnames class * extends androidx.fragment.app.Fragment
+-keepnames class * extends android.app.Fragment


### PR DESCRIPTION
## Goal

Adds a keep rule that avoids obfuscating Fragment class names but allows for shrinking of code.