### PR TITLE
Make tracing api non-null

### DIFF
--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/spans/TracingApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/spans/TracingApi.kt
@@ -8,27 +8,27 @@ public interface TracingApi {
 
     /**
      * Create an [EmbraceSpan] with the given name and parent. Passing in a parent that is null result in a new trace with this
-     * [EmbraceSpan] as its root. Returns null if the [EmbraceSpan] cannot be created, e.g if the parent has not been started,
+     * [EmbraceSpan] as its root. Returns a no-op instance if a span cannot be created, e.g if the parent has not been started,
      * the name is invalid, or some other factor due to the current conditions of the SDK.
      *
-     * * Note: the [EmbraceSpan] created will not be started. For a method that creates and starts the span, use [startSpan]
+     * Note: the [EmbraceSpan] created will not be started. For a method that creates and starts the span, use [startSpan]
      */
     public fun createSpan(
         name: String,
         parent: EmbraceSpan? = null,
         autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
-    ): EmbraceSpan?
+    ): EmbraceSpan
 
     /**
      * Create, start, and return a new [EmbraceSpan] with the given name, parent, and start time (epoch time in milliseconds).
-     * Returns null if the [EmbraceSpan] cannot be created or started, like if the parent has been started.
+     * Returns a noop instance if the span cannot be created or started, like if the parent has been started.
      */
     public fun startSpan(
         name: String,
         parent: EmbraceSpan? = null,
         startTimeMs: Long? = null,
         autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
-    ): EmbraceSpan?
+    ): EmbraceSpan
 
     /**
      * Execute the given block of code and record a new span around it with the given parent with optional attributes and list

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
@@ -16,12 +16,11 @@ class EmbraceTracer(
         name: String,
         parent: EmbraceSpan?,
         autoTerminationMode: AutoTerminationMode,
-    ): EmbraceSpan? =
+    ): EmbraceSpan =
         spanService.createSpan(
             name = name,
             parent = parent,
             internal = false,
-            private = false,
             autoTerminationMode = autoTerminationMode
         )
 
@@ -30,13 +29,12 @@ class EmbraceTracer(
         parent: EmbraceSpan?,
         startTimeMs: Long?,
         autoTerminationMode: AutoTerminationMode,
-    ): EmbraceSpan? =
+    ): EmbraceSpan =
         spanService.startSpan(
             name = name,
             parent = parent,
             startTimeMs = startTimeMs?.normalizeTimestampAsMillis(),
             internal = false,
-            private = false,
             autoTerminationMode = autoTerminationMode
         )
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
@@ -11,6 +11,7 @@ import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanData
+import io.embrace.android.embracesdk.internal.otel.spans.NoopEmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSink
@@ -20,7 +21,6 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.tracing.StatusCode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -108,7 +108,7 @@ internal class EmbraceTracerTest {
     @Test
     fun `cannot start a span if given parent has not started`() {
         val notStartedParent = checkNotNull(embraceTracer.createSpan(name = "test-span"))
-        assertNull(embraceTracer.startSpan(name = "child-span", notStartedParent))
+        assertEquals(NoopEmbraceSdkSpan, embraceTracer.startSpan(name = "child-span", notStartedParent))
     }
 
     @Test

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanService.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanService.kt
@@ -63,7 +63,7 @@ class EmbraceSpanService(
         internal: Boolean,
         private: Boolean,
         autoTerminationMode: AutoTerminationMode,
-    ): EmbraceSdkSpan? =
+    ): EmbraceSdkSpan =
         currentDelegate.createSpan(
             name = name,
             parent = parent,
@@ -73,7 +73,7 @@ class EmbraceSpanService(
             autoTerminationMode = autoTerminationMode
         )
 
-    override fun createSpan(otelSpanStartArgs: OtelSpanStartArgs): EmbraceSdkSpan? = currentDelegate.createSpan(otelSpanStartArgs)
+    override fun createSpan(otelSpanStartArgs: OtelSpanStartArgs): EmbraceSdkSpan = currentDelegate.createSpan(otelSpanStartArgs)
 
     override fun <T> recordSpan(
         name: String,

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/NoopEmbraceSdkSpan.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/NoopEmbraceSdkSpan.kt
@@ -1,0 +1,94 @@
+package io.embrace.android.embracesdk.internal.otel.spans
+
+import io.embrace.android.embracesdk.internal.arch.attrs.EmbraceAttribute
+import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.arch.schema.LinkType
+import io.embrace.android.embracesdk.internal.payload.Link
+import io.embrace.android.embracesdk.internal.payload.Span
+import io.embrace.android.embracesdk.internal.payload.SpanEvent
+import io.embrace.android.embracesdk.spans.AutoTerminationMode
+import io.embrace.android.embracesdk.spans.EmbraceSpan
+import io.embrace.android.embracesdk.spans.ErrorCode
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.context.Context
+import io.embrace.opentelemetry.kotlin.tracing.data.StatusData
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanContext
+import io.embrace.opentelemetry.kotlin.tracing.model.SpanKind
+
+@OptIn(ExperimentalApi::class)
+object NoopEmbraceSdkSpan : EmbraceSdkSpan {
+
+    override val spanContext: SpanContext? = null
+    override val traceId: String? = null
+    override val spanId: String? = null
+    override val isRecording: Boolean = false
+    override val parent: EmbraceSpan? = null
+    override val autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE
+
+    override fun start(startTimeMs: Long?): Boolean = false
+
+    override fun stop(errorCode: ErrorCode?, endTimeMs: Long?): Boolean = false
+
+    override fun addEvent(
+        name: String,
+        timestampMs: Long?,
+        attributes: Map<String, String>,
+    ): Boolean = false
+
+    override fun recordException(
+        exception: Throwable,
+        attributes: Map<String, String>,
+    ): Boolean = false
+
+    override fun addAttribute(key: String, value: String): Boolean = false
+
+    override fun updateName(newName: String): Boolean = false
+
+    override fun addLink(
+        linkedSpanContext: SpanContext,
+        attributes: Map<String, String>,
+    ): Boolean = false
+
+    override fun asNewContext(): Context? = null
+
+    override fun snapshot(): Span? = null
+
+    override fun hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean = false
+
+    override fun getSystemAttribute(key: String): String? = null
+
+    override fun setSystemAttribute(key: String, value: String) {
+    }
+
+    override fun addSystemAttribute(key: String, value: String) {
+    }
+
+    override fun removeSystemAttribute(key: String) {
+    }
+
+    override fun addSystemEvent(
+        name: String,
+        timestampMs: Long?,
+        attributes: Map<String, String>?,
+    ): Boolean = false
+
+    override fun removeSystemEvents(type: EmbType): Boolean = false
+
+    override fun getStartTimeMs(): Long? = null
+
+    override fun addSystemLink(
+        linkedSpanContext: SpanContext,
+        type: LinkType,
+        attributes: Map<String, String>,
+    ): Boolean = false
+
+    override fun attributes(): Map<String, Any> = emptyMap()
+
+    override fun name(): String = ""
+
+    override val spanKind: SpanKind = SpanKind.INTERNAL
+    override var status: StatusData = StatusData.Unset
+
+    override fun events(): List<SpanEvent> = emptyList()
+    override fun links(): List<Link> = emptyList()
+}

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanService.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanService.kt
@@ -13,8 +13,8 @@ import io.embrace.android.embracesdk.spans.ErrorCode
 interface SpanService : Initializable {
 
     /**
-     * Return an [EmbraceSpan] instance that can be used to record spans. Returns null if at least one input parameter is not valid or if
-     * the SDK or session is not in a state where a new span can be recorded.
+     * Return an [EmbraceSpan] instance that can be used to record spans. Returns noop instance if at least one input parameter
+     * is not valid or if the SDK or session is not in a state where a new span can be recorded.
      */
     fun createSpan(
         name: String,
@@ -23,13 +23,13 @@ interface SpanService : Initializable {
         internal: Boolean = true,
         private: Boolean = false,
         autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
-    ): EmbraceSdkSpan?
+    ): EmbraceSdkSpan
 
     /**
-     * Return an [EmbraceSpan] instance that can be used to record spans given the [OtelSpanStartArgs]. Returns null if the builder
+     * Return an [EmbraceSpan] instance that can be used to record spans given the [OtelSpanStartArgs]. Returns noop instance if the builder
      * will not build a valid span or if the SDK and session is not in a state where a new span can be recorded.
      */
-    fun createSpan(otelSpanStartArgs: OtelSpanStartArgs): EmbraceSdkSpan?
+    fun createSpan(otelSpanStartArgs: OtelSpanStartArgs): EmbraceSdkSpan
 
     /**
      * Create, start, and return a new [EmbraceSpan] with the given parameters
@@ -42,21 +42,19 @@ interface SpanService : Initializable {
         internal: Boolean = true,
         private: Boolean = false,
         autoTerminationMode: AutoTerminationMode = AutoTerminationMode.NONE,
-    ): EmbraceSdkSpan? {
-        createSpan(
+    ): EmbraceSdkSpan {
+        val newSpan = createSpan(
             name = name,
             parent = parent,
             type = type,
             internal = internal,
             private = private,
             autoTerminationMode = autoTerminationMode,
-        )?.let { newSpan ->
-            if (newSpan.start(startTimeMs)) {
-                return newSpan
-            }
+        )
+        return when {
+            newSpan.start(startTimeMs) -> newSpan
+            else -> NoopEmbraceSdkSpan
         }
-
-        return null
     }
 
     /**

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImpl.kt
@@ -44,7 +44,7 @@ class SpanServiceImpl(
         internal: Boolean,
         private: Boolean,
         autoTerminationMode: AutoTerminationMode,
-    ): EmbraceSdkSpan? {
+    ): EmbraceSdkSpan {
         EmbTrace.trace("span-create") {
             return if (name.isNotBlank() && canStartNewSpan(parent, internal)) {
                 embraceSpanFactory.create(
@@ -60,12 +60,12 @@ class SpanServiceImpl(
                     )
                 )
             } else {
-                null
+                NoopEmbraceSdkSpan
             }
         }
     }
 
-    override fun createSpan(otelSpanStartArgs: OtelSpanStartArgs): EmbraceSdkSpan? {
+    override fun createSpan(otelSpanStartArgs: OtelSpanStartArgs): EmbraceSdkSpan {
         EmbTrace.trace("span-create") {
             return if (
                 otelSpanStartArgs.initialSpanName.isNotBlank() &&
@@ -76,7 +76,7 @@ class SpanServiceImpl(
             ) {
                 embraceSpanFactory.create(otelSpanStartArgs)
             } else {
-                null
+                NoopEmbraceSdkSpan
             }
         }
     }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/UninitializedSdkSpanService.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/UninitializedSdkSpanService.kt
@@ -28,9 +28,9 @@ class UninitializedSdkSpanService : SpanService {
         internal: Boolean,
         private: Boolean,
         autoTerminationMode: AutoTerminationMode,
-    ): EmbraceSdkSpan? = null
+    ): EmbraceSdkSpan = NoopEmbraceSdkSpan
 
-    override fun createSpan(otelSpanStartArgs: OtelSpanStartArgs): EmbraceSdkSpan? = null
+    override fun createSpan(otelSpanStartArgs: OtelSpanStartArgs): EmbraceSdkSpan = NoopEmbraceSdkSpan
 
     override fun <T> recordSpan(
         name: String,

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanServiceTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanServiceTest.kt
@@ -21,7 +21,6 @@ import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -95,8 +94,8 @@ internal class EmbraceSpanServiceTest {
             openTelemetrySupplier = { fakeOpenTelemetry() }
         )
         assertFalse(uninitializedService.initialized())
-        assertNull(uninitializedService.createSpan("test-span"))
-        assertNull(uninitializedService.startSpan("test-span"))
+        assertEquals(NoopEmbraceSdkSpan, uninitializedService.createSpan("test-span"))
+        assertEquals(NoopEmbraceSdkSpan, uninitializedService.startSpan("test-span"))
         assertTrue(uninitializedService.recordCompletedSpan("test-span", 10, 20))
         var lambdaRan = false
         uninitializedService.recordSpan("test-span") { lambdaRan = true }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
@@ -161,13 +161,13 @@ internal class SpanServiceImplTest {
     @Test
     fun `cannot create span with if validation fails`() {
         spanCreationAllowed = false
-        assertNull(spansService.createSpan(name = "test"))
+        assertEquals(NoopEmbraceSdkSpan, spansService.createSpan(name = "test"))
     }
 
     @Test
     fun `cannot create span with blank name`() {
-        assertNull(spansService.createSpan(name = ""))
-        assertNull(spansService.createSpan(name = " "))
+        assertEquals(NoopEmbraceSdkSpan, spansService.createSpan(name = ""))
+        assertEquals(NoopEmbraceSdkSpan, spansService.createSpan(name = " "))
     }
 
     @Test

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -30,6 +30,7 @@ import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.internal.session.getSessionSpan
 import io.embrace.android.embracesdk.internal.arch.state.AppState
+import io.embrace.android.embracesdk.internal.otel.spans.NoopEmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.toEmbraceSpanData
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -44,7 +45,6 @@ import java.util.concurrent.TimeUnit
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -345,13 +345,13 @@ internal class TracingApiTest {
     fun `can only create span if there is a valid session`() {
         testRule.runTest(
             preSdkStartAction = {
-                assertNull(embrace.startSpan("test"))
+                assertEquals(NoopEmbraceSdkSpan, embrace.startSpan("test"))
             },
             testCaseAction = {
                 recordSession {
                     assertNotNull(embrace.startSpan("test"))
                 }
-                assertNull(embrace.startSpan("test"))
+                assertEquals(NoopEmbraceSdkSpan, embrace.startSpan("test"))
                 recordSession {
                     assertNotNull(embrace.startSpan("test"))
                 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
@@ -19,6 +19,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
+import io.embrace.android.embracesdk.internal.otel.spans.NoopEmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
@@ -62,7 +63,7 @@ internal class BackgroundActivityDisabledTest {
                 assertTrue(embrace.isStarted)
                 assertTrue(embrace.currentSessionId.isNullOrBlank())
                 assertTrue(embrace.deviceId.isNotBlank())
-                assertNull(embrace.startSpan("test"))
+                assertEquals(NoopEmbraceSdkSpan, embrace.startSpan("test"))
                 embrace.logError("error")
 
                 embrace.addBreadcrumb("not-logged")


### PR DESCRIPTION
## Goal

Alters `TracingApi` so that if a span cannot be created, a noop instance is returned rather than null. This results in better usability for folks creating/starting spans.

## Testing

Updated existing tests.
