### PR TITLE
Verify app name is used as service name in resource

### DIFF
--- a/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeProjectConfig.kt
+++ b/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeProjectConfig.kt
@@ -10,10 +10,12 @@ class FakeProjectConfig(
     private val buildId: String? = base.getBuildId(),
     private val buildType: String? = base.getBuildType(),
     private val buildFlavor: String? = base.getBuildFlavor(),
+    private val packageName: String? = base.getPackageName(),
 ) : ProjectConfig {
     override fun getAppId(): String? = appId
     override fun getAppFramework(): String? = appFramework
     override fun getBuildId(): String? = buildId
     override fun getBuildType(): String? = buildType
     override fun getBuildFlavor(): String? = buildFlavor
+    override fun getPackageName(): String? = packageName
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeInitModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeInitModule.kt
@@ -28,7 +28,7 @@ class FakeInitModule(
     override var instrumentedConfig: InstrumentedConfig = FakeInstrumentedConfig(),
 ) : InitModule by initModule {
 
-    val openTelemetryModule: OpenTelemetryModule by lazy { OpenTelemetryModuleImpl(initModule = initModule) }
+    val openTelemetryModule: OpenTelemetryModule by lazy { OpenTelemetryModuleImpl(initModule = this) }
 
     fun getFakeClock(): FakeClock? = clock as? FakeClock
 }


### PR DESCRIPTION
## Goal

Make the package name picked up during at app build overridable in tests. To thread this through, we also need to thread through the overridden instrumentation config via the fully overridden InitModule in order for that to be picked up. It should've been like that anyway.

<!-- Describe how this change has been tested -->