### PR TITLE
Do not populate native crash logs with current state data

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/TelemetryDestinationImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/TelemetryDestinationImpl.kt
@@ -89,6 +89,10 @@ class TelemetryDestinationImpl(
                 }
                 val state = sessionState ?: appStateTracker.getAppState()
                 setStringAttribute(embState.name, state.description)
+
+                currentStatesProvider().forEach {
+                    setStringAttribute(it.key.name, it.value.toString())
+                }
             }
 
             if (isPrivate) {
@@ -100,10 +104,6 @@ class TelemetryDestinationImpl(
                 attributes().forEach {
                     setStringAttribute(it.key, it.value)
                 }
-            }
-
-            currentStatesProvider().forEach {
-                setStringAttribute(it.key.name, it.value.toString())
             }
 
             sessionUpdateAction?.invoke()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/SessionPropertiesTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/SessionPropertiesTest.kt
@@ -29,7 +29,7 @@ internal class SessionPropertiesTest {
         testRule.runTest(
             instrumentedConfig = FakeInstrumentedConfig(enabledFeatures = FakeEnabledFeatureConfig(bgActivityCapture = true)),
             setupAction = {
-                setupPermanentProperties()
+                setupDefaultPermanentSessionProperties()
             },
             testCaseAction = {
                 addAndRemoveProperties()
@@ -70,7 +70,7 @@ internal class SessionPropertiesTest {
     fun `session properties work with background activity disabled`() {
         testRule.runTest(
             setupAction = {
-                setupPermanentProperties()
+                setupDefaultPermanentSessionProperties()
             },
             testCaseAction = {
                 addAndRemoveProperties()
@@ -101,7 +101,7 @@ internal class SessionPropertiesTest {
     fun `session properties are persisted in cached payloads`() {
         testRule.runTest(
             setupAction = {
-                setupPermanentProperties()
+                setupDefaultPermanentSessionProperties()
             },
             testCaseAction = {
                 addAndRemoveProperties()
@@ -116,7 +116,7 @@ internal class SessionPropertiesTest {
     fun `session properties are persisted in cached payloads when bg activities are disabled`() {
         testRule.runTest(
             setupAction = {
-                setupPermanentProperties()
+                setupDefaultPermanentSessionProperties()
             },
             testCaseAction = {
                 addAndRemoveProperties()
@@ -127,17 +127,14 @@ internal class SessionPropertiesTest {
         )
     }
 
-    private fun EmbraceSetupInterface.setupPermanentProperties() {
-        getStore().edit {
-            putStringMap(
-                "io.embrace.session.properties", mapOf(
-                    EXISTING_KEY_1 to VALUE,
-                    EXISTING_KEY_2 to VALUE,
-                    EXISTING_KEY_3 to VALUE,
-                )
+    private fun EmbraceSetupInterface.setupDefaultPermanentSessionProperties() =
+        setupPermanentSessionProperties(
+            mapOf(
+                EXISTING_KEY_1 to VALUE,
+                EXISTING_KEY_2 to VALUE,
+                EXISTING_KEY_3 to VALUE,
             )
-        }
-    }
+        )
 
     private fun EmbraceActionInterface.addAndRemoveProperties() {
         embrace.removeSessionProperty(EXISTING_KEY_1)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -20,8 +20,8 @@ import io.embrace.android.embracesdk.internal.arch.InstrumentationRegistry
 import io.embrace.android.embracesdk.internal.config.BuildInfo
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.config.ConfigServiceImpl
-import io.embrace.android.embracesdk.internal.delivery.debug.DeliveryTracer
 import io.embrace.android.embracesdk.internal.config.CpuAbi
+import io.embrace.android.embracesdk.internal.delivery.debug.DeliveryTracer
 import io.embrace.android.embracesdk.internal.injection.CoreModule
 import io.embrace.android.embracesdk.internal.injection.CoreModuleImpl
 import io.embrace.android.embracesdk.internal.injection.DeliveryModuleImpl
@@ -199,6 +199,17 @@ internal class EmbraceSetupInterface(
         val key = crashData.getCrashFile().absolutePath
         val json = serializer.toJson(crashData.nativeCrash, NativeCrashData::class.java)
         fakeJniDelegate.addCrashRaw(key, json)
+    }
+
+    /**
+     * Setup permanent session properties without using the SDK interfaces
+     */
+    fun setupPermanentSessionProperties(properties: Map<String, String>) {
+        getStore().edit {
+            putStringMap(
+                "io.embrace.session.properties", properties
+            )
+        }
     }
 
     fun getClock(): FakeClock = fakeClock


### PR DESCRIPTION
## Goal

We were erroneously populating native crashes with the current metadata generated via State datasources on the SDK instance, when the log itself is sending data recorded for a previous SDK instance associated with a crashed instance of the app. I fixed it so that like all other session-based attributes, we check the boolean first.

<!-- Describe what this change seeks to address -->

## Testing

Added a test to verify this when the State feature flag is on.

<!-- Describe how this change has been tested -->