### PR TITLE
Only grab session properties off dead sessions for native crashes

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/EnvelopeExt.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/EnvelopeExt.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.session
 
+import io.embrace.android.embracesdk.internal.arch.attrs.isEmbraceAttributeName
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.otel.spans.hasEmbraceAttribute
@@ -29,4 +30,10 @@ fun Envelope<SessionPayload>.getSessionProperties(): Map<String, String> {
 
 @Suppress("UNCHECKED_CAST")
 private fun Span.getSessionProperties(): Map<String, String> =
-    attributes?.filter { it.key != null && it.data != null }?.associate { it.key to it.data } as Map<String, String>
+    attributes
+        ?.filter {
+            val keyName = it.key
+            keyName != null && keyName.isEmbraceAttributeName() && it.data != null
+        }?.associate {
+            it.key to it.data
+        } as Map<String, String>

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/SessionExtensions.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/SessionExtensions.kt
@@ -7,5 +7,3 @@ import io.embrace.android.embracesdk.internal.payload.Span
 fun Span.getSessionProperty(key: String): String? {
     return attributes?.findAttributeValue(key.toEmbraceAttributeName())
 }
-
-fun Map<String, String>.getSessionProperty(key: String): String? = this[key.toEmbraceAttributeName()]

--- a/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashDataSourceImpl.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashDataSourceImpl.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.internal.instrumentation.crash.ndk
 
 import io.embrace.android.embracesdk.internal.arch.InstrumentationArgs
 import io.embrace.android.embracesdk.internal.arch.attrs.embCrashNumber
-import io.embrace.android.embracesdk.internal.arch.attrs.toEmbraceAttributeName
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceImpl
 import io.embrace.android.embracesdk.internal.arch.datasource.LogSeverity
 import io.embrace.android.embracesdk.internal.arch.limits.NoopLimitStrategy
@@ -71,7 +70,7 @@ internal class NativeCrashDataSourceImpl(
                 }
 
                 sessionProperties.forEach {
-                    setAttribute(key = it.key.toEmbraceAttributeName(), it.value)
+                    setAttribute(key = it.key, it.value)
                 }
             }
             addLog(

--- a/embrace-android-instrumentation-crash-ndk/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashDataSourceImplTest.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashDataSourceImplTest.kt
@@ -49,16 +49,17 @@ internal class NativeCrashDataSourceImplTest {
 
     @Test
     fun `native crash sent with session properties and metadata`() {
+        val sessionPropertyName = "prop".toEmbraceAttributeName()
         nativeCrashDataSource.sendNativeCrash(
             nativeCrash = testNativeCrashData,
-            sessionProperties = mapOf("prop" to "value"),
+            sessionProperties = mapOf(sessionPropertyName to "value"),
             metadata = mapOf(embState.name to "background")
         )
 
         with(args.destination.logEvents.single()) {
             val attributes = schemaType.attributes()
             assertEquals(EmbType.System.NativeCrash, schemaType.telemetryType)
-            assertEquals("value", attributes["prop".toEmbraceAttributeName()])
+            assertEquals("value", attributes[sessionPropertyName])
             assertEquals("background", attributes[embState.name])
             assertEquals(
                 testNativeCrashData.sessionId,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NativeCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NativeCrashFeatureTest.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.fakes.fakeEnvelopeMetadata
 import io.embrace.android.embracesdk.fakes.fakeEnvelopeResource
 import io.embrace.android.embracesdk.fakes.fakeLaterEnvelopeMetadata
 import io.embrace.android.embracesdk.fakes.fakeLaterEnvelopeResource
+import io.embrace.android.embracesdk.internal.arch.attrs.isEmbraceAttributeName
 import io.embrace.android.embracesdk.internal.arch.attrs.toEmbraceAttributeName
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.delivery.PayloadType
@@ -140,6 +141,7 @@ internal class NativeCrashFeatureTest {
                 }
                 val log = envelope.getLogOfType(EmbType.System.NativeCrash)
                 assertNativeCrashSent(log, crashData, fakeSymbols)
+                assertEquals(1, log.attributes?.filter { it.key?.isEmbraceAttributeName() == true }?.size)
                 assertEquals(0, log.attributes?.filter { it.key == newSessionProperty.toEmbraceAttributeName() }?.size)
                 assertEquals(0, log.attributes?.filter { it.key == "emb-state-test" }?.size)
             }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/StoredNdkData.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/StoredNdkData.kt
@@ -76,6 +76,7 @@ internal fun createStoredNativeCrashData(
                 startMs = sessionMetadata.timestamp,
                 lastHeartbeatTimeMs = sessionMetadata.timestamp + 1000L,
                 sessionId = nativeCrashData.sessionId,
+                sessionProperties = mapOf("dead-session-prop" to "some-val"),
                 processIdentifier = sessionMetadata.processIdentifier,
                 resource = envelopeResource,
                 metadata = envelopeMetadata


### PR DESCRIPTION
## Goal

`Span.getSessionProperties()` was grabbing all attributes off the session span and assuming they were that session's session properties. This was pointed out in the original code review way back when but I missed it. This resulted in a bunch of junk data on native crash logs that might've been erroneously interpreted as attributes.  
  
This addresses that by making that helper function look for only session properties - it also means we don't have to stick the prefix on there, as the original filtered attributes should already have it.

<!-- Describe how this change has been tested -->