### PR TITLE
Refactor session properties reification

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
@@ -85,6 +85,8 @@ class EssentialServiceModuleImpl(
             spanService = openTelemetryModule.spanService,
             eventService = openTelemetryModule.eventService,
             currentSessionSpan = openTelemetryModule.currentSessionSpan,
-        )
+        ) {
+            sessionPropertiesService.getProperties()
+        }
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/LogModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/LogModuleImpl.kt
@@ -30,7 +30,6 @@ class LogModuleImpl(
         LogServiceImpl(
             essentialServiceModule.telemetryDestination,
             configService,
-            essentialServiceModule.sessionPropertiesService,
             logLimitingService
         )
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogServiceImpl.kt
@@ -5,7 +5,6 @@ import io.embrace.android.embracesdk.internal.arch.datasource.LogSeverity
 import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.arch.schema.TelemetryAttributes
-import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
 import io.embrace.android.embracesdk.internal.payload.AppFramework
@@ -23,7 +22,6 @@ import java.io.Serializable
 class LogServiceImpl(
     private val destination: TelemetryDestination,
     private val configService: ConfigService,
-    private val sessionPropertiesService: SessionPropertiesService,
     private val logLimitingService: LogLimitingService,
 ) : LogService {
 
@@ -42,7 +40,6 @@ class LogServiceImpl(
 
         val redactedAttributes = redactSensitiveAttributes(attributes)
         val telemetryAttributes = TelemetryAttributes(
-            sessionPropertiesProvider = sessionPropertiesService::getProperties,
             customAttributes = redactedAttributes.plus(LogAttributes.LOG_RECORD_UID to Uuid.getEmbUuid()),
         )
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/schema/TelemetryAttributesTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/schema/TelemetryAttributesTest.kt
@@ -1,9 +1,6 @@
 package io.embrace.android.embracesdk.internal.arch.schema
 
-import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.internal.arch.attrs.embProcessIdentifier
-import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
-import io.embrace.android.embracesdk.internal.session.getSessionProperty
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.opentelemetry.kotlin.semconv.ExceptionAttributes
 import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
@@ -16,14 +13,12 @@ import org.junit.Test
 internal class TelemetryAttributesTest {
 
     private lateinit var customAttributes: Map<String, String>
-    private lateinit var sessionPropertiesService: SessionPropertiesService
     private lateinit var telemetryAttributes: TelemetryAttributes
     private lateinit var sessionId: String
 
     @Before
     fun setup() {
         customAttributes = mapOf("custom" to "attributeValue")
-        sessionPropertiesService = FakeSessionPropertiesService()
         sessionId = Uuid.getEmbUuid()
     }
 
@@ -43,41 +38,26 @@ internal class TelemetryAttributesTest {
     @Test
     fun `all attributes types`() {
         telemetryAttributes = TelemetryAttributes(
-            sessionPropertiesProvider = sessionPropertiesService::getProperties,
             customAttributes = customAttributes
         )
         val sessionIdKey = SessionAttributes.SESSION_ID
         telemetryAttributes.setAttribute(sessionIdKey, sessionId)
-        sessionPropertiesService.addProperty("perm", "permVal", true)
-        sessionPropertiesService.addProperty("temp", "tempVal", false)
 
         val attributes = telemetryAttributes.snapshot()
         assertEquals("attributeValue", attributes["custom"])
-        assertEquals("permVal", attributes.getSessionProperty("perm"))
-        assertEquals("tempVal", attributes.getSessionProperty("temp"))
         assertEquals(sessionId, attributes[sessionIdKey])
-        sessionPropertiesService.addProperty("temp", "newVal", false)
-        assertEquals("newVal", telemetryAttributes.snapshot().getSessionProperty("temp"))
     }
 
     @Test
     fun `overwritten values returned`() {
         val newSessionId = Uuid.getEmbUuid()
-        telemetryAttributes = TelemetryAttributes(
-            sessionPropertiesProvider = sessionPropertiesService::getProperties,
-        )
+        telemetryAttributes = TelemetryAttributes()
         val sessionIdKey = SessionAttributes.SESSION_ID
         telemetryAttributes.setAttribute(sessionIdKey, sessionId)
         telemetryAttributes.setAttribute(sessionIdKey, newSessionId)
-        sessionPropertiesService.addProperty("perm", "permVal", true)
-        sessionPropertiesService.addProperty("temp", "tempVal", false)
-        sessionPropertiesService.addProperty("perm", "newPermVal", true)
-        sessionPropertiesService.addProperty("temp", "newTempVal", false)
 
         val attributes = telemetryAttributes.snapshot()
-        assertEquals(3, attributes.size)
-        assertEquals("newPermVal", attributes.getSessionProperty("perm"))
-        assertEquals("newTempVal", attributes.getSessionProperty("temp"))
+        assertEquals(1, attributes.size)
         assertEquals(newSessionId, attributes[sessionIdKey])
     }
 
@@ -95,17 +75,13 @@ internal class TelemetryAttributesTest {
 
     @Test
     fun `log properties and session properties are included in the attributes`() {
-        sessionPropertiesService.addProperty("perm", "permVal", true)
-        sessionPropertiesService.addProperty("temp", "tempVal", false)
-
         telemetryAttributes = TelemetryAttributes(
-            sessionPropertiesProvider = sessionPropertiesService::getProperties,
             customAttributes = customAttributes
         )
         telemetryAttributes.setAttribute(SessionAttributes.SESSION_ID, sessionId)
 
         val attributes = telemetryAttributes.snapshot()
-        assertEquals(4, attributes.size)
+        assertEquals(2, attributes.size)
     }
 
     @Test

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -7,7 +7,6 @@ import io.embrace.android.embracesdk.fakes.FakeTelemetryDestination
 import io.embrace.android.embracesdk.fakes.behavior.FakeLogMessageBehavior
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.config.FakeRedactionConfig
-import io.embrace.android.embracesdk.internal.arch.attrs.toEmbraceAttributeName
 import io.embrace.android.embracesdk.internal.arch.datasource.LogSeverity
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType.Log
 import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
@@ -48,7 +47,6 @@ internal class EmbraceLogServiceTest {
     private fun createEmbraceLogService() = LogServiceImpl(
         destination = destination,
         configService = fakeConfigService,
-        sessionPropertiesService = fakeSessionPropertiesService,
         logLimitingService = logLimitingService
     )
 
@@ -68,18 +66,13 @@ internal class EmbraceLogServiceTest {
     }
 
     @Test
-    fun `telemetry attributes are set correctly, including session properties and LOG_RECORD_UID`() {
-        // given a session with properties
-        fakeSessionPropertiesService.props["someProperty"] = "someValue"
-        logService = createEmbraceLogService()
-
+    fun `LOG_RECORD_UID set properly`() {
         // when logging the message
         logService.log("message", LogSeverity.INFO, emptyMap(), ::Log)
 
         // then the telemetry attributes are set correctly
         val log = destination.logEvents.single()
         val attributes = log.schemaType.attributes()
-        assertEquals("someValue", attributes["someProperty".toEmbraceAttributeName()])
         assertTrue(attributes.containsKey(LogAttributes.LOG_RECORD_UID))
     }
 

--- a/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/TelemetryAttributes.kt
+++ b/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/TelemetryAttributes.kt
@@ -1,14 +1,12 @@
 package io.embrace.android.embracesdk.internal.arch.schema
 
 import io.embrace.android.embracesdk.internal.arch.attrs.EmbraceAttributeKey
-import io.embrace.android.embracesdk.internal.arch.attrs.toEmbraceAttributeName
 import io.embrace.android.embracesdk.internal.arch.isBlankish
 
 /**
  * Object that aggregates various attributes and returns a [Map] that represents the values at the current state
  */
 class TelemetryAttributes(
-    private val sessionPropertiesProvider: () -> Map<String, String>? = { null },
     private val customAttributes: Map<String, String>? = null,
 ) {
     private val map: MutableMap<String, String> = mutableMapOf()
@@ -20,9 +18,6 @@ class TelemetryAttributes(
     fun snapshot(): Map<String, String> {
         val result = mutableMapOf<String, String>()
         customAttributes?.let { result.putAll(it) }
-        sessionPropertiesProvider()?.let { properties ->
-            result.putAll(properties.mapKeys { property -> property.key.toEmbraceAttributeName() })
-        }
 
         result.putAll(map.mapKeys { it.key })
 

--- a/embrace-microbenchmark/src/androidTest/kotlin/io/embrace/android/embracesdk/benchmark/TelemetryDestinationHarness.kt
+++ b/embrace-microbenchmark/src/androidTest/kotlin/io/embrace/android/embracesdk/benchmark/TelemetryDestinationHarness.kt
@@ -38,6 +38,8 @@ internal class TelemetryDestinationHarness {
     val spanService = otelModule.spanService
     val currentSessionSpan = otelModule.currentSessionSpan
 
+    val sessionProperties: MutableMap<String, String> = mutableMapOf()
+
     val destination: TelemetryDestination = TelemetryDestinationImpl(
         sessionTracker = NoopSessionTracker,
         appStateTracker = NoopAppStateTracker,
@@ -45,6 +47,7 @@ internal class TelemetryDestinationHarness {
         spanService = spanService,
         eventService = otelModule.eventService,
         currentSessionSpan = otelModule.currentSessionSpan,
+        sessionPropertiesProvider = sessionProperties::toMap
     )
 
     private class TestInitModule : InitModule {

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeLogModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeLogModule.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.fakes.injection
 
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeLogLimitingService
-import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.fakes.FakeTelemetryDestination
 import io.embrace.android.embracesdk.internal.injection.LogModule
 import io.embrace.android.embracesdk.internal.logs.LogLimitingService
@@ -16,7 +15,6 @@ class FakeLogModule(
     override val logService: LogService = LogServiceImpl(
         FakeTelemetryDestination(),
         FakeConfigService(),
-        FakeSessionPropertiesService(),
         logLimitingService
     ),
 ) : LogModule {


### PR DESCRIPTION
## Goal

Session properties were being provided by `SessionPropertiesService`and put into logs via `TelemetryAttributes`, though a few different places do the job of passing the data from one place to another, including `LogService`. Moving this lower down into `TelemetryDestination` so that it could all be obtained and written into the logs in one place (instead of in `TelemetryAttributes`) for logs for the current session, and for dead sessions, just write them directly in `NativeCrashDataSource`.

This also allows us to be more deliberate when checking attribute names and only need to do the conversion to the `emb.properties.` attribute name if we are checking in the OTel payload.

<!-- Describe how this change has been tested -->