### PR TITLE
Track applied limits for log operations

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/LogModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/LogModuleImpl.kt
@@ -30,7 +30,8 @@ class LogModuleImpl(
         LogServiceImpl(
             essentialServiceModule.telemetryDestination,
             configService,
-            logLimitingService
+            logLimitingService,
+            initModule.telemetryService
         )
     }
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeLogModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeLogModule.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.fakes.injection
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeLogLimitingService
 import io.embrace.android.embracesdk.fakes.FakeTelemetryDestination
+import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.internal.injection.LogModule
 import io.embrace.android.embracesdk.internal.logs.LogLimitingService
 import io.embrace.android.embracesdk.internal.logs.LogOrchestrator
@@ -15,7 +16,8 @@ class FakeLogModule(
     override val logService: LogService = LogServiceImpl(
         FakeTelemetryDestination(),
         FakeConfigService(),
-        logLimitingService
+        logLimitingService,
+        FakeTelemetryService(),
     ),
 ) : LogModule {
 


### PR DESCRIPTION
## Goal
Enable tracking of applied limits for log operations to provide visibility into when logs are dropped, truncated, or otherwise limited by the SDK.

## Changes
  - Add `TelemetryService` parameter to `LogServiceImpl` to track applied limits
  - Track when logs are dropped due to rate limiting
  - Track when log messages exceed maximum length and are truncated
  - Track when log attributes exceed count limit
  - Track when log attribute keys or values are truncated
  - Add tests for limit tracking scenarios