### PR TITLE
Rename the internal logger to avoid confusion

### DIFF
--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
@@ -22,8 +22,8 @@ import io.embrace.android.embracesdk.internal.config.source.OkHttpRemoteConfigSo
 import io.embrace.android.embracesdk.internal.config.source.RemoteConfigSource
 import io.embrace.android.embracesdk.internal.config.store.RemoteConfigStore
 import io.embrace.android.embracesdk.internal.config.store.RemoteConfigStoreImpl
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.payload.NativeSymbols
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
@@ -47,7 +47,7 @@ class ConfigServiceImpl(
     private val sdkVersion: String,
     private val apiLevel: Int,
     private val filesDir: File,
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
     private val hasConfiguredOtelExporters: () -> Boolean,
 ) : ConfigService {
 

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImplTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.config
 
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.config.FakeProjectConfig
@@ -118,7 +118,7 @@ internal class ConfigServiceImplTest {
         sdkVersion = "1.2.3",
         apiLevel = 36,
         filesDir = Files.createTempDirectory("tmp").toFile(),
-        logger = FakeEmbLogger(),
+        logger = FakeInternalLogger(),
         hasConfiguredOtelExporters = hasConfiguredExporters,
     )
 }

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/NativeSymbolTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/NativeSymbolTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.config
 
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
 import io.embrace.android.embracesdk.fakes.config.FakeBase64SharedObjectFilesMap
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
@@ -81,7 +81,7 @@ class NativeSymbolTest {
             sdkVersion = "1.2.3",
             apiLevel = 36,
             filesDir = Files.createTempDirectory("tmp").toFile(),
-            logger = FakeEmbLogger(),
+            logger = FakeInternalLogger(),
             hasConfiguredOtelExporters = { false },
         )
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/InstrumentationArgsImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/InstrumentationArgsImpl.kt
@@ -11,7 +11,7 @@ import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesS
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.injection.WorkerThreadModule
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.session.id.SessionTracker
 import io.embrace.android.embracesdk.internal.store.KeyValueStore
@@ -26,7 +26,7 @@ import java.util.concurrent.ConcurrentHashMap
 internal class InstrumentationArgsImpl(
     override val configService: ConfigService,
     override val destination: TelemetryDestination,
-    override val logger: EmbLogger,
+    override val logger: InternalLogger,
     override val clock: Clock,
     override val context: Context,
     override val application: Application,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/EmbraceNetworkConnectivityService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/EmbraceNetworkConnectivityService.kt
@@ -6,8 +6,8 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.net.ConnectivityManager
 import io.embrace.android.embracesdk.internal.comms.delivery.NetworkStatus
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import java.net.Inet4Address
 import java.net.NetworkInterface
@@ -17,7 +17,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 internal class EmbraceNetworkConnectivityService(
     private val context: Context,
     private val backgroundWorker: BackgroundWorker,
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
     private val connectivityManager: ConnectivityManager?,
 ) : BroadcastReceiver(), NetworkConnectivityService {
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
@@ -11,8 +11,8 @@ import android.os.storage.StorageManager
 import androidx.annotation.RequiresApi
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.envelope.resource.EnvelopeResourceSource
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 
@@ -27,7 +27,7 @@ internal class EmbraceMetadataService(
     private val configService: ConfigService,
     private val store: KeyValueStore,
     private val metadataBackgroundWorker: BackgroundWorker,
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
 ) : MetadataService {
 
     private val res by lazy { resourceSource.value.getEnvelopeResource() }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/user/EmbraceUserService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/user/EmbraceUserService.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.internal.capture.user
 
 import io.embrace.android.embracesdk.internal.clock.Clock
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.UserInfo
 import io.embrace.android.embracesdk.internal.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
@@ -14,7 +14,7 @@ import java.util.regex.Pattern
 internal class EmbraceUserService(
     private val impl: KeyValueStore,
     private val clock: Clock,
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
 ) : UserService {
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPayloadSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPayloadSourceImpl.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.arch.state.AppStateTracker
 import io.embrace.android.embracesdk.internal.clock.Clock
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.otel.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
@@ -24,7 +24,7 @@ internal class SessionPayloadSourceImpl(
     private val otelPayloadMapper: OtelPayloadMapper?,
     private val appStateTracker: AppStateTracker,
     private val clock: Clock,
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
 ) : SessionPayloadSource {
 
     override fun getSessionPayload(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitModule.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.injection
 import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.InstrumentedConfig
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.telemetry.TelemetryService
 import okhttp3.OkHttpClient
@@ -26,7 +26,7 @@ interface InitModule {
     /**
      * Logger used by the SDK
      */
-    val logger: EmbLogger
+    val logger: InternalLogger
 
     /**
      * Info about the system available at startup time without expensive disk or API calls

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitModuleImpl.kt
@@ -5,8 +5,8 @@ import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.clock.NormalizedIntervalClock
 import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfigImpl
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.InstrumentedConfig
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLoggerImpl
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.telemetry.EmbraceTelemetryService
@@ -17,7 +17,7 @@ import okhttp3.Protocol
 import java.util.concurrent.TimeUnit
 
 class InitModuleImpl(
-    override val logger: EmbLogger = EmbLoggerImpl(),
+    override val logger: InternalLogger = InternalLoggerImpl(),
     override val clock: Clock = NormalizedIntervalClock(),
     override val systemInfo: SystemInfo = SystemInfo(),
 ) : InitModule {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/InternalLoggerImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/InternalLoggerImpl.kt
@@ -7,26 +7,26 @@ import java.util.concurrent.atomic.AtomicBoolean
 internal const val EMBRACE_TAG = "[Embrace]"
 
 /**
- * Implementation of [EmbLogger] that logs to Android logcat & also allows tracking of internal
+ * Implementation of [InternalLogger] that logs to Android logcat & also allows tracking of internal
  * errors for our telemetry.
  */
-class EmbLoggerImpl : EmbLogger {
+class InternalLoggerImpl : InternalLogger {
 
     private val loggedSdkNotStarted = AtomicBoolean(false)
     override var errorHandlerProvider: Provider<InternalErrorHandler?> = { null }
 
     override fun logInfo(msg: String, throwable: Throwable?) {
-        log(msg, EmbLogger.Severity.INFO, throwable)
+        log(msg, InternalLogger.Severity.INFO, throwable)
     }
 
     override fun logError(msg: String, throwable: Throwable?) {
-        log(msg, EmbLogger.Severity.ERROR, throwable)
+        log(msg, InternalLogger.Severity.ERROR, throwable)
     }
 
     override fun logSdkNotInitialized(action: String) {
         if (!loggedSdkNotStarted.getAndSet(true)) {
             val msg = "Embrace SDK is not initialized yet, cannot $action."
-            log(msg, EmbLogger.Severity.WARNING, Throwable(msg))
+            log(msg, InternalLogger.Severity.WARNING, Throwable(msg))
         }
     }
 
@@ -47,8 +47,8 @@ class EmbLoggerImpl : EmbLogger {
      * @param throwable exception, if any.
      */
     @Suppress("NOTHING_TO_INLINE") // hot path - optimize by inlining
-    private inline fun log(msg: String, severity: EmbLogger.Severity, throwable: Throwable?) {
-        if (severity >= EmbLogger.Severity.INFO) {
+    private inline fun log(msg: String, severity: InternalLogger.Severity, throwable: Throwable?) {
+        if (severity >= InternalLogger.Severity.INFO) {
             logcatImpl(throwable, severity, msg)
         }
     }
@@ -59,14 +59,14 @@ class EmbLoggerImpl : EmbLogger {
     @Suppress("NOTHING_TO_INLINE") // hot path - optimize by inlining
     private inline fun logcatImpl(
         throwable: Throwable?,
-        severity: EmbLogger.Severity,
+        severity: InternalLogger.Severity,
         msg: String,
     ) {
         when (severity) {
-            EmbLogger.Severity.DEBUG -> Log.d(EMBRACE_TAG, msg, throwable)
-            EmbLogger.Severity.INFO -> Log.i(EMBRACE_TAG, msg, throwable)
-            EmbLogger.Severity.WARNING -> Log.w(EMBRACE_TAG, msg, throwable)
-            EmbLogger.Severity.ERROR -> Log.e(EMBRACE_TAG, msg, throwable)
+            InternalLogger.Severity.DEBUG -> Log.d(EMBRACE_TAG, msg, throwable)
+            InternalLogger.Severity.INFO -> Log.i(EMBRACE_TAG, msg, throwable)
+            InternalLogger.Severity.WARNING -> Log.w(EMBRACE_TAG, msg, throwable)
+            InternalLogger.Severity.ERROR -> Log.e(EMBRACE_TAG, msg, throwable)
         }
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
@@ -14,8 +14,8 @@ import io.embrace.android.embracesdk.internal.delivery.storage.CachedLogEnvelope
 import io.embrace.android.embracesdk.internal.delivery.storage.CachedLogEnvelopeStore.Companion.createNativeCrashEnvelopeMetadata
 import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageService
 import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.NativeCrashService
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.otel.spans.hasEmbraceAttribute
 import io.embrace.android.embracesdk.internal.otel.spans.toFailedSpan
@@ -41,7 +41,7 @@ internal class PayloadResurrectionServiceImpl(
     private val intakeService: IntakeService,
     private val cacheStorageService: PayloadStorageService,
     private val cachedLogEnvelopeStore: CachedLogEnvelopeStore,
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
     private val serializer: PlatformSerializer,
 ) : PayloadResurrectionService {
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/SafeCaptureExtension.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/SafeCaptureExtension.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.session
 
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.utils.Provider
 
 /**
@@ -9,7 +9,7 @@ import io.embrace.android.embracesdk.internal.utils.Provider
  * This is intended for use when building the session/background activity payloads. If an
  * exception is thrown during capture, then we still want to send the request.
  */
-internal inline fun <R> captureDataSafely(logger: EmbLogger, result: Provider<R>): R? {
+internal inline fun <R> captureDataSafely(logger: InternalLogger, result: Provider<R>): R? {
     return try {
         result()
     } catch (exc: Throwable) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/caching/PeriodicSessionCacher.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/caching/PeriodicSessionCacher.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.session.caching
 
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeUnit
 
 class PeriodicSessionCacher(
     private val worker: BackgroundWorker,
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
     private val intervalMs: Long = 2000,
 ) {
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionTrackerImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionTrackerImpl.kt
@@ -5,14 +5,14 @@ import android.os.Build
 import io.embrace.android.embracesdk.internal.arch.SessionChangeListener
 import io.embrace.android.embracesdk.internal.arch.SessionEndListener
 import io.embrace.android.embracesdk.internal.arch.state.AppState
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.session.SessionToken
 import java.util.concurrent.CopyOnWriteArraySet
 
 internal class SessionTrackerImpl(
     private val activityManager: ActivityManager?,
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
 ) : SessionTracker {
 
     private val sessionChangeListeners = CopyOnWriteArraySet<SessionChangeListener>()

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/AppStateTrackerImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/AppStateTrackerImpl.kt
@@ -8,8 +8,8 @@ import androidx.lifecycle.LifecycleOwner
 import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.arch.state.AppStateListener
 import io.embrace.android.embracesdk.internal.arch.state.AppStateTracker
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionOrchestrator
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -18,7 +18,7 @@ import java.util.concurrent.CopyOnWriteArrayList
  * by ProcessLifecycleOwner.
  */
 internal class AppStateTrackerImpl(
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
     private val lifecycleOwner: LifecycleOwner,
 ) : AppStateTracker, LifecycleEventObserver {
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/FinalEnvelopeParams.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/FinalEnvelopeParams.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.session.message
 
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.session.SessionToken
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapshotType
 
@@ -11,7 +11,7 @@ import io.embrace.android.embracesdk.internal.session.orchestrator.SessionSnapsh
 class FinalEnvelopeParams(
     val initial: SessionToken,
     val endType: SessionSnapshotType,
-    val logger: EmbLogger,
+    val logger: InternalLogger,
     continueMonitoring: Boolean,
     crashId: String? = null,
 ) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImpl.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.session.message
 import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.envelope.log.LogEnvelopeSource
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.payload.SessionPayload
@@ -15,7 +15,7 @@ internal class PayloadFactoryImpl(
     private val payloadMessageCollator: PayloadMessageCollator,
     private val logEnvelopeSource: LogEnvelopeSource,
     private val configService: ConfigService,
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
 ) : PayloadFactory {
 
     override fun startPayloadWithState(state: AppState, timestamp: Long, coldStart: Boolean): SessionToken? =

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistryTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistryTest.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.fakes.FakeDataSource
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationProvider
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
-import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
+import io.embrace.android.embracesdk.internal.logging.InternalLoggerImpl
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -29,7 +29,7 @@ internal class InstrumentationRegistryTest {
         configService = FakeConfigService()
         executorService = BlockingScheduledExecutorService(blockingMode = false)
         registry = InstrumentationRegistryImpl(
-            EmbLoggerImpl(),
+            InternalLoggerImpl(),
         )
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/EmbraceNetworkConnectivityServiceTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/EmbraceNetworkConnectivityServiceTest.kt
@@ -7,8 +7,8 @@ import android.net.ConnectivityManager
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.comms.delivery.NetworkStatus
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLoggerImpl
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -30,7 +30,7 @@ internal class EmbraceNetworkConnectivityServiceTest {
 
     companion object {
         private lateinit var context: Context
-        private lateinit var logger: EmbLogger
+        private lateinit var logger: InternalLogger
         private lateinit var mockConnectivityManager: ConnectivityManager
         private lateinit var worker: BackgroundWorker
         private lateinit var fakeClock: FakeClock
@@ -42,7 +42,7 @@ internal class EmbraceNetworkConnectivityServiceTest {
         @JvmStatic
         fun setupBeforeAll() {
             context = mockk(relaxed = true)
-            logger = EmbLoggerImpl()
+            logger = InternalLoggerImpl()
             mockConnectivityManager = mockk()
             fakeClock = FakeClock()
             worker = fakeBackgroundWorker()

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/user/EmbraceUserServiceTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/user/EmbraceUserServiceTest.kt
@@ -1,9 +1,9 @@
 package io.embrace.android.embracesdk.internal.capture.user
 
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeKeyValueStore
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.UserInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -30,12 +30,12 @@ internal class EmbraceUserServiceTest {
 
     private lateinit var service: EmbraceUserService
     private lateinit var store: FakeKeyValueStore
-    private lateinit var logger: EmbLogger
+    private lateinit var logger: InternalLogger
     private lateinit var clock: FakeClock
 
     @Before
     fun setUp() {
-        logger = FakeEmbLogger()
+        logger = FakeInternalLogger()
         clock = FakeClock()
         store = FakeKeyValueStore()
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingServiceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingServiceImplTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.delivery.caching
 
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakePayloadStore
 import io.embrace.android.embracesdk.fakes.FakeSessionTracker
 import io.embrace.android.embracesdk.fakes.fakeSessionEnvelope
@@ -27,7 +27,7 @@ class PayloadCachingServiceImplTest {
     @Before
     fun setUp() {
         executorService = BlockingScheduledExecutorService(FakeClock())
-        val cacher = PeriodicSessionCacher(BackgroundWorker(executorService), FakeEmbLogger(), INTERVAL)
+        val cacher = PeriodicSessionCacher(BackgroundWorker(executorService), FakeInternalLogger(), INTERVAL)
         sessionTracker = FakeSessionTracker()
 
         sessionTracker.newActiveSession(

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPayloadSourceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPayloadSourceImplTest.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.fakes.FakeCurrentSessionSpan
 import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.FakeOtelPayloadMapper
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
-import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
+import io.embrace.android.embracesdk.internal.logging.InternalLoggerImpl
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSinkImpl
@@ -50,7 +50,7 @@ internal class SessionPayloadSourceImplTest {
             FakeOtelPayloadMapper(),
             FakeAppStateTracker(),
             FakeClock(),
-            EmbLoggerImpl()
+            InternalLoggerImpl()
         )
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
@@ -9,9 +9,9 @@ import io.embrace.android.embracesdk.assertions.getLastHeartbeatTimeMs
 import io.embrace.android.embracesdk.assertions.getSessionId
 import io.embrace.android.embracesdk.assertions.getStartTime
 import io.embrace.android.embracesdk.fakes.FakeCachedLogEnvelopeStore
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.FakeIntakeService
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeNativeCrashService
 import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
 import io.embrace.android.embracesdk.fakes.FakeSpanData.Companion.perfSpanSnapshot
@@ -56,7 +56,7 @@ class PayloadResurrectionServiceImplTest {
     private lateinit var cacheStorageService: FakePayloadStorageService
     private lateinit var cachedLogEnvelopeStore: FakeCachedLogEnvelopeStore
     private lateinit var nativeCrashService: FakeNativeCrashService
-    private lateinit var logger: FakeEmbLogger
+    private lateinit var logger: FakeInternalLogger
     private lateinit var serializer: TestPlatformSerializer
     private lateinit var resurrectionService: PayloadResurrectionServiceImpl
 
@@ -66,7 +66,7 @@ class PayloadResurrectionServiceImplTest {
         cacheStorageService = FakePayloadStorageService()
         cachedLogEnvelopeStore = FakeCachedLogEnvelopeStore()
         nativeCrashService = FakeNativeCrashService()
-        logger = FakeEmbLogger(false)
+        logger = FakeInternalLogger(false)
         serializer = TestPlatformSerializer()
         resurrectionService = PayloadResurrectionServiceImpl(
             intakeService = intakeService,

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/AppStateTrackerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/AppStateTrackerTest.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.testing.TestLifecycleOwner
 import io.embrace.android.embracesdk.fakes.FakeAppStateListener
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeSessionOrchestrator
 import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.arch.state.AppStateListener
@@ -52,7 +52,7 @@ internal class AppStateTrackerTest {
         }
     }
 
-    private lateinit var fakeEmbLogger: FakeEmbLogger
+    private lateinit var fakeEmbLogger: FakeInternalLogger
 
     @Before
     fun before() {
@@ -62,7 +62,7 @@ internal class AppStateTrackerTest {
             constructorMocks = false,
             staticMocks = false
         )
-        fakeEmbLogger = FakeEmbLogger()
+        fakeEmbLogger = FakeInternalLogger()
         stateService = AppStateTrackerImpl(
             fakeEmbLogger,
             TestLifecycleOwner(Lifecycle.State.INITIALIZED)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/PayloadFactoryBaTest.kt
@@ -19,7 +19,7 @@ import io.embrace.android.embracesdk.internal.capture.user.UserService
 import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.envelope.session.SessionPayloadSourceImpl
-import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
+import io.embrace.android.embracesdk.internal.logging.InternalLoggerImpl
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSink
@@ -109,7 +109,7 @@ internal class PayloadFactoryBaTest {
     }
 
     private fun createService(createInitialSession: Boolean = true): PayloadFactoryImpl {
-        val logger = EmbLoggerImpl()
+        val logger = InternalLoggerImpl()
         val payloadSourceModule = FakePayloadSourceModule(
             sessionPayloadSource = SessionPayloadSourceImpl(
                 null,

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/PayloadFactorySessionTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/PayloadFactorySessionTest.kt
@@ -13,7 +13,7 @@ import io.embrace.android.embracesdk.fakes.injection.FakePayloadSourceModule
 import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.internal.capture.user.UserService
-import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
+import io.embrace.android.embracesdk.internal.logging.InternalLoggerImpl
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSink
@@ -98,7 +98,7 @@ internal class PayloadFactorySessionTest {
         appStateTracker.state = AppState.BACKGROUND
 
         val payloadSourceModule = FakePayloadSourceModule()
-        val logger = EmbLoggerImpl()
+        val logger = InternalLoggerImpl()
         val collator = PayloadMessageCollatorImpl(
             payloadSourceModule.sessionEnvelopeSource,
             store,

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/SessionHandlerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/SessionHandlerTest.kt
@@ -20,8 +20,8 @@ import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.capture.session.SessionPropertiesService
 import io.embrace.android.embracesdk.internal.envelope.session.SessionEnvelopeSourceImpl
 import io.embrace.android.embracesdk.internal.envelope.session.SessionPayloadSourceImpl
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLoggerImpl
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSink
@@ -59,7 +59,7 @@ internal class SessionHandlerTest {
     private lateinit var payloadFactory: PayloadFactory
     private lateinit var executorService: BlockingScheduledExecutorService
     private lateinit var worker: BackgroundWorker
-    private lateinit var logger: EmbLogger
+    private lateinit var logger: InternalLogger
     private lateinit var spanRepository: SpanRepository
     private lateinit var currentSessionSpan: CurrentSessionSpan
     private lateinit var sessionPropertiesService: SessionPropertiesService
@@ -68,7 +68,7 @@ internal class SessionHandlerTest {
     fun before() {
         executorService = BlockingScheduledExecutorService()
         worker = BackgroundWorker(executorService)
-        logger = EmbLoggerImpl()
+        logger = InternalLoggerImpl()
         clock.setCurrentTime(NOW)
         sessionPropertiesService = FakeSessionPropertiesService()
         metadataService = FakeMetadataService()

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionTrackerImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionTrackerImplTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.session.id
 
 import io.embrace.android.embracesdk.fakes.fakeSessionToken
 import io.embrace.android.embracesdk.internal.arch.state.AppState
-import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
+import io.embrace.android.embracesdk.internal.logging.InternalLoggerImpl
 import io.embrace.android.embracesdk.internal.session.LifeEventType
 import io.embrace.android.embracesdk.internal.session.SessionToken
 import org.junit.Assert.assertEquals
@@ -15,7 +15,7 @@ internal class SessionTrackerImplTest {
 
     @Before
     fun setUp() {
-        tracker = SessionTrackerImpl(null, EmbLoggerImpl())
+        tracker = SessionTrackerImpl(null, InternalLoggerImpl())
     }
 
     @Test

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -29,8 +29,8 @@ import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRe
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.delivery.caching.PayloadCachingService
 import io.embrace.android.embracesdk.internal.delivery.caching.PayloadCachingServiceImpl
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLoggerImpl
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.session.LifeEventType
 import io.embrace.android.embracesdk.internal.session.caching.PeriodicSessionCacher
@@ -63,7 +63,7 @@ internal class SessionOrchestratorTest {
     private lateinit var sessionCacheExecutor: BlockingScheduledExecutorService
     private lateinit var instrumentationRegistry: InstrumentationRegistry
     private lateinit var fakeDataSource: FakeDataSource
-    private lateinit var logger: EmbLogger
+    private lateinit var logger: InternalLogger
     private lateinit var currentSessionSpan: FakeCurrentSessionSpan
     private lateinit var destination: FakeTelemetryDestination
     private var orchestratorStartTimeMs: Long = 0
@@ -71,7 +71,7 @@ internal class SessionOrchestratorTest {
     @Before
     fun setUp() {
         clock = FakeClock()
-        logger = EmbLoggerImpl()
+        logger = InternalLoggerImpl()
         configService = FakeConfigService(
             backgroundActivityBehavior = createBackgroundActivityBehavior(
                 remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 100f))

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionService.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionService.kt
@@ -6,8 +6,8 @@ import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
 import io.embrace.android.embracesdk.internal.delivery.debug.DeliveryTracer
 import io.embrace.android.embracesdk.internal.delivery.execution.ExecutionResult.Companion.getResult
 import io.embrace.android.embracesdk.internal.delivery.storage.loadAttachment
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import okhttp3.Headers.Companion.toHeaders
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
@@ -28,7 +28,7 @@ class OkHttpRequestExecutionService(
     private val lazyDeviceId: Lazy<String>,
     private val appId: String,
     private val embraceVersionName: String,
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
     private val deliveryTracer: DeliveryTracer? = null,
 ) : RequestExecutionService {
 

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImpl.kt
@@ -6,8 +6,8 @@ import io.embrace.android.embracesdk.internal.delivery.debug.DeliveryTracer
 import io.embrace.android.embracesdk.internal.delivery.scheduling.SchedulingService
 import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageService
 import io.embrace.android.embracesdk.internal.delivery.storage.storeAttachment
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.worker.PriorityWorker
@@ -18,7 +18,7 @@ class IntakeServiceImpl(
     private val schedulingService: SchedulingService,
     private val payloadStorageService: PayloadStorageService,
     private val cacheStorageService: PayloadStorageService,
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
     private val serializer: PlatformSerializer,
     private val worker: PriorityWorker<StoredTelemetryMetadata>,
     private val deliveryTracer: DeliveryTracer? = null,

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImpl.kt
@@ -9,8 +9,8 @@ import io.embrace.android.embracesdk.internal.delivery.execution.ExecutionResult
 import io.embrace.android.embracesdk.internal.delivery.execution.RequestExecutionService
 import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageService
 import io.embrace.android.embracesdk.internal.delivery.storedTelemetryComparator
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import java.io.InputStream
 import java.util.Collections
@@ -25,7 +25,7 @@ class SchedulingServiceImpl(
     private val schedulingWorker: BackgroundWorker,
     private val deliveryWorker: BackgroundWorker,
     private val clock: Clock,
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
     private val deliveryTracer: DeliveryTracer? = null,
 ) : SchedulingService {
 

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/CachedLogEnvelopeStoreImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/CachedLogEnvelopeStoreImpl.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.delivery.storage
 
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.Envelope.Companion.createLogEnvelope
 import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
@@ -14,7 +14,7 @@ import java.io.File
 class CachedLogEnvelopeStoreImpl(
     outputDir: Lazy<File>,
     worker: PriorityWorker<StoredTelemetryMetadata>,
-    logger: EmbLogger,
+    logger: InternalLogger,
     private val serializer: PlatformSerializer,
     storageLimit: Int = 100,
 ) : CachedLogEnvelopeStore {

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImpl.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.delivery.storage
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.debug.DeliveryTracer
 import io.embrace.android.embracesdk.internal.delivery.storedTelemetryComparator
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.worker.PriorityWorker
 import java.io.File
 import java.io.InputStream
@@ -18,7 +18,7 @@ class PayloadStorageServiceImpl(
     outputDir: Lazy<File>,
     worker: PriorityWorker<StoredTelemetryMetadata>,
     private val processIdProvider: () -> String,
-    logger: EmbLogger,
+    logger: InternalLogger,
     private val deliveryTracer: DeliveryTracer? = null,
     storageLimit: Int = 500,
 ) : PayloadStorageService {

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionServiceTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionServiceTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.delivery.execution
 
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.internal.delivery.PayloadType
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
 import okhttp3.Headers.Companion.toHeaders
@@ -22,7 +22,7 @@ class OkHttpRequestExecutionServiceTest {
     private lateinit var requestExecutionService: OkHttpRequestExecutionService
     private lateinit var server: MockWebServer
     private lateinit var testServerUrl: String
-    private lateinit var logger: FakeEmbLogger
+    private lateinit var logger: FakeInternalLogger
     private lateinit var client: OkHttpClient
 
     private val testAppId = "test_app_id"
@@ -46,7 +46,7 @@ class OkHttpRequestExecutionServiceTest {
 
     @Before
     fun setUp() {
-        logger = FakeEmbLogger()
+        logger = FakeInternalLogger()
         server = MockWebServer().apply {
             protocols = listOf(Protocol.HTTP_2, Protocol.HTTP_1_1)
             start()

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImplTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.delivery.intake
 
 import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
 import io.embrace.android.embracesdk.fakes.FakeSchedulingService
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
@@ -50,7 +50,7 @@ class IntakeServiceImplTest {
     private lateinit var cacheStorageService: FakePayloadStorageService
     private lateinit var schedulingService: FakeSchedulingService
     private lateinit var executorService: BlockableExecutorService
-    private lateinit var logger: FakeEmbLogger
+    private lateinit var logger: FakeInternalLogger
 
     private val serializer = TestPlatformSerializer()
     private val sessionEnvelope = Envelope(
@@ -93,7 +93,7 @@ class IntakeServiceImplTest {
         cacheStorageService = FakePayloadStorageService()
         schedulingService = FakeSchedulingService()
         executorService = BlockableExecutorService(blockingMode = true)
-        logger = FakeEmbLogger(false)
+        logger = FakeInternalLogger(false)
         intakeService = IntakeServiceImpl(
             schedulingService,
             payloadStorageService,

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServicePeriodicCacheTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServicePeriodicCacheTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.delivery.intake
 
 import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
 import io.embrace.android.embracesdk.fakes.FakeSchedulingService
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
@@ -23,7 +23,7 @@ class IntakeServicePeriodicCacheTest {
     private lateinit var cacheStorageService: FakePayloadStorageService
     private lateinit var schedulingService: FakeSchedulingService
     private lateinit var executorService: BlockableExecutorService
-    private lateinit var logger: FakeEmbLogger
+    private lateinit var logger: FakeInternalLogger
 
     private val serializer = TestPlatformSerializer()
     private val sessionEnvelope = Envelope(
@@ -37,7 +37,7 @@ class IntakeServicePeriodicCacheTest {
         cacheStorageService = FakePayloadStorageService()
         schedulingService = FakeSchedulingService()
         executorService = BlockableExecutorService(blockingMode = true)
-        logger = FakeEmbLogger(false)
+        logger = FakeInternalLogger(false)
         intakeService = IntakeServiceImpl(
             schedulingService,
             payloadStorageService,

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImplTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.delivery.scheduling
 
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeNetworkConnectivityService
 import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
 import io.embrace.android.embracesdk.fakes.FakeRequestExecutionService
@@ -28,7 +28,7 @@ internal class SchedulingServiceImplTest {
     private lateinit var schedulingExecutor: BlockingScheduledExecutorService
     private lateinit var deliveryExecutor: BlockingScheduledExecutorService
     private lateinit var networkConnectivityService: FakeNetworkConnectivityService
-    private lateinit var logger: FakeEmbLogger
+    private lateinit var logger: FakeInternalLogger
     private lateinit var schedulingService: SchedulingServiceImpl
 
     @Volatile
@@ -45,7 +45,7 @@ internal class SchedulingServiceImplTest {
             addFakePayload(fakeSessionStoredTelemetryMetadata)
         }
         executionService = FakeRequestExecutionService()
-        logger = FakeEmbLogger()
+        logger = FakeInternalLogger()
         allSendsSucceed()
         schedulingService = SchedulingServiceImpl(
             storageService = storageService,

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/CachedLogEnvelopeStoreImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/CachedLogEnvelopeStoreImplTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.delivery.storage
 
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
 import io.embrace.android.embracesdk.fakes.fakeEnvelopeMetadata
 import io.embrace.android.embracesdk.fakes.fakeEnvelopeResource
@@ -19,7 +19,7 @@ class CachedLogEnvelopeStoreImplTest {
 
     private lateinit var outputDir: File
     private lateinit var store: CachedLogEnvelopeStoreImpl
-    private lateinit var logger: FakeEmbLogger
+    private lateinit var logger: FakeInternalLogger
     private lateinit var serializer: PlatformSerializer
     private lateinit var executor: BlockingScheduledExecutorService
 
@@ -28,7 +28,7 @@ class CachedLogEnvelopeStoreImplTest {
         outputDir = Files.createTempDirectory("temp").toFile().apply {
             mkdirs()
         }
-        logger = FakeEmbLogger()
+        logger = FakeInternalLogger()
         serializer = TestPlatformSerializer()
         executor = BlockingScheduledExecutorService()
 

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.delivery.storage
 
 import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.BLOB
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.CRASH
@@ -30,7 +30,7 @@ class PayloadStorageServiceImplTest {
     private val metadata = StoredTelemetryMetadata(TIMESTAMP, UUID, PROCESS_ID, SESSION)
     private lateinit var service: PayloadStorageService
     private lateinit var outputDir: File
-    private lateinit var logger: FakeEmbLogger
+    private lateinit var logger: FakeInternalLogger
     private lateinit var worker: PriorityWorker<StoredTelemetryMetadata>
     private lateinit var currentProcessId: String
 
@@ -39,7 +39,7 @@ class PayloadStorageServiceImplTest {
         outputDir = Files.createTempDirectory("output").toFile()
         outputDir.deleteRecursively()
         worker = PriorityWorker(BlockableExecutorService(false))
-        logger = FakeEmbLogger(false)
+        logger = FakeInternalLogger(false)
         currentProcessId = PROCESS_ID
         service = PayloadStorageServiceImpl(lazy { outputDir }, worker, { currentProcessId }, logger)
     }

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/DeviceImpl.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/DeviceImpl.kt
@@ -6,8 +6,8 @@ import android.util.DisplayMetrics
 import android.view.WindowManager
 import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.isEmulator
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import java.io.File
@@ -18,7 +18,7 @@ class DeviceImpl(
     private val store: KeyValueStore,
     private val backgroundWorker: BackgroundWorker,
     override val systemInfo: SystemInfo,
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
 ) : Device {
     override var isJailbroken: Boolean? = false
     override var screenResolution: String = ""

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/InternalLogger.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/InternalLogger.kt
@@ -3,9 +3,9 @@ package io.embrace.android.embracesdk.internal.logging
 import io.embrace.android.embracesdk.internal.utils.Provider
 
 /**
- * A simple interface that is used within the Embrace SDK for logging.
+ * A simple interface that is used within the Embrace SDK for internal diagnostics logging.
  */
-interface EmbLogger : InternalErrorHandler {
+interface InternalLogger : InternalErrorHandler {
 
     enum class Severity {
         DEBUG, INFO, WARNING, ERROR

--- a/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/BlockedThreadDetector.kt
+++ b/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/BlockedThreadDetector.kt
@@ -8,8 +8,8 @@ import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.instrumentation.thread.blockage.ThreadBlockageEvent.BLOCKED
 import io.embrace.android.embracesdk.internal.instrumentation.thread.blockage.ThreadBlockageEvent.BLOCKED_INTERVAL
 import io.embrace.android.embracesdk.internal.instrumentation.thread.blockage.ThreadBlockageEvent.UNBLOCKED
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
@@ -28,7 +28,7 @@ class BlockedThreadDetector(
     private val watchdogWorker: BackgroundWorker,
     private val clock: Clock,
     private val looper: Looper,
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
     private val listener: ThreadBlockageListener,
     private val intervalMs: Long,
     private val blockedDurationThreshold: Int,

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/BlockedThreadDetectorTest.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/BlockedThreadDetectorTest.kt
@@ -4,13 +4,13 @@ import android.os.Looper
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeThreadBlockageListener
 import io.embrace.android.embracesdk.fakes.createThreadBlockageBehavior
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.ThreadBlockageRemoteConfig
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.mockk.every
 import io.mockk.mockk
@@ -29,7 +29,7 @@ internal class BlockedThreadDetectorTest {
     private lateinit var listener: FakeThreadBlockageListener
     private lateinit var watchdogThread: AtomicReference<Thread>
     private lateinit var watchdogExecutorService: BlockingScheduledExecutorService
-    private lateinit var logger: EmbLogger
+    private lateinit var logger: InternalLogger
     private lateinit var looper: Looper
     private lateinit var cfg: ThreadBlockageRemoteConfig
 
@@ -46,7 +46,7 @@ internal class BlockedThreadDetectorTest {
             )
         )
         watchdogExecutorService = BlockingScheduledExecutorService(clock)
-        logger = FakeEmbLogger()
+        logger = FakeInternalLogger()
         looper = mockk {
             every { thread } returns Thread.currentThread()
         }

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadBlockageServiceRule.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadBlockageServiceRule.kt
@@ -4,8 +4,8 @@ import android.os.Looper
 import io.embrace.android.embracesdk.fakes.FakeAppStateTracker
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.behavior.FakeThreadBlockageBehavior
 import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.utils.Provider
@@ -24,7 +24,7 @@ internal class ThreadBlockageServiceRule<T : ScheduledExecutorService>(
     val clock: FakeClock = FakeClock(),
     private val scheduledExecutorSupplier: Provider<T>,
 ) : ExternalResource() {
-    val logger = FakeEmbLogger()
+    val logger = FakeInternalLogger()
 
     lateinit var fakeConfigService: FakeConfigService
     lateinit var fakeAppStateTracker: FakeAppStateTracker

--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationArgs.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationArgs.kt
@@ -19,7 +19,7 @@ class FakeInstrumentationArgs(
     override val configService: FakeConfigService = FakeConfigService(),
     override val context: Context = application,
     override val destination: FakeTelemetryDestination = FakeTelemetryDestination(),
-    override val logger: FakeEmbLogger = FakeEmbLogger(),
+    override val logger: FakeInternalLogger = FakeInternalLogger(),
     override val clock: FakeClock = FakeClock(),
     override val store: FakeKeyValueStore = FakeKeyValueStore(),
     override val serializer: PlatformSerializer = TestPlatformSerializer(),

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationArgs.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationArgs.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestinati
 import io.embrace.android.embracesdk.internal.arch.state.AppStateTracker
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.ConfigService
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.store.OrdinalStore
@@ -39,7 +39,7 @@ interface InstrumentationArgs {
     /**
      * Embrace SDK's internal logger.
      */
-    val logger: EmbLogger
+    val logger: InternalLogger
 
     /**
      * A clock that can be used for time measurements in telemetry.

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistryImpl.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistryImpl.kt
@@ -4,8 +4,8 @@ import io.embrace.android.embracesdk.internal.arch.attrs.EmbraceAttributeKey
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSource
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
 import io.embrace.android.embracesdk.internal.arch.datasource.StateDataSource
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.reflect.KClass
 
@@ -14,7 +14,7 @@ import kotlin.reflect.KClass
  * place to coordinate everything in one place.
  */
 class InstrumentationRegistryImpl(
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
 ) : InstrumentationRegistry {
 
     private val dataSourceStates = CopyOnWriteArrayList<DataSourceState<*>>()

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/DataSourceImpl.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/DataSourceImpl.kt
@@ -5,8 +5,8 @@ import io.embrace.android.embracesdk.internal.arch.InstrumentationArgs
 import io.embrace.android.embracesdk.internal.arch.limits.LimitStrategy
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.ConfigService
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.telemetry.AppliedLimitType
 
 /**
@@ -19,7 +19,7 @@ abstract class DataSourceImpl(
 ) : DataSource {
 
     protected val clock: Clock = args.clock
-    protected val logger: EmbLogger = args.logger
+    protected val logger: InternalLogger = args.logger
     protected val configService: ConfigService = args.configService
     protected val destination: TelemetryDestination = args.destination
     private val telemetryService = args.telemetryService

--- a/embrace-android-instrumentation-api/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/DataSourceImplTest.kt
+++ b/embrace-android-instrumentation-api/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/DataSourceImplTest.kt
@@ -2,8 +2,8 @@ package io.embrace.android.embracesdk.internal.arch
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceImpl
 import io.embrace.android.embracesdk.internal.arch.limits.LimitStrategy
 import io.embrace.android.embracesdk.internal.arch.limits.NoopLimitStrategy
@@ -77,7 +77,7 @@ internal class DataSourceImplTest {
         limitStrategy: LimitStrategy = NoopLimitStrategy,
         args: FakeInstrumentationArgs = FakeInstrumentationArgs(
             ApplicationProvider.getApplicationContext(),
-            logger = FakeEmbLogger(throwOnInternalError = false)
+            logger = FakeInternalLogger(throwOnInternalError = false)
         ),
     ) : DataSourceImpl(
         args,

--- a/embrace-android-instrumentation-compose-tap/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/ComposeActivityListener.kt
+++ b/embrace-android-instrumentation-compose-tap/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/ComposeActivityListener.kt
@@ -5,10 +5,10 @@ import android.app.Application.ActivityLifecycleCallbacks
 import android.os.Bundle
 import android.view.GestureDetector
 import android.view.Window
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 
 internal class ComposeActivityListener(
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
     private val dataSource: ComposeTapDataSource,
 ) : ActivityLifecycleCallbacks {
 

--- a/embrace-android-instrumentation-compose-tap/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/ComposeClickedTargetIterator.kt
+++ b/embrace-android-instrumentation-compose-tap/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/ComposeClickedTargetIterator.kt
@@ -3,12 +3,12 @@ package io.embrace.android.embracesdk.internal.instrumentation.compose.tap
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import java.util.LinkedList
 import java.util.Queue
 
 internal class ComposeClickedTargetIterator(
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
     dataSource: ComposeTapDataSource,
 ) : EmbraceClickedTargetIterator {
 

--- a/embrace-android-instrumentation-compose-tap/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/EmbraceGestureListener.kt
+++ b/embrace-android-instrumentation-compose-tap/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/EmbraceGestureListener.kt
@@ -4,7 +4,7 @@ import android.app.Activity
 import android.view.GestureDetector
 import android.view.MotionEvent
 import android.view.View
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import java.lang.ref.WeakReference
 
 /**
@@ -13,7 +13,7 @@ import java.lang.ref.WeakReference
  */
 internal class EmbraceGestureListener(
     activity: Activity,
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
     dataSource: ComposeTapDataSource,
 ) : GestureDetector.SimpleOnGestureListener() {
 

--- a/embrace-android-instrumentation-compose-tap/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/EmbraceWindowCallback.kt
+++ b/embrace-android-instrumentation-compose-tap/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/EmbraceWindowCallback.kt
@@ -6,7 +6,7 @@ import android.view.KeyboardShortcutGroup
 import android.view.Menu
 import android.view.MotionEvent
 import android.view.Window
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 
 /**
  * Custom Window callback that triggers onTouch event
@@ -15,7 +15,7 @@ import io.embrace.android.embracesdk.internal.logging.EmbLogger
 internal class EmbraceWindowCallback(
     private val delegate: Window.Callback,
     private val gestureDetector: GestureDetector,
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
 ) : Window.Callback by delegate {
 
     override fun dispatchTouchEvent(event: MotionEvent?): Boolean {

--- a/embrace-android-instrumentation-crash-jvm/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/EmbraceUncaughtExceptionHandler.kt
+++ b/embrace-android-instrumentation-crash-jvm/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/EmbraceUncaughtExceptionHandler.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.instrumentation.crash.jvm
 
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 
 /**
  * Intercepts uncaught exceptions from the JVM and forwards them to the Embrace API. Once handled,
@@ -18,7 +18,7 @@ internal class EmbraceUncaughtExceptionHandler(
      * The crash service which will submit the exception to the API as a crash
      */
     private val dataSource: JvmCrashDataSource,
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
 ) : Thread.UncaughtExceptionHandler {
 
     override fun uncaughtException(thread: Thread, exception: Throwable) {

--- a/embrace-android-instrumentation-crash-jvm/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/EmbraceUncaughtExceptionHandlerTest.kt
+++ b/embrace-android-instrumentation-crash-jvm/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/EmbraceUncaughtExceptionHandlerTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.instrumentation.crash.jvm
 
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.internal.arch.CrashTeardownHandler
 import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
@@ -17,7 +17,7 @@ import org.junit.Test
  */
 internal class EmbraceUncaughtExceptionHandlerTest {
 
-    private val logger = FakeEmbLogger(false)
+    private val logger = FakeInternalLogger(false)
 
     /**
      * Tests that [EmbraceUncaughtExceptionHandler] accepts a null arg.

--- a/embrace-android-instrumentation-crash-jvm/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/JvmCrashDataSourceImplTest.kt
+++ b/embrace-android-instrumentation-crash-jvm/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/JvmCrashDataSourceImplTest.kt
@@ -4,12 +4,12 @@ import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeConfigService
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.arch.schema.TelemetryAttributes
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.opentelemetry.kotlin.semconv.IncubatingApi
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
@@ -23,7 +23,7 @@ internal class JvmCrashDataSourceImplTest {
 
     private lateinit var crashDataSource: JvmCrashDataSourceImpl
     private lateinit var args: FakeInstrumentationArgs
-    private lateinit var logger: EmbLogger
+    private lateinit var logger: InternalLogger
     private lateinit var testException: Exception
     private lateinit var ctx: Application
     private var modifier: ((TelemetryAttributes) -> SchemaType)? = null
@@ -32,7 +32,7 @@ internal class JvmCrashDataSourceImplTest {
     fun setUp() {
         ctx = ApplicationProvider.getApplicationContext()
         args = FakeInstrumentationArgs(ctx)
-        logger = FakeEmbLogger()
+        logger = FakeInternalLogger()
         testException = RuntimeException("Test exception")
         Thread.setDefaultUncaughtExceptionHandler(null)
     }
@@ -75,7 +75,7 @@ internal class JvmCrashDataSourceImplTest {
         val embraceDefaultHandler = EmbraceUncaughtExceptionHandler(
             defaultHandler = null,
             dataSource = FakeJvmCrashDataSource(),
-            logger = FakeEmbLogger()
+            logger = FakeInternalLogger()
         )
         Thread.setDefaultUncaughtExceptionHandler(embraceDefaultHandler)
         setupForHandleCrash(true)

--- a/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImpl.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImpl.kt
@@ -8,8 +8,8 @@ import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
 import io.embrace.android.embracesdk.internal.handler.MainThreadHandler
 import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.jni.JniDelegate
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
@@ -32,7 +32,7 @@ internal class NativeCrashHandlerInstallerImpl(
     private val markerFilePath = args.crashMarkerFile.absolutePath
 
     private val configService: ConfigService = args.configService
-    private val logger: EmbLogger = args.logger
+    private val logger: InternalLogger = args.logger
     private val backgroundWorker: BackgroundWorker =
         args.backgroundWorker(Worker.Background.IoRegWorker)
     private val clock: Clock = args.clock

--- a/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashProcessorImpl.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashProcessorImpl.kt
@@ -5,8 +5,8 @@ import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.storage.FileStorageService
 import io.embrace.android.embracesdk.internal.delivery.storage.FileStorageServiceImpl
 import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.jni.JniDelegate
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.worker.PriorityWorker
@@ -22,7 +22,7 @@ internal class NativeCrashProcessorImpl(
     worker: PriorityWorker<StoredTelemetryMetadata>,
 ) : NativeCrashProcessor {
 
-    private val logger: EmbLogger = args.logger
+    private val logger: InternalLogger = args.logger
     private val serializer: PlatformSerializer = args.serializer
     private val fileStorageService: FileStorageService = FileStorageServiceImpl(
         outputDir,

--- a/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/SharedObjectLoaderImpl.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/SharedObjectLoaderImpl.kt
@@ -1,12 +1,12 @@
 package io.embrace.android.embracesdk.internal.instrumentation.crash.ndk
 
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import java.util.concurrent.atomic.AtomicBoolean
 
 internal class SharedObjectLoaderImpl(
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
 ) : SharedObjectLoader {
     override val loaded = AtomicBoolean(false)
     private val loggedFailure = AtomicBoolean(false)

--- a/embrace-android-instrumentation-crash-ndk/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImplTest.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImplTest.kt
@@ -4,8 +4,8 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeConfigService
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeJniDelegate
 import io.embrace.android.embracesdk.fakes.FakeMainThreadHandler
 import io.embrace.android.embracesdk.fakes.FakeSharedObjectLoader
@@ -50,7 +50,7 @@ class NativeCrashHandlerInstallerImplTest {
         args = FakeInstrumentationArgs(
             ApplicationProvider.getApplicationContext(),
             configService = fakeConfigService,
-            logger = FakeEmbLogger(false),
+            logger = FakeInternalLogger(false),
             backgroundWorkerSupplier = { BackgroundWorker(executorService) },
             sessionIdSupplier = { sessionId },
             processIdentifier = "pid"

--- a/embrace-android-instrumentation-huc-lite/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/HucLiteDataSource.kt
+++ b/embrace-android-instrumentation-huc-lite/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/HucLiteDataSource.kt
@@ -13,8 +13,8 @@ import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.instrumentation.network.getOverriddenURLString
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.utils.NetworkUtils
 import io.embrace.android.embracesdk.internal.utils.toNonNullMap
 import io.embrace.opentelemetry.kotlin.semconv.ErrorAttributes
@@ -82,7 +82,7 @@ class HucLiteDataSource(
 
     private fun installURLStreamHandlerFactory(
         clock: Clock,
-        logger: EmbLogger,
+        logger: InternalLogger,
     ) {
         runCatching {
             @SuppressLint("PrivateApi")

--- a/embrace-android-instrumentation-huc-lite/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huclite/HucTestHarness.kt
+++ b/embrace-android-instrumentation-huc-lite/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huclite/HucTestHarness.kt
@@ -3,8 +3,8 @@ package io.embrace.android.embracesdk.instrumentation.huclite
 import androidx.test.core.app.ApplicationProvider
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeClock.Companion.DEFAULT_FAKE_CURRENT_TIME
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeSpanToken
 import io.embrace.android.embracesdk.fakes.FakeTelemetryDestination
 import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
@@ -24,7 +24,7 @@ import javax.net.ssl.HttpsURLConnection
 internal class HucTestHarness {
     val fakeTelemetryDestination: FakeTelemetryDestination = FakeTelemetryDestination()
     val fakeClock = FakeClock(FAKE_TIME_MS)
-    val fakeEmbLogger = FakeEmbLogger(throwOnInternalError = false)
+    val fakeEmbLogger = FakeInternalLogger(throwOnInternalError = false)
     val hucLiteDataSource = HucLiteDataSource(
         FakeInstrumentationArgs(
             application = ApplicationProvider.getApplicationContext(),

--- a/embrace-android-instrumentation-huc-lite/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/HucLiteDataSourceTest.kt
+++ b/embrace-android-instrumentation-huc-lite/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/HucLiteDataSourceTest.kt
@@ -4,8 +4,8 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeTelemetryDestination
 import io.embrace.android.embracesdk.fakes.FakeURLStreamHandlerFactory
 import io.embrace.android.embracesdk.fakes.behavior.FakeNetworkBehavior
@@ -31,7 +31,7 @@ class HucLiteDataSourceTest {
     private lateinit var factoryFieldRef: Field
     private lateinit var fakeTelemetryDestination: FakeTelemetryDestination
     private lateinit var fakeClock: FakeClock
-    private lateinit var fakeEmbLogger: FakeEmbLogger
+    private lateinit var fakeEmbLogger: FakeInternalLogger
     private lateinit var domainCountLimiter: EmbraceDomainCountLimiter
     private lateinit var fakeConfigService: FakeConfigService
     private lateinit var mockedConnection: HttpsURLConnection
@@ -57,7 +57,7 @@ class HucLiteDataSourceTest {
         )
         fakeTelemetryDestination = FakeTelemetryDestination()
         fakeClock = FakeClock(FAKE_TIME_MS)
-        fakeEmbLogger = FakeEmbLogger(throwOnInternalError = false)
+        fakeEmbLogger = FakeInternalLogger(throwOnInternalError = false)
         mockedConnection =
             mockk<HttpsURLConnection>(relaxed = true).apply {
                 every { url } returns testUrl

--- a/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/HttpUrlConnectionTrackerTest.kt
+++ b/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/HttpUrlConnectionTrackerTest.kt
@@ -2,9 +2,9 @@ package io.embrace.android.embracesdk.instrumentation.huc
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeEmbraceInternalInterface
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
 import io.embrace.android.embracesdk.internal.api.NetworkRequestApi
 import org.junit.Assert.assertEquals
@@ -24,7 +24,7 @@ internal class HttpUrlConnectionTrackerTest {
 
     @Before
     fun setup() {
-        args = FakeInstrumentationArgs(ApplicationProvider.getApplicationContext(), logger = FakeEmbLogger(false))
+        args = FakeInstrumentationArgs(ApplicationProvider.getApplicationContext(), logger = FakeInternalLogger(false))
         fakeNetworkingApi = FakeNetworkRequestApi()
         fakeInternalInterface = FakeEmbraceInternalInterface()
     }

--- a/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/InternalNetworkApiImplTest.kt
+++ b/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/InternalNetworkApiImplTest.kt
@@ -2,8 +2,8 @@ package io.embrace.android.embracesdk.instrumentation.huc
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.behavior.FakeNetworkSpanForwardingBehavior
 import io.embrace.android.embracesdk.fixtures.fakeCompleteEmbraceNetworkRequest
 import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
@@ -23,7 +23,7 @@ internal class InternalNetworkApiImplTest {
 
     @Before
     fun setup() {
-        args = FakeInstrumentationArgs(ApplicationProvider.getApplicationContext(), logger = FakeEmbLogger(false))
+        args = FakeInstrumentationArgs(ApplicationProvider.getApplicationContext(), logger = FakeInternalLogger(false))
         requestDataSource = FakeNetworkRequestDataSource()
     }
 

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/AppStartupTraceEmitter.kt
@@ -9,8 +9,8 @@ import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.instrumentation.startup.ui.hasRenderEvent
 import io.embrace.android.embracesdk.internal.instrumentation.startup.ui.supportFrameCommitCallback
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
@@ -44,7 +44,7 @@ internal class AppStartupTraceEmitter(
     private val startupServiceProvider: Provider<StartupService?>,
     private val destination: TelemetryDestination,
     private val versionChecker: VersionChecker,
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
     manualEnd: Boolean,
     processInfo: ProcessInfo,
 ) : AppStartupDataCollector {

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleImpl.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleImpl.kt
@@ -10,13 +10,13 @@ import io.embrace.android.embracesdk.internal.instrumentation.startup.activity.U
 import io.embrace.android.embracesdk.internal.instrumentation.startup.activity.UiLoadTraceEmitter
 import io.embrace.android.embracesdk.internal.instrumentation.startup.activity.createActivityLoadEventEmitter
 import io.embrace.android.embracesdk.internal.instrumentation.startup.ui.createDrawEventEmitter
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
 
 class DataCaptureServiceModuleImpl(
     clock: Clock,
-    logger: EmbLogger,
+    logger: InternalLogger,
     destination: TelemetryDestination,
     configService: ConfigService,
     versionChecker: VersionChecker = BuildVersionChecker,

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleSupplier.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleSupplier.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.instrumentation.startup
 import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.ConfigService
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
 
 /**
@@ -12,7 +12,7 @@ import io.embrace.android.embracesdk.internal.utils.VersionChecker
  */
 typealias DataCaptureServiceModuleSupplier = (
     clock: Clock,
-    logger: EmbLogger,
+    logger: InternalLogger,
     destination: TelemetryDestination,
     configService: ConfigService,
     versionChecker: VersionChecker,

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/ui/DrawEventEmitter.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/ui/DrawEventEmitter.kt
@@ -4,7 +4,7 @@ import android.app.Activity
 import android.os.Build
 import android.os.Build.VERSION_CODES
 import io.embrace.android.embracesdk.internal.handler.AndroidMainThreadHandler
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
 
 /**
@@ -29,7 +29,7 @@ interface DrawEventEmitter {
 
 internal fun createDrawEventEmitter(
     versionChecker: VersionChecker,
-    logger: EmbLogger,
+    logger: InternalLogger,
 ): DrawEventEmitter? = if (supportFrameCommitCallback(versionChecker)) {
     FirstDrawDetector(logger)
 } else if (hasRenderEvent(versionChecker)) {

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/ui/FirstDrawDetector.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/ui/FirstDrawDetector.kt
@@ -9,8 +9,8 @@ import android.view.ViewTreeObserver
 import android.view.Window
 import androidx.annotation.RequiresApi
 import io.embrace.android.embracesdk.internal.instrumentation.startup.activity.traceInstanceId
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -22,7 +22,7 @@ import java.util.concurrent.ConcurrentHashMap
  */
 @RequiresApi(Build.VERSION_CODES.Q)
 internal class FirstDrawDetector(
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
 ) : DrawEventEmitter {
 
     private val loadingActivities: MutableMap<Int, Runnable> = ConcurrentHashMap()

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleImplTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleImplTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.instrumentation.startup
 
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeTelemetryDestination
 import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import org.junit.Assert.assertNotNull
@@ -15,7 +15,7 @@ internal class DataCaptureServiceModuleImplTest {
     fun testDefaultImplementations() {
         val module = DataCaptureServiceModuleImpl(
             FakeClock(),
-            FakeEmbLogger(),
+            FakeInternalLogger(),
             FakeTelemetryDestination(),
             FakeConfigService(),
         )
@@ -30,7 +30,7 @@ internal class DataCaptureServiceModuleImplTest {
     fun `disable ui load performance capture`() {
         val module = DataCaptureServiceModuleImpl(
             FakeClock(),
-            FakeEmbLogger(),
+            FakeInternalLogger(),
             FakeTelemetryDestination(),
             FakeConfigService(
                 autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(uiLoadTracingEnabled = false)
@@ -45,7 +45,7 @@ internal class DataCaptureServiceModuleImplTest {
     fun `enable only selected ui load performance capture`() {
         val module = DataCaptureServiceModuleImpl(
             FakeClock(),
-            FakeEmbLogger(),
+            FakeInternalLogger(),
             FakeTelemetryDestination(),
             FakeConfigService(
                 autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(uiLoadTracingTraceAll = false)

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/AppStartupTraceEmitterTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/AppStartupTraceEmitterTest.kt
@@ -4,7 +4,7 @@ import android.os.Build.VERSION_CODES
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeClock.Companion.DEFAULT_FAKE_CURRENT_TIME
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeProcessInfo
 import io.embrace.android.embracesdk.fakes.FakeSpanToken
 import io.embrace.android.embracesdk.fakes.FakeTelemetryDestination
@@ -60,7 +60,7 @@ internal class AppStartupTraceEmitterTest {
 
     private lateinit var clock: FakeClock
     private lateinit var destination: FakeTelemetryDestination
-    private lateinit var logger: FakeEmbLogger
+    private lateinit var logger: FakeInternalLogger
 
     @Before
     fun setUp() {
@@ -68,7 +68,7 @@ internal class AppStartupTraceEmitterTest {
         destination = FakeTelemetryDestination()
         startupService = StartupServiceImpl(destination)
         clock.tick(100L)
-        logger = FakeEmbLogger(false)
+        logger = FakeInternalLogger(false)
         firePreAndPostCreate = hasPrePostEvents(BuildVersionChecker)
         trackProcessStart = BuildVersionChecker.isAtLeast(VERSION_CODES.N)
         hasRenderEvent = hasRenderEvent(BuildVersionChecker)

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/StartupTrackerTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/StartupTrackerTest.kt
@@ -9,11 +9,11 @@ import io.embrace.android.embracesdk.fakes.FakeActivityLifecycleListener
 import io.embrace.android.embracesdk.fakes.FakeAppStartupDataCollector
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeDrawEventEmitter
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeSplashScreenActivity
 import io.embrace.android.embracesdk.internal.instrumentation.startup.StartupTracker
 import io.embrace.android.embracesdk.internal.instrumentation.startup.ui.hasRenderEvent
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
@@ -32,7 +32,7 @@ internal class StartupTrackerTest {
     private lateinit var application: Application
     private lateinit var clock: FakeClock
     private lateinit var dataCollector: FakeAppStartupDataCollector
-    private lateinit var logger: EmbLogger
+    private lateinit var logger: InternalLogger
     private lateinit var activityLifecycleListener: FakeActivityLifecycleListener
     private lateinit var drawEventEmitter: FakeDrawEventEmitter
     private lateinit var startupTracker: StartupTracker
@@ -42,7 +42,7 @@ internal class StartupTrackerTest {
     fun setUp() {
         application = RuntimeEnvironment.getApplication()
         clock = FakeClock()
-        logger = FakeEmbLogger()
+        logger = FakeInternalLogger()
         dataCollector = FakeAppStartupDataCollector(clock = clock)
         activityLifecycleListener = FakeActivityLifecycleListener()
         drawEventEmitter = FakeDrawEventEmitter()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/DisableSdkFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/DisableSdkFeatureTest.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.returnIfConditionMet
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.internal.delivery.storage.StorageLocation
 import io.embrace.android.embracesdk.internal.delivery.storage.asFile
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
@@ -40,7 +40,7 @@ internal class DisableSdkFeatureTest {
     fun setUp() {
         val ctx = ApplicationProvider.getApplicationContext<Context>()
         embraceDirs = StorageLocation.entries.map { it.asFile(
-            logger = FakeEmbLogger(),
+            logger = FakeInternalLogger(),
             rootDirSupplier = { ctx.filesDir },
             fallbackDirSupplier = { ctx.cacheDir }
         ).value }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/InternalErrorLogTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/InternalErrorLogTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.testcases.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.getLogWithAttributeValue
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
@@ -21,7 +21,7 @@ internal class InternalErrorLogTest {
 
     @Test
     fun `internal error log delivered`() {
-        lateinit var logger: EmbLogger
+        lateinit var logger: InternalLogger
 
         testRule.runTest(
             setupAction = {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PayloadTypesHeaderTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PayloadTypesHeaderTest.kt
@@ -1,13 +1,12 @@
 package io.embrace.android.embracesdk.testcases.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.EmbraceImpl
 import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.config.FakeProjectConfig
 import io.embrace.android.embracesdk.internal.EmbraceInternalApi
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import org.junit.Assert.assertEquals
@@ -50,7 +49,7 @@ internal class PayloadTypesHeaderTest {
 
     @Test
     fun `batched logs of different types send a list of header types`() {
-        lateinit var logger: EmbLogger
+        lateinit var logger: InternalLogger
 
         testRule.runTest(
             setupAction = {
@@ -84,7 +83,7 @@ internal class PayloadTypesHeaderTest {
                 appFramework = "flutter"
             )
         )
-        lateinit var logger: EmbLogger
+        lateinit var logger: InternalLogger
 
         testRule.runTest(
             instrumentedConfig = instrumentedConfig,
@@ -132,7 +131,7 @@ internal class PayloadTypesHeaderTest {
                 appFramework = "unity"
             )
         )
-        lateinit var logger: EmbLogger
+        lateinit var logger: InternalLogger
 
         testRule.runTest(
             instrumentedConfig = instrumentedConfig,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.testing.TestLifecycleOwner
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.core.BuildConfig
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeJniDelegate
 import io.embrace.android.embracesdk.fakes.FakeNetworkConnectivityService
 import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
@@ -78,7 +78,7 @@ internal class EmbraceSetupInterface(
 
     private val fakeInitModule: FakeInitModule = FakeInitModule(
         clock = fakeClock,
-        logger = FakeEmbLogger(ignoredErrors = ignoredInternalErrors),
+        logger = FakeInternalLogger(ignoredErrors = ignoredInternalErrors),
     )
 
     private val workerThreadModule: WorkerThreadModule = initWorkerThreadModule(
@@ -218,7 +218,7 @@ internal class EmbraceSetupInterface(
 
     fun getCurrentSessionSpan(): CurrentSessionSpan = fakeInitModule.openTelemetryModule.currentSessionSpan
 
-    fun getEmbLogger(): FakeEmbLogger = fakeInitModule.logger as FakeEmbLogger
+    fun getEmbLogger(): FakeInternalLogger = fakeInitModule.logger as FakeInternalLogger
 
     fun getFakedWorkerExecutor(): BlockingScheduledExecutorService = (workerThreadModule as FakeWorkerThreadModule).executor
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/StoredNdkData.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/StoredNdkData.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.testframework.actions
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import io.embrace.android.embracesdk.ResourceReader
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.fakeEmptyLogEnvelope
 import io.embrace.android.embracesdk.fakes.fakeEnvelopeMetadata
 import io.embrace.android.embracesdk.fakes.fakeEnvelopeResource
@@ -34,7 +34,7 @@ internal data class StoredNativeCrashData(
     fun getCrashFile(): File {
         val ctx = ApplicationProvider.getApplicationContext<Context>()
         val outputDir = StorageLocation.NATIVE.asFile(
-            logger = FakeEmbLogger(),
+            logger = FakeInternalLogger(),
             rootDirSupplier = { ctx.filesDir },
             fallbackDirSupplier = { ctx.cacheDir }
         ) .value.apply {

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/FlutterInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/FlutterInternalInterfaceImpl.kt
@@ -4,13 +4,13 @@ import io.embrace.android.embracesdk.EmbraceImpl
 import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
 import io.embrace.android.embracesdk.internal.FlutterInternalInterface
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 
 internal class FlutterInternalInterfaceImpl(
     private val embrace: EmbraceImpl,
     private val impl: EmbraceInternalInterface,
     private val hostedSdkVersionInfo: HostedSdkVersionInfo,
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
 ) : EmbraceInternalInterface by impl, FlutterInternalInterface {
 
     override fun setEmbraceFlutterSdkVersion(version: String?) {

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ReactNativeInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ReactNativeInternalInterfaceImpl.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.internal.capture.metadata.RnBundleIdTracker
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.instrumentation.crash.jvm.JvmCrashDataSource
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.JsException
 import io.embrace.android.embracesdk.internal.utils.encodeToUTF8String
 
@@ -20,7 +20,7 @@ internal class ReactNativeInternalInterfaceImpl(
     private val bootstrapper: ModuleInitBootstrapper,
     private val rnBundleIdTracker: RnBundleIdTracker,
     private val hostedSdkVersionInfo: HostedSdkVersionInfo,
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
 ) : EmbraceInternalInterface by impl, ReactNativeInternalInterface {
 
     override fun logUnhandledJsException(

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/SdkCallChecker.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/SdkCallChecker.kt
@@ -1,11 +1,11 @@
 package io.embrace.android.embracesdk.internal.api.delegate
 
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.telemetry.TelemetryService
 import java.util.concurrent.atomic.AtomicBoolean
 
 internal class SdkCallChecker(
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
     private val telemetryService: TelemetryService?,
 ) {
 

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/UnityInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/UnityInternalInterfaceImpl.kt
@@ -5,14 +5,14 @@ import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.internal.EmbraceInternalInterface
 import io.embrace.android.embracesdk.internal.UnityInternalInterface
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.logs.LogExceptionType
 
 internal class UnityInternalInterfaceImpl(
     private val embrace: EmbraceImpl,
     private val impl: EmbraceInternalInterface,
     private val hostedSdkVersionInfo: HostedSdkVersionInfo,
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
 ) : EmbraceInternalInterface by impl, UnityInternalInterface {
 
     override fun setUnityMetaData(

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -20,7 +20,7 @@ import io.embrace.android.embracesdk.internal.instrumentation.startup.DataCaptur
 import io.embrace.android.embracesdk.internal.instrumentation.thread.blockage.ThreadBlockageService
 import io.embrace.android.embracesdk.internal.instrumentation.thread.blockage.ThreadBlockageServiceSupplier
 import io.embrace.android.embracesdk.internal.instrumentation.thread.blockage.createThreadBlockageService
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionOrchestrator
 import io.embrace.android.embracesdk.internal.storage.EmbraceStorageService
 import io.embrace.android.embracesdk.internal.storage.StatFsAvailabilityChecker
@@ -138,7 +138,7 @@ internal class ModuleInitBootstrapper(
     },
     private val dataCaptureServiceModuleSupplier: DataCaptureServiceModuleSupplier = {
             clock: Clock,
-            logger: EmbLogger,
+            logger: InternalLogger,
             destination: TelemetryDestination,
             configService: ConfigService,
             versionChecker: VersionChecker,

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationModule.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationModule.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.internal.injection.InstrumentationModule
 
 class FakeInstrumentationModule(
     application: Application,
-    private val logger: FakeEmbLogger = FakeEmbLogger(),
+    private val logger: FakeInternalLogger = FakeInternalLogger(),
     override val instrumentationArgs: InstrumentationArgs = FakeInstrumentationArgs(application, logger = logger)
 ) : InstrumentationModule {
     override val instrumentationRegistry: InstrumentationRegistry = InstrumentationRegistryImpl(

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
@@ -5,8 +5,8 @@ import android.os.Build.VERSION_CODES.TIRAMISU
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationModule
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.internal.arch.InstrumentationRegistry
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
@@ -30,7 +30,7 @@ import org.robolectric.annotation.Config
 internal class ModuleInitBootstrapperTest {
 
     private lateinit var moduleInitBootstrapper: ModuleInitBootstrapper
-    private lateinit var logger: FakeEmbLogger
+    private lateinit var logger: FakeInternalLogger
     private lateinit var clock: Clock
     private lateinit var coreModule: FakeCoreModule
     private lateinit var context: Context
@@ -38,7 +38,7 @@ internal class ModuleInitBootstrapperTest {
 
     @Before
     fun setup() {
-        logger = FakeEmbLogger(false)
+        logger = FakeInternalLogger(false)
         clock = FakeClock()
         coreModule = FakeCoreModule()
         val application = RuntimeEnvironment.getApplication()

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/EmbraceInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/EmbraceInternalInterfaceImplTest.kt
@@ -3,8 +3,8 @@ package io.embrace.android.embracesdk.internal.api
 import io.embrace.android.embracesdk.EmbraceImpl
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.behavior.FakeNetworkSpanForwardingBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.api.delegate.EmbraceInternalInterfaceImpl
@@ -28,7 +28,7 @@ internal class EmbraceInternalInterfaceImplTest {
     fun setUp() {
         embraceImpl = mockk(relaxed = true)
         fakeClock = FakeClock(currentTime = beforeObjectInitTime)
-        initModule = FakeInitModule(clock = fakeClock, logger = FakeEmbLogger(false))
+        initModule = FakeInitModule(clock = fakeClock, logger = FakeInternalLogger(false))
         fakeConfigService = FakeConfigService()
         resourceSource = FakeEnvelopeResourceSource()
         internalImpl = EmbraceInternalInterfaceImpl(fakeConfigService, resourceSource)

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/FlutterInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/FlutterInternalInterfaceImplTest.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.fakes.FakeKeyValueStore
 import io.embrace.android.embracesdk.internal.api.delegate.FlutterInternalInterfaceImpl
 import io.embrace.android.embracesdk.internal.envelope.metadata.FlutterSdkVersionInfo
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -16,7 +16,7 @@ internal class FlutterInternalInterfaceImplTest {
 
     private lateinit var impl: FlutterInternalInterfaceImpl
     private lateinit var embrace: EmbraceImpl
-    private lateinit var logger: EmbLogger
+    private lateinit var logger: InternalLogger
     private lateinit var hostedSdkVersionInfo: HostedSdkVersionInfo
     private lateinit var store: FakeKeyValueStore
 

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/ReactNativeInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/ReactNativeInternalInterfaceImplTest.kt
@@ -4,9 +4,9 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.EmbraceImpl
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
 import io.embrace.android.embracesdk.fakes.FakeEmbraceInternalInterface
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationModule
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeKeyValueStore
 import io.embrace.android.embracesdk.fakes.FakeRnBundleIdTracker
 import io.embrace.android.embracesdk.fakes.FakeTelemetryDestination
@@ -33,7 +33,7 @@ internal class ReactNativeInternalInterfaceImplTest {
     private lateinit var store: FakeKeyValueStore
     private lateinit var bootstrapper: ModuleInitBootstrapper
     private lateinit var rnBundleIdTracker: FakeRnBundleIdTracker
-    private lateinit var logger: FakeEmbLogger
+    private lateinit var logger: FakeInternalLogger
     private lateinit var context: Context
     private lateinit var hostedSdkVersionInfo: HostedSdkVersionInfo
 
@@ -43,7 +43,7 @@ internal class ReactNativeInternalInterfaceImplTest {
         store = FakeKeyValueStore()
         rnBundleIdTracker = FakeRnBundleIdTracker()
         hostedSdkVersionInfo = ReactNativeSdkVersionInfo(store)
-        logger = FakeEmbLogger(false)
+        logger = FakeInternalLogger(false)
         context = ApplicationProvider.getApplicationContext()
         bootstrapper = ModuleInitBootstrapper(
             FakeInitModule(),

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/UnityInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/UnityInternalInterfaceImplTest.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.fakes.FakeKeyValueStore
 import io.embrace.android.embracesdk.internal.api.delegate.UnityInternalInterfaceImpl
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.envelope.metadata.UnitySdkVersionInfo
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -19,7 +19,7 @@ internal class UnityInternalInterfaceImplTest {
     private lateinit var impl: UnityInternalInterfaceImpl
     private lateinit var embrace: EmbraceImpl
     private lateinit var store: FakeKeyValueStore
-    private lateinit var logger: EmbLogger
+    private lateinit var logger: InternalLogger
 
     @Before
     fun setUp() {

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/LogsApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/LogsApiDelegateTest.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.api.delegate
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.Severity
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeLogService
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
@@ -34,7 +34,7 @@ internal class LogsApiDelegateTest {
         )
         moduleInitBootstrapper.init(ApplicationProvider.getApplicationContext())
 
-        val sdkCallChecker = SdkCallChecker(FakeEmbLogger(), FakeTelemetryService())
+        val sdkCallChecker = SdkCallChecker(FakeInternalLogger(), FakeTelemetryService())
         sdkCallChecker.started.set(true)
         delegate = LogsApiDelegate(moduleInitBootstrapper, sdkCallChecker)
     }

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/NetworkRequestApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/NetworkRequestApiDelegateTest.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.api.delegate
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeConfigService
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.behavior.FakeNetworkSpanForwardingBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
@@ -31,7 +31,7 @@ internal class NetworkRequestApiDelegateTest {
         moduleInitBootstrapper.init(ApplicationProvider.getApplicationContext())
 
         configService = moduleInitBootstrapper.configService as FakeConfigService
-        val sdkCallChecker = SdkCallChecker(FakeEmbLogger(), FakeTelemetryService())
+        val sdkCallChecker = SdkCallChecker(FakeInternalLogger(), FakeTelemetryService())
         sdkCallChecker.started.set(true)
         delegate = NetworkRequestApiDelegate(moduleInitBootstrapper, sdkCallChecker)
     }

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/OTelApiDelegateTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.api.delegate
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeLogRecordExporter
 import io.embrace.android.embracesdk.fakes.FakeMutableAttributeContainer
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
@@ -41,7 +41,7 @@ internal class OTelApiDelegateTest {
         bootstrapper.init(ApplicationProvider.getApplicationContext())
         cfg = bootstrapper.openTelemetryModule.otelSdkConfig
 
-        sdkCallChecker = SdkCallChecker(FakeEmbLogger(), FakeTelemetryService())
+        sdkCallChecker = SdkCallChecker(FakeInternalLogger(), FakeTelemetryService())
         sdkCallChecker.started.set(true)
         delegate = OTelApiDelegate(bootstrapper, sdkCallChecker)
     }

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/SdkCallCheckerTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/SdkCallCheckerTest.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.api.delegate
 
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -11,13 +11,13 @@ import org.junit.Test
 internal class SdkCallCheckerTest {
 
     private val action = "foo"
-    private lateinit var logger: FakeEmbLogger
+    private lateinit var logger: FakeInternalLogger
     private lateinit var telemetryService: FakeTelemetryService
     private lateinit var checker: SdkCallChecker
 
     @Before
     fun setUp() {
-        logger = FakeEmbLogger()
+        logger = FakeInternalLogger()
         telemetryService = FakeTelemetryService()
         checker = SdkCallChecker(logger, telemetryService)
     }

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegateTest.kt
@@ -4,7 +4,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.LastRunEndState
 import io.embrace.android.embracesdk.fakes.FakeConfigService
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeLogService
 import io.embrace.android.embracesdk.fakes.FakeSessionTracker
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
@@ -28,7 +28,7 @@ internal class SdkStateApiDelegateTest {
     private lateinit var configService: FakeConfigService
     private lateinit var sessionTracker: FakeSessionTracker
     private lateinit var sdkCallChecker: SdkCallChecker
-    private lateinit var logger: FakeEmbLogger
+    private lateinit var logger: FakeInternalLogger
 
     @Before
     fun setUp() {
@@ -48,7 +48,7 @@ internal class SdkStateApiDelegateTest {
         )
         moduleInitBootstrapper.init(ApplicationProvider.getApplicationContext())
         sessionTracker = moduleInitBootstrapper.essentialServiceModule.sessionTracker as FakeSessionTracker
-        logger = FakeEmbLogger()
+        logger = FakeInternalLogger()
         sdkCallChecker = SdkCallChecker(logger, FakeTelemetryService())
         sdkCallChecker.started.set(true)
         delegate = SdkStateApiDelegate(moduleInitBootstrapper, sdkCallChecker)

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/SessionApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/SessionApiDelegateTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.api.delegate
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeSessionOrchestrator
 import io.embrace.android.embracesdk.fakes.FakeSessionPropertiesService
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
@@ -23,7 +23,7 @@ internal class SessionApiDelegateTest {
     private lateinit var orchestrator: FakeSessionOrchestrator
     private lateinit var sdkCallChecker: SdkCallChecker
     private lateinit var sessionPropertiesService: FakeSessionPropertiesService
-    private lateinit var logger: FakeEmbLogger
+    private lateinit var logger: FakeInternalLogger
 
     @Before
     fun setUp() {
@@ -40,7 +40,7 @@ internal class SessionApiDelegateTest {
         orchestrator = moduleInitBootstrapper.sessionOrchestrator as FakeSessionOrchestrator
         sessionPropertiesService =
             moduleInitBootstrapper.essentialServiceModule.sessionPropertiesService as FakeSessionPropertiesService
-        logger = FakeEmbLogger()
+        logger = FakeInternalLogger()
         sdkCallChecker = SdkCallChecker(logger, FakeTelemetryService())
         sdkCallChecker.started.set(true)
         delegate = SessionApiDelegate(moduleInitBootstrapper, sdkCallChecker)

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/UserApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/UserApiDelegateTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.api.delegate
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
@@ -34,7 +34,7 @@ internal class UserApiDelegateTest {
             }
         )
         moduleInitBootstrapper.init(ApplicationProvider.getApplicationContext())
-        val sdkCallChecker = SdkCallChecker(FakeEmbLogger(), FakeTelemetryService())
+        val sdkCallChecker = SdkCallChecker(FakeInternalLogger(), FakeTelemetryService())
         sdkCallChecker.started.set(true)
         delegate = UserApiDelegate(moduleInitBootstrapper, sdkCallChecker)
     }

--- a/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImpl.kt
+++ b/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImpl.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.internal.delivery.storage
 
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.worker.PriorityWorker
 import java.io.File
 import java.io.FileNotFoundException
@@ -13,7 +13,7 @@ import java.util.concurrent.RejectedExecutionException
 class FileStorageServiceImpl(
     outputDir: Lazy<File>,
     private val worker: PriorityWorker<StoredTelemetryMetadata>,
-    private val logger: EmbLogger,
+    private val logger: InternalLogger,
     private val storageLimit: Int = 500,
 ) : FileStorageService {
 

--- a/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/StorageLocationExt.kt
+++ b/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/StorageLocationExt.kt
@@ -1,14 +1,14 @@
 package io.embrace.android.embracesdk.internal.delivery.storage
 
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import java.io.File
 
 /**
  * Get the directory as a [File] object
  */
 fun StorageLocation.asFile(
-    logger: EmbLogger,
+    logger: InternalLogger,
     rootDirSupplier: () -> File,
     fallbackDirSupplier: () -> File,
 ): Lazy<File> = lazy {

--- a/embrace-android-telemetry-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImplTest.kt
+++ b/embrace-android-telemetry-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImplTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.delivery.storage
 
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock.Companion.DEFAULT_FAKE_CURRENT_TIME
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.internal.delivery.PayloadType
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
@@ -22,7 +22,7 @@ class FileStorageServiceImplTest {
 
     private lateinit var outputDir: File
     private lateinit var service: FileStorageService
-    private lateinit var logger: FakeEmbLogger
+    private lateinit var logger: FakeInternalLogger
     private lateinit var executor: BlockingScheduledExecutorService
 
     @Before
@@ -30,7 +30,7 @@ class FileStorageServiceImplTest {
         outputDir = Files.createTempDirectory("temp").toFile().apply {
             mkdirs()
         }
-        logger = FakeEmbLogger(throwOnInternalError = false)
+        logger = FakeInternalLogger(throwOnInternalError = false)
         executor = BlockingScheduledExecutorService()
         service = FileStorageServiceImpl(
             lazy { outputDir },

--- a/embrace-microbenchmark/src/androidTest/kotlin/io/embrace/android/embracesdk/benchmark/TelemetryDestinationHarness.kt
+++ b/embrace-microbenchmark/src/androidTest/kotlin/io/embrace/android/embracesdk/benchmark/TelemetryDestinationHarness.kt
@@ -8,8 +8,8 @@ import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedCo
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.InstrumentedConfig
 import io.embrace.android.embracesdk.internal.injection.InitModule
 import io.embrace.android.embracesdk.internal.injection.OpenTelemetryModuleImpl
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
-import io.embrace.android.embracesdk.internal.logging.EmbLoggerImpl
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLoggerImpl
 import io.embrace.android.embracesdk.internal.otel.logs.LogSink
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSink
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
@@ -42,7 +42,7 @@ internal class TelemetryDestinationHarness {
     private class TestInitModule : InitModule {
         override val clock: io.embrace.android.embracesdk.internal.clock.Clock = NormalizedIntervalClock()
         override val telemetryService: TelemetryService = NoopTelemetryService
-        override val logger: EmbLogger = EmbLoggerImpl()
+        override val logger: InternalLogger = InternalLoggerImpl()
         override val systemInfo: SystemInfo = SystemInfo()
         override val jsonSerializer: PlatformSerializer = EmbraceSerializer()
         override val instrumentedConfig: InstrumentedConfig = InstrumentedConfigImpl

--- a/embrace-test-common/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeInternalLogger.kt
+++ b/embrace-test-common/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeInternalLogger.kt
@@ -1,15 +1,15 @@
 package io.embrace.android.embracesdk.fakes
 
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorHandler
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.utils.Provider
 
-class FakeEmbLogger(
+class FakeInternalLogger(
     var throwOnInternalError: Boolean = true,
     override var errorHandlerProvider: Provider<InternalErrorHandler?> = { null },
     val ignoredErrors: List<InternalErrorType> = emptyList()
-) : EmbLogger {
+) : InternalLogger {
 
     data class LogMessage(
         val msg: String,

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeInitModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeInitModule.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.fakes.injection
 
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.FakeEmbLogger
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.clock.Clock
@@ -10,11 +10,11 @@ import io.embrace.android.embracesdk.internal.injection.InitModule
 import io.embrace.android.embracesdk.internal.injection.InitModuleImpl
 import io.embrace.android.embracesdk.internal.injection.OpenTelemetryModule
 import io.embrace.android.embracesdk.internal.injection.OpenTelemetryModuleImpl
-import io.embrace.android.embracesdk.internal.logging.EmbLogger
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
 
 class FakeInitModule(
     clock: Clock = FakeClock(),
-    logger: EmbLogger = FakeEmbLogger(),
+    logger: InternalLogger = FakeInternalLogger(),
     systemInfo: SystemInfo = SystemInfo(
         osVersion = "99.0.0",
         deviceManufacturer = "Fake Manufacturer",


### PR DESCRIPTION
## Goal

Rename the internal logging interface to `InternalLogger` so as to not confuse the Embrace implementation of the OTel Logger, which is also called `EmbLogger`

<!-- Describe how this change has been tested -->