### PR TITLE
Implement storage of user session metadata

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStore.kt
@@ -1,0 +1,52 @@
+@file:OptIn(ExperimentalSemconv::class)
+
+package io.embrace.android.embracesdk.internal.session
+
+import io.embrace.android.embracesdk.internal.store.KeyValueStore
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
+import io.embrace.android.embracesdk.semconv.ExperimentalSemconv
+
+internal class UserSessionMetadataStore(private val store: KeyValueStore) {
+
+    private companion object {
+        const val KEY_SESSION = "embrace.user_session"
+    }
+
+    /**
+     * Persists the given [UserSessionMetadata] to the store.
+     */
+    fun save(metadata: UserSessionMetadata) {
+        store.edit {
+            putStringMap(KEY_SESSION, metadata.attributes.mapValues { it.value.toString() })
+        }
+    }
+
+    /**
+     * Clears the persisted session from the store.
+     */
+    fun clear() {
+        store.edit {
+            putStringMap(KEY_SESSION, null)
+        }
+    }
+
+    /**
+     * Loads a [UserSessionMetadata] from the store, or returns null if any required attribute
+     * is absent or cannot be parsed.
+     */
+    fun load(): UserSessionMetadata? {
+        val attrs = store.getStringMap(KEY_SESSION) ?: return null
+        val id = attrs[EmbSessionAttributes.EMB_USER_SESSION_ID] ?: return null
+        val startMs = attrs[EmbSessionAttributes.EMB_USER_SESSION_START_TS]?.toLongOrNull() ?: return null
+        val number = attrs[EmbSessionAttributes.EMB_USER_SESSION_NUMBER]?.toLongOrNull() ?: return null
+        val maxDurationMins = attrs[EmbSessionAttributes.EMB_USER_SESSION_MAX_DURATION_MINUTES]?.toLongOrNull() ?: return null
+        val inactivityTimeoutMins = attrs[EmbSessionAttributes.EMB_USER_SESSION_INACTIVITY_TIMEOUT_MINUTES]?.toLongOrNull() ?: return null
+        return UserSessionMetadata(
+            startTimeMs = startMs,
+            userSessionId = id,
+            userSessionNumber = number,
+            maxDurationMins = maxDurationMins,
+            inactivityTimeoutMins = inactivityTimeoutMins,
+        )
+    }
+}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionOrchestratorImpl.kt
@@ -7,13 +7,15 @@ import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.session.UserSessionState.NO_ACTIVE_USER_SESSION
 import io.embrace.android.embracesdk.internal.session.UserSessionState.USER_SESSION_ACTIVE
 import io.embrace.android.embracesdk.internal.session.UserSessionState.USER_SESSION_TERMINATED
+import io.embrace.android.embracesdk.internal.store.Ordinal
+import io.embrace.android.embracesdk.internal.store.OrdinalStore
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.semconv.ExperimentalSemconv
-import java.util.concurrent.atomic.AtomicLong
 
 internal class UserSessionOrchestratorImpl(
     private val clock: Clock,
     configService: ConfigService,
+    private val ordinalStore: OrdinalStore,
 ) : UserSessionOrchestrator {
 
     private val lock = Any()
@@ -24,9 +26,6 @@ internal class UserSessionOrchestratorImpl(
 
     @Volatile
     private var metadata: UserSessionMetadata? = null
-
-    // TODO: future: persist the incremented ordinal
-    private val sessionCounter = AtomicLong(0L)
 
     private val maxDurationMs: Long = configService.sessionBehavior.getMaxSessionDurationMs()
     private val inactivityTimeoutMs: Long = configService.sessionBehavior.getSessionInactivityTimeoutMs()
@@ -64,7 +63,7 @@ internal class UserSessionOrchestratorImpl(
         metadata = UserSessionMetadata(
             startTimeMs = clock.now(),
             userSessionId = Uuid.getEmbUuid(),
-            userSessionNumber = sessionCounter.incrementAndGet(),
+            userSessionNumber = ordinalStore.incrementAndGet(Ordinal.USER_SESSION).toLong(),
             maxDurationMins = maxDurationMs / 60_000L,
             inactivityTimeoutMins = inactivityTimeoutMs / 60_000L,
         )

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStoreTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStoreTest.kt
@@ -1,0 +1,122 @@
+package io.embrace.android.embracesdk.internal.session
+
+import io.embrace.android.embracesdk.fakes.FakeKeyValueStore
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+internal class UserSessionMetadataStoreTest {
+
+    private lateinit var kvStore: FakeKeyValueStore
+    private lateinit var metadataStore: UserSessionMetadataStore
+
+    private val metadata = UserSessionMetadata(
+        startTimeMs = 1000L,
+        userSessionId = "test-uuid",
+        userSessionNumber = 3L,
+        maxDurationMins = 60L,
+        inactivityTimeoutMins = 30L,
+    )
+    private val metadata2 = UserSessionMetadata(
+        startTimeMs = 2000L,
+        userSessionId = "test-uuid-2",
+        userSessionNumber = 5L,
+        maxDurationMins = 120L,
+        inactivityTimeoutMins = 60L,
+    )
+
+    @Before
+    fun setUp() {
+        kvStore = FakeKeyValueStore()
+        metadataStore = UserSessionMetadataStore(kvStore)
+    }
+
+    @Test
+    fun `load returns null when store is empty`() {
+        assertNull(metadataStore.load())
+    }
+
+    @Test
+    fun `save and load round-trips all fields`() {
+        metadataStore.save(metadata)
+        val loaded = checkNotNull(metadataStore.load())
+
+        assertEquals(metadata.startTimeMs, loaded.startTimeMs)
+        assertEquals(metadata.userSessionId, loaded.userSessionId)
+        assertEquals(metadata.userSessionNumber, loaded.userSessionNumber)
+        assertEquals(metadata.maxDurationMins, loaded.maxDurationMins)
+        assertEquals(metadata.inactivityTimeoutMins, loaded.inactivityTimeoutMins)
+    }
+
+    @Test
+    fun `values can be overwritten`() {
+        metadataStore.save(metadata)
+        metadataStore.save(metadata2)
+        val loaded = checkNotNull(metadataStore.load())
+
+        assertEquals(metadata2.startTimeMs, loaded.startTimeMs)
+        assertEquals(metadata2.userSessionId, loaded.userSessionId)
+        assertEquals(metadata2.userSessionNumber, loaded.userSessionNumber)
+        assertEquals(metadata2.maxDurationMins, loaded.maxDurationMins)
+        assertEquals(metadata2.inactivityTimeoutMins, loaded.inactivityTimeoutMins)
+    }
+
+    @Test
+    fun `clear causes load to return null`() {
+        metadataStore.save(metadata)
+        metadataStore.clear()
+        assertNull(metadataStore.load())
+    }
+
+    @Test
+    fun `load returns null when session id is missing`() {
+        metadataStore.save(metadata)
+        val stored = checkNotNull(kvStore.getStringMap("embrace.user_session")).toMutableMap()
+        stored.remove(EmbSessionAttributes.EMB_USER_SESSION_ID)
+        kvStore.edit { putStringMap("embrace.user_session", stored) }
+
+        assertNull(metadataStore.load())
+    }
+
+    @Test
+    fun `load returns null when start timestamp is missing`() {
+        metadataStore.save(metadata)
+        val stored = checkNotNull(kvStore.getStringMap("embrace.user_session")).toMutableMap()
+        stored.remove(EmbSessionAttributes.EMB_USER_SESSION_START_TS)
+        kvStore.edit { putStringMap("embrace.user_session", stored) }
+
+        assertNull(metadataStore.load())
+    }
+
+    @Test
+    fun `load returns null when session number is missing`() {
+        metadataStore.save(metadata)
+        val stored = checkNotNull(kvStore.getStringMap("embrace.user_session")).toMutableMap()
+        stored.remove(EmbSessionAttributes.EMB_USER_SESSION_NUMBER)
+        kvStore.edit { putStringMap("embrace.user_session", stored) }
+
+        assertNull(metadataStore.load())
+    }
+
+    @Test
+    fun `load returns null when max duration is missing`() {
+        metadataStore.save(metadata)
+        val stored = checkNotNull(kvStore.getStringMap("embrace.user_session")).toMutableMap()
+        stored.remove(EmbSessionAttributes.EMB_USER_SESSION_MAX_DURATION_MINUTES)
+        kvStore.edit { putStringMap("embrace.user_session", stored) }
+
+        assertNull(metadataStore.load())
+    }
+
+    @Test
+    fun `load returns null when inactivity timeout is missing`() {
+        metadataStore.save(metadata)
+        val stored = checkNotNull(kvStore.getStringMap("embrace.user_session")).toMutableMap()
+        stored.remove(EmbSessionAttributes.EMB_USER_SESSION_INACTIVITY_TIMEOUT_MINUTES)
+        kvStore.edit { putStringMap("embrace.user_session", stored) }
+
+        assertNull(metadataStore.load())
+    }
+}

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionOrchestratorImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionOrchestratorImplTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.session
 
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeOrdinalStore
 import io.embrace.android.embracesdk.fakes.behavior.FakeUserSessionBehavior
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import org.junit.Assert.assertEquals
@@ -31,6 +32,7 @@ internal class UserSessionOrchestratorImplTest {
                     sessionInactivityTimeoutMs = inactivityMs,
                 ),
             ),
+            ordinalStore = FakeOrdinalStore(),
         )
     }
 
@@ -76,6 +78,37 @@ internal class UserSessionOrchestratorImplTest {
         assertEquals(2L, second.userSessionNumber)
         assertNotEquals(first.userSessionId, second.userSessionId)
         assertEquals(maxDurationMs - 1, second.startTimeMs)
+    }
+
+    @Test
+    fun `user session ordinal persistence`() {
+        val store = FakeOrdinalStore()
+        val first = UserSessionOrchestratorImpl(
+            clock = clock,
+            configService = FakeConfigService(
+                sessionBehavior = FakeUserSessionBehavior(
+                    maxSessionDurationMs = maxDurationMs,
+                    sessionInactivityTimeoutMs = inactivityMs,
+                ),
+            ),
+            ordinalStore = store,
+        )
+        first.onNewSessionPart()
+        assertEquals(1L, checkNotNull(first.currentUserSession()).userSessionNumber)
+
+        // create a new orchestrator sharing the same store
+        val second = UserSessionOrchestratorImpl(
+            clock = clock,
+            configService = FakeConfigService(
+                sessionBehavior = FakeUserSessionBehavior(
+                    maxSessionDurationMs = maxDurationMs,
+                    sessionInactivityTimeoutMs = inactivityMs,
+                ),
+            ),
+            ordinalStore = store,
+        )
+        second.onNewSessionPart()
+        assertEquals(2L, checkNotNull(second.currentUserSession()).userSessionNumber)
     }
 
     @Test

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/store/Ordinal.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/store/Ordinal.kt
@@ -30,5 +30,11 @@ enum class Ordinal(val key: String) {
      * Increments at the start of every background activity. This allows us to check
      * the % of background activities that didn't get delivered to the backend.
      */
-    BACKGROUND_ACTIVITY("io.embrace.bgactivitynumber")
+    BACKGROUND_ACTIVITY("io.embrace.bgactivitynumber"),
+
+    /**
+     * Increments at the start of every user session. This allows us to check the % of user sessions
+     * that didn't get delivered to the backend.
+     */
+    USER_SESSION("io.embrace.usersessionnumber")
 }


### PR DESCRIPTION
## Goal

Implements a persistence solution for metadata around the user session so that session stitching can be maintained even if the first process dies.

## Testing

Added unit tests.
