### PR TITLE
Delete telemetry older than 7 days

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
@@ -90,6 +90,7 @@ class DeliveryModuleImpl(
                 dataPersistenceWorker,
                 processIdProvider,
                 initModule.logger,
+                initModule.clock,
                 deliveryTracer
             )
         }
@@ -107,6 +108,7 @@ class DeliveryModuleImpl(
                 dataPersistenceWorker,
                 processIdProvider,
                 initModule.logger,
+                initModule.clock,
                 deliveryTracer
             )
         }
@@ -122,7 +124,8 @@ class DeliveryModuleImpl(
             outputDir = location,
             worker = dataPersistenceWorker,
             logger = initModule.logger,
-            serializer = initModule.jsonSerializer
+            serializer = initModule.jsonSerializer,
+            clock = initModule.clock,
         )
     }
 

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/CachedLogEnvelopeStoreImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/CachedLogEnvelopeStoreImpl.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.delivery.storage
 
+import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.Envelope
@@ -16,6 +17,7 @@ class CachedLogEnvelopeStoreImpl(
     worker: PriorityWorker<StoredTelemetryMetadata>,
     logger: InternalLogger,
     private val serializer: PlatformSerializer,
+    clock: Clock,
     storageLimit: Int = 100,
 ) : CachedLogEnvelopeStore {
 
@@ -23,6 +25,7 @@ class CachedLogEnvelopeStoreImpl(
         outputDir,
         worker,
         logger,
+        clock,
         storageLimit
     )
 

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImpl.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.delivery.storage
 
+import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.debug.DeliveryTracer
 import io.embrace.android.embracesdk.internal.delivery.storedTelemetryComparator
@@ -19,6 +20,7 @@ class PayloadStorageServiceImpl(
     worker: PriorityWorker<StoredTelemetryMetadata>,
     private val processIdProvider: () -> String,
     logger: InternalLogger,
+    clock: Clock,
     private val deliveryTracer: DeliveryTracer? = null,
     storageLimit: Int = 500,
 ) : PayloadStorageService {
@@ -27,6 +29,7 @@ class PayloadStorageServiceImpl(
         outputDir,
         worker,
         logger,
+        clock,
         storageLimit
     )
 

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/CachedLogEnvelopeStoreImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/CachedLogEnvelopeStoreImplTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.delivery.storage
 
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
+import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
 import io.embrace.android.embracesdk.fakes.fakeEnvelopeMetadata
@@ -36,7 +37,8 @@ class CachedLogEnvelopeStoreImplTest {
             outputDir = lazy { outputDir },
             worker = PriorityWorker(executor),
             logger = logger,
-            serializer = serializer
+            serializer = serializer,
+            clock = FakeClock(),
         )
     }
 

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.delivery.storage
 
 import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
+import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.BLOB
@@ -33,6 +34,7 @@ class PayloadStorageServiceImplTest {
     private lateinit var logger: FakeInternalLogger
     private lateinit var worker: PriorityWorker<StoredTelemetryMetadata>
     private lateinit var currentProcessId: String
+    private lateinit var clock: FakeClock
 
     @Before
     fun setUp() {
@@ -41,7 +43,8 @@ class PayloadStorageServiceImplTest {
         worker = PriorityWorker(BlockableExecutorService(false))
         logger = FakeInternalLogger(false)
         currentProcessId = PROCESS_ID
-        service = PayloadStorageServiceImpl(lazy { outputDir }, worker, { currentProcessId }, logger)
+        clock = FakeClock(0L)
+        service = PayloadStorageServiceImpl(lazy { outputDir }, worker, { currentProcessId }, logger, clock)
     }
 
     @Test
@@ -91,7 +94,7 @@ class PayloadStorageServiceImplTest {
     @Test
     fun `test objects pruned past limit`() {
         assertNull(outputDir.listFiles())
-        service = PayloadStorageServiceImpl(lazy { outputDir }, worker, { currentProcessId }, logger, null, 4)
+        service = PayloadStorageServiceImpl(lazy { outputDir }, worker, { currentProcessId }, logger, FakeClock(0L), null, 4)
 
         // exceed storage limit
         listOf(

--- a/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashProcessorImpl.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashProcessorImpl.kt
@@ -28,6 +28,7 @@ internal class NativeCrashProcessorImpl(
         outputDir,
         worker,
         logger,
+        args.clock,
     )
 
     override fun getLatestNativeCrash(): NativeCrashData? {

--- a/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImpl.kt
+++ b/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImpl.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.delivery.storage
 
+import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
@@ -14,8 +15,14 @@ class FileStorageServiceImpl(
     outputDir: Lazy<File>,
     private val worker: PriorityWorker<StoredTelemetryMetadata>,
     private val logger: InternalLogger,
+    private val clock: Clock,
     private val storageLimit: Int = 500,
+    private val maxAgeMs: Long = DEFAULT_MAX_AGE_MS,
 ) : FileStorageService {
+
+    private companion object {
+        const val DEFAULT_MAX_AGE_MS = 7L * 24L * 60L * 60L * 1_000L
+    }
 
     private val payloadDir by lazy {
         outputDir.value.apply { mkdirs() }
@@ -45,7 +52,11 @@ class FileStorageServiceImpl(
         metadata: StoredTelemetryMetadata,
         action: SerializationAction,
     ) {
-        if (pruneStorage(metadata)) {
+        if (pruneStorage(
+                newPayload = metadata,
+                cutoffMs = clock.now() - maxAgeMs
+            )
+        ) {
             return
         }
 
@@ -101,12 +112,26 @@ class FileStorageServiceImpl(
         return storedFiles.toList()
     }
 
-    private fun pruneStorage(metadata: StoredTelemetryMetadata): Boolean {
+    /**
+     * When [cutoffMs] > 0 all payloads whose timestamp is strictly less than [cutoffMs] are
+     * removed.  When [newPayload] is non-null the count-based limit
+     * is then enforced and the return value indicates whether [newPayload]
+     * itself was not written to disk.
+     */
+    private fun pruneStorage(newPayload: StoredTelemetryMetadata?, cutoffMs: Long = 0L): Boolean {
+        // remove old payloads created before the cutoff
+        if (cutoffMs > 0L) {
+            storedFiles.filter { it.timestamp < cutoffMs }.forEach(::processDelete)
+        }
+
+        newPayload ?: return false
+
+        // remove payloads by count
         val count = storedFiles.size
         if (count < storageLimit) {
             return false
         }
-        val input = storedFiles.plus(metadata)
+        val input = storedFiles.plus(newPayload)
         val removalCount = input.size - storageLimit
         if (removalCount < 0) {
             return false
@@ -120,7 +145,7 @@ class FileStorageServiceImpl(
         logger.trackInternalError(InternalErrorType.PAYLOAD_STORAGE_FAIL, RuntimeException("Pruned payload storage"))
 
         // notify the caller whether the new payload should be dropped
-        val shouldNotPersist = removals.contains(metadata)
+        val shouldNotPersist = removals.contains(newPayload)
         return shouldNotPersist
     }
 

--- a/embrace-android-telemetry-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImplTest.kt
+++ b/embrace-android-telemetry-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImplTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.delivery.storage
 
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
+import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeClock.Companion.DEFAULT_FAKE_CURRENT_TIME
 import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.internal.delivery.PayloadType
@@ -19,12 +20,14 @@ class FileStorageServiceImplTest {
 
     private companion object {
         private const val DUMMY_CONTENT = "my file contents"
+        private const val MAX_AGE_MS = 10L
     }
 
     private lateinit var outputDir: File
     private lateinit var service: FileStorageService
     private lateinit var logger: FakeInternalLogger
     private lateinit var executor: BlockingScheduledExecutorService
+    private lateinit var clock: FakeClock
 
     @Before
     fun setUp() {
@@ -33,10 +36,13 @@ class FileStorageServiceImplTest {
         }
         logger = FakeInternalLogger(throwOnInternalError = false)
         executor = BlockingScheduledExecutorService()
+        clock = FakeClock()
         service = FileStorageServiceImpl(
             lazy { outputDir },
             PriorityWorker(executor),
-            logger
+            logger,
+            clock,
+            maxAgeMs = MAX_AGE_MS,
         )
     }
 
@@ -60,6 +66,69 @@ class FileStorageServiceImplTest {
     fun `load payload stream error`() {
         assertNull(service.loadPayloadAsStream(fakeSessionStoredTelemetryMetadata))
         checkNotNull(logger.internalErrorMessages.single())
+    }
+
+    @Test
+    fun `stale payloads are pruned on the next store call`() {
+        clock.setCurrentTime(100L)
+        val staleMetadata = StoredTelemetryMetadata(
+            timestamp = clock.now(),
+            uuid = "aaaaaaaa-0000-0000-0000-000000000001",
+            processIdentifier = "proc1",
+            envelopeType = SupportedEnvelopeType.SESSION,
+            complete = true,
+            payloadType = PayloadType.SESSION,
+        )
+        storeDummyFile(staleMetadata)
+        assertEquals(1, service.getStoredPayloads().size)
+
+        // payload removed
+        clock.setCurrentTime(115L)
+        val freshMetadata = StoredTelemetryMetadata(
+            timestamp = clock.now(),
+            uuid = "aaaaaaaa-0000-0000-0000-000000000002",
+            processIdentifier = "proc1",
+            envelopeType = SupportedEnvelopeType.SESSION,
+            complete = true,
+            payloadType = PayloadType.SESSION,
+        )
+        storeDummyFile(freshMetadata)
+
+        val remaining = service.getStoredPayloads().map { it.uuid }
+        assertEquals(1, remaining.size)
+        assertTrue(freshMetadata.uuid in remaining)
+        assertNull(service.loadPayloadAsStream(staleMetadata))
+    }
+
+    @Test
+    fun `payload at exactly the cutoff boundary is not pruned`() {
+        clock.setCurrentTime(100L)
+        val borderMetadata = StoredTelemetryMetadata(
+            timestamp = clock.now(),
+            uuid = "aaaaaaaa-0000-0000-0000-000000000001",
+            processIdentifier = "proc1",
+            envelopeType = SupportedEnvelopeType.SESSION,
+            complete = true,
+            payloadType = PayloadType.SESSION,
+        )
+        storeDummyFile(borderMetadata)
+
+        // payload not removed
+        clock.setCurrentTime(110L)
+        val anotherMetadata = StoredTelemetryMetadata(
+            timestamp = clock.now(),
+            uuid = "aaaaaaaa-0000-0000-0000-000000000002",
+            processIdentifier = "proc1",
+            envelopeType = SupportedEnvelopeType.SESSION,
+            complete = true,
+            payloadType = PayloadType.SESSION,
+        )
+        storeDummyFile(anotherMetadata)
+
+        val remaining = service.getStoredPayloads().map { it.uuid }
+        assertEquals(2, remaining.size)
+        assertTrue(borderMetadata.uuid in remaining)
+        assertTrue(anotherMetadata.uuid in remaining)
     }
 
     @Test


### PR DESCRIPTION
## Goal

Deletes telemetry that is older than 7 days. This is intended to avoid the scenario where in-order delivery gets indefinitely stuck for a given payload type.

## Testing

Added unit tests.
