### PR TITLE
Set allWarningsAsErrors to true

### DIFF
--- a/buildSrc/src/main/kotlin/embrace-android-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/embrace-android-conventions.gradle.kts
@@ -18,7 +18,7 @@ android {
     }
     lint {
         abortOnError = true
-        warningsAsErrors = false
+        warningsAsErrors = true
         checkAllWarnings = true
         htmlReport = false
         baseline = project.file("lint-baseline.xml")
@@ -55,6 +55,7 @@ kotlin.compilerOptions {
     apiVersion.set(minKotlinVersion)
     languageVersion.set(minKotlinVersion)
     jvmTarget.set(target)
-    allWarningsAsErrors.set(false)
+    allWarningsAsErrors.set(true)
+    freeCompilerArgs.add("-Xsuppress-version-warnings")
 }
 kotlin.coreLibrariesVersion = coreLibrariesVersion

--- a/buildSrc/src/main/kotlin/embrace-jvm-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/embrace-jvm-conventions.gradle.kts
@@ -19,7 +19,8 @@ kotlin.compilerOptions {
     apiVersion.set(minKotlinVersion)
     languageVersion.set(minKotlinVersion)
     jvmTarget.set(target)
-    allWarningsAsErrors.set(false)
+    allWarningsAsErrors.set(true)
+    freeCompilerArgs.add("-Xsuppress-version-warnings")
 }
 kotlin.coreLibrariesVersion = coreLibrariesVersion
 

--- a/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/EmbraceHttpUrlConnectionImplTest.kt
+++ b/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/EmbraceHttpUrlConnectionImplTest.kt
@@ -67,7 +67,7 @@ internal class EmbraceHttpUrlConnectionImplTest {
 
     @Test
     fun testGetContentWithClasses() {
-        val array = arrayOf(Object::class.java)
+        val array = arrayOf(Any::class.java)
         embraceHttpUrlConnectionImpl.getContent(array)
         verify(exactly = 1) { mockDelegate.getContent(array) }
     }

--- a/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/EmbraceHttpsUrlConnectionImplTest.kt
+++ b/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/EmbraceHttpsUrlConnectionImplTest.kt
@@ -68,7 +68,7 @@ internal class EmbraceHttpsUrlConnectionImplTest {
 
     @Test
     fun testGetContentWithClasses() {
-        val array = arrayOf(Object::class.java)
+        val array = arrayOf(Any::class.java)
         embraceHttpsUrlConnectionImpl.getContent(array)
         verify(exactly = 1) { mockDelegate.getContent(array) }
     }

--- a/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/EmbraceUrlConnectionDelegateDelegationTest.kt
+++ b/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/EmbraceUrlConnectionDelegateDelegationTest.kt
@@ -78,7 +78,7 @@ internal class EmbraceUrlConnectionDelegateDelegationTest {
 
     @Test
     fun testGetContentWithClasses() {
-        val array = arrayOf(Object::class.java)
+        val array = arrayOf(Any::class.java)
         connectionDelegate.getContent(array)
         verify(exactly = 1) { mockConnection.getContent(array) }
     }

--- a/embrace-bytecode-instrumentation-tests/build.gradle.kts
+++ b/embrace-bytecode-instrumentation-tests/build.gradle.kts
@@ -20,7 +20,8 @@ android {
     kotlin {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_11)
-            allWarningsAsErrors.set(false)
+            allWarningsAsErrors.set(true)
+            freeCompilerArgs.add("-Xsuppress-version-warnings")
         }
     }
 }


### PR DESCRIPTION
## Goal

Set allWarningsAsErrors = true, and add a compiler flag `("-Xsuppress-version-warnings")` to avoid the "Language version 2.0 is deprecated" warning.