### PR TITLE
Tweak inactivity timeout minimum for user sessions

### DIFF
--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/UserSessionBehaviorImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/UserSessionBehaviorImpl.kt
@@ -16,7 +16,7 @@ class UserSessionBehaviorImpl(private val remote: RemoteConfig?) : UserSessionBe
         private const val MAX_DURATION_SECONDS_MAX: Int = 24 * 60 * 60
         private const val INACTIVITY_TIMEOUT_SECONDS_DEFAULT: Int = 30 * 60
         private const val INACTIVITY_TIMEOUT_SECONDS_MAX: Int = 24 * 60 * 60
-        private const val INACTIVITY_TIMEOUT_SECONDS_MIN: Int = 0
+        private const val INACTIVITY_TIMEOUT_SECONDS_MIN: Int = 30
         private const val MIN_SESSION_MS: Long = 5_000L
     }
 

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/UserSessionBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/UserSessionBehaviorImplTest.kt
@@ -84,10 +84,17 @@ internal class UserSessionBehaviorImplTest {
     }
 
     @Test
-    fun `inactivity timeout is valid when remote value is zero`() {
+    fun `inactivity timeout defaults when remote value is below minimum`() {
         val cfg =
             RemoteConfig(userSession = UserSessionRemoteConfig(maxDurationSeconds = 86400, inactivityTimeoutSeconds = 0))
-        assertEquals(0L, createSessionBehavior(remoteCfg = cfg).getSessionInactivityTimeoutMs())
+        assertEquals(defaultInactivityTimeoutMs, createSessionBehavior(remoteCfg = cfg).getSessionInactivityTimeoutMs())
+    }
+
+    @Test
+    fun `inactivity timeout is valid when remote value equals minimum`() {
+        val cfg =
+            RemoteConfig(userSession = UserSessionRemoteConfig(maxDurationSeconds = 86400, inactivityTimeoutSeconds = 30))
+        assertEquals(30 * 1_000L, createSessionBehavior(remoteCfg = cfg).getSessionInactivityTimeoutMs())
     }
 
     @Test


### PR DESCRIPTION
## Goal

Tweaks the minimum inactivity timeout for user sessions, as this should now be 30s.
