### PR TITLE
Defer default log ID generation to EventService

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogServiceImpl.kt
@@ -9,10 +9,8 @@ import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.utils.PropertyUtils.truncate
-import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.opentelemetry.kotlin.semconv.ExceptionAttributes
 import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
-import io.embrace.opentelemetry.kotlin.semconv.LogAttributes
 import java.io.Serializable
 
 /**
@@ -38,12 +36,15 @@ class LogServiceImpl(
             return
         }
 
-        val redactedAttributes = redactSensitiveAttributes(attributes)
-        val telemetryAttributes = TelemetryAttributes(
-            customAttributes = redactedAttributes.plus(LogAttributes.LOG_RECORD_UID to Uuid.getEmbUuid()),
+        destination.addLog(
+            schemaType = schemaProvider(
+                TelemetryAttributes(
+                    customAttributes = redactSensitiveAttributes(attributes)
+                )
+            ),
+            severity = severity,
+            message = trimToMaxLength(message)
         )
-
-        destination.addLog(schemaProvider(telemetryAttributes), severity, trimToMaxLength(message))
     }
 
     private fun trimToMaxLength(message: String): String {

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -13,10 +13,7 @@ import io.embrace.android.embracesdk.internal.config.behavior.REDACTED_LABEL
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
-import io.embrace.opentelemetry.kotlin.semconv.LogAttributes
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotEquals
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -63,34 +60,6 @@ internal class EmbraceLogServiceTest {
         val attributes = log.schemaType.attributes()
         assertEquals(REDACTED_LABEL, attributes["password"])
         assertEquals("success", attributes["status"])
-    }
-
-    @Test
-    fun `LOG_RECORD_UID set properly`() {
-        // when logging the message
-        logService.log("message", LogSeverity.INFO, emptyMap(), ::Log)
-
-        // then the telemetry attributes are set correctly
-        val log = destination.logEvents.single()
-        val attributes = log.schemaType.attributes()
-        assertTrue(attributes.containsKey(LogAttributes.LOG_RECORD_UID))
-    }
-
-    @Test
-    fun `Embrace properties can not be overridden by custom properties`() {
-        val props = mapOf(LogAttributes.LOG_RECORD_UID to "fakeUid")
-        logService.log(
-            message = "Hello world",
-            severity = LogSeverity.INFO,
-            attributes = props,
-            schemaProvider = ::Log,
-        )
-
-        val log = destination.logEvents.single()
-        assertNotEquals(
-            "fakeUid",
-            log.schemaType.attributes()[LogAttributes.LOG_RECORD_UID]
-        )
     }
 
     @Test

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/LogAssertions.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/LogAssertions.kt
@@ -14,6 +14,7 @@ import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
 import io.embrace.opentelemetry.kotlin.semconv.ExceptionAttributes
 import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
+import io.embrace.opentelemetry.kotlin.semconv.LogAttributes
 import io.embrace.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -60,6 +61,7 @@ fun assertOtelLogReceived(
             val serializedStack = EmbraceSerializer().truncatedStacktrace(it.toTypedArray())
             assertAttribute(log, ExceptionAttributes.EXCEPTION_STACKTRACE, serializedStack)
         }
+        assertNotNull(expectedEmbType, log.attributes?.single { it.key == LogAttributes.LOG_RECORD_UID }?.data)
         expectedProperties?.forEach { (key, value) ->
             assertAttribute(log, key, value.toString())
         }


### PR DESCRIPTION
## Goal

Ensuring a log ID attribute should exist for every OTel log should be done at the lowest level, which is now `EventService`

<!-- Describe how this change has been tested -->