### PR TITLE
Add OTel resource attributes to the embrace payload envelopes

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
@@ -109,6 +109,10 @@ class PayloadSourceModuleImpl(
         AppEnvironment(isDebug)
     }
 
+    private val otelResourceAttributes: Map<String, String> by lazy {
+        otelModule.otelSdkConfig.getOTelResourceAttributes()
+    }
+
     override val resourceSource: EnvelopeResourceSource by singleton {
         EmbTrace.trace("resource-source") {
             EnvelopeResourceSourceImpl(
@@ -126,8 +130,10 @@ class PayloadSourceModuleImpl(
                 },
                 rnBundleIdProvider = { rnBundleIdTracker.getReactNativeBundleId() },
                 versionName = BuildConfig.VERSION_NAME,
-                versionCode = BuildConfig.VERSION_CODE.toIntOrNull()
-            )
+                versionCode = BuildConfig.VERSION_CODE.toIntOrNull(),
+            ) {
+                otelResourceAttributes
+            }
         }
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImplTest.kt
@@ -46,7 +46,9 @@ internal class EnvelopeResourceSourceImplTest {
             "",
             53,
             { "fakeReactNativeBundleId" }
-        )
+        ) {
+            mapOf("resource-attr" to "foo")
+        }
         val envelope = source.getEnvelopeResource()
 
         assertEquals("2.5.1", envelope.appVersion)
@@ -73,5 +75,6 @@ internal class EnvelopeResourceSourceImplTest {
         assertEquals("26", envelope.osCode)
         assertEquals("1920x1080", envelope.screenResolution)
         assertEquals(8, envelope.numCores)
+        assertEquals("foo", envelope.extras["resource-attr"])
     }
 }

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImpl.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImpl.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.internal.capture.metadata.AppEnvironment
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
+import io.embrace.android.embracesdk.internal.utils.Provider
 import java.util.concurrent.ConcurrentHashMap
 
 class EnvelopeResourceSourceImpl(
@@ -14,6 +15,7 @@ class EnvelopeResourceSourceImpl(
     private val versionName: String,
     private val versionCode: Int?,
     private val rnBundleIdProvider: () -> String?,
+    private val otelResourceAttributesSupplier: Provider<Map<String, String>>,
 ) : EnvelopeResourceSource {
 
     private val extras = ConcurrentHashMap<String, String>()
@@ -48,7 +50,7 @@ class EnvelopeResourceSourceImpl(
             osCode = device.systemInfo.androidOsApiLevel,
             screenResolution = device.screenResolution,
             numCores = device.numberOfCores,
-            extras = extras.toMap()
+            extras = extras.toMap() + otelResourceAttributesSupplier()
         )
     }
 

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.otel.config
 
 import io.embrace.android.embracesdk.internal.SystemInfo
+import io.embrace.android.embracesdk.internal.otel.impl.EmbMutableAttributeContainer
 import io.embrace.android.embracesdk.internal.otel.logs.DefaultLogRecordExporter
 import io.embrace.android.embracesdk.internal.otel.logs.DefaultLogRecordProcessor
 import io.embrace.android.embracesdk.internal.otel.logs.LogSink
@@ -128,5 +129,11 @@ class OtelSdkConfig(
 
     fun setResourceAttribute(key: String, value: String) {
         customAttributes[key] = value
+    }
+
+    fun getOTelResourceAttributes(): Map<String, String> {
+        val resourceAttrContainer = EmbMutableAttributeContainer()
+        resourceAction(resourceAttrContainer)
+        return resourceAttrContainer.attributes
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/EmbraceInternalInterfaceTest.kt
@@ -58,12 +58,11 @@ internal class EmbraceInternalInterfaceTest {
                 }
             },
             assertAction = {
-                val expected = mapOf("foo" to "bar")
                 val sessionResource = checkNotNull(getSingleSessionEnvelope().resource)
-                assertEquals(expected, sessionResource.extras)
+                assertEquals("bar", sessionResource.extras["foo"])
 
                 val logResource = checkNotNull(getSingleLogEnvelope().resource)
-                assertEquals(expected, logResource.extras)
+                assertEquals("bar", logResource.extras["foo"])
             }
         )
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/OTelExportTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/OTelExportTest.kt
@@ -22,6 +22,7 @@ import io.embrace.android.embracesdk.otel.java.addJavaSpanProcessor
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.opentelemetry.kotlin.semconv.ServiceAttributes
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -46,6 +47,7 @@ internal class OTelExportTest {
                 embrace.addSpanExporter(fakeSpanExporter)
             },
             testCaseAction = {
+                embrace.setResourceAttribute("bad-test", "foo")
                 recordSession {
                     embrace.startSpan("test-span").stop()
                 }
@@ -57,9 +59,10 @@ internal class OTelExportTest {
             },
             otelExportAssertion = {
                 val span = awaitSpans(1) { it.name == "test-span" }
-                with(span.single()) {
-                    assertEquals("my.app", resource.attributes.toStringMap()[ServiceAttributes.SERVICE_NAME])
-                    assertEquals("foo", resource.attributes.asMap().filter { it.key.key == "test" }.values.single())
+                with(span.single().resource.attributes.toStringMap()) {
+                    assertEquals("my.app", this[ServiceAttributes.SERVICE_NAME])
+                    assertEquals("foo", this["test"])
+                    assertFalse(contains("bad-test"))
                 }
             }
         )
@@ -93,6 +96,7 @@ internal class OTelExportTest {
                 embrace.setResourceAttribute("test", "foo")
             },
             testCaseAction = {
+                embrace.setResourceAttribute("bad-test", "foo")
                 recordSession {
                     logTimestampNanos = clock.now().millisToNanos()
                     embrace.logMessage("test message", Severity.INFO)
@@ -106,8 +110,11 @@ internal class OTelExportTest {
                     assertEquals("test message", body.asString())
                     assertEquals(logTimestampNanos, timestampEpochNanos)
                     assertEquals(logTimestampNanos, observedTimestampEpochNanos)
-                    assertEquals("my.app", resource.attributes.toStringMap()[ServiceAttributes.SERVICE_NAME])
-                    assertEquals("foo", resource.attributes.asMap().filter { it.key.key == "test" }.values.single())
+                    with(resource.attributes.toStringMap()) {
+                        assertEquals("my.app", this[ServiceAttributes.SERVICE_NAME])
+                        assertEquals("foo", this["test"])
+                        assertFalse(contains("bad-test"))
+                    }
                 }
             }
         )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionPayloadTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionPayloadTest.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.assertions.getSessionId
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -23,6 +24,7 @@ internal class SessionPayloadTest {
                 embrace.setResourceAttribute("resource-attr", "foo")
             },
             testCaseAction = {
+                embrace.setResourceAttribute("bad-resource-attr", "foo")
                 recordSession()
 
             },
@@ -37,6 +39,7 @@ internal class SessionPayloadTest {
                         assertTrue(checkNotNull(deviceModel).isNotBlank())
                         assertEquals(AppFramework.NATIVE, appFramework)
                         assertEquals("foo", extras["resource-attr"])
+                        assertFalse(extras.contains("bad-resource-attr"))
                     }
                     assertTrue(getSessionId().isNotBlank())
                 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionPayloadTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionPayloadTest.kt
@@ -17,8 +17,11 @@ internal class SessionPayloadTest {
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule()
 
     @Test
-    fun `device and app attributes are present in session envelope`() {
+    fun `device, app, and otel resource attributes are present in session envelope`() {
         testRule.runTest(
+            preSdkStartAction = {
+                embrace.setResourceAttribute("resource-attr", "foo")
+            },
             testCaseAction = {
                 recordSession()
 
@@ -33,6 +36,7 @@ internal class SessionPayloadTest {
                         assertTrue(checkNotNull(osName).isNotBlank())
                         assertTrue(checkNotNull(deviceModel).isNotBlank())
                         assertEquals(AppFramework.NATIVE, appFramework)
+                        assertEquals("foo", extras["resource-attr"])
                     }
                     assertTrue(getSessionId().isNotBlank())
                 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/assertions/JsonComparator.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/assertions/JsonComparator.kt
@@ -20,6 +20,7 @@ internal object JsonComparator {
      */
     fun compare(expected: JSONObject, observed: JSONObject, path: String = ""): List<String> {
         val mismatches = mutableListOf<String>()
+        var findMissingKeys = true
 
         expected.keys().forEach { key ->
             val expectedValue = expected.get(key)
@@ -30,6 +31,7 @@ internal object JsonComparator {
                 else -> "$path.$key"
             }
             if (expectedValue == IGNORE_VALUE) {
+                findMissingKeys = false
                 return@forEach
             }
             if (observedValue == null) {
@@ -39,8 +41,10 @@ internal object JsonComparator {
             compareJsonValue(expectedValue, observedValue, mismatches, currentPath)
         }
 
-        // Check for keys in observed JSON that are not present in expected JSON recursively
-        findMissingExpectedKeys(observed, expected, mismatches)
+        // Check for keys in observed JSON that are not present in expected JSON recursively only if the parent value isn't ignored
+        if (findMissingKeys) {
+            findMissingExpectedKeys(observed, expected, mismatches)
+        }
         return mismatches
     }
 

--- a/embrace-android-sdk/src/test/resources/v2_session_expected.json
+++ b/embrace-android-sdk/src/test/resources/v2_session_expected.json
@@ -33,7 +33,8 @@
     "os_version": "__EMBRACE_TEST_IGNORE__",
     "os_code": "__EMBRACE_TEST_IGNORE__",
     "screen_resolution": "__EMBRACE_TEST_IGNORE__",
-    "num_cores": "__EMBRACE_TEST_IGNORE__"
+    "num_cores": "__EMBRACE_TEST_IGNORE__",
+    "extras": "__EMBRACE_TEST_IGNORE__"
   },
   "type": "spans",
   "version": "0.1.0"


### PR DESCRIPTION
## Goal

Add OTel resource attributes to the Embrace payload envelope `resource` object

<!-- Describe how this change has been tested -->