### PR TITLE
Reset main thread crash handler on integration test iteration

### DIFF
--- a/embrace-android-instrumentation-crash-jvm/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/JvmCrashDataSourceImpl.kt
+++ b/embrace-android-instrumentation-crash-jvm/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/JvmCrashDataSourceImpl.kt
@@ -136,7 +136,9 @@ class JvmCrashDataSourceImpl(
      */
     private fun registerExceptionHandler() {
         val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
-        val embraceHandler = EmbraceUncaughtExceptionHandler(defaultHandler, this, logger)
-        Thread.setDefaultUncaughtExceptionHandler(embraceHandler)
+        if (defaultHandler !is EmbraceUncaughtExceptionHandler) {
+            val embraceHandler = EmbraceUncaughtExceptionHandler(defaultHandler, this, logger)
+            Thread.setDefaultUncaughtExceptionHandler(embraceHandler)
+        }
     }
 }

--- a/embrace-android-instrumentation-crash-jvm/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/JvmCrashDataSourceImplTest.kt
+++ b/embrace-android-instrumentation-crash-jvm/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/JvmCrashDataSourceImplTest.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.TelemetryAttributes
 import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -67,6 +68,18 @@ internal class JvmCrashDataSourceImplTest {
         assert(Thread.getDefaultUncaughtExceptionHandler() is EmbraceUncaughtExceptionHandler)
         crashDataSource.logUnhandledJvmThrowable(IllegalStateException())
         assertEquals(1, args.destination.logEvents.size)
+    }
+
+    @Test
+    fun `default crash handler delegate will not be set if it is already an embrace handler`() {
+        val embraceDefaultHandler = EmbraceUncaughtExceptionHandler(
+            defaultHandler = null,
+            dataSource = FakeJvmCrashDataSource(),
+            logger = FakeEmbLogger()
+        )
+        Thread.setDefaultUncaughtExceptionHandler(embraceDefaultHandler)
+        setupForHandleCrash(true)
+        assertSame(Thread.getDefaultUncaughtExceptionHandler(), embraceDefaultHandler)
     }
 
     @Test

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/SdkIntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/SdkIntegrationTestRule.kt
@@ -34,11 +34,11 @@ import io.embrace.android.embracesdk.testframework.server.FakeApiServer
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.logging.export.toOtelKotlinLogRecordExporter
 import io.embrace.opentelemetry.kotlin.tracing.export.toOtelKotlinSpanExporter
-import java.io.File
 import okhttp3.Protocol
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Assert.assertEquals
 import org.junit.rules.ExternalResource
+import java.io.File
 
 /**
  * A [org.junit.Rule] that is responsible for setting up and tearing down the Embrace SDK for use in
@@ -201,7 +201,7 @@ internal class SdkIntegrationTestRule(
      * Setup the Embrace SDK so it's ready for testing.
      */
     override fun before() {
-
+        Thread.setDefaultUncaughtExceptionHandler(null)
     }
 
     /**


### PR DESCRIPTION
## Goal

When initializing the JVM crash data source, we were assuming that if there was a main thread exception handler already, it was set by the app. This affected our integration tests because we just reset the SDK, so we were setting wrapping our own handler. 

So first, lets ensure that we don't double-set the main thread exception handler in production (it won't happen anyway, but just in case), and we do a reset on every integration test run.

<!-- Describe how this change has been tested -->