### PR TITLE
Make state spans private

### DIFF
--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanToken.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanToken.kt
@@ -32,6 +32,8 @@ class FakeSpanToken(
 
     override fun isRecording(): Boolean = endTimeMs == null
 
+    override fun isValid(): Boolean = true
+
     override fun addAttribute(key: String, value: String) {
         attrs[key] = value
     }

--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTelemetryDestination.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTelemetryDestination.kt
@@ -51,6 +51,7 @@ class FakeTelemetryDestination : TelemetryDestination {
         schemaType: SchemaType,
         startTimeMs: Long,
         autoTerminate: Boolean,
+        private: Boolean,
     ): SpanToken {
         val token = FakeSpanToken(
             name = schemaType.fixedObjectName,
@@ -74,6 +75,7 @@ class FakeTelemetryDestination : TelemetryDestination {
         startTimeMs: Long,
         parent: SpanToken?,
         type: EmbType,
+        private: Boolean,
     ): SpanToken {
         val token = FakeSpanToken(
             name = name,

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/SpanToken.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/SpanToken.kt
@@ -19,6 +19,11 @@ interface SpanToken {
     fun isRecording(): Boolean
 
     /**
+     * Returns true if this object represents a valid span instance
+     */
+    fun isValid(): Boolean
+
+    /**
      * Adds an attribute to the span
      */
     fun addAttribute(key: String, value: String)

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/TelemetryDestination.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/TelemetryDestination.kt
@@ -50,7 +50,8 @@ interface TelemetryDestination {
         schemaType: SchemaType,
         startTimeMs: Long,
         autoTerminate: Boolean = false,
-    ): SpanToken?
+        private: Boolean = false,
+    ): SpanToken
 
     /**
      * Starts a new span with the given [name] and [startTimeMs].
@@ -60,7 +61,8 @@ interface TelemetryDestination {
         startTimeMs: Long,
         parent: SpanToken? = null,
         type: EmbType = EmbType.Performance.Default,
-    ): SpanToken?
+        private: Boolean = false,
+    ): SpanToken
 
     /**
      * Start a recording the given [SchemaType.State] for the current session

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/AppStartupTraceEmitter.kt
@@ -244,7 +244,7 @@ internal class AppStartupTraceEmitter(
             )
         }
 
-        if (rootSpan != null) {
+        if (rootSpan.isValid()) {
             appStartupRootSpan.set(rootSpan)
         } else {
             logger.trackInternalError(

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/activity/UiLoadTraceEmitter.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/activity/UiLoadTraceEmitter.kt
@@ -291,8 +291,8 @@ internal class UiLoadTraceEmitter(
         if (trace != null && !trace.children.containsKey(lifecycleStage)) {
             destination.startSpanCapture(
                 name = lifecycleStage.spanName(trace.activityName),
-                parent = trace.root,
                 startTimeMs = timestampMs,
+                parent = trace.root,
             )?.let { newSpan ->
                 val newChildren = trace.children.plus(lifecycleStage to newSpan)
                 activeTraces[instanceId] = trace.copy(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/StateFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/StateFeatureTest.kt
@@ -13,8 +13,10 @@ import io.embrace.android.embracesdk.internal.arch.attrs.embStateDroppedByInstru
 import io.embrace.android.embracesdk.internal.arch.attrs.embStateInitialValue
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.LinkType
+import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
+import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttributeValue
 import io.embrace.android.embracesdk.internal.otel.spans.hasEmbraceAttributeValue
 import io.embrace.android.embracesdk.internal.session.getSessionSpan
@@ -94,6 +96,7 @@ internal class StateFeatureTest {
                 val sessions = listOf(background.first(), foreground.first(), background.last())
                 repeat(sessions.size) { i ->
                     val stateSpan = checkNotNull(sessions[i].getStateSpan("emb-state-test"))
+                    assertTrue(checkNotNull(stateSpan.attributes).hasEmbraceAttribute(PrivateSpan))
                     with(checkNotNull(stateSpan.events)) {
                         repeat(size) { j ->
                             val event = transitions[i][j]


### PR DESCRIPTION
## Goal

Make state spans private for now for dark mode testing. All the other session metadata will remain the same - this just prevents the span from being exported via the custom exporters

<!-- Describe how this change has been tested -->