### PR TITLE
Attempt to fix flaky AeiFeatureTest

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AeiFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AeiFeatureTest.kt
@@ -183,12 +183,12 @@ internal class AeiFeatureTest {
 
     @Test
     fun `aei limit exceeded`() {
-        val timestamps = 0..100L
-        val aeis = timestamps.map { anr.copy(timestamp = it) }.map(TestAeiData::toAeiObject)
         val expectedSize = 64
 
         testRule.runTest(
             setupAction = {
+                val timestamps = 0..100L
+                val aeis = timestamps.map { anr.copy(timestamp = it + fakeClock.now()) }.map(TestAeiData::toAeiObject)
                 setupFakeAeiData(aeis)
             },
             testCaseAction = {


### PR DESCRIPTION
## Goal

Attempts to fix the flaky `AeiFeatureTest` by setting the timestamps of AEI objects so that they always exceed or are equal to the `FakeClock`. 