### PR TITLE
Set emb.is_final_session_part attribute

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -274,7 +274,8 @@ internal class SessionOrchestratorImpl(
                 sessionSpanAttrPopulator.populateSessionSpanEndAttrs(
                     endType = transitionType.lifeEventType(state),
                     crashId = crashId,
-                    coldStart = endingSession.isColdStart
+                    coldStart = endingSession.isColdStart,
+                    endAttributes = transitionType.endAttributes,
                 )
             }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulator.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulator.kt
@@ -16,5 +16,10 @@ interface SessionPartSpanAttrPopulator {
     /**
      * Populates session span attributes at the end of the session.
      */
-    fun populateSessionSpanEndAttrs(endType: LifeEventType?, crashId: String?, coldStart: Boolean)
+    fun populateSessionSpanEndAttrs(
+        endType: LifeEventType?,
+        crashId: String?,
+        coldStart: Boolean,
+        endAttributes: Map<String, String>,
+    )
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImpl.kt
@@ -30,7 +30,12 @@ internal class SessionPartSpanAttrPopulatorImpl(
         }
     }
 
-    override fun populateSessionSpanEndAttrs(endType: LifeEventType?, crashId: String?, coldStart: Boolean) {
+    override fun populateSessionSpanEndAttrs(
+        endType: LifeEventType?,
+        crashId: String?,
+        coldStart: Boolean,
+        endAttributes: Map<String, String>,
+    ) {
         with(destination) {
             addSessionPartAttribute(EmbSessionAttributes.EMB_CLEAN_EXIT, true.toString())
             addSessionPartAttribute(EmbSessionAttributes.EMB_TERMINATED, false.toString())
@@ -51,6 +56,10 @@ internal class SessionPartSpanAttrPopulatorImpl(
 
             metadataService.getDiskUsage()?.deviceDiskFree?.let { free ->
                 addSessionPartAttribute(EmbSessionAttributes.EMB_DISK_FREE_BYTES, free.toString())
+            }
+
+            endAttributes.forEach { (key, value) ->
+                addSessionPartAttribute(key, value)
             }
         }
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/TransitionType.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/TransitionType.kt
@@ -1,10 +1,23 @@
+@file:OptIn(ExperimentalSemconv::class)
+
 package io.embrace.android.embracesdk.internal.session.orchestrator
 
 import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.session.LifeEventType
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
+import io.embrace.android.embracesdk.semconv.ExperimentalSemconv
 
 enum class TransitionType {
     INITIAL, END_MANUAL, ON_FOREGROUND, ON_BACKGROUND, CRASH, INACTIVITY_TIMEOUT, INACTIVITY_FOREGROUND, MAX_DURATION;
+
+    val endAttributes: Map<String, String> by lazy {
+        when (this) {
+            END_MANUAL, INACTIVITY_TIMEOUT, INACTIVITY_FOREGROUND, MAX_DURATION ->
+                mapOf(EmbSessionAttributes.EMB_IS_FINAL_SESSION_PART to "1")
+
+            else -> emptyMap()
+        }
+    }
 
     fun endState(currentState: AppState): AppState = when (this) {
         ON_FOREGROUND, INACTIVITY_FOREGROUND -> AppState.FOREGROUND

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
@@ -49,7 +49,7 @@ internal class SessionPartSpanAttrPopulatorImplTest {
 
     @Test
     fun `end attributes populated`() {
-        populator.populateSessionSpanEndAttrs(LifeEventType.STATE, "crashId", false)
+        populator.populateSessionSpanEndAttrs(LifeEventType.STATE, "crashId", false, emptyMap())
 
         val attrs = destination.attributes
         val expected = mapOf(
@@ -59,6 +59,27 @@ internal class SessionPartSpanAttrPopulatorImplTest {
             EmbSessionAttributes.EMB_SESSION_END_TYPE to "state",
             EmbSessionAttributes.EMB_ERROR_LOG_COUNT to "0",
             EmbSessionAttributes.EMB_DISK_FREE_BYTES to "500000000"
+        )
+        assertEquals(expected, attrs)
+    }
+
+    @Test
+    fun `end attributes - final session part`() {
+        populator.populateSessionSpanEndAttrs(
+            LifeEventType.STATE,
+            null,
+            false,
+            mapOf(EmbSessionAttributes.EMB_IS_FINAL_SESSION_PART to "1"),
+        )
+
+        val attrs = destination.attributes
+        val expected = mapOf(
+            EmbSessionAttributes.EMB_CLEAN_EXIT to "true",
+            EmbSessionAttributes.EMB_TERMINATED to "false",
+            EmbSessionAttributes.EMB_SESSION_END_TYPE to "state",
+            EmbSessionAttributes.EMB_ERROR_LOG_COUNT to "0",
+            EmbSessionAttributes.EMB_DISK_FREE_BYTES to "500000000",
+            EmbSessionAttributes.EMB_IS_FINAL_SESSION_PART to "1",
         )
         assertEquals(expected, attrs)
     }

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionPartSpanAttrPopulator.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionPartSpanAttrPopulator.kt
@@ -13,6 +13,7 @@ class FakeSessionPartSpanAttrPopulator : SessionPartSpanAttrPopulator {
         endType: LifeEventType?,
         crashId: String?,
         coldStart: Boolean,
+        endAttributes: Map<String, String>,
     ) {
     }
 }


### PR DESCRIPTION
## Goal

Sets the `emb.is_final_session_part` attribute to 1 if the session part is known to be the last in the user session. Other session parts don't need to set the value.

## Testing

Added unit tests.
