### PR TITLE
Set instrumentation name for all states at the base class

### DIFF
--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/TestStateDataSource.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/TestStateDataSource.kt
@@ -11,7 +11,6 @@ class TestStateDataSource(
     stateTypeFactory = ::TestState,
     defaultValue = "UNKNOWN",
     maxTransitions = 4,
-    instrumentationName = "test_state_data_source"
 )
 
 class TestState(initialValue: String) : State<String>(initialValue, "test")

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/StateDataSource.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/StateDataSource.kt
@@ -19,11 +19,10 @@ abstract class StateDataSource<T : Any>(
     private val stateTypeFactory: (initialValue: T) -> SchemaType.State<T>,
     defaultValue: T,
     maxTransitions: Int = DEFAULT_MAX_TRANSITIONS,
-    instrumentationName: String,
 ) : SessionEndListener, SessionChangeListener, DataSourceImpl(
     args = args,
     limitStrategy = UpToLimitStrategy { maxTransitions },
-    instrumentationName = instrumentationName
+    instrumentationName = "${stateTypeFactory(defaultValue).stateName}_state_data_source"
 ) {
     val stateAttributeKey = createStateKey(stateTypeFactory(defaultValue).stateName)
     private val currentState: AtomicReference<T> = AtomicReference(defaultValue)

--- a/embrace-android-instrumentation-network-status/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkStateDataSource.kt
+++ b/embrace-android-instrumentation-network-status/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkStateDataSource.kt
@@ -14,7 +14,6 @@ class NetworkStateDataSource(
     stateTypeFactory = ::NetworkState,
     defaultValue = Status.UNKNOWN,
     maxTransitions = MAX_CAPTURED_NETWORK_STATE_TRANSITIONS,
-    instrumentationName = "network_state_data_source"
 ) {
     override fun onNetworkConnectivityStatusChanged(status: NetworkStatus) {
         onStateChange(clock.now(), status.toState())

--- a/embrace-android-instrumentation-power-save/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/powersave/PowerStateDataSource.kt
+++ b/embrace-android-instrumentation-power-save/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/powersave/PowerStateDataSource.kt
@@ -15,7 +15,6 @@ class PowerStateDataSource(
     args = args,
     stateTypeFactory = ::PowerState,
     defaultValue = PowerMode.UNKNOWN,
-    instrumentationName = "power_state_data_source"
 ) {
     private val powerManagerProvider: Provider<PowerManager?> = { args.systemService(Context.POWER_SERVICE) }
     private val receiver = PowerSaveModeReceiver(powerManagerProvider, ::onPowerSaveModeChanged)


### PR DESCRIPTION
## Goal

Set the name of the state instrumentation in a common place in the base class

<!-- Describe how this change has been tested -->