### PR TITLE
Remove error log count method from log service

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SessionOrchestrationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SessionOrchestrationModuleImpl.kt
@@ -52,7 +52,7 @@ class SessionOrchestrationModuleImpl(
         SessionSpanAttrPopulatorImpl(
             essentialServiceModule.telemetryDestination,
             startupDurationProvider,
-            logModule.logService,
+            logModule.logLimitingService,
             payloadSourceModule.metadataService
         )
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogService.kt
@@ -18,11 +18,4 @@ interface LogService {
         attributes: Map<String, Any>,
         schemaProvider: (TelemetryAttributes) -> SchemaType,
     )
-
-    /**
-     * Gets the number of error logs that have been recorded.
-     *
-     * @return the error logs count
-     */
-    fun getErrorLogsCount(): Int
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogServiceImpl.kt
@@ -49,10 +49,6 @@ class LogServiceImpl(
         destination.addLog(schemaProvider(telemetryAttributes), severity, trimToMaxLength(message))
     }
 
-    override fun getErrorLogsCount(): Int {
-        return logLimitingService.getCount(LogSeverity.ERROR)
-    }
-
     private fun trimToMaxLength(message: String): String {
         val maxLength = if (configService.appFramework == AppFramework.UNITY) {
             LOG_MESSAGE_UNITY_MAXIMUM_ALLOWED_LENGTH

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionSpanAttrPopulatorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionSpanAttrPopulatorImpl.kt
@@ -11,9 +11,10 @@ import io.embrace.android.embracesdk.internal.arch.attrs.embSessionStartType
 import io.embrace.android.embracesdk.internal.arch.attrs.embSessionStartupDuration
 import io.embrace.android.embracesdk.internal.arch.attrs.embState
 import io.embrace.android.embracesdk.internal.arch.attrs.embTerminated
+import io.embrace.android.embracesdk.internal.arch.datasource.LogSeverity
 import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
 import io.embrace.android.embracesdk.internal.capture.metadata.MetadataService
-import io.embrace.android.embracesdk.internal.logs.LogService
+import io.embrace.android.embracesdk.internal.logs.LogLimitingService
 import io.embrace.android.embracesdk.internal.session.LifeEventType
 import io.embrace.android.embracesdk.internal.session.SessionToken
 import java.util.Locale
@@ -21,7 +22,7 @@ import java.util.Locale
 internal class SessionSpanAttrPopulatorImpl(
     private val destination: TelemetryDestination,
     private val startupDurationProvider: () -> Long?,
-    private val logService: LogService,
+    private val logLimitingService: LogLimitingService,
     private val metadataService: MetadataService,
 ) : SessionSpanAttrPopulator {
 
@@ -55,7 +56,7 @@ internal class SessionSpanAttrPopulatorImpl(
                 }
             }
 
-            val logCount = logService.getErrorLogsCount()
+            val logCount = logLimitingService.getCount(LogSeverity.ERROR)
             addSessionAttribute(embErrorLogCount.name, logCount.toString())
 
             metadataService.getDiskUsage()?.deviceDiskFree?.let { free ->

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -28,6 +28,7 @@ internal class EmbraceLogServiceTest {
     private lateinit var destination: FakeTelemetryDestination
     private lateinit var fakeSessionPropertiesService: FakeSessionPropertiesService
     private lateinit var fakeConfigService: FakeConfigService
+    private lateinit var logLimitingService: LogLimitingService
     private lateinit var payloadStore: FakePayloadStore
 
     @Before
@@ -40,6 +41,7 @@ internal class EmbraceLogServiceTest {
         fakeSessionPropertiesService = FakeSessionPropertiesService()
         destination = FakeTelemetryDestination()
         payloadStore = FakePayloadStore()
+        logLimitingService = LogLimitingServiceImpl(fakeConfigService)
         logService = createEmbraceLogService()
     }
 
@@ -47,7 +49,7 @@ internal class EmbraceLogServiceTest {
         destination = destination,
         configService = fakeConfigService,
         sessionPropertiesService = fakeSessionPropertiesService,
-        logLimitingService = LogLimitingServiceImpl(fakeConfigService)
+        logLimitingService = logLimitingService
     )
 
     @Test
@@ -109,6 +111,7 @@ internal class EmbraceLogServiceTest {
                 errorLogLimit = testLogLimit
             )
         )
+        logLimitingService = LogLimitingServiceImpl(fakeConfigService)
         logService = createEmbraceLogService()
 
         // when logging exactly the allowed count of each type
@@ -213,7 +216,7 @@ internal class EmbraceLogServiceTest {
         }
 
         // then the correct number of error logs is returned
-        assertEquals(5, logService.getErrorLogsCount())
+        assertEquals(5, logLimitingService.getCount(LogSeverity.ERROR))
     }
 
     @Test

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.fakes.FakeDataSource
 import io.embrace.android.embracesdk.fakes.FakeLogEnvelopeSource
-import io.embrace.android.embracesdk.fakes.FakeLogService
+import io.embrace.android.embracesdk.fakes.FakeLogLimitingService
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakePayloadMessageCollator
 import io.embrace.android.embracesdk.fakes.FakePayloadStore
@@ -439,7 +439,7 @@ internal class SessionOrchestratorTest {
             SessionSpanAttrPopulatorImpl(
                 destination,
                 { 0 },
-                FakeLogService(),
+                FakeLogLimitingService(),
                 FakeMetadataService()
             )
         )

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionSpanAttrPopulatorImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionSpanAttrPopulatorImplTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.session.orchestrator
 
-import io.embrace.android.embracesdk.fakes.FakeLogService
+import io.embrace.android.embracesdk.fakes.FakeLogLimitingService
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.fakes.FakeTelemetryDestination
@@ -25,7 +25,7 @@ internal class SessionSpanAttrPopulatorImplTest {
         populator = SessionSpanAttrPopulatorImpl(
             destination,
             { 0 },
-            FakeLogService(),
+            FakeLogLimitingService(),
             FakeMetadataService()
         )
     }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogService.kt
@@ -15,7 +15,6 @@ class FakeLogService : LogService {
 
     val logs: MutableList<String> = mutableListOf()
     val loggedMessages: MutableList<LogData> = mutableListOf()
-    var errorLogIds: List<String> = listOf()
 
     override fun log(
         message: String,
@@ -31,9 +30,5 @@ class FakeLogService : LogService {
                 schemaType = schemaProvider(TelemetryAttributes())
             )
         )
-    }
-
-    override fun getErrorLogsCount(): Int {
-        return errorLogIds.count()
     }
 }


### PR DESCRIPTION
## Goal

Get the error log count from a session directly from `LogLimitingService` so that `LogService` doesn't have to expose that.

<!-- Describe how this change has been tested -->