### PR TITLE
Support tracking session part number correctly

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadata.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadata.kt
@@ -5,12 +5,13 @@ import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 /**
  * Holds metadata about the user session.
  */
-class UserSessionMetadata(
+data class UserSessionMetadata(
     val startTimeMs: Long,
     val userSessionId: String,
     val userSessionNumber: Long,
     val maxDurationSecs: Long,
     val inactivityTimeoutSecs: Long,
+    val partNumber: Int,
 ) {
     val attributes: Map<String, Any> = mapOf(
         EmbSessionAttributes.EMB_USER_SESSION_START_TS to startTimeMs,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStore.kt
@@ -17,7 +17,9 @@ internal class UserSessionMetadataStore(private val store: KeyValueStore) {
      */
     fun save(metadata: UserSessionMetadata) {
         store.edit {
-            putStringMap(KEY_SESSION, metadata.attributes.mapValues { it.value.toString() })
+            val map = metadata.attributes.mapValues { it.value.toString() }.toMutableMap()
+            map[EmbSessionAttributes.EMB_USER_SESSION_PART_NUMBER] = metadata.partNumber.toString()
+            putStringMap(KEY_SESSION, map)
         }
     }
 
@@ -41,12 +43,14 @@ internal class UserSessionMetadataStore(private val store: KeyValueStore) {
         val number = attrs[EmbSessionAttributes.EMB_USER_SESSION_NUMBER]?.toLongOrNull() ?: return null
         val maxDurationSecs = attrs[EmbSessionAttributes.EMB_USER_SESSION_MAX_DURATION_SECONDS]?.toLongOrNull() ?: return null
         val inactivityTimeoutSecs = attrs[EmbSessionAttributes.EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS]?.toLongOrNull() ?: return null
+        val partNumber = attrs[EmbSessionAttributes.EMB_USER_SESSION_PART_NUMBER]?.toIntOrNull() ?: return null
         return UserSessionMetadata(
             startTimeMs = startMs,
             userSessionId = id,
             userSessionNumber = number,
             maxDurationSecs = maxDurationSecs,
             inactivityTimeoutSecs = inactivityTimeoutSecs,
+            partNumber = partNumber,
         )
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -317,6 +317,12 @@ internal class SessionOrchestratorImpl(
             if (isUserSessionOverMaxDuration(current.metadata)) {
                 terminateUserSession()
                 startNewUserSession(timestamp)
+            } else {
+                val updatedMetadata = current.metadata.copy(
+                    partNumber = current.metadata.partNumber + 1,
+                )
+                metadataStore.save(updatedMetadata)
+                userSessionState = UserSessionState.Active(updatedMetadata)
             }
         } else {
             startNewUserSession(timestamp)
@@ -346,6 +352,7 @@ internal class SessionOrchestratorImpl(
             userSessionNumber = ordinalStore.incrementAndGet(Ordinal.USER_SESSION).toLong(),
             maxDurationSecs = maxDurationMs / 1_000L,
             inactivityTimeoutSecs = inactivityTimeoutMs / 1_000L,
+            partNumber = 1,
         )
         metadataStore.save(newMetadata)
         userSessionState = UserSessionState.Active(newMetadata)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStoreTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStoreTest.kt
@@ -18,6 +18,7 @@ internal class UserSessionMetadataStoreTest {
         userSessionNumber = 3L,
         maxDurationSecs = 3600L,
         inactivityTimeoutSecs = 1800L,
+        partNumber = 1,
     )
     private val metadata2 = UserSessionMetadata(
         startTimeMs = 2000L,
@@ -25,6 +26,7 @@ internal class UserSessionMetadataStoreTest {
         userSessionNumber = 5L,
         maxDurationSecs = 7200L,
         inactivityTimeoutSecs = 3600L,
+        partNumber = 2,
     )
 
     @Before
@@ -48,6 +50,7 @@ internal class UserSessionMetadataStoreTest {
         assertEquals(metadata.userSessionNumber, loaded.userSessionNumber)
         assertEquals(metadata.maxDurationSecs, loaded.maxDurationSecs)
         assertEquals(metadata.inactivityTimeoutSecs, loaded.inactivityTimeoutSecs)
+        assertEquals(metadata.partNumber, loaded.partNumber)
     }
 
     @Test
@@ -61,6 +64,7 @@ internal class UserSessionMetadataStoreTest {
         assertEquals(metadata2.userSessionNumber, loaded.userSessionNumber)
         assertEquals(metadata2.maxDurationSecs, loaded.maxDurationSecs)
         assertEquals(metadata2.inactivityTimeoutSecs, loaded.inactivityTimeoutSecs)
+        assertEquals(metadata2.partNumber, loaded.partNumber)
     }
 
     @Test
@@ -115,6 +119,16 @@ internal class UserSessionMetadataStoreTest {
         metadataStore.save(metadata)
         val stored = checkNotNull(kvStore.getStringMap("embrace.user_session")).toMutableMap()
         stored.remove(EmbSessionAttributes.EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS)
+        kvStore.edit { putStringMap("embrace.user_session", stored) }
+
+        assertNull(metadataStore.load())
+    }
+
+    @Test
+    fun `load returns null when part number is missing`() {
+        metadataStore.save(metadata)
+        val stored = checkNotNull(kvStore.getStringMap("embrace.user_session")).toMutableMap()
+        stored.remove(EmbSessionAttributes.EMB_USER_SESSION_PART_NUMBER)
         kvStore.edit { putStringMap("embrace.user_session", stored) }
 
         assertNull(metadataStore.load())

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -399,6 +399,7 @@ internal class SessionOrchestratorTest {
 
         val first = checkNotNull(orchestrator.currentUserSession())
         assertEquals(1L, first.userSessionNumber)
+        assertEquals(1, first.partNumber)
         assertEquals(TimeUnit.MILLISECONDS.toSeconds(maxDurationMs), first.maxDurationSecs)
         assertEquals(TimeUnit.MILLISECONDS.toSeconds(inactivityMs), first.inactivityTimeoutSecs)
         assertNotNull(first.userSessionId)
@@ -409,6 +410,7 @@ internal class SessionOrchestratorTest {
         orchestrator.onForeground()
         val repeat = checkNotNull(orchestrator.currentUserSession())
         assertEquals(first.userSessionId, repeat.userSessionId)
+        assertEquals(3, repeat.partNumber)
 
         // at/past max duration — new user session starts
         clock.tick(1)
@@ -417,6 +419,7 @@ internal class SessionOrchestratorTest {
         val second = checkNotNull(orchestrator.currentUserSession())
         assertNotEquals(first.userSessionId, second.userSessionId)
         assertEquals(2L, second.userSessionNumber)
+        assertEquals(2, second.partNumber)
     }
 
     @Test
@@ -431,6 +434,7 @@ internal class SessionOrchestratorTest {
 
         val first = checkNotNull(orchestrator.currentUserSession())
         assertEquals(1L, first.userSessionNumber)
+        assertEquals(1, first.partNumber)
 
         // manual end always terminates and starts a new user session
         clock.tick(10000)
@@ -438,6 +442,31 @@ internal class SessionOrchestratorTest {
         val second = checkNotNull(orchestrator.currentUserSession())
         assertEquals(2L, second.userSessionNumber)
         assertNotEquals(first.userSessionId, second.userSessionId)
+        assertEquals(1, second.partNumber)
+    }
+
+    @Test
+    fun `part number increments within user session`() {
+        configService = FakeConfigService(
+            sessionBehavior = FakeUserSessionBehavior(
+                maxSessionDurationMs = maxDurationMs,
+                sessionInactivityTimeoutMs = inactivityMs,
+            )
+        )
+        createOrchestrator(AppState.FOREGROUND)
+
+        assertEquals(1, checkNotNull(orchestrator.currentUserSession()).partNumber)
+
+        orchestrator.onBackground()
+        assertEquals(2, checkNotNull(orchestrator.currentUserSession()).partNumber)
+
+        orchestrator.onForeground()
+        assertEquals(3, checkNotNull(orchestrator.currentUserSession()).partNumber)
+
+        // new user session resets part number to 1
+        clock.tick(10000)
+        orchestrator.endSessionWithManual(false)
+        assertEquals(1, checkNotNull(orchestrator.currentUserSession()).partNumber)
     }
 
     @Test
@@ -497,6 +526,7 @@ internal class SessionOrchestratorTest {
                 userSessionNumber = 7L,
                 maxDurationSecs = TimeUnit.MILLISECONDS.toSeconds(maxDurationMs),
                 inactivityTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(inactivityMs),
+                partNumber = 1,
             )
         )
 
@@ -505,6 +535,7 @@ internal class SessionOrchestratorTest {
         val session = checkNotNull(orchestrator.currentUserSession())
         assertEquals("restored-id", session.userSessionId)
         assertEquals(7L, session.userSessionNumber)
+        assertEquals(2, session.partNumber)
     }
 
     @Test
@@ -549,6 +580,7 @@ internal class SessionOrchestratorTest {
                 userSessionNumber = 3L,
                 maxDurationSecs = TimeUnit.MILLISECONDS.toSeconds(maxDurationMs),
                 inactivityTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(inactivityMs),
+                partNumber = 1,
             )
         )
 
@@ -633,6 +665,7 @@ internal class SessionOrchestratorTest {
                 userSessionNumber = 5L,
                 maxDurationSecs = persistedMaxSecs,
                 inactivityTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(inactivityMs),
+                partNumber = 1,
             )
         )
 
@@ -667,6 +700,7 @@ internal class SessionOrchestratorTest {
                 userSessionNumber = 3L,
                 maxDurationSecs = TimeUnit.MILLISECONDS.toSeconds(maxDurationMs),
                 inactivityTimeoutSecs = persistedInactivitySecs,
+                partNumber = 1,
             )
         )
 
@@ -701,6 +735,7 @@ internal class SessionOrchestratorTest {
                 userSessionNumber = 5L,
                 maxDurationSecs = TimeUnit.MILLISECONDS.toSeconds(maxDurationMs),
                 inactivityTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(inactivityMs),
+                partNumber = 1,
             )
         )
 


### PR DESCRIPTION
## Goal

Track the session part number correctly and persist it so that the information is available between processes.

## Testing

Added unit tests.
