### PR TITLE
Make defensive copy of attributes before adding each to event

### DIFF
--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EventServiceImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EventServiceImpl.kt
@@ -53,7 +53,7 @@ class EventServiceImpl(
                 }
             }
 
-            embraceAttributes.forEach {
+            embraceAttributes.toMap().forEach {
                 setStringAttribute(it.key, it.value)
             }
         }


### PR DESCRIPTION
## Goal

Make defensive copy of attributes map before iteration so as to not assume the immutability of the underlying map impl backing the `Map`

<!-- Describe how this change has been tested -->