### PR TITLE
Use AGP 9 in test matrix

### DIFF
--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/config/TestMatrix.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/config/TestMatrix.kt
@@ -46,5 +46,5 @@ sealed class TestMatrix(
      * The maximum version we currently run tests against. Newer versions may work, but are not
      * explicitly tested.
      */
-    object MaxVersion : TestMatrix("8.13.0", "9.2.0", "2.2.21", JdkEnv.JAVA_21, "36")
+    object MaxVersion : TestMatrix("9.0.0-rc02", "9.2.0", "2.3.0", JdkEnv.JAVA_21, "36")
 }


### PR DESCRIPTION
## Goal

Use AGP 9 in the test matrix to confirm compatibility with the latest versions.