### PR TITLE
Create OTel-agnostic service to create OTel logs

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
@@ -79,11 +79,11 @@ class EssentialServiceModuleImpl(
 
     override val telemetryDestination: TelemetryDestination by singleton {
         TelemetryDestinationImpl(
-            logger = openTelemetryModule.otelSdkWrapper.logger,
             sessionTracker = sessionTracker,
             appStateTracker = appStateTracker,
             clock = initModule.clock,
             spanService = openTelemetryModule.spanService,
+            eventService = openTelemetryModule.eventService,
             currentSessionSpan = openTelemetryModule.currentSessionSpan,
         )
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModule.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.injection
 import io.embrace.android.embracesdk.internal.config.behavior.OtelBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehavior
 import io.embrace.android.embracesdk.internal.otel.config.OtelSdkConfig
+import io.embrace.android.embracesdk.internal.otel.logs.EventService
 import io.embrace.android.embracesdk.internal.otel.logs.LogSink
 import io.embrace.android.embracesdk.internal.otel.sdk.OtelSdkWrapper
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
@@ -47,6 +48,11 @@ interface OpenTelemetryModule {
      * Implementation of public tracing API
      */
     val embraceTracer: EmbraceTracer
+
+    /**
+     * Service to record events
+     */
+    val eventService: EventService
 
     /**
      * Provides storage for completed logs that have not been forwarded yet to the delivery service

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
@@ -6,6 +6,8 @@ import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehavior
 import io.embrace.android.embracesdk.internal.otel.config.OtelSdkConfig
 import io.embrace.android.embracesdk.internal.otel.impl.EmbClock
+import io.embrace.android.embracesdk.internal.otel.logs.EventService
+import io.embrace.android.embracesdk.internal.otel.logs.EventServiceImpl
 import io.embrace.android.embracesdk.internal.otel.logs.LogSink
 import io.embrace.android.embracesdk.internal.otel.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.otel.sdk.DataValidator
@@ -140,6 +142,12 @@ class OpenTelemetryModuleImpl(
     override val embraceTracer: EmbraceTracer by singleton {
         EmbraceTracer(
             spanService = spanService,
+        )
+    }
+
+    override val eventService: EventService by lazy {
+        EventServiceImpl(
+            loggerProvider = { otelSdkWrapper.logger }
         )
     }
 

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEventService.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEventService.kt
@@ -1,0 +1,36 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.Severity
+import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
+import io.embrace.android.embracesdk.internal.otel.logs.EventService
+
+class FakeEventService : EventService {
+    val events: MutableList<EventData> = mutableListOf()
+
+    override fun log(
+        logTimeMs: Long,
+        schemaType: SchemaType,
+        severity: Severity,
+        message: String,
+        isPrivate: Boolean,
+        embraceAttributes: Map<String, String>,
+    ) {
+        events.add(EventData(
+            logTimeMs = logTimeMs,
+            schemaType = schemaType,
+            severity = severity,
+            message = message,
+            isPrivate = isPrivate,
+            attributes = embraceAttributes
+        ))
+    }
+
+    class EventData(
+        val logTimeMs: Long,
+        val schemaType: SchemaType,
+        val severity: Severity,
+        val message: String,
+        val isPrivate: Boolean,
+        val attributes: Map<String, String>,
+    )
+}

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EventService.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EventService.kt
@@ -1,0 +1,18 @@
+package io.embrace.android.embracesdk.internal.otel.logs
+
+import io.embrace.android.embracesdk.Severity
+import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
+
+/**
+ * An OTel-agnostic API to create telemetry modeled as OTel LogRecords aka Events
+ */
+interface EventService {
+    fun log(
+        logTimeMs: Long,
+        schemaType: SchemaType,
+        severity: Severity,
+        message: String,
+        isPrivate: Boolean,
+        embraceAttributes: Map<String, String>
+    )
+}

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EventServiceImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EventServiceImpl.kt
@@ -1,0 +1,66 @@
+package io.embrace.android.embracesdk.internal.otel.logs
+
+import io.embrace.android.embracesdk.Severity
+import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
+import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
+import io.embrace.android.embracesdk.internal.utils.Provider
+import io.embrace.android.embracesdk.internal.utils.Uuid
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.logging.Logger
+import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.LogAttributes
+import java.util.concurrent.TimeUnit
+
+@OptIn(ExperimentalApi::class, IncubatingApi::class)
+class EventServiceImpl(
+    loggerProvider: Provider<Logger>
+) : EventService {
+
+    private val logger: Logger = loggerProvider()
+
+    override fun log(
+        logTimeMs: Long,
+        schemaType: SchemaType,
+        severity: Severity,
+        message: String,
+        isPrivate: Boolean,
+        embraceAttributes: Map<String, String>
+    ) {
+        val severityNumber = when (severity) {
+            Severity.INFO -> SeverityNumber.INFO
+            Severity.WARNING -> SeverityNumber.WARN
+            Severity.ERROR -> SeverityNumber.ERROR
+        }
+        logger.log(
+            body = message,
+            severityNumber = severityNumber,
+            severityText = getSeverityText(severityNumber),
+            timestamp = TimeUnit.MILLISECONDS.toNanos(logTimeMs)
+        ) {
+            if (!embraceAttributes.contains(LogAttributes.LOG_RECORD_UID)) {
+                setStringAttribute(LogAttributes.LOG_RECORD_UID, Uuid.getEmbUuid())
+            }
+
+            if (isPrivate) {
+                setStringAttribute(PrivateSpan.key.name, PrivateSpan.value)
+            }
+
+            with(schemaType) {
+                setStringAttribute(telemetryType.key.name, telemetryType.value)
+                attributes().forEach {
+                    setStringAttribute(it.key, it.value)
+                }
+            }
+
+            embraceAttributes.forEach {
+                setStringAttribute(it.key, it.value)
+            }
+        }
+    }
+
+    private fun getSeverityText(severity: SeverityNumber) = when (severity) {
+        SeverityNumber.WARN -> "WARNING"
+        else -> severity.name
+    }
+}

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EventServiceImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EventServiceImplTest.kt
@@ -1,0 +1,86 @@
+package io.embrace.android.embracesdk.internal.otel.logs
+
+import io.embrace.android.embracesdk.Severity
+import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryLogger
+import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
+import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
+import io.embrace.android.embracesdk.internal.arch.schema.TelemetryAttributes
+import io.embrace.android.embracesdk.internal.clock.nanosToMillis
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
+import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.LogAttributes
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalApi::class, IncubatingApi::class)
+class EventServiceImplTest {
+    lateinit var logger: FakeOpenTelemetryLogger
+    lateinit var impl: EventServiceImpl
+
+    @Before
+    fun setup() {
+        logger = FakeOpenTelemetryLogger()
+        impl = EventServiceImpl(
+            loggerProvider = { logger }
+        )
+    }
+
+    @Test
+    fun `check expected values added to every event`() {
+        val embraceAttributes = mapOf("foo" to "bar")
+        impl.log(
+            logTimeMs = 1000L,
+            schemaType = SchemaType.Log(TelemetryAttributes(customAttributes = mapOf("custom" to "attr"))),
+            severity = Severity.ERROR,
+            message = "test",
+            isPrivate = true,
+            embraceAttributes = embraceAttributes
+        )
+
+        with(logger.logs.single()) {
+            assertEquals(1000L, timestamp?.nanosToMillis())
+            assertEquals("test", body)
+            assertEquals(SeverityNumber.ERROR, severityNumber)
+            assertEquals("true", attributes[PrivateSpan.key.name])
+            assertEquals("attr", attributes["custom"])
+            assertEquals("bar", attributes["foo"])
+            assertNotNull(attributes[LogAttributes.LOG_RECORD_UID])
+        }
+    }
+
+    @Test
+    fun `no extra attribute added when event is non-private`() {
+        impl.log(
+            logTimeMs = 1000L,
+            schemaType = SchemaType.Log(TelemetryAttributes()),
+            severity = Severity.INFO,
+            message = "test",
+            isPrivate = false,
+            embraceAttributes = emptyMap(),
+        )
+
+        with(logger.logs.single()) {
+            assertFalse(attributes.containsKey(PrivateSpan.key.name))
+        }
+    }
+
+    @Test
+    fun `existing log id not overridden`() {
+        impl.log(
+            logTimeMs = 1000L,
+            schemaType = SchemaType.Log(TelemetryAttributes(customAttributes = mapOf(LogAttributes.LOG_RECORD_UID to "foo"))),
+            severity = Severity.INFO,
+            message = "test",
+            isPrivate = false,
+            embraceAttributes = emptyMap(),
+        )
+
+        with(logger.logs.single()) {
+            assertEquals("foo", attributes[LogAttributes.LOG_RECORD_UID])
+        }
+    }
+}

--- a/embrace-microbenchmark/src/androidTest/kotlin/io/embrace/android/embracesdk/benchmark/TelemetryDestinationHarness.kt
+++ b/embrace-microbenchmark/src/androidTest/kotlin/io/embrace/android/embracesdk/benchmark/TelemetryDestinationHarness.kt
@@ -39,11 +39,11 @@ internal class TelemetryDestinationHarness {
     val currentSessionSpan = otelModule.currentSessionSpan
 
     val destination: TelemetryDestination = TelemetryDestinationImpl(
-        logger = otelModule.otelSdkWrapper.logger,
         sessionTracker = NoopSessionTracker,
         appStateTracker = NoopAppStateTracker,
         clock = initModule.clock,
         spanService = spanService,
+        eventService = otelModule.eventService,
         currentSessionSpan = otelModule.currentSessionSpan,
     )
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.internal.config.behavior.OtelBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehavior
 import io.embrace.android.embracesdk.internal.injection.OpenTelemetryModule
 import io.embrace.android.embracesdk.internal.otel.config.OtelSdkConfig
+import io.embrace.android.embracesdk.internal.otel.logs.EventService
 import io.embrace.android.embracesdk.internal.otel.logs.LogSink
 import io.embrace.android.embracesdk.internal.otel.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.otel.sdk.OtelSdkWrapper
@@ -38,6 +39,8 @@ class FakeOpenTelemetryModule(
             packageName = "com.test.app",
             systemInfo = systemInfo,
         )
+
+    override val eventService: EventService = FakeEventService()
 
     override val spanService: SpanService = FakeSpanService()
 


### PR DESCRIPTION
## Goal

Create a new entry point, `EventService`, in the `embrace-android-otel` module responsible for converting all parameters into OTel and using its API to create a LogRecord. `TelemetryDestination` did that previously for logs, but like `SpanService` for Spans, it should be consolidated within that module. Note that `LogService` is not the analogue for `SpanService`, as it is closer to a DataSource for Embrace Logs rather than a general purpose creator of OTel LogRecords which is what's needed.

It's called `EventService` because OTel is moving in that direction in calling its logging API an Events API. Also we already have a LogService...

<!-- Describe what this change seeks to address -->

## Testing

Moved testing of capabilities previously done at `TelemetryDestination` into new tests at the lower level, `EventService`

<!-- Describe how this change has been tested -->