### PR TITLE
Rate limit manual end of user session

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/OrchestratorTerminationConditions.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/OrchestratorTerminationConditions.kt
@@ -7,14 +7,14 @@ import io.embrace.android.embracesdk.internal.config.ConfigService
 internal fun shouldEndManualSession(
     configService: ConfigService,
     clock: Clock,
-    activeSessionStartTime: Long?,
+    userSessionStartTimeMs: Long?,
     state: AppState,
 ): Boolean {
-    if (state == AppState.BACKGROUND || configService.sessionBehavior.isSessionControlEnabled() || activeSessionStartTime == null) {
+    if (state == AppState.BACKGROUND || configService.sessionBehavior.isSessionControlEnabled() || userSessionStartTimeMs == null) {
         return true
     }
 
-    val delta = clock.now() - activeSessionStartTime
+    val delta = clock.now() - userSessionStartTimeMs
     return delta < configService.sessionBehavior.getMinSessionDurationMs()
 }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -182,7 +182,7 @@ internal class SessionOrchestratorImpl(
                 return@transitionState shouldEndManualSession(
                     configService,
                     clock,
-                    sessionTracker.getActiveSessionPart()?.startTime,
+                    currentUserSession()?.startTimeMs,
                     state
                 )
             }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -287,6 +287,24 @@ internal class SessionOrchestratorTest {
     }
 
     @Test
+    fun `rate limit of manual end`() {
+        configService = FakeConfigService()
+        createOrchestrator(AppState.FOREGROUND)
+
+        clock.tick(10000)
+        orchestrator.endSessionWithManual()
+        orchestrator.endSessionWithManual()
+        assertEquals(2, payloadCollator.sessionCount.get())
+
+        clock.tick(4000)
+        orchestrator.endSessionWithManual()
+
+        clock.tick(2000)
+        orchestrator.endSessionWithManual()
+        assertEquals(3, payloadCollator.sessionCount.get())
+    }
+
+    @Test
     fun `ending session manually when no session exists does not start a new session`() {
         configService = FakeConfigService()
         createOrchestrator(AppState.BACKGROUND)


### PR DESCRIPTION
## Goal

Rate limits the manual ending of user sessions via the user session start timestamp, not the session part timestamp.

## Testing

Added a unit test.
