### PR TITLE
Use system event to track state transitions

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/TelemetryDestinationImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/TelemetryDestinationImpl.kt
@@ -229,8 +229,8 @@ class TelemetryDestinationImpl(
 
         override fun setSystemAttribute(key: String, value: String) = span.setSystemAttribute(key, value)
 
-        override fun addEvent(name: String, eventTimeMs: Long, attributes: Map<String, String>) {
-            span.addEvent(
+        override fun addSystemEvent(name: String, eventTimeMs: Long, attributes: Map<String, String>) {
+            span.addSystemEvent(
                 name = name,
                 timestampMs = eventTimeMs,
                 attributes = attributes
@@ -251,7 +251,7 @@ class TelemetryDestinationImpl(
             if (!spanToken.isRecording()) {
                 return false
             }
-            spanToken.addEvent(
+            spanToken.addSystemEvent(
                 name = "transition",
                 eventTimeMs = updateDetectedTimeMs,
                 attributes = mutableMapOf(EmbStateTransitionAttributes.EMB_STATE_NEW_VALUE to newValue.toString())

--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanToken.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanToken.kt
@@ -46,7 +46,7 @@ class FakeSpanToken(
 
     override fun asW3cTraceparent(): String = hashCode().toString()
 
-    override fun addEvent(
+    override fun addSystemEvent(
         name: String,
         eventTimeMs: Long,
         attributes: Map<String, String>,

--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/TestStateDataSource.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/TestStateDataSource.kt
@@ -10,7 +10,6 @@ class TestStateDataSource(
     args = args,
     stateTypeFactory = ::TestState,
     defaultValue = "UNKNOWN",
-    maxTransitions = 4,
 )
 
 class TestState(initialValue: String) : State<String>(initialValue, "test")

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/SpanToken.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/SpanToken.kt
@@ -44,7 +44,7 @@ interface SpanToken {
     fun setSystemAttribute(key: String, value: String)
 
     /**
-     * Add an event to the span
+     * Add a system event to the span
      */
-    fun addEvent(name: String, eventTimeMs: Long, attributes: Map<String, String>)
+    fun addSystemEvent(name: String, eventTimeMs: Long, attributes: Map<String, String>)
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSdkSpan.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSdkSpan.kt
@@ -62,7 +62,7 @@ interface EmbraceSdkSpan : EmbraceSpan {
     fun removeSystemAttribute(key: String)
 
     /**
-     * Add a system event to the span that will subjected to a different maximum than typical span events.
+     * Add a system event to the span that will be subjected to a different maximum than typical span events.
      */
     fun addSystemEvent(
         name: String,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/StateFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/StateFeatureTest.kt
@@ -8,7 +8,6 @@ import io.embrace.android.embracesdk.assertions.hasLinkToEmbraceSpan
 import io.embrace.android.embracesdk.fakes.TestStateDataSource
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
-import io.embrace.android.embracesdk.semconv.EmbStateTransitionAttributes
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.LinkType
 import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
@@ -20,6 +19,7 @@ import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttributeValue
 import io.embrace.android.embracesdk.internal.otel.spans.hasEmbraceAttributeValue
 import io.embrace.android.embracesdk.internal.session.getSessionSpan
 import io.embrace.android.embracesdk.internal.session.getStateSpan
+import io.embrace.android.embracesdk.semconv.EmbStateTransitionAttributes
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface.Companion.LIFECYCLE_EVENT_GAP
@@ -177,23 +177,21 @@ internal class StateFeatureTest {
 
     @Test
     fun `max transitions`() {
-        val stateUpdates = listOf("foo", "bar", "baz", "bar", "baz")
-        var transitions: List<Pair<Long, String>> = listOf()
         testRule.runTest(
             persistedRemoteConfig = stateEnabledRemoteConfig,
             testCaseAction = {
                 recordSession {
-                    transitions = executeTransitions(stateUpdates)
+                    repeat(101) { i ->
+                        findDataSource<TestStateDataSource>().onStateChange(
+                            updateDetectedTimeMs = clock.tick(),
+                            newState = i.toString(),
+                        )
+                    }
                 }
             },
             assertAction = {
                 val stateSpan = checkNotNull(getSingleSessionEnvelope().getStateSpan("emb-state-test"))
-                with(checkNotNull(stateSpan.events)) {
-                    assertEquals(4, size)
-                    repeat(size) { i ->
-                        this[i].assertStateTransition(transitions[i].first, transitions[i].second)
-                    }
-                }
+                assertEquals(100, checkNotNull(stateSpan.events).size)
             }
         )
     }


### PR DESCRIPTION
## Goal

The previous integration test artificationally lowered to limit of the transition cap to 4 from the default of 100. But there's a implicit cap of 10 in the implemention because we were not adding the events as system events, which have a higher limit, but custom span events, which we limit to 10. Used the right method and unleashed the test to verify the default.

<!-- Describe how this change has been tested -->