### PR TITLE
Support max duration timer

### DIFF
--- a/embrace-android-core/config/detekt/baseline.xml
+++ b/embrace-android-core/config/detekt/baseline.xml
@@ -1,5 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <SmellBaseline>
   <ManuallySuppressedIssues/>
-  <CurrentIssues/>
+  <CurrentIssues>
+    <ID>ComplexCondition:SessionOrchestratorImpl.kt$SessionOrchestratorImpl$transitionType == TransitionType.END_MANUAL || transitionType == TransitionType.INACTIVITY_TIMEOUT || transitionType == TransitionType.INACTIVITY_FOREGROUND || transitionType == TransitionType.MAX_DURATION</ID>
+  </CurrentIssues>
 </SmellBaseline>

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -29,6 +29,7 @@ import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.semconv.ExperimentalSemconv
 import java.util.concurrent.TimeUnit
+import kotlin.math.max
 
 internal class SessionOrchestratorImpl(
     appStateTracker: AppStateTracker,
@@ -62,7 +63,10 @@ internal class SessionOrchestratorImpl(
     private var userSessionState: UserSessionState = UserSessionState.Initializing
 
     @Volatile
-    private var inactivityTimerState: InactivityTimerState? = null
+    private var inactivityTimerState: SessionTimerState? = null
+
+    @Volatile
+    private var maxDurationTimerState: SessionTimerState? = null
 
     init {
         loadPersistedUserSession()
@@ -89,6 +93,7 @@ internal class SessionOrchestratorImpl(
                     }
 
                     stored != null && !isUserSessionOverMaxDuration(stored) -> {
+                        scheduleMaxDurationTimeout(stored)
                         UserSessionState.Active(stored)
                     }
 
@@ -271,7 +276,8 @@ internal class SessionOrchestratorImpl(
                     if (transitionType != TransitionType.CRASH) {
                         if (transitionType == TransitionType.END_MANUAL ||
                             transitionType == TransitionType.INACTIVITY_TIMEOUT ||
-                            transitionType == TransitionType.INACTIVITY_FOREGROUND
+                            transitionType == TransitionType.INACTIVITY_FOREGROUND ||
+                            transitionType == TransitionType.MAX_DURATION
                         ) {
                             handleUserSessionEnd(timestamp)
                         } else {
@@ -318,13 +324,45 @@ internal class SessionOrchestratorImpl(
 
     private fun scheduleInactivityTimeout() {
         val metadata = (userSessionState as? UserSessionState.Active)?.metadata ?: return
-        inactivityTimerState = InactivityTimerState(
+        inactivityTimerState = SessionTimerState(
             backgroundWorker.schedule<Unit>(
                 ::onInactivityTimeout,
                 metadata.inactivityTimeoutSecs,
                 TimeUnit.SECONDS,
             )
         )
+    }
+
+    private fun scheduleMaxDurationTimeout(metadata: UserSessionMetadata) {
+        val remainingSecs = metadata.maxDurationSecs - ((clock.now() - metadata.startTimeMs) / 1_000L)
+        val delay = max(remainingSecs, 0)
+        maxDurationTimerState = SessionTimerState(
+            backgroundWorker.schedule<Unit>(
+                ::onMaxDurationTimeout,
+                delay,
+                TimeUnit.SECONDS,
+            )
+        )
+    }
+
+    private fun onMaxDurationTimeout() {
+        synchronized(lock) {
+            if (userSessionState !is UserSessionState.Active) {
+                return
+            }
+            val currentAppState = state
+            val timestamp = clock.now()
+            transitionState(
+                transitionType = TransitionType.MAX_DURATION,
+                timestamp = timestamp,
+                oldSessionAction = { initial: SessionPartToken ->
+                    payloadFactory.endPayloadWithState(currentAppState, timestamp, initial)
+                },
+                newSessionAction = {
+                    payloadFactory.startPayloadWithState(currentAppState, timestamp, false)
+                },
+            )
+        }
     }
 
     private fun onInactivityTimeout() {
@@ -413,9 +451,15 @@ internal class SessionOrchestratorImpl(
         )
         metadataStore.save(newMetadata)
         userSessionState = UserSessionState.Active(newMetadata)
+
+        if (state == AppState.FOREGROUND) {
+            scheduleMaxDurationTimeout(newMetadata)
+        }
     }
 
     private fun terminateUserSession() {
+        maxDurationTimerState?.cancel()
+        maxDurationTimerState = null
         metadataStore.clear()
         userSessionState = UserSessionState.Terminated
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionTimerState.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionTimerState.kt
@@ -3,10 +3,10 @@ package io.embrace.android.embracesdk.internal.session.orchestrator
 import java.util.concurrent.ScheduledFuture
 
 /**
- * Holds the state of the inactivity timer for a background period.
+ * Holds the state of a session-scoped timer (e.g. inactivity timeout, max duration).
  * [cancel] cancels any pending timer future.
  */
-internal class InactivityTimerState(
+internal class SessionTimerState(
     private val future: ScheduledFuture<*>,
 
     @Volatile

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/TransitionType.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/TransitionType.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.session.LifeEventType
 
 enum class TransitionType {
-    INITIAL, END_MANUAL, ON_FOREGROUND, ON_BACKGROUND, CRASH, INACTIVITY_TIMEOUT, INACTIVITY_FOREGROUND;
+    INITIAL, END_MANUAL, ON_FOREGROUND, ON_BACKGROUND, CRASH, INACTIVITY_TIMEOUT, INACTIVITY_FOREGROUND, MAX_DURATION;
 
     fun endState(currentState: AppState): AppState = when (this) {
         ON_FOREGROUND, INACTIVITY_FOREGROUND -> AppState.FOREGROUND

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -1011,6 +1011,7 @@ internal class SessionOrchestratorTest {
                 userSessionNumber = 4L,
                 maxDurationSecs = TimeUnit.MILLISECONDS.toSeconds(maxDurationMs),
                 inactivityTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(inactivityMs),
+                partNumber = 1,
             )
         )
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -912,6 +912,125 @@ internal class SessionOrchestratorTest {
         userSessionPropertiesService.addProperty("key", "value", false)
     }
 
+    @Test
+    fun `max duration timeout creates new session`() {
+        configService = FakeConfigService(
+            backgroundActivityBehavior = createBackgroundActivityBehavior(
+                remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 100f))
+            ),
+            sessionBehavior = FakeUserSessionBehavior(
+                maxSessionDurationMs = maxDurationMs,
+                sessionInactivityTimeoutMs = inactivityMs,
+            )
+        )
+        createOrchestrator(AppState.FOREGROUND)
+
+        val first = checkNotNull(orchestrator.currentUserSession())
+        assertEquals(1L, first.userSessionNumber)
+
+        clock.tick(maxDurationMs)
+        inactivityWorkerExecutor.runCurrentlyBlocked()
+
+        val second = checkNotNull(orchestrator.currentUserSession())
+        assertNotEquals(first.userSessionId, second.userSessionId)
+        assertEquals(2L, second.userSessionNumber)
+    }
+
+    @Test
+    fun `max duration timeout does not create new session in background`() {
+        configService = FakeConfigService(
+            backgroundActivityBehavior = createBackgroundActivityBehavior(
+                remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 100f))
+            ),
+            sessionBehavior = FakeUserSessionBehavior(
+                maxSessionDurationMs = maxDurationMs,
+                sessionInactivityTimeoutMs = inactivityMs,
+            )
+        )
+        createOrchestrator(AppState.BACKGROUND)
+
+        val first = checkNotNull(orchestrator.currentUserSession())
+        assertEquals(1L, first.userSessionNumber)
+
+        clock.tick(maxDurationMs * 2)
+        inactivityWorkerExecutor.runCurrentlyBlocked()
+
+        val current = checkNotNull(orchestrator.currentUserSession())
+        assertEquals(1L, current.userSessionNumber)
+        assertEquals(first.userSessionId, current.userSessionId)
+    }
+
+    @Test
+    fun `max duration timer cancelled on manual session end and rescheduled for new session`() {
+        configService = FakeConfigService(
+            sessionBehavior = FakeUserSessionBehavior(
+                maxSessionDurationMs = maxDurationMs,
+                sessionInactivityTimeoutMs = inactivityMs,
+            )
+        )
+        createOrchestrator(AppState.FOREGROUND)
+
+        val first = checkNotNull(orchestrator.currentUserSession())
+        assertEquals(1L, first.userSessionNumber)
+
+        // manual end cancels the old timer and starts a new one
+        clock.tick(10000)
+        orchestrator.endSessionWithManual(false)
+        val second = checkNotNull(orchestrator.currentUserSession())
+        assertEquals(2L, second.userSessionNumber)
+
+        // old timer (from first session) fires but should be a no-op since the session changed
+        inactivityWorkerExecutor.runCurrentlyBlocked()
+        assertEquals(second.userSessionId, checkNotNull(orchestrator.currentUserSession()).userSessionId)
+
+        // advance by the new session's full max duration and fire — now a new session should start
+        clock.tick(maxDurationMs)
+        inactivityWorkerExecutor.runCurrentlyBlocked()
+        val third = checkNotNull(orchestrator.currentUserSession())
+        assertNotEquals(second.userSessionId, third.userSessionId)
+        assertEquals(3L, third.userSessionNumber)
+    }
+
+    @Test
+    fun `restored session schedules timer for remaining duration`() {
+        configService = FakeConfigService(
+            backgroundActivityBehavior = createBackgroundActivityBehavior(
+                remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 100f))
+            ),
+            sessionBehavior = FakeUserSessionBehavior(
+                maxSessionDurationMs = maxDurationMs,
+                sessionInactivityTimeoutMs = inactivityMs,
+            )
+        )
+        val halfElapsed = maxDurationMs / 2
+        val restoredStore = UserSessionMetadataStore(FakeKeyValueStore())
+        restoredStore.save(
+            UserSessionMetadata(
+                startTimeMs = clock.now() - halfElapsed,
+                userSessionId = "restored-id",
+                userSessionNumber = 4L,
+                maxDurationSecs = TimeUnit.MILLISECONDS.toSeconds(maxDurationMs),
+                inactivityTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(inactivityMs),
+            )
+        )
+
+        createOrchestrator(AppState.FOREGROUND, metadataStoreOverride = restoredStore)
+
+        val restored = checkNotNull(orchestrator.currentUserSession())
+        assertEquals("restored-id", restored.userSessionId)
+
+        // advance to just before the remaining window expires — session should not rotate
+        clock.tick(halfElapsed - 1)
+        inactivityWorkerExecutor.runCurrentlyBlocked()
+        assertEquals("restored-id", checkNotNull(orchestrator.currentUserSession()).userSessionId)
+
+        // advance past the remaining window — timer fires, session rotates
+        clock.tick(1)
+        inactivityWorkerExecutor.runCurrentlyBlocked()
+        val newSession = checkNotNull(orchestrator.currentUserSession())
+        assertNotEquals("restored-id", newSession.userSessionId)
+    }
+
     private fun validateSession(
         sessionSpan: EmbraceSdkSpan?,
         endTimeMs: Long,

--- a/embrace-android-sdk/config/detekt/baseline.xml
+++ b/embrace-android-sdk/config/detekt/baseline.xml
@@ -1,7 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <SmellBaseline>
   <ManuallySuppressedIssues/>
-  <CurrentIssues>
-    <ID>CyclomaticComplexMethod:LogsApiDelegate.kt$LogsApiDelegate$private fun sendLog( attributes: Map&lt;String, Any>, exceptionData: ExceptionData?, attachment: Attachment?, severity: Severity, dst: LogService, message: String, )</ID>
-  </CurrentIssues>
+  <CurrentIssues/>
 </SmellBaseline>


### PR DESCRIPTION
## Goal

Adds a max duration timer for foreground user sessions that terminates the active user session and starts a new one if the threshold is exceeded.

## Testing

Added unit tests.
