### PR TITLE
Reduce the surface area of EventService to one method

### DIFF
--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEventService.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEventService.kt
@@ -1,7 +1,5 @@
 package io.embrace.android.embracesdk.fakes
 
-import io.embrace.android.embracesdk.Severity
-import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.otel.logs.EventService
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
@@ -12,32 +10,12 @@ import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
 
 @OptIn(ExperimentalApi::class)
 class FakeEventService : EventService {
-    val events: MutableList<EventData> = mutableListOf()
-    val otelEvents: MutableList<OTelEventData> = mutableListOf()
+    val eventData: MutableList<FakeEventData> = mutableListOf()
     var initTime: Long? = null
 
     override fun log(
-        logTimeMs: Long,
-        schemaType: SchemaType,
-        severity: Severity,
-        message: String,
-        isPrivate: Boolean,
-        addCurrentMetadata: Boolean,
-    ) {
-        events.add(
-            EventData(
-                logTimeMs = logTimeMs,
-                schemaType = schemaType,
-                severity = severity,
-                message = message,
-                isPrivate = isPrivate,
-                addCurrentMetadata = addCurrentMetadata
-            )
-        )
-    }
-
-    override fun logRecord(
-        impl: Logger,
+        impl: Logger?,
+        eventName: String?,
         body: String?,
         timestamp: Long?,
         observedTimestamp: Long?,
@@ -45,38 +23,10 @@ class FakeEventService : EventService {
         severityNumber: SeverityNumber?,
         severityText: String?,
         addCurrentMetadata: Boolean,
-        attributes: (MutableAttributeContainer.() -> Unit)?,
+        eventAttributes: (MutableAttributeContainer.() -> Unit)?,
     ) {
-        otelEvents.add(
-            OTelEventData(
-                logger = impl,
-                eventName = null,
-                body = body,
-                timestamp = timestamp,
-                observedTimestamp = observedTimestamp,
-                context = context,
-                severityNumber = severityNumber,
-                severityText = severityText,
-                addCurrentMetadata = addCurrentMetadata,
-                attributes = attributes
-            )
-        )
-    }
-
-    override fun logEvent(
-        impl: Logger,
-        eventName: String,
-        body: String?,
-        timestamp: Long?,
-        observedTimestamp: Long?,
-        context: Context?,
-        severityNumber: SeverityNumber?,
-        severityText: String?,
-        addCurrentMetadata: Boolean,
-        attributes: (MutableAttributeContainer.() -> Unit)?,
-    ) {
-        otelEvents.add(
-            OTelEventData(
+        eventData.add(
+            FakeEventData(
                 logger = impl,
                 eventName = eventName,
                 body = body,
@@ -86,7 +36,7 @@ class FakeEventService : EventService {
                 severityNumber = severityNumber,
                 severityText = severityText,
                 addCurrentMetadata = addCurrentMetadata,
-                attributes = attributes
+                attributes = eventAttributes
             )
         )
     }
@@ -100,17 +50,8 @@ class FakeEventService : EventService {
 
     override fun initialized(): Boolean = true
 
-    data class EventData(
-        val logTimeMs: Long,
-        val schemaType: SchemaType,
-        val severity: Severity,
-        val message: String,
-        val isPrivate: Boolean,
-        val addCurrentMetadata: Boolean,
-    )
-
-    data class OTelEventData(
-        val logger: Logger,
+    data class FakeEventData(
+        val logger: Logger?,
         val eventName: String?,
         val body: String?,
         val timestamp: Long?,

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogRecord.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogRecord.kt
@@ -6,10 +6,12 @@ import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
 
 @OptIn(ExperimentalApi::class)
 class FakeLogRecord(
-    val observedTimestamp: Long?,
-    val severityNumber: SeverityNumber?,
-    val timestamp: Long?,
+    val eventName: String?,
     val body: String?,
+    val timestamp: Long?,
+    val observedTimestamp: Long?,
     val context: Context?,
+    val severityNumber: SeverityNumber?,
+    val severityText: String?,
     val attributes: Map<String, Any>,
 )

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryLogger.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryLogger.kt
@@ -20,7 +20,16 @@ class FakeOpenTelemetryLogger : Logger {
         severityText: String?,
         attributes: (MutableAttributeContainer.() -> Unit)?,
     ) {
-        processTelemetry(attributes, body, timestamp, observedTimestamp, context, severityNumber)
+        processTelemetry(
+            eventName = null,
+            body = body,
+            timestamp = timestamp,
+            observedTimestamp = observedTimestamp,
+            context = context,
+            severityNumber = severityNumber,
+            severityText = severityText,
+            attributes = attributes
+        )
     }
 
     override fun logEvent(
@@ -33,16 +42,27 @@ class FakeOpenTelemetryLogger : Logger {
         severityText: String?,
         attributes: (MutableAttributeContainer.() -> Unit)?,
     ) {
-        processTelemetry(attributes, body, timestamp, observedTimestamp, context, severityNumber)
+        processTelemetry(
+            eventName = eventName,
+            body = body,
+            timestamp = timestamp,
+            observedTimestamp = observedTimestamp,
+            context = context,
+            severityNumber = severityNumber,
+            severityText = severityText,
+            attributes = attributes
+        )
     }
 
     private fun processTelemetry(
-        attributes: (MutableAttributeContainer.() -> Unit)?,
+        eventName: String?,
         body: String?,
         timestamp: Long?,
         observedTimestamp: Long?,
         context: Context?,
         severityNumber: SeverityNumber?,
+        severityText: String?,
+        attributes: (MutableAttributeContainer.() -> Unit)?,
     ) {
         val container = FakeMutableAttributeContainer()
         if (attributes != null) {
@@ -50,11 +70,13 @@ class FakeOpenTelemetryLogger : Logger {
         }
         logs.add(
             FakeLogRecord(
+                eventName = eventName,
                 body = body,
                 timestamp = timestamp,
                 observedTimestamp = observedTimestamp,
                 context = context,
                 severityNumber = severityNumber,
+                severityText = severityText,
                 attributes = container.attributes
             )
         )

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EventService.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EventService.kt
@@ -1,8 +1,6 @@
 package io.embrace.android.embracesdk.internal.otel.logs
 
-import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.internal.Initializable
-import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.opentelemetry.kotlin.ExperimentalApi
 import io.embrace.opentelemetry.kotlin.attributes.MutableAttributeContainer
@@ -15,24 +13,12 @@ import io.embrace.opentelemetry.kotlin.logging.model.SeverityNumber
  */
 @OptIn(ExperimentalApi::class)
 interface EventService : Initializable {
-
     /**
-     * Records a log with Embrace-aware parameters
+     * Records an event using the given OTel Logger instance. Defaults to the SDK instance if not provided
      */
     fun log(
-        logTimeMs: Long,
-        schemaType: SchemaType,
-        severity: Severity,
-        message: String,
-        isPrivate: Boolean,
-        addCurrentMetadata: Boolean
-    )
-
-    /**
-     * Records a log using the given OTel Logger instance
-     */
-    fun logRecord(
-        impl: Logger,
+        impl: Logger? = null,
+        eventName: String?,
         body: String?,
         timestamp: Long?,
         observedTimestamp: Long?,
@@ -40,23 +26,7 @@ interface EventService : Initializable {
         severityNumber: SeverityNumber?,
         severityText: String?,
         addCurrentMetadata: Boolean,
-        attributes: (MutableAttributeContainer.() -> Unit)?,
-    )
-
-    /**
-     * Records an event using the given OTel Logger instance
-     */
-    fun logEvent(
-        impl: Logger,
-        eventName: String,
-        body: String?,
-        timestamp: Long?,
-        observedTimestamp: Long?,
-        context: Context?,
-        severityNumber: SeverityNumber?,
-        severityText: String?,
-        addCurrentMetadata: Boolean,
-        attributes: (MutableAttributeContainer.() -> Unit)?,
+        eventAttributes: (MutableAttributeContainer.() -> Unit)?,
     )
 
     /**


### PR DESCRIPTION
## Goal

Reduce the surface area of `EventService` to just one method which will be called by all consumers. Constructing the right parameters to fit this interface will be the responsibility of the caller now.

<!-- Describe what this change seeks to address -->

## Testing

Moved all tests to the right layer.

<!-- Describe how this change has been tested -->