### PR TITLE
Use ordinal for user session number

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionOrchestratorImpl.kt
@@ -7,13 +7,15 @@ import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.session.UserSessionState.NO_ACTIVE_USER_SESSION
 import io.embrace.android.embracesdk.internal.session.UserSessionState.USER_SESSION_ACTIVE
 import io.embrace.android.embracesdk.internal.session.UserSessionState.USER_SESSION_TERMINATED
+import io.embrace.android.embracesdk.internal.store.Ordinal
+import io.embrace.android.embracesdk.internal.store.OrdinalStore
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.semconv.ExperimentalSemconv
-import java.util.concurrent.atomic.AtomicLong
 
 internal class UserSessionOrchestratorImpl(
     private val clock: Clock,
     configService: ConfigService,
+    private val ordinalStore: OrdinalStore,
 ) : UserSessionOrchestrator {
 
     private val lock = Any()
@@ -24,9 +26,6 @@ internal class UserSessionOrchestratorImpl(
 
     @Volatile
     private var metadata: UserSessionMetadata? = null
-
-    // TODO: future: persist the incremented ordinal
-    private val sessionCounter = AtomicLong(0L)
 
     private val maxDurationMs: Long = configService.sessionBehavior.getMaxSessionDurationMs()
     private val inactivityTimeoutMs: Long = configService.sessionBehavior.getSessionInactivityTimeoutMs()
@@ -64,7 +63,7 @@ internal class UserSessionOrchestratorImpl(
         metadata = UserSessionMetadata(
             startTimeMs = clock.now(),
             userSessionId = Uuid.getEmbUuid(),
-            userSessionNumber = sessionCounter.incrementAndGet(),
+            userSessionNumber = ordinalStore.incrementAndGet(Ordinal.USER_SESSION).toLong(),
             maxDurationMins = maxDurationMs / 60_000L,
             inactivityTimeoutMins = inactivityTimeoutMs / 60_000L,
         )

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionOrchestratorImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionOrchestratorImplTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.session
 
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeOrdinalStore
 import io.embrace.android.embracesdk.fakes.behavior.FakeUserSessionBehavior
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import org.junit.Assert.assertEquals
@@ -31,6 +32,7 @@ internal class UserSessionOrchestratorImplTest {
                     sessionInactivityTimeoutMs = inactivityMs,
                 ),
             ),
+            ordinalStore = FakeOrdinalStore(),
         )
     }
 
@@ -76,6 +78,37 @@ internal class UserSessionOrchestratorImplTest {
         assertEquals(2L, second.userSessionNumber)
         assertNotEquals(first.userSessionId, second.userSessionId)
         assertEquals(maxDurationMs - 1, second.startTimeMs)
+    }
+
+    @Test
+    fun `user session ordinal persistence`() {
+        val store = FakeOrdinalStore()
+        val first = UserSessionOrchestratorImpl(
+            clock = clock,
+            configService = FakeConfigService(
+                sessionBehavior = FakeUserSessionBehavior(
+                    maxSessionDurationMs = maxDurationMs,
+                    sessionInactivityTimeoutMs = inactivityMs,
+                ),
+            ),
+            ordinalStore = store,
+        )
+        first.onNewSessionPart()
+        assertEquals(1L, checkNotNull(first.currentUserSession()).userSessionNumber)
+
+        // create a new orchestrator sharing the same store
+        val second = UserSessionOrchestratorImpl(
+            clock = clock,
+            configService = FakeConfigService(
+                sessionBehavior = FakeUserSessionBehavior(
+                    maxSessionDurationMs = maxDurationMs,
+                    sessionInactivityTimeoutMs = inactivityMs,
+                ),
+            ),
+            ordinalStore = store,
+        )
+        second.onNewSessionPart()
+        assertEquals(2L, checkNotNull(second.currentUserSession()).userSessionNumber)
     }
 
     @Test

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/store/Ordinal.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/store/Ordinal.kt
@@ -30,5 +30,11 @@ enum class Ordinal(val key: String) {
      * Increments at the start of every background activity. This allows us to check
      * the % of background activities that didn't get delivered to the backend.
      */
-    BACKGROUND_ACTIVITY("io.embrace.bgactivitynumber")
+    BACKGROUND_ACTIVITY("io.embrace.bgactivitynumber"),
+
+    /**
+     * Increments at the start of every user session. This allows us to check the % of user sessions
+     * that didn't get delivered to the backend.
+     */
+    USER_SESSION("io.embrace.usersessionnumber")
 }


### PR DESCRIPTION
## Goal

Supply the user session number with a persisted ordinal.

## Testing

Added a unit test case.