### PR TITLE
Add callbacks for user sessions

### DIFF
--- a/embrace-android-api/api/embrace-android-api.api
+++ b/embrace-android-api/api/embrace-android-api.api
@@ -17,6 +17,19 @@ public final class io/embrace/android/embracesdk/PropertyScope : java/lang/Enum 
 	public static fun values ()[Lio/embrace/android/embracesdk/PropertyScope;
 }
 
+public abstract class io/embrace/android/embracesdk/SessionStateEvent {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getUserSessionId ()Ljava/lang/String;
+}
+
+public final class io/embrace/android/embracesdk/SessionStateEvent$UserSessionActive : io/embrace/android/embracesdk/SessionStateEvent {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class io/embrace/android/embracesdk/SessionStateEvent$UserSessionEnded : io/embrace/android/embracesdk/SessionStateEvent {
+	public fun <init> (Ljava/lang/String;)V
+}
+
 public final class io/embrace/android/embracesdk/Severity : java/lang/Enum {
 	public static final field ERROR Lio/embrace/android/embracesdk/Severity;
 	public static final field INFO Lio/embrace/android/embracesdk/Severity;
@@ -24,6 +37,10 @@ public final class io/embrace/android/embracesdk/Severity : java/lang/Enum {
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lio/embrace/android/embracesdk/Severity;
 	public static fun values ()[Lio/embrace/android/embracesdk/Severity;
+}
+
+public abstract interface class io/embrace/android/embracesdk/UserSessionListener {
+	public abstract fun onSessionStateEvent (Lio/embrace/android/embracesdk/SessionStateEvent;)V
 }
 
 public abstract interface annotation class io/embrace/android/embracesdk/annotation/CustomLoadTracedActivity : java/lang/annotation/Annotation {
@@ -133,6 +150,7 @@ public abstract interface class io/embrace/android/embracesdk/internal/api/UserA
 }
 
 public abstract interface class io/embrace/android/embracesdk/internal/api/UserSessionApi {
+	public abstract fun addUserSessionListener (Lio/embrace/android/embracesdk/UserSessionListener;)V
 	public abstract fun addUserSessionProperty (Ljava/lang/String;Ljava/lang/String;Lio/embrace/android/embracesdk/PropertyScope;)Z
 	public abstract fun endUserSession (Z)V
 	public abstract fun removeUserSessionProperty (Ljava/lang/String;)Z

--- a/embrace-android-api/lint-baseline.xml
+++ b/embrace-android-api/lint-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.1.0" type="baseline" client="gradle" dependencies="false" name="AGP (9.1.0)" variant="all" version="9.1.0">
+<issues format="6" by="lint 9.1.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.1.1)" variant="all" version="9.1.1">
 
     <issue
         id="EmbracePublicApiPackageRule"
@@ -26,12 +26,56 @@
     <issue
         id="EmbracePublicApiPackageRule"
         message="Don&apos;t put classes in the io.embrace.android.embracesdk package unless they&apos;re part of the public API. Please move the new class to an appropriate package or (if you&apos;re adding to the public API) suppress this error via the lint baseline file."
+        errorLine1="public sealed class SessionStateEvent("
+        errorLine2="                    ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/SessionStateEvent.kt"
+            line="6"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="EmbracePublicApiPackageRule"
+        message="Don&apos;t put classes in the io.embrace.android.embracesdk package unless they&apos;re part of the public API. Please move the new class to an appropriate package or (if you&apos;re adding to the public API) suppress this error via the lint baseline file."
+        errorLine1="    public class UserSessionActive(userSessionId: String) : SessionStateEvent(userSessionId)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/SessionStateEvent.kt"
+            line="21"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="EmbracePublicApiPackageRule"
+        message="Don&apos;t put classes in the io.embrace.android.embracesdk package unless they&apos;re part of the public API. Please move the new class to an appropriate package or (if you&apos;re adding to the public API) suppress this error via the lint baseline file."
+        errorLine1="    public class UserSessionEnded(userSessionId: String) : SessionStateEvent(userSessionId)"
+        errorLine2="                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/SessionStateEvent.kt"
+            line="26"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="EmbracePublicApiPackageRule"
+        message="Don&apos;t put classes in the io.embrace.android.embracesdk package unless they&apos;re part of the public API. Please move the new class to an appropriate package or (if you&apos;re adding to the public API) suppress this error via the lint baseline file."
         errorLine1="public enum class Severity {"
         errorLine2="                  ~~~~~~~~">
         <location
             file="src/main/kotlin/io/embrace/android/embracesdk/Severity.kt"
             line="6"
             column="19"/>
+    </issue>
+
+    <issue
+        id="EmbracePublicApiPackageRule"
+        message="Don&apos;t put classes in the io.embrace.android.embracesdk package unless they&apos;re part of the public API. Please move the new class to an appropriate package or (if you&apos;re adding to the public API) suppress this error via the lint baseline file."
+        errorLine1="public fun interface UserSessionListener {"
+        errorLine2="                     ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/embrace/android/embracesdk/UserSessionListener.kt"
+            line="8"
+            column="22"/>
     </issue>
 
 </issues>

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/SessionStateEvent.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/SessionStateEvent.kt
@@ -17,6 +17,11 @@ public sealed class SessionStateEvent(
      * 1. When a new user session starts
      * 2. When an existing user session is restored in a new process
      * 3. When a listener is registered, if a user session is already active
+     *
+     * It's important to note that the same userSessionId value may be present in multiple, distinct events of
+     * [io.embrace.android.embracesdk.SessionStateEvent.UserSessionActive]. This API is primarily intended so that
+     * library consumers can perform operations when a user session is brought into memory, such as setting
+     * a user ID or user session properties.
      */
     public class UserSessionActive(userSessionId: String) : SessionStateEvent(userSessionId)
 

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/SessionStateEvent.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/SessionStateEvent.kt
@@ -1,0 +1,27 @@
+package io.embrace.android.embracesdk
+
+/**
+ * Represents an event in the user session lifecycle.
+ */
+public sealed class SessionStateEvent(
+
+    /**
+     * ID representing the user session.
+     */
+    public val userSessionId: String
+) {
+
+    /**
+     * A user session is active. This event is fired in the following conditions:
+     *
+     * 1. When a new user session starts
+     * 2. When an existing user session is restored in a new process
+     * 3. When a listener is registered, if a user session is already active
+     */
+    public class UserSessionActive(userSessionId: String) : SessionStateEvent(userSessionId)
+
+    /**
+     * The current user session has ended.
+     */
+    public class UserSessionEnded(userSessionId: String) : SessionStateEvent(userSessionId)
+}

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/UserSessionListener.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/UserSessionListener.kt
@@ -1,0 +1,14 @@
+package io.embrace.android.embracesdk
+
+/**
+ * Listens for events in the user session lifecycle.
+ *
+ * @see SessionStateEvent
+ */
+public fun interface UserSessionListener {
+
+    /**
+     * Invoked when a [SessionStateEvent] occurs in the user session lifecycle.
+     */
+    public fun onSessionStateEvent(event: SessionStateEvent)
+}

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/UserSessionApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/UserSessionApi.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.api
 
 import io.embrace.android.embracesdk.PropertyScope
+import io.embrace.android.embracesdk.UserSessionListener
 import io.embrace.android.embracesdk.annotation.InternalApi
 
 /**
@@ -43,4 +44,9 @@ public interface UserSessionApi {
      * @param clearUserInfo Pass in true to clear all user info set on this device.
      */
     public fun endUserSession(clearUserInfo: Boolean = false)
+
+    /**
+     * Registers a listener that is invoked for user session lifecycle events.
+     */
+    public fun addUserSessionListener(listener: UserSessionListener)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionListener.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionListener.kt
@@ -1,12 +1,11 @@
 package io.embrace.android.embracesdk.internal.session
 
+import io.embrace.android.embracesdk.SessionStateEvent
+
 /**
  * Listens for events in the 'user session' lifecycle.
  */
 fun interface UserSessionListener {
 
-    /**
-     * Invoked when a new user session has started.
-     */
-    fun onNewUserSession()
+    fun onSessionStateEvent(event: SessionStateEvent)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestrator.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestrator.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.session.orchestrator
 
 import io.embrace.android.embracesdk.internal.arch.CrashTeardownHandler
 import io.embrace.android.embracesdk.internal.arch.state.AppStateListener
+import io.embrace.android.embracesdk.internal.session.UserSessionListener
 import io.embrace.android.embracesdk.internal.session.UserSessionMetadata
 
 /**
@@ -26,4 +27,9 @@ interface SessionOrchestrator : AppStateListener, CrashTeardownHandler {
      * Retrieves metadata on the current user session, if any exists.
      */
     fun currentUserSession(): UserSessionMetadata?
+
+    /**
+     * Registers a listener that is invoked for user session lifecycle events.
+     */
+    fun addUserSessionListener(listener: UserSessionListener)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -2,6 +2,7 @@
 
 package io.embrace.android.embracesdk.internal.session.orchestrator
 
+import io.embrace.android.embracesdk.SessionStateEvent
 import io.embrace.android.embracesdk.internal.arch.InstrumentationRegistry
 import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
 import io.embrace.android.embracesdk.internal.arch.state.AppState
@@ -15,6 +16,7 @@ import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
 import io.embrace.android.embracesdk.internal.session.SessionPartToken
+import io.embrace.android.embracesdk.internal.session.UserSessionListener
 import io.embrace.android.embracesdk.internal.session.UserSessionMetadata
 import io.embrace.android.embracesdk.internal.session.UserSessionMetadataStore
 import io.embrace.android.embracesdk.internal.session.UserSessionState
@@ -27,6 +29,7 @@ import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.Uuid
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.semconv.ExperimentalSemconv
+import java.util.concurrent.CopyOnWriteArrayList
 
 internal class SessionOrchestratorImpl(
     appStateTracker: AppStateTracker,
@@ -52,6 +55,7 @@ internal class SessionOrchestratorImpl(
     private var coldStart = true
 
     private val lock = Any()
+    private val userSessionListeners = CopyOnWriteArrayList<UserSessionListener>()
 
     private var state = appStateTracker.getAppState()
 
@@ -85,6 +89,7 @@ internal class SessionOrchestratorImpl(
                     stored != null && !isUserSessionOverMaxDuration(stored) -> {
                         UserSessionState.Active(stored)
                     }
+
                     else -> UserSessionState.NoActiveSession
                 }
             } catch (e: Exception) {
@@ -182,6 +187,28 @@ internal class SessionOrchestratorImpl(
 
     override fun currentUserSession(): UserSessionMetadata? =
         (userSessionState as? UserSessionState.Active)?.metadata
+
+    override fun addUserSessionListener(listener: UserSessionListener) {
+        userSessionListeners.add(listener)
+        val state = userSessionState
+        if (state is UserSessionState.Active) {
+            try {
+                listener.onSessionStateEvent(SessionStateEvent.UserSessionActive(state.metadata.userSessionId))
+            } catch (e: Exception) {
+                logger.trackInternalError(InternalErrorType.USER_SESSION_CALLBACK_FAIL, e)
+            }
+        }
+    }
+
+    private fun notifyListeners(event: SessionStateEvent) {
+        userSessionListeners.forEach { listener ->
+            try {
+                listener.onSessionStateEvent(event)
+            } catch (e: Exception) {
+                logger.trackInternalError(InternalErrorType.USER_SESSION_CALLBACK_FAIL, e)
+            }
+        }
+    }
 
     /**
      * This function is responsible for transitioning state from one session to another. This can
@@ -315,7 +342,7 @@ internal class SessionOrchestratorImpl(
         val current = userSessionState
         if (current is UserSessionState.Active) {
             if (isUserSessionOverMaxDuration(current.metadata)) {
-                terminateUserSession()
+                terminateUserSession(current)
                 startNewUserSession(timestamp)
             }
         } else {
@@ -328,8 +355,9 @@ internal class SessionOrchestratorImpl(
      * then always starts a new one.
      */
     private fun handleUserSessionEnd(timestamp: Long) {
-        if (userSessionState is UserSessionState.Active) {
-            terminateUserSession()
+        val state = userSessionState
+        if (state is UserSessionState.Active) {
+            terminateUserSession(state)
         }
         startNewUserSession(timestamp)
     }
@@ -349,10 +377,12 @@ internal class SessionOrchestratorImpl(
         )
         metadataStore.save(newMetadata)
         userSessionState = UserSessionState.Active(newMetadata)
+        notifyListeners(SessionStateEvent.UserSessionActive(newMetadata.userSessionId))
     }
 
-    private fun terminateUserSession() {
+    private fun terminateUserSession(state: UserSessionState.Active) {
         metadataStore.clear()
         userSessionState = UserSessionState.Terminated
+        notifyListeners(SessionStateEvent.UserSessionEnded(state.metadata.userSessionId))
     }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorListenerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorListenerTest.kt
@@ -1,0 +1,316 @@
+package io.embrace.android.embracesdk.internal.session.orchestrator
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.SessionStateEvent
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
+import io.embrace.android.embracesdk.fakes.FakeAppStateTracker
+import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeCurrentSessionPartSpan
+import io.embrace.android.embracesdk.fakes.FakeDataSource
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
+import io.embrace.android.embracesdk.fakes.FakeKeyValueStore
+import io.embrace.android.embracesdk.fakes.FakeLogEnvelopeSource
+import io.embrace.android.embracesdk.fakes.FakeLogLimitingService
+import io.embrace.android.embracesdk.fakes.FakeMetadataService
+import io.embrace.android.embracesdk.fakes.FakeOrdinalStore
+import io.embrace.android.embracesdk.fakes.FakePayloadMessageCollator
+import io.embrace.android.embracesdk.fakes.FakePayloadStore
+import io.embrace.android.embracesdk.fakes.FakeTelemetryDestination
+import io.embrace.android.embracesdk.fakes.FakeUserService
+import io.embrace.android.embracesdk.fakes.FakeUserSessionPropertiesService
+import io.embrace.android.embracesdk.fakes.behavior.FakeUserSessionBehavior
+import io.embrace.android.embracesdk.fakes.createBackgroundActivityBehavior
+import io.embrace.android.embracesdk.fakes.injection.FakePayloadSourceModule
+import io.embrace.android.embracesdk.internal.arch.InstrumentationRegistry
+import io.embrace.android.embracesdk.internal.arch.InstrumentationRegistryImpl
+import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
+import io.embrace.android.embracesdk.internal.arch.state.AppState
+import io.embrace.android.embracesdk.internal.capture.session.PropertyScope
+import io.embrace.android.embracesdk.internal.capture.session.UserSessionPropertiesService
+import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.delivery.caching.PayloadCachingService
+import io.embrace.android.embracesdk.internal.delivery.caching.PayloadCachingServiceImpl
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.session.UserSessionMetadata
+import io.embrace.android.embracesdk.internal.session.UserSessionMetadataStore
+import io.embrace.android.embracesdk.internal.session.caching.PeriodicSessionPartCacher
+import io.embrace.android.embracesdk.internal.session.id.SessionPartTracker
+import io.embrace.android.embracesdk.internal.session.id.SessionPartTrackerImpl
+import io.embrace.android.embracesdk.internal.session.message.PayloadFactoryImpl
+import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RuntimeEnvironment
+import java.util.concurrent.TimeUnit
+
+@RunWith(AndroidJUnit4::class)
+internal class SessionOrchestratorListenerTest {
+
+    private lateinit var orchestrator: SessionOrchestratorImpl
+    private lateinit var payloadFactory: PayloadFactoryImpl
+    private lateinit var payloadCollator: FakePayloadMessageCollator
+    private lateinit var logEnvelopeSource: FakeLogEnvelopeSource
+    private lateinit var appStateTracker: FakeAppStateTracker
+    private lateinit var clock: FakeClock
+    private lateinit var configService: FakeConfigService
+    private lateinit var userService: FakeUserService
+    private lateinit var store: FakePayloadStore
+    private lateinit var userSessionPropertiesService: UserSessionPropertiesService
+    private lateinit var sessionTracker: SessionPartTracker
+    private lateinit var payloadCachingService: PayloadCachingService
+    private lateinit var sessionCacheExecutor: BlockingScheduledExecutorService
+    private lateinit var instrumentationRegistry: InstrumentationRegistry
+    private lateinit var fakeDataSource: FakeDataSource
+    private lateinit var logger: FakeInternalLogger
+    private lateinit var currentSessionPartSpan: FakeCurrentSessionPartSpan
+    private lateinit var destination: FakeTelemetryDestination
+    private var orchestratorStartTimeMs: Long = 0
+
+    private val maxDurationMs = TimeUnit.MINUTES.toMillis(10)
+    private val inactivityMs = TimeUnit.MINUTES.toMillis(5)
+
+    @Before
+    fun setUp() {
+        clock = FakeClock()
+        logger = FakeInternalLogger(throwOnInternalError = false)
+        configService = FakeConfigService(
+            backgroundActivityBehavior = createBackgroundActivityBehavior(
+                remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 100f))
+            )
+        )
+    }
+
+    @Test
+    fun `USER_SESSION_ACTIVE fired on fresh session transitions`() {
+        configService = sessionBehaviorConfig()
+        createOrchestrator(AppState.FOREGROUND)
+        // registration fires immediately since a session is already active
+        val events = collectEvents(SessionStateEvent.UserSessionActive::class)
+        assertEquals(1, events.size)
+
+        // manual end always starts a new user session
+        clock.tick(10000)
+        orchestrator.endSessionWithManual(false)
+        assertEquals(2, events.size)
+
+        // foreground/background within max duration keeps same user session
+        orchestrator.onBackground()
+        orchestrator.onForeground()
+        assertEquals(2, events.size)
+
+        // past max duration — new user session
+        clock.tick(maxDurationMs)
+        orchestrator.onBackground()
+        orchestrator.onForeground()
+        assertEquals(3, events.size)
+    }
+
+    @Test
+    fun `USER_SESSION_ACTIVE not fired by session part transitions when restored session continues`() {
+        configService = sessionBehaviorConfig()
+        createOrchestrator(AppState.FOREGROUND, metadataStoreOverride = restoredMetadataStore())
+        // registration fires immediately since the restored session is still active
+        val events = collectEvents(SessionStateEvent.UserSessionActive::class)
+        assertEquals(1, events.size)
+
+        // session part transitions within max duration do not fire USER_SESSION_ACTIVE again
+        orchestrator.onBackground()
+        orchestrator.onForeground()
+        assertEquals(1, events.size)
+    }
+
+    @Test
+    fun `USER_SESSION_ENDED fired when user session terminates`() {
+        configService = sessionBehaviorConfig()
+        createOrchestrator(AppState.FOREGROUND)
+        val events = collectEvents(SessionStateEvent.UserSessionEnded::class)
+
+        // manual end terminates then creates a new session
+        clock.tick(10000)
+        orchestrator.endSessionWithManual(false)
+        assertEquals(1, events.size)
+
+        // foreground/background within max duration
+        orchestrator.onBackground()
+        orchestrator.onForeground()
+        assertEquals(1, events.size)
+
+        // past max duration — old session terminates
+        clock.tick(maxDurationMs)
+        orchestrator.onBackground()
+        orchestrator.onForeground()
+        assertEquals(2, events.size)
+    }
+
+    @Test
+    fun `event order on manual end is USER_SESSION_ACTIVE then USER_SESSION_ENDED then USER_SESSION_ACTIVE then NEW_SESSION_PART`() {
+        configService = sessionBehaviorConfig()
+        createOrchestrator(AppState.FOREGROUND)
+        val events = mutableListOf<SessionStateEvent>()
+        // registration fires USER_SESSION_ACTIVE immediately
+        orchestrator.addUserSessionListener { event -> events.add(event) }
+
+        clock.tick(10000)
+        orchestrator.endSessionWithManual(false)
+
+        assertEquals(
+            listOf(
+                SessionStateEvent.UserSessionActive::class,
+                SessionStateEvent.UserSessionEnded::class,
+                SessionStateEvent.UserSessionActive::class,
+            ),
+            events.map { it::class }
+        )
+    }
+
+    @Test
+    fun `multiple listeners all notified`() {
+        configService = sessionBehaviorConfig()
+        createOrchestrator(AppState.FOREGROUND)
+
+        val events1 = mutableListOf<SessionStateEvent>()
+        val events2 = mutableListOf<SessionStateEvent>()
+        orchestrator.addUserSessionListener { event -> events1.add(event) }
+        orchestrator.addUserSessionListener { event -> events2.add(event) }
+
+        clock.tick(10000)
+        orchestrator.endSessionWithManual(false)
+        assertEquals(events1.map { it::class to it.userSessionId }, events2.map { it::class to it.userSessionId })
+        assertTrue(events1.any { it is SessionStateEvent.UserSessionActive })
+    }
+
+    @Test
+    fun `adding a listener fires USER_SESSION_ACTIVE immediately when a session is active`() {
+        configService = sessionBehaviorConfig()
+        createOrchestrator(AppState.FOREGROUND)
+        val events = mutableListOf<SessionStateEvent>()
+        orchestrator.addUserSessionListener { event -> events.add(event) }
+        assertEquals(listOf(SessionStateEvent.UserSessionActive::class), events.map { it::class })
+    }
+
+    @Test
+    fun `exception in listener is swallowed and does not prevent other listeners from being notified`() {
+        configService = sessionBehaviorConfig()
+        createOrchestrator(AppState.FOREGROUND)
+
+        var secondListenerInvoked = false
+        orchestrator.addUserSessionListener { error("simulated listener failure") }
+        orchestrator.addUserSessionListener { secondListenerInvoked = true }
+
+        clock.tick(10000)
+        orchestrator.endSessionWithManual(false)
+        assertTrue(secondListenerInvoked)
+        assertTrue(logger.internalErrorMessages.any { it.msg == InternalErrorType.USER_SESSION_CALLBACK_FAIL.toString() })
+    }
+
+    private fun restoredMetadataStore() = UserSessionMetadataStore(FakeKeyValueStore()).also { store ->
+        store.save(
+            UserSessionMetadata(
+                startTimeMs = clock.now(),
+                userSessionId = "restored-id",
+                userSessionNumber = 7L,
+                maxDurationSecs = TimeUnit.MILLISECONDS.toSeconds(maxDurationMs),
+                inactivityTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(inactivityMs),
+            )
+        )
+    }
+
+    private fun sessionBehaviorConfig() = FakeConfigService(
+        backgroundActivityBehavior = createBackgroundActivityBehavior(
+            remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 100f))
+        ),
+        sessionBehavior = FakeUserSessionBehavior(
+            maxSessionDurationMs = maxDurationMs,
+            sessionInactivityTimeoutMs = inactivityMs,
+        )
+    )
+
+    private fun collectEvents(vararg targetTypes: kotlin.reflect.KClass<out SessionStateEvent>): MutableList<SessionStateEvent> {
+        val events = mutableListOf<SessionStateEvent>()
+        orchestrator.addUserSessionListener { event ->
+            if (targetTypes.any { it.isInstance(event) }) {
+                events.add(event)
+            }
+        }
+        return events
+    }
+
+    private fun createOrchestrator(
+        state: AppState,
+        ordinalStoreOverride: FakeOrdinalStore? = null,
+        metadataStoreOverride: UserSessionMetadataStore? = null,
+    ) {
+        store = FakePayloadStore()
+        appStateTracker = FakeAppStateTracker(state)
+        currentSessionPartSpan = FakeCurrentSessionPartSpan(clock).apply { initializeService(clock.now()) }
+        destination = FakeTelemetryDestination()
+        payloadCollator = FakePayloadMessageCollator(currentSessionPartSpan = currentSessionPartSpan)
+        val payloadSourceModule = FakePayloadSourceModule()
+        logEnvelopeSource = payloadSourceModule.logEnvelopeSource
+        payloadFactory = PayloadFactoryImpl(
+            payloadMessageCollator = payloadCollator,
+            logEnvelopeSource = payloadSourceModule.logEnvelopeSource,
+            configService = configService,
+            logger = logger
+        )
+        userSessionPropertiesService = FakeUserSessionPropertiesService()
+        userService = FakeUserService()
+        sessionTracker = SessionPartTrackerImpl(
+            activityManager = null,
+            logger = logger
+        )
+        sessionCacheExecutor = BlockingScheduledExecutorService(clock, true)
+        payloadCachingService = PayloadCachingServiceImpl(
+            PeriodicSessionPartCacher(
+                BackgroundWorker(sessionCacheExecutor),
+                logger
+            ),
+            clock,
+            sessionTracker,
+            store
+        )
+        fakeDataSource = FakeDataSource(RuntimeEnvironment.getApplication())
+        instrumentationRegistry = InstrumentationRegistryImpl(
+            logger
+        ).apply {
+            add(
+                DataSourceState(
+                    factory = { fakeDataSource },
+                    configGate = { true }
+                )
+            )
+        }
+
+        orchestrator = SessionOrchestratorImpl(
+            appStateTracker,
+            payloadFactory,
+            clock,
+            configService,
+            sessionTracker,
+            OrchestratorBoundaryDelegate(
+                userService,
+                userSessionPropertiesService
+            ),
+            store,
+            payloadCachingService,
+            instrumentationRegistry,
+            destination,
+            SessionPartSpanAttrPopulatorImpl(
+                destination,
+                { 0 },
+                FakeLogLimitingService(),
+                FakeMetadataService()
+            ),
+            ordinalStoreOverride ?: FakeOrdinalStore(),
+            metadataStoreOverride ?: UserSessionMetadataStore(FakeKeyValueStore()),
+            logger,
+        )
+        orchestratorStartTimeMs = clock.now()
+        userSessionPropertiesService.addProperty("key", "value", PropertyScope.USER_SESSION)
+    }
+}

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -13,6 +13,7 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun addStartupTraceChildSpan (Ljava/lang/String;JJ)V
 	public fun addStartupTraceChildSpan (Ljava/lang/String;JJLjava/util/Map;Ljava/util/List;Lio/embrace/android/embracesdk/spans/ErrorCode;)V
 	public fun addUserPersona (Ljava/lang/String;)V
+	public fun addUserSessionListener (Lio/embrace/android/embracesdk/UserSessionListener;)V
 	public fun addUserSessionProperty (Ljava/lang/String;Ljava/lang/String;Lio/embrace/android/embracesdk/PropertyScope;)Z
 	public fun appReady ()V
 	public fun applicationInitEnd ()V

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/UserSessionApiDelegate.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/UserSessionApiDelegate.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.api.delegate
 
 import io.embrace.android.embracesdk.PropertyScope
+import io.embrace.android.embracesdk.UserSessionListener
 import io.embrace.android.embracesdk.internal.api.UserSessionApi
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.injection.embraceImplInject
@@ -50,6 +51,14 @@ internal class UserSessionApiDelegate(
     override fun endUserSession(clearUserInfo: Boolean) {
         if (sdkCallChecker.check("end_session")) {
             sessionOrchestrator?.endSessionWithManual(clearUserInfo)
+        }
+    }
+
+    override fun addUserSessionListener(listener: UserSessionListener) {
+        if (sdkCallChecker.check("add_user_session_listener")) {
+            sessionOrchestrator?.addUserSessionListener { event ->
+                listener.onSessionStateEvent(event)
+            }
         }
     }
 }

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/UserSessionApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/UserSessionApiDelegateTest.kt
@@ -14,6 +14,7 @@ import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -82,5 +83,19 @@ internal class UserSessionApiDelegateTest {
     fun `end session clear user info`() {
         delegate.endUserSession(true)
         assertEquals(1, (fakeModule.sessionOrchestrator as FakeSessionOrchestrator).manualEndCount)
+    }
+
+    @Test
+    fun `add user session listener when SDK started`() {
+        delegate.addUserSessionListener { }
+        assertEquals(1, (fakeModule.sessionOrchestrator as FakeSessionOrchestrator).userSessionListeners.size)
+    }
+
+    @Test
+    fun `add user session listener when SDK not started`() {
+        logger.throwOnInternalError = false
+        sdkCallChecker.started.set(false)
+        delegate.addUserSessionListener { }
+        assertTrue((fakeModule.sessionOrchestrator as FakeSessionOrchestrator).userSessionListeners.isEmpty())
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionOrchestrator.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionOrchestrator.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.internal.session.UserSessionListener
 import io.embrace.android.embracesdk.internal.session.UserSessionMetadata
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionOrchestrator
 
@@ -9,6 +10,7 @@ class FakeSessionOrchestrator : SessionOrchestrator {
     var manualEndCount: Int = 0
     var stateChangeCount: Int = 0
     var currentSession: UserSessionMetadata? = null
+    val userSessionListeners = mutableListOf<UserSessionListener>()
 
     override fun endSessionWithManual(clearUserInfo: Boolean) {
         manualEndCount++
@@ -29,4 +31,8 @@ class FakeSessionOrchestrator : SessionOrchestrator {
     }
 
     override fun currentUserSession(): UserSessionMetadata? = currentSession
+
+    override fun addUserSessionListener(listener: UserSessionListener) {
+        userSessionListeners.add(listener)
+    }
 }


### PR DESCRIPTION
## Goal

Adds an API for registering callbacks for user sessions. This allows a library consumer to register a callback and react to changes in the session lifecycle. These states are currently available:

1. Creation of an active user session
2. End of a user session
3. A user session restoring itself in a new process

This attempts to fill parity with the existing functionality on iOS. This is also required because we plan on deprecating `endSession(clearUserInfo: Boolean)` and asking users who want to clear user data to do so in a callback.

## Testing

Added unit tests.