### PR TITLE
Support inactivity timeout for user sessions

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SessionOrchestratorSupplier.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SessionOrchestratorSupplier.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.internal.session.orchestrator.SessionOrches
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionOrchestratorImpl
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionPartSpanAttrPopulatorImpl
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
+import io.embrace.android.embracesdk.internal.worker.Worker
 
 fun createSessionOrchestrator(
     initModule: InitModule,
@@ -21,6 +22,7 @@ fun createSessionOrchestrator(
     payloadSourceModule: PayloadSourceModule,
     startupDurationProvider: () -> Long?,
     logModule: LogModule,
+    workerThreadModule: WorkerThreadModule,
 ): SessionOrchestrator {
     val payloadMessageCollator = PayloadMessageCollatorImpl(
         EmbTrace.trace("sessionEnvelopeSource") { payloadSourceModule.sessionPartEnvelopeSource },
@@ -62,5 +64,6 @@ fun createSessionOrchestrator(
         coreModule.ordinalStore,
         UserSessionMetadataStore(coreModule.store),
         initModule.logger,
+        workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker),
     )
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SupplierTypealiases.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SupplierTypealiases.kt
@@ -94,6 +94,7 @@ typealias UserSessionOrchestrationModuleSupplier = (
     payloadSourceModule: PayloadSourceModule,
     startupDurationProvider: () -> Long?,
     logModule: LogModule,
+    workerThreadModule: WorkerThreadModule,
 ) -> UserSessionOrchestrationModule
 
 typealias StorageServiceSupplier = (

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.internal.session.orchestrator.SessionOrches
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionOrchestratorImpl
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionPartSpanAttrPopulatorImpl
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
+import io.embrace.android.embracesdk.internal.worker.Worker
 
 class UserSessionOrchestrationModuleImpl(
     initModule: InitModule,
@@ -21,6 +22,7 @@ class UserSessionOrchestrationModuleImpl(
     payloadSourceModule: PayloadSourceModule,
     startupDurationProvider: () -> Long?,
     logModule: LogModule,
+    workerThreadModule: WorkerThreadModule,
 ) : UserSessionOrchestrationModule {
 
     override val sessionOrchestrator: SessionOrchestrator by singleton {
@@ -64,6 +66,7 @@ class UserSessionOrchestrationModuleImpl(
             coreModule.ordinalStore,
             UserSessionMetadataStore(coreModule.store),
             initModule.logger,
+            workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker),
         )
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/InactivityTimerState.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/InactivityTimerState.kt
@@ -1,0 +1,20 @@
+package io.embrace.android.embracesdk.internal.session.orchestrator
+
+import java.util.concurrent.ScheduledFuture
+
+/**
+ * Holds the state of the inactivity timer for a background period.
+ * [cancel] cancels any pending timer future.
+ */
+internal class InactivityTimerState(
+    private val future: ScheduledFuture<*>,
+
+    @Volatile
+    var exceeded: Boolean = false,
+) {
+    fun cancel() {
+        runCatching {
+            future.cancel(false)
+        }
+    }
+}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -25,8 +25,10 @@ import io.embrace.android.embracesdk.internal.store.OrdinalStore
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.Uuid
+import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.semconv.ExperimentalSemconv
+import java.util.concurrent.TimeUnit
 
 internal class SessionOrchestratorImpl(
     appStateTracker: AppStateTracker,
@@ -43,6 +45,7 @@ internal class SessionOrchestratorImpl(
     private val ordinalStore: OrdinalStore,
     private val metadataStore: UserSessionMetadataStore,
     private val logger: InternalLogger,
+    private val backgroundWorker: BackgroundWorker,
 ) : SessionOrchestrator {
 
     /**
@@ -58,12 +61,15 @@ internal class SessionOrchestratorImpl(
     @Volatile
     private var userSessionState: UserSessionState = UserSessionState.Initializing
 
+    @Volatile
+    private var inactivityTimerState: InactivityTimerState? = null
+
     init {
         loadPersistedUserSession()
         appStateTracker.addListener(this)
         sessionTracker.addSessionPartEndListener(instrumentationRegistry)
         sessionTracker.addSessionPartChangeListener(instrumentationRegistry)
-        EmbTrace.trace("start-first-session") { createInitialSession() }
+        EmbTrace.trace("start-first-session") { createInitialSessionPart() }
     }
 
     private fun loadPersistedUserSession() {
@@ -85,6 +91,7 @@ internal class SessionOrchestratorImpl(
                     stored != null && !isUserSessionOverMaxDuration(stored) -> {
                         UserSessionState.Active(stored)
                     }
+
                     else -> UserSessionState.NoActiveSession
                 }
             } catch (e: Exception) {
@@ -93,7 +100,7 @@ internal class SessionOrchestratorImpl(
         }
     }
 
-    private fun createInitialSession() {
+    private fun createInitialSessionPart() {
         val timestamp = clock.now()
         transitionState(
             transitionType = TransitionType.INITIAL,
@@ -105,9 +112,20 @@ internal class SessionOrchestratorImpl(
     }
 
     override fun onForeground() {
+        val exceeded = synchronized(lock) {
+            inactivityTimerState?.cancel()
+            val exceeded = inactivityTimerState?.exceeded ?: false
+            inactivityTimerState = null
+            exceeded
+        }
+
         val timestamp = clock.now()
+
         transitionState(
-            transitionType = TransitionType.ON_FOREGROUND,
+            transitionType = when {
+                exceeded -> TransitionType.INACTIVITY_FOREGROUND
+                else -> TransitionType.ON_FOREGROUND
+            },
             timestamp = timestamp,
             oldSessionAction = { initial: SessionPartToken ->
                 payloadFactory.endPayloadWithState(AppState.BACKGROUND, timestamp, initial)
@@ -137,6 +155,7 @@ internal class SessionOrchestratorImpl(
                 return@transitionState shouldRunOnBackground(state)
             }
         )
+        scheduleInactivityTimeout()
     }
 
     override fun endSessionWithManual(clearUserInfo: Boolean) {
@@ -250,7 +269,10 @@ internal class SessionOrchestratorImpl(
                     // transition the user session before creating the new session part so that
                     // the user session is always ready
                     if (transitionType != TransitionType.CRASH) {
-                        if (transitionType == TransitionType.END_MANUAL) {
+                        if (transitionType == TransitionType.END_MANUAL ||
+                            transitionType == TransitionType.INACTIVITY_TIMEOUT ||
+                            transitionType == TransitionType.INACTIVITY_FOREGROUND
+                        ) {
                             handleUserSessionEnd(timestamp)
                         } else {
                             handleNewSessionPart(timestamp)
@@ -291,6 +313,41 @@ internal class SessionOrchestratorImpl(
             }
 
             EmbTrace.end()
+        }
+    }
+
+    private fun scheduleInactivityTimeout() {
+        val metadata = (userSessionState as? UserSessionState.Active)?.metadata ?: return
+        inactivityTimerState = InactivityTimerState(
+            backgroundWorker.schedule<Unit>(
+                ::onInactivityTimeout,
+                metadata.inactivityTimeoutSecs,
+                TimeUnit.SECONDS,
+            )
+        )
+    }
+
+    private fun onInactivityTimeout() {
+        synchronized(lock) {
+            if (state != AppState.BACKGROUND) {
+                return
+            }
+            inactivityTimerState?.exceeded = true
+
+            if (configService.backgroundActivityBehavior.isBackgroundActivityCaptureEnabled()) {
+                val timestamp = clock.now()
+                transitionState(
+                    transitionType = TransitionType.INACTIVITY_TIMEOUT,
+                    timestamp = timestamp,
+                    oldSessionAction = { initial: SessionPartToken ->
+                        payloadFactory.endPayloadWithState(AppState.BACKGROUND, timestamp, initial)
+                    },
+                    newSessionAction = {
+                        payloadFactory.startPayloadWithState(AppState.BACKGROUND, timestamp, false)
+                    },
+                    earlyTerminationCondition = { state != AppState.BACKGROUND },
+                )
+            }
         }
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/TransitionType.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/TransitionType.kt
@@ -4,11 +4,11 @@ import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.session.LifeEventType
 
 enum class TransitionType {
-    INITIAL, END_MANUAL, ON_FOREGROUND, ON_BACKGROUND, CRASH;
+    INITIAL, END_MANUAL, ON_FOREGROUND, ON_BACKGROUND, CRASH, INACTIVITY_TIMEOUT, INACTIVITY_FOREGROUND;
 
     fun endState(currentState: AppState): AppState = when (this) {
-        ON_FOREGROUND -> AppState.FOREGROUND
-        ON_BACKGROUND -> AppState.BACKGROUND
+        ON_FOREGROUND, INACTIVITY_FOREGROUND -> AppState.FOREGROUND
+        ON_BACKGROUND, INACTIVITY_TIMEOUT -> AppState.BACKGROUND
         else -> currentState
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/SessionPartOrchestrationModuleImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/SessionPartOrchestrationModuleImplTest.kt
@@ -50,7 +50,8 @@ internal class SessionPartOrchestrationModuleImplTest {
             dataSourceModule,
             FakePayloadSourceModule(),
             { 0 },
-            FakeLogModule()
+            FakeLogModule(),
+            workerThreadModule,
         )
         assertNotNull(orchestrator)
     }
@@ -79,7 +80,8 @@ internal class SessionPartOrchestrationModuleImplTest {
             dataSourceModule,
             FakePayloadSourceModule(),
             { 0 },
-            FakeLogModule()
+            FakeLogModule(),
+            workerThreadModule,
         )
         assertNotNull(orchestrator)
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -70,6 +70,7 @@ internal class SessionOrchestratorTest {
     private lateinit var sessionTracker: SessionPartTracker
     private lateinit var payloadCachingService: PayloadCachingService
     private lateinit var sessionCacheExecutor: BlockingScheduledExecutorService
+    private lateinit var inactivityWorkerExecutor: BlockingScheduledExecutorService
     private lateinit var instrumentationRegistry: InstrumentationRegistry
     private lateinit var fakeDataSource: FakeDataSource
     private lateinit var logger: FakeInternalLogger
@@ -715,6 +716,69 @@ internal class SessionOrchestratorTest {
     }
 
     @Test
+    fun `exceeding inactivity timeout creates new user sessions`() {
+        configService = FakeConfigService(
+            backgroundActivityBehavior = createBackgroundActivityBehavior(
+                remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 100f))
+            ),
+            sessionBehavior = FakeUserSessionBehavior(
+                maxSessionDurationMs = maxDurationMs,
+                sessionInactivityTimeoutMs = inactivityMs,
+            )
+        )
+        createOrchestrator(AppState.FOREGROUND)
+
+        val firstSession = checkNotNull(orchestrator.currentUserSession())
+        assertEquals(1L, firstSession.userSessionNumber)
+
+        orchestrator.onBackground()
+
+        // 1. exceed inactivity timeout. create new bg session part + user session
+        clock.tick(inactivityMs)
+        inactivityWorkerExecutor.runCurrentlyBlocked()
+
+        val secondSession = checkNotNull(orchestrator.currentUserSession())
+        assertNotEquals(firstSession.userSessionId, secondSession.userSessionId)
+        assertEquals(2L, secondSession.userSessionNumber)
+
+        // foreground after inactivity timeout always creates a new user session
+        clock.tick(1000)
+        orchestrator.onForeground()
+
+        val thirdSession = checkNotNull(orchestrator.currentUserSession())
+        assertNotEquals(secondSession.userSessionId, thirdSession.userSessionId)
+        assertEquals(3L, thirdSession.userSessionNumber)
+    }
+
+    @Test
+    fun `inactivity timeout not exceeded keeps existing user session`() {
+        configService = FakeConfigService(
+            backgroundActivityBehavior = createBackgroundActivityBehavior(
+                remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 0f))
+            ),
+            sessionBehavior = FakeUserSessionBehavior(
+                maxSessionDurationMs = maxDurationMs,
+                sessionInactivityTimeoutMs = inactivityMs,
+            )
+        )
+        createOrchestrator(AppState.FOREGROUND)
+
+        val firstSession = checkNotNull(orchestrator.currentUserSession())
+        assertEquals(1L, firstSession.userSessionNumber)
+
+        orchestrator.onBackground()
+
+        // foreground before timer fires — timer is cancelled, same user session continues
+        clock.tick(inactivityMs - 1)
+        orchestrator.onForeground()
+        clock.tick(inactivityMs + 1)
+
+        val sessionAfterForeground = checkNotNull(orchestrator.currentUserSession())
+        assertEquals(firstSession.userSessionId, sessionAfterForeground.userSessionId)
+        assertEquals(1L, sessionAfterForeground.userSessionNumber)
+    }
+
+    @Test
     fun `user session start time matches initial session part start time`() {
         createOrchestrator(AppState.FOREGROUND)
         val userSession = checkNotNull(orchestrator.currentUserSession())
@@ -762,6 +826,7 @@ internal class SessionOrchestratorTest {
             logger = logger
         )
         sessionCacheExecutor = BlockingScheduledExecutorService(clock, true)
+        inactivityWorkerExecutor = BlockingScheduledExecutorService(clock, true)
         payloadCachingService = PayloadCachingServiceImpl(
             PeriodicSessionPartCacher(
                 BackgroundWorker(sessionCacheExecutor),
@@ -806,6 +871,7 @@ internal class SessionOrchestratorTest {
             ordinalStoreOverride ?: FakeOrdinalStore(),
             metadataStoreOverride ?: UserSessionMetadataStore(FakeKeyValueStore()),
             logger,
+            BackgroundWorker(inactivityWorkerExecutor),
         )
         orchestratorStartTimeMs = clock.now()
         userSessionPropertiesService.addProperty("key", "value", false)

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
@@ -173,7 +173,8 @@ internal class InitializedModuleGraph(
             instrumentationModule,
             payloadSourceModule,
             dataCaptureServiceModule.startupService::getSdkStartupDuration,
-            logModule
+            logModule,
+            workerThreadModule,
         )
     }
 

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -208,6 +208,7 @@ internal class ModuleInitBootstrapper(
             payloadSourceModule: PayloadSourceModule,
             startupDurationProvider: () -> Long?,
             logModule: LogModule,
+            workerThreadModule: WorkerThreadModule,
         ->
         UserSessionOrchestrationModuleImpl(
             initModule,
@@ -219,7 +220,8 @@ internal class ModuleInitBootstrapper(
             instrumentationModule,
             payloadSourceModule,
             startupDurationProvider,
-            logModule
+            logModule,
+            workerThreadModule,
         )
     },
     private val payloadSourceModuleSupplier: PayloadSourceModuleSupplier = {

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/UserSessionApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/UserSessionApiDelegateTest.kt
@@ -34,7 +34,7 @@ internal class UserSessionApiDelegateTest {
             essentialServiceModuleSupplier = { _, _, _, _, _, _, _ ->
                 FakeEssentialServiceModule()
             },
-            userSessionOrchestrationModuleSupplier = { _, _, _, _, _, _, _, _, _, _ ->
+            userSessionOrchestrationModuleSupplier = { _, _, _, _, _, _, _, _, _, _, _ ->
                 fakeModule
             }
         )


### PR DESCRIPTION
## Goal

Support inactivity timeout for user sessions. In summary, once the process has been in the background for X ms, the background session part should be split and a new user session created. On reentering the foreground a new user session must always be created.

## Testing

Added unit tests.
