### PR TITLE
Integration test for internal API to track NavControllers

### DIFF
--- a/embrace-android-sdk/build.gradle.kts
+++ b/embrace-android-sdk/build.gradle.kts
@@ -80,6 +80,7 @@ dependencies {
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.navigation.fragment)
     testImplementation(libs.androidx.navigation.common)
+    testImplementation(libs.androidx.navigation.testing)
     testImplementation(libs.opentelemetry.kotlin.compat)
 
     lintChecks(project(":embrace-lint"))

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/fakes/HasNavController.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/fakes/HasNavController.kt
@@ -1,0 +1,7 @@
+package io.embrace.android.embracesdk.fakes
+
+import androidx.navigation.NavController
+
+interface HasNavController {
+    fun getNavController(): NavController
+}

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/fakes/TestFragmentActivity.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/fakes/TestFragmentActivity.kt
@@ -9,7 +9,7 @@ import androidx.navigation.createGraph
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.fragment.fragment
 
-class TestFragmentActivity : FragmentActivity() {
+class TestFragmentActivity : HasNavController, FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val navHostFragment = NavHostFragment()
@@ -23,7 +23,7 @@ class TestFragmentActivity : FragmentActivity() {
         }
     }
 
-    fun getNavController(): NavController {
+    override fun getNavController(): NavController {
         val navHostFragment = supportFragmentManager.fragments
             .first { it is NavHostFragment } as NavHostFragment
         return navHostFragment.navController

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/fakes/TestFragmentActivity.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/fakes/TestFragmentActivity.kt
@@ -9,7 +9,7 @@ import androidx.navigation.createGraph
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.fragment.fragment
 
-class NavControllerFragmentActivity : FragmentActivity() {
+class TestFragmentActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val navHostFragment = NavHostFragment()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/fakes/TestNavControllerActivity.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/fakes/TestNavControllerActivity.kt
@@ -1,0 +1,30 @@
+package io.embrace.android.embracesdk.fakes
+
+import android.app.Activity
+import android.os.Bundle
+import androidx.navigation.NavController
+import androidx.navigation.NavDestination
+import androidx.navigation.NavGraphNavigator
+import androidx.navigation.testing.TestNavHostController
+
+/**
+ * An [Activity] that creates a custom [NavController] on create and exposes it.
+ */
+class TestNavControllerActivity : Activity() {
+    private lateinit var navController: TestNavHostController
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        navController = TestNavHostController(this).apply {
+            val graphNavigator = navigatorProvider.getNavigator(NavGraphNavigator::class.java)
+            graph = graphNavigator.createDestination().apply {
+                addDestination(NavDestination("test").apply { route = "home" })
+                addDestination(NavDestination("test").apply { route = "about" })
+                addDestination(NavDestination("test").apply { route = "contacts" })
+                setStartDestination("home")
+            }
+        }
+    }
+
+    fun getNavController(): NavController = navController
+}

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/fakes/TestNavControllerActivity.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/fakes/TestNavControllerActivity.kt
@@ -10,7 +10,7 @@ import androidx.navigation.testing.TestNavHostController
 /**
  * An [Activity] that creates a custom [NavController] on create and exposes it.
  */
-class TestNavControllerActivity : Activity() {
+class TestNavControllerActivity : HasNavController, Activity() {
     private lateinit var navController: TestNavHostController
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -26,5 +26,5 @@ class TestNavControllerActivity : Activity() {
         }
     }
 
-    fun getNavController(): NavController = navController
+    override fun getNavController(): NavController = navController
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NavigationStateFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NavigationStateFeatureTest.kt
@@ -2,13 +2,13 @@ package io.embrace.android.embracesdk.testcases.features
 
 import android.app.Activity
 import android.os.Build
+import androidx.navigation.NavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.assertStateTransition
-import io.embrace.android.embracesdk.assertions.findSpansOfType
-import io.embrace.android.embracesdk.fakes.NavControllerFragmentActivity
+import io.embrace.android.embracesdk.fakes.TestFragmentActivity
+import io.embrace.android.embracesdk.fakes.TestNavControllerActivity
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
-import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.otel.spans.hasEmbraceAttributeValue
@@ -23,6 +23,7 @@ import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterfac
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface.Companion.POST_ACTIVITY_ACTION_DWELL
 import io.embrace.android.embracesdk.testframework.actions.SessionPartTimestamps
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -60,10 +61,7 @@ internal class NavigationStateFeatureTest {
                 recordSession {}
             },
             assertAction = {
-                val navigationStateSpans = getSingleSessionEnvelope()
-                    .findSpansOfType(EmbType.State)
-                    .filter { it.name == "emb-state-screen-automatic" }
-                assertEquals(0, navigationStateSpans.size)
+                assertNull(getSingleSessionEnvelope().getNavigationStateSpan())
             },
         )
     }
@@ -81,10 +79,7 @@ internal class NavigationStateFeatureTest {
                 recordSession {}
             },
             assertAction = {
-                val navigationStateSpans = getSingleSessionEnvelope()
-                    .findSpansOfType(EmbType.State)
-                    .filter { it.name == "emb-state-screen-automatic" }
-                assertEquals(0, navigationStateSpans.size)
+                assertNull(getSingleSessionEnvelope().getNavigationStateSpan())
             },
         )
     }
@@ -125,7 +120,6 @@ internal class NavigationStateFeatureTest {
                 val stateSpan1 = checkNotNull(sessionPayloads[0].getNavigationStateSpan())
                 checkNotNull(firstSessionTimestamps)
                 stateSpan1.assertStateSpan(
-                    activityLoaded = false,
                     transitionTimesMs = foregroundTimes.map { it - LIFECYCLE_EVENT_GAP * 2 } + firstSessionTimestamps.lastBackgroundTimeMs,
                     newStateValues = loadedActivities.map { it.get().localClassName }
                 )
@@ -133,6 +127,7 @@ internal class NavigationStateFeatureTest {
                 val stateSpan2 = checkNotNull(sessionPayloads[1].getNavigationStateSpan())
                 checkNotNull(secondSessionTimestamps)
                 stateSpan2.assertStateSpan(
+                    stateUninitialized = false,
                     transitionTimesMs = listOf(secondSessionTimestamps.startTimeMs, secondSessionTimestamps.endTimeMs),
                     newStateValues = listOf(loadedActivities.last().get().localClassName)
                 )
@@ -182,25 +177,25 @@ internal class NavigationStateFeatureTest {
 
                 val baStateSpan1 = checkNotNull(baPayloads[0].getNavigationStateSpan())
                 baStateSpan1.assertStateSpan(
-                    activityLoaded = false,
                     isForeground = false
                 )
 
                 val sessionStateSpan1 = checkNotNull(sessionPayloads[0].getNavigationStateSpan())
                 checkNotNull(firstSessionTimestamps)
                 sessionStateSpan1.assertStateSpan(
-                    activityLoaded = false,
                     transitionTimesMs = foregroundTimes.map { it - LIFECYCLE_EVENT_GAP * 2 } + firstSessionTimestamps.lastBackgroundTimeMs,
                     newStateValues = loadedActivities.map { it.get().localClassName }
                 )
 
                 val baStateSpan2 = checkNotNull(baPayloads[1].getNavigationStateSpan())
                 baStateSpan2.assertStateSpan(
+                    stateUninitialized = false,
                     isForeground = false
                 )
 
                 val sessionStateSpan2 = checkNotNull(sessionPayloads[1].getNavigationStateSpan())
                 sessionStateSpan2.assertStateSpan(
+                    stateUninitialized = false,
                     transitionTimesMs = listOf(checkNotNull(secondSessionTimestamps).startTimeMs, secondSessionTimestamps.endTimeMs),
                     newStateValues = listOf(loadedActivities.last().get().localClassName)
                 )
@@ -209,7 +204,7 @@ internal class NavigationStateFeatureTest {
     }
 
     @Test
-    fun `NavController destinations recorded as state span`() {
+    fun `FragmentActivity navigation recorded as state span`() {
         val navRoutes = listOf("contacts", "about", "home")
         var timestamps: AppExecutionTimestamps? = null
 
@@ -217,11 +212,10 @@ internal class NavigationStateFeatureTest {
             instrumentedConfig = enabledConfig,
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
-                timestamps = simulateNavControllerNavigation(routes = navRoutes)
+                timestamps = simulateFragmentActivityNavigation(routes = navRoutes)
             },
             assertAction = {
                 val stateSpan = checkNotNull(getSingleSessionEnvelope().getNavigationStateSpan())
-                val events = checkNotNull(stateSpan.events)
                 checkNotNull(timestamps)
                 val eventTimes = mutableListOf(
                     timestamps.firstForegroundTimeMs,
@@ -231,25 +225,25 @@ internal class NavigationStateFeatureTest {
                     timestamps.lastBackgroundTimeMs,
                 )
                 val expectedRoutes = listOf("home") + navRoutes + listOf("Backgrounded")
-                assertEquals(expectedRoutes.size, events.size)
-                expectedRoutes.forEachIndexed { index, route ->
-                    events[index].assertStateTransition(
-                        timestampMs = eventTimes[index],
-                        newStateValue = route,
-                    )
-                }
+                stateSpan.assertStateSpan(
+                    transitionTimesMs = eventTimes,
+                    newStateValues = expectedRoutes
+                )
             },
         )
     }
 
     @Test
     fun `NavController destination restored when same Activity returns from background`() {
-        val navActivity = Robolectric.buildActivity(NavControllerFragmentActivity::class.java)
+        val navActivity = Robolectric.buildActivity(TestFragmentActivity::class.java)
         testRule.runTest(
             instrumentedConfig = enabledConfig,
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
-                simulateNavControllerNavigation(navActivity, listOf("about"))
+                simulateFragmentActivityNavigation(
+                    routes = listOf("about"),
+                    activityController = navActivity
+                )
                 simulateOpeningActivities(
                     addStartupActivity = false,
                     startInBackground = true,
@@ -261,17 +255,10 @@ internal class NavigationStateFeatureTest {
             },
             assertAction = {
                 val sessions = getSessionEnvelopes(2)
-                val firstSpan = checkNotNull(sessions[0].getNavigationStateSpan())
-                val firstStateValues = checkNotNull(firstSpan.events).map { event ->
-                    checkNotNull(event.attributes).first { it.key == "emb.state.new_value" }.data
-                }
-                assertEquals("about", firstStateValues[1])
-
-                val secondSpan = checkNotNull(sessions[1].getNavigationStateSpan())
-                val secondStateValues = checkNotNull(secondSpan.events).map { event ->
-                    checkNotNull(event.attributes).first { it.key == "emb.state.new_value" }.data
-                }
-                assertEquals("about", secondStateValues.first())
+                val stateSpan = checkNotNull(sessions[1].getNavigationStateSpan())
+                val events = checkNotNull(stateSpan.events)
+                val stateValue = checkNotNull(events.first().attributes).single { it.key == "emb.state.new_value" }.data
+                assertEquals("about", stateValue)
             },
         )
     }
@@ -280,7 +267,8 @@ internal class NavigationStateFeatureTest {
     fun `navigate from plain startup activity to NavController activity`() {
         var timestamps: AppExecutionTimestamps? = null
         val startupActivity = Robolectric.buildActivity(HomeActivity::class.java)
-        val navActivity = Robolectric.buildActivity(NavControllerFragmentActivity::class.java)
+        val navActivity = Robolectric.buildActivity(TestFragmentActivity::class.java)
+        var navigationTime: Long = 0
         testRule.runTest(
             instrumentedConfig = enabledConfig,
             persistedRemoteConfig = enabledRemoteConfig,
@@ -291,7 +279,7 @@ internal class NavigationStateFeatureTest {
                     activitiesAndActions = listOf(
                         startupActivity to {},
                         navActivity to {
-                            clock.tick(POST_ACTIVITY_ACTION_DWELL)
+                            navigationTime = clock.tick(POST_ACTIVITY_ACTION_DWELL)
                             navActivity.get().getNavController().navigate("about")
                         },
                     )
@@ -299,30 +287,69 @@ internal class NavigationStateFeatureTest {
             },
             assertAction = {
                 val stateSpan = checkNotNull(getSingleSessionEnvelope().getNavigationStateSpan())
-                val events = checkNotNull(stateSpan.events)
-                val stateValues = events.map { event ->
-                    checkNotNull(event.attributes).first { it.key == "emb.state.new_value" }.data
-                }
-                assertEquals(4, stateValues.size)
-                assertEquals(startupActivity.get().localClassName, stateValues[0])
-                assertEquals("home", stateValues[1])
-                assertEquals("about", stateValues[2])
-                assertEquals("Backgrounded", stateValues[3])
+                checkNotNull(timestamps)
+                stateSpan.assertStateSpan(
+                    transitionTimesMs = listOf(
+                        timestamps.firstForegroundTimeMs,
+                        navigationTime - POST_ACTIVITY_ACTION_DWELL - 2 * LIFECYCLE_EVENT_GAP,
+                        navigationTime,
+                        timestamps.lastBackgroundTimeMs
+                    ),
+                    newStateValues = listOf(
+                        startupActivity.get().localClassName,
+                        "home",
+                        "about",
+                        "Backgrounded"
+                    )
+                )
+            },
+        )
+    }
 
+    @Test
+    fun `navigation of NavController tracked using internal API creates state span`() {
+        var timestamps: AppExecutionTimestamps? = null
+        val activityController = Robolectric.buildActivity(TestNavControllerActivity::class.java)
+        val expectedStateValues = listOf("home", "contacts", "about", "Backgrounded")
+        testRule.runTest(
+            instrumentedConfig = enabledConfig,
+            persistedRemoteConfig = enabledRemoteConfig,
+            testCaseAction = {
+                timestamps = simulateNavControllerTrackingAndNavigation(
+                    routes = listOf("contacts", "about"),
+                    activityController = activityController,
+                    navControllerProvider = fun(activity: TestNavControllerActivity): NavController {
+                        return activity.getNavController()
+                    }
+                )
+            },
+            assertAction = {
+                val stateSpan = checkNotNull(getSingleSessionEnvelope().getNavigationStateSpan())
+                checkNotNull(timestamps)
+                val expectedTransitionTimes = listOf(
+                    timestamps.firstForegroundTimeMs,
+                    timestamps.firstForegroundTimeMs + POST_ACTIVITY_ACTION_DWELL + LIFECYCLE_EVENT_GAP * 2,
+                    timestamps.firstForegroundTimeMs + POST_ACTIVITY_ACTION_DWELL * 2 + LIFECYCLE_EVENT_GAP * 2,
+                    timestamps.lastBackgroundTimeMs,
+                )
+                stateSpan.assertStateSpan(
+                    transitionTimesMs = expectedTransitionTimes,
+                    newStateValues = expectedStateValues
+                )
             },
         )
     }
 
     private fun Span.assertStateSpan(
-        activityLoaded: Boolean = true,
+        stateUninitialized: Boolean = true,
         isForeground: Boolean = true,
         transitionTimesMs: List<Long> = listOf(),
         newStateValues: List<String> = listOf(),
     ) {
-        val startStateValue = if (activityLoaded) {
-            "Backgrounded"
-        } else {
+        val startStateValue = if (stateUninitialized) {
             "Initializing"
+        } else {
+            "Backgrounded"
         }
         assertTrue(hasEmbraceAttributeValue(EMB_STATE_INITIAL_VALUE, startStateValue))
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NavigationStateFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NavigationStateFeatureTest.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.testcases.features
 
 import android.app.Activity
 import android.os.Build
-import androidx.navigation.NavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.assertStateTransition
 import io.embrace.android.embracesdk.fakes.TestFragmentActivity
@@ -318,9 +317,6 @@ internal class NavigationStateFeatureTest {
                 timestamps = simulateNavControllerTrackingAndNavigation(
                     routes = listOf("contacts", "about"),
                     activityController = activityController,
-                    navControllerProvider = fun(activity: TestNavControllerActivity): NavController {
-                        return activity.getNavController()
-                    }
                 )
             },
             assertAction = {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
@@ -2,9 +2,10 @@ package io.embrace.android.embracesdk.testframework.actions
 
 import android.app.Activity
 import androidx.lifecycle.Lifecycle
+import androidx.navigation.NavController
 import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.fakes.FakeClock
-import io.embrace.android.embracesdk.fakes.NavControllerFragmentActivity
+import io.embrace.android.embracesdk.fakes.TestFragmentActivity
 import io.embrace.android.embracesdk.internal.api.SdkApi
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSource
 import io.embrace.android.embracesdk.internal.capture.connectivity.ConnectionType
@@ -91,11 +92,15 @@ internal class EmbraceActionInterface(
     }
 
     private fun onForeground() {
-        setup.fakeLifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_START)
+        invokeWithMainLooperUnblock {
+            setup.fakeLifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_START)
+        }
     }
 
     private fun onBackground() {
-        setup.fakeLifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+        invokeWithMainLooperUnblock {
+            setup.fakeLifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+        }
     }
 
     fun simulateConnectivityChange(status: ConnectivityStatus) {
@@ -132,12 +137,13 @@ internal class EmbraceActionInterface(
         }
     }
 
-    internal fun simulateOpeningActivities(
+    fun simulateOpeningActivities(
         addStartupActivity: Boolean = true,
         startInBackground: Boolean = false,
         endInBackground: Boolean = true,
         createFirstActivity: Boolean = true,
         invokeManualEnd: Boolean = false,
+        toBeRegisteredNavControllerProvider: () -> NavController? = { null },
         activitiesAndActions: List<Pair<ActivityController<*>, () -> Unit>> = listOf(
             Robolectric.buildActivity(Activity::class.java) to {},
         ),
@@ -148,15 +154,15 @@ internal class EmbraceActionInterface(
         } else {
             null
         }?.apply {
-            create()
-            start()
+            invokeWithMainLooperUnblock(::create)
+            invokeWithMainLooperUnblock(::start)
             appExecutionTimes.firstForegroundTimeMs = clock.now()
             onForeground()
-            resume()
-            pause()
+            invokeWithMainLooperUnblock(::resume)
+            invokeWithMainLooperUnblock(::pause)
 
             if (startInBackground) {
-                stop()
+                invokeWithMainLooperUnblock(::stop)
                 appExecutionTimes.lastBackgroundTimeMs = clock.now()
                 onBackground()
                 setup.getClock().tick(STARTUP_BACKGROUND_TIME)
@@ -166,7 +172,7 @@ internal class EmbraceActionInterface(
         }
         activitiesAndActions.forEachIndexed { index, (activityController, action) ->
             if (index != 0 || createFirstActivity) {
-                activityController.create()
+                invokeWithMainLooperUnblock(activityController::create)
                 setup.getClock().tick(LIFECYCLE_EVENT_GAP)
             }
             if (index == 0 && startInBackground) {
@@ -175,9 +181,14 @@ internal class EmbraceActionInterface(
                 }
                 onForeground()
             }
-            activityController.start()
+            invokeWithMainLooperUnblock(activityController::start)
+            toBeRegisteredNavControllerProvider()?.let {
+                invokeWithMainLooperUnblock {
+                    bootstrapper.essentialServiceModule.navigationTrackingService.trackNavigation(activityController.get(), it)
+                }
+            }
             setup.getClock().tick(LIFECYCLE_EVENT_GAP)
-            activityController.resume()
+            invokeWithMainLooperUnblock(activityController::resume)
             setup.getClock().tick(LIFECYCLE_EVENT_GAP)
 
             if (invokeManualEnd) {
@@ -194,13 +205,15 @@ internal class EmbraceActionInterface(
                 embrace.activityLoaded(activityController.get())
             }
 
-            lastActivity?.stop()
+            invokeWithMainLooperUnblock {
+                lastActivity?.stop()
+            }
 
             appExecutionTimes.firstActionTimeMs = clock.now()
             action()
 
             setup.getClock().tick(POST_ACTIVITY_ACTION_DWELL)
-            activityController.pause()
+            invokeWithMainLooperUnblock(activityController::pause)
             setup.getClock().tick(ACTIVITY_GAP)
             lastActivity = activityController
         }
@@ -208,7 +221,9 @@ internal class EmbraceActionInterface(
         if (endInBackground) {
             setup.getClock().tick()
             appExecutionTimes.lastBackgroundTimeMs = clock.now()
-            lastActivity?.stop()
+            invokeWithMainLooperUnblock {
+                lastActivity?.stop()
+            }
             onBackground()
         }
 
@@ -216,26 +231,25 @@ internal class EmbraceActionInterface(
     }
 
     /**
-     * Simulates opening a [NavControllerFragmentActivity] and navigating through the given routes.
+     * Simulates opening a [TestFragmentActivity] and navigating through the given routes. No explicit [NavController] tracking is done.
      */
-    fun simulateNavControllerNavigation(
-        activityController: ActivityController<NavControllerFragmentActivity> =
-            Robolectric.buildActivity(NavControllerFragmentActivity::class.java),
+    fun simulateFragmentActivityNavigation(
         routes: List<String>,
-    ): AppExecutionTimestamps =
-        simulateOpeningActivities(
-            addStartupActivity = false,
-            startInBackground = true,
-            activitiesAndActions = listOf(
-                activityController to {
-                    val navController = activityController.get().getNavController()
-                    routes.forEach { route ->
-                        clock.tick(POST_ACTIVITY_ACTION_DWELL)
-                        navController.navigate(route)
-                    }
-                },
-            )
-        )
+        activityController: ActivityController<TestFragmentActivity> = Robolectric.buildActivity(TestFragmentActivity::class.java),
+    ) = simulateNavControllerNavigation(routes, false, activityController) {
+        activityController.get().getNavController()
+    }
+
+    /**
+     * Simulates opening the given [Activity] and navigating through the destinations [routes] defined on the [NavController] provided by
+     * [navControllerProvider]. The provider will be called during the activity's onStart hook, so the initialization of the
+     * [NavController] by the activity needs to be done by then.
+     */
+    inline fun <reified T : Activity> simulateNavControllerTrackingAndNavigation(
+        routes: List<String>,
+        activityController: ActivityController<T> = Robolectric.buildActivity(T::class.java),
+        crossinline navControllerProvider: (T) -> NavController,
+    ) = simulateNavControllerNavigation(routes, true, activityController, navControllerProvider)
 
     fun simulateJvmUncaughtException(exc: Throwable) {
         Thread.getDefaultUncaughtExceptionHandler()?.uncaughtException(Thread.currentThread(), exc)
@@ -248,6 +262,39 @@ internal class EmbraceActionInterface(
     inline fun <reified T : DataSource> findDataSource(): T {
         val registry = (bootstrapper.instrumentationModule.instrumentationRegistry as FakeInstrumentationRegistry)
         return checkNotNull(registry.findByType(T::class))
+    }
+
+    private inline fun <reified T : Activity> simulateNavControllerNavigation(
+        routes: List<String>,
+        registerNavController: Boolean,
+        activityController: ActivityController<T>,
+        crossinline navControllerProvider: (T) -> NavController,
+    ): AppExecutionTimestamps =
+        simulateOpeningActivities(
+            addStartupActivity = false,
+            startInBackground = true,
+            toBeRegisteredNavControllerProvider = {
+                if (registerNavController) {
+                    navControllerProvider(activityController.get())
+                } else {
+                    null
+                }
+            },
+            activitiesAndActions = listOf(
+                activityController to {
+                    routes.forEach { route ->
+                        clock.tick(POST_ACTIVITY_ACTION_DWELL)
+                        navControllerProvider(activityController.get()).navigate(route)
+                    }
+                },
+            )
+        )
+
+    private fun invokeWithMainLooperUnblock(action: () -> Unit) {
+        action()
+        if (setup.unblockMainLooperOnNavigation) {
+            setup.shadowMainLooper.idle()
+        }
     }
 
     companion object {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.navigation.NavController
 import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.HasNavController
 import io.embrace.android.embracesdk.fakes.TestFragmentActivity
 import io.embrace.android.embracesdk.internal.api.SdkApi
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSource
@@ -236,20 +237,16 @@ internal class EmbraceActionInterface(
     fun simulateFragmentActivityNavigation(
         routes: List<String>,
         activityController: ActivityController<TestFragmentActivity> = Robolectric.buildActivity(TestFragmentActivity::class.java),
-    ) = simulateNavControllerNavigation(routes, false, activityController) {
-        activityController.get().getNavController()
-    }
+    ) = simulateNavControllerNavigation(routes, false, activityController)
 
     /**
      * Simulates opening the given [Activity] and navigating through the destinations [routes] defined on the [NavController] provided by
-     * [navControllerProvider]. The provider will be called during the activity's onStart hook, so the initialization of the
-     * [NavController] by the activity needs to be done by then.
+     * the [HasNavController] interface. The [NavController] will be accessed during onStart, so its initialization has to be done by then.
      */
-    inline fun <reified T : Activity> simulateNavControllerTrackingAndNavigation(
+    inline fun <reified T> simulateNavControllerTrackingAndNavigation(
         routes: List<String>,
         activityController: ActivityController<T> = Robolectric.buildActivity(T::class.java),
-        crossinline navControllerProvider: (T) -> NavController,
-    ) = simulateNavControllerNavigation(routes, true, activityController, navControllerProvider)
+    ) where T : Activity, T : HasNavController = simulateNavControllerNavigation(routes, true, activityController)
 
     fun simulateJvmUncaughtException(exc: Throwable) {
         Thread.getDefaultUncaughtExceptionHandler()?.uncaughtException(Thread.currentThread(), exc)
@@ -264,18 +261,17 @@ internal class EmbraceActionInterface(
         return checkNotNull(registry.findByType(T::class))
     }
 
-    private inline fun <reified T : Activity> simulateNavControllerNavigation(
+    private inline fun <reified T> simulateNavControllerNavigation(
         routes: List<String>,
         registerNavController: Boolean,
         activityController: ActivityController<T>,
-        crossinline navControllerProvider: (T) -> NavController,
-    ): AppExecutionTimestamps =
+    ): AppExecutionTimestamps where T : Activity, T : HasNavController =
         simulateOpeningActivities(
             addStartupActivity = false,
             startInBackground = true,
             toBeRegisteredNavControllerProvider = {
                 if (registerNavController) {
-                    navControllerProvider(activityController.get())
+                    activityController.get().getNavController()
                 } else {
                     null
                 }
@@ -284,7 +280,7 @@ internal class EmbraceActionInterface(
                 activityController to {
                     routes.forEach { route ->
                         clock.tick(POST_ACTIVITY_ACTION_DWELL)
-                        navControllerProvider(activityController.get()).navigate(route)
+                        activityController.get().getNavController().navigate(route)
                     }
                 },
             )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.testframework.actions
 
 import android.os.Build
+import android.os.Looper
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.testing.TestLifecycleOwner
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
@@ -43,6 +44,8 @@ import io.embrace.android.embracesdk.internal.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
+import org.robolectric.Shadows
+import org.robolectric.shadows.ShadowLooper
 
 /**
  * Test harness for which an instance is generated each test run and provided to the test by the Rule
@@ -74,6 +77,9 @@ internal class EmbraceSetupInterface(
     } else {
         null
     }
+
+    val shadowMainLooper: ShadowLooper = Shadows.shadowOf(Looper.getMainLooper())
+    val unblockMainLooperOnNavigation: Boolean = threadBlockageWatchdogThread == null
 
     private val fakeInitModule: FakeInitModule = FakeInitModule(
         clock = fakeClock,


### PR DESCRIPTION
## Goal

Add to the integration test interface the ability to open up an activity and navigate through an associated `NavController`. This is used to test that internal API. Additional changes to the infra needed to be made in order to support having Activities' lifecycle hooks be invoked (e.g. so the test activities can create NavControllers in the onCreate hook).

<!-- Describe how this change has been tested -->