### PR TITLE
Return correct ID in SdkStateApiDelegate

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadata.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadata.kt
@@ -13,6 +13,7 @@ data class UserSessionMetadata(
     val maxDurationSecs: Long,
     val inactivityTimeoutSecs: Long,
     val partNumber: Int,
+    val lastActivityMs: Long,
 ) {
     val attributes: Map<String, Any> = mapOf(
         EmbSessionAttributes.EMB_USER_SESSION_START_TS to startTimeMs,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStore.kt
@@ -10,6 +10,7 @@ internal class UserSessionMetadataStore(private val store: KeyValueStore) {
 
     private companion object {
         const val KEY_SESSION = "embrace.user_session"
+        const val KEY_LAST_ACTIVITY_TS = "emb.user_session_last_activity_ts"
     }
 
     /**
@@ -19,6 +20,7 @@ internal class UserSessionMetadataStore(private val store: KeyValueStore) {
         store.edit {
             val map = metadata.attributes.mapValues { it.value.toString() }.toMutableMap()
             map[EmbSessionAttributes.EMB_USER_SESSION_PART_NUMBER] = metadata.partNumber.toString()
+            map[KEY_LAST_ACTIVITY_TS] = metadata.lastActivityMs.toString()
             putStringMap(KEY_SESSION, map)
         }
     }
@@ -44,6 +46,7 @@ internal class UserSessionMetadataStore(private val store: KeyValueStore) {
         val maxDurationSecs = attrs[EmbSessionAttributes.EMB_USER_SESSION_MAX_DURATION_SECONDS]?.toLongOrNull() ?: return null
         val inactivityTimeoutSecs = attrs[EmbSessionAttributes.EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS]?.toLongOrNull() ?: return null
         val partNumber = attrs[EmbSessionAttributes.EMB_USER_SESSION_PART_NUMBER]?.toIntOrNull() ?: return null
+        val lastActivityMs = attrs[KEY_LAST_ACTIVITY_TS]?.toLongOrNull() ?: return null
         return UserSessionMetadata(
             startTimeMs = startMs,
             userSessionId = id,
@@ -51,6 +54,7 @@ internal class UserSessionMetadataStore(private val store: KeyValueStore) {
             maxDurationSecs = maxDurationSecs,
             inactivityTimeoutSecs = inactivityTimeoutSecs,
             partNumber = partNumber,
+            lastActivityMs = lastActivityMs,
         )
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/OrchestratorTerminationConditions.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/OrchestratorTerminationConditions.kt
@@ -7,14 +7,14 @@ import io.embrace.android.embracesdk.internal.config.ConfigService
 internal fun shouldEndManualSession(
     configService: ConfigService,
     clock: Clock,
-    activeSessionStartTime: Long?,
+    userSessionStartTimeMs: Long?,
     state: AppState,
 ): Boolean {
-    if (state == AppState.BACKGROUND || configService.sessionBehavior.isSessionControlEnabled() || activeSessionStartTime == null) {
+    if (state == AppState.BACKGROUND || configService.sessionBehavior.isSessionControlEnabled() || userSessionStartTimeMs == null) {
         return true
     }
 
-    val delta = clock.now() - activeSessionStartTime
+    val delta = clock.now() - userSessionStartTimeMs
     return delta < configService.sessionBehavior.getMinSessionDurationMs()
 }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -182,7 +182,7 @@ internal class SessionOrchestratorImpl(
                 return@transitionState shouldEndManualSession(
                     configService,
                     clock,
-                    sessionTracker.getActiveSessionPart()?.startTime,
+                    currentUserSession()?.startTimeMs,
                     state
                 )
             }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -96,7 +96,7 @@ internal class SessionOrchestratorImpl(
                         UserSessionState.NoActiveSession
                     }
 
-                    stored != null && !isUserSessionOverMaxDuration(stored) -> {
+                    stored != null && !isUserSessionOverMaxDuration(stored) && !isUserSessionInactive(stored) -> {
                         scheduleMaxDurationTimeout(stored)
                         UserSessionState.Active(stored)
                     }
@@ -440,6 +440,7 @@ internal class SessionOrchestratorImpl(
             } else {
                 val updatedMetadata = current.metadata.copy(
                     partNumber = current.metadata.partNumber + 1,
+                    lastActivityMs = timestamp,
                 )
                 metadataStore.save(updatedMetadata)
                 userSessionState = UserSessionState.Active(updatedMetadata)
@@ -464,6 +465,9 @@ internal class SessionOrchestratorImpl(
     private fun isUserSessionOverMaxDuration(metadata: UserSessionMetadata): Boolean =
         clock.now() - metadata.startTimeMs >= metadata.maxDurationSecs * 1_000L
 
+    private fun isUserSessionInactive(metadata: UserSessionMetadata): Boolean =
+        clock.now() - metadata.lastActivityMs >= metadata.inactivityTimeoutSecs * 1_000L
+
     private fun startNewUserSession(startTimeMs: Long) {
         val maxDurationMs = configService.sessionBehavior.getMaxSessionDurationMs()
         val inactivityTimeoutMs = configService.sessionBehavior.getSessionInactivityTimeoutMs()
@@ -474,6 +478,7 @@ internal class SessionOrchestratorImpl(
             maxDurationSecs = maxDurationMs / 1_000L,
             inactivityTimeoutSecs = inactivityTimeoutMs / 1_000L,
             partNumber = 1,
+            lastActivityMs = startTimeMs,
         )
         metadataStore.save(newMetadata)
         userSessionState = UserSessionState.Active(newMetadata)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStoreTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStoreTest.kt
@@ -19,6 +19,7 @@ internal class UserSessionMetadataStoreTest {
         maxDurationSecs = 3600L,
         inactivityTimeoutSecs = 1800L,
         partNumber = 1,
+        lastActivityMs = 5000L,
     )
     private val metadata2 = UserSessionMetadata(
         startTimeMs = 2000L,
@@ -27,6 +28,7 @@ internal class UserSessionMetadataStoreTest {
         maxDurationSecs = 7200L,
         inactivityTimeoutSecs = 3600L,
         partNumber = 2,
+        lastActivityMs = 9000L,
     )
 
     @Before
@@ -51,6 +53,7 @@ internal class UserSessionMetadataStoreTest {
         assertEquals(metadata.maxDurationSecs, loaded.maxDurationSecs)
         assertEquals(metadata.inactivityTimeoutSecs, loaded.inactivityTimeoutSecs)
         assertEquals(metadata.partNumber, loaded.partNumber)
+        assertEquals(metadata.lastActivityMs, loaded.lastActivityMs)
     }
 
     @Test
@@ -65,6 +68,7 @@ internal class UserSessionMetadataStoreTest {
         assertEquals(metadata2.maxDurationSecs, loaded.maxDurationSecs)
         assertEquals(metadata2.inactivityTimeoutSecs, loaded.inactivityTimeoutSecs)
         assertEquals(metadata2.partNumber, loaded.partNumber)
+        assertEquals(metadata2.lastActivityMs, loaded.lastActivityMs)
     }
 
     @Test

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorListenerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorListenerTest.kt
@@ -218,7 +218,8 @@ internal class SessionOrchestratorListenerTest {
                 userSessionNumber = 7L,
                 maxDurationSecs = TimeUnit.MILLISECONDS.toSeconds(maxDurationMs),
                 inactivityTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(inactivityMs),
-                partNumber = 1
+                partNumber = 1,
+                lastActivityMs = clock.now(),
             )
         )
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -287,6 +287,24 @@ internal class SessionOrchestratorTest {
     }
 
     @Test
+    fun `rate limit of manual end`() {
+        configService = FakeConfigService()
+        createOrchestrator(AppState.FOREGROUND)
+
+        clock.tick(10000)
+        orchestrator.endSessionWithManual()
+        orchestrator.endSessionWithManual()
+        assertEquals(2, payloadCollator.sessionCount.get())
+
+        clock.tick(4000)
+        orchestrator.endSessionWithManual()
+
+        clock.tick(2000)
+        orchestrator.endSessionWithManual()
+        assertEquals(3, payloadCollator.sessionCount.get())
+    }
+
+    @Test
     fun `ending session manually when no session exists does not start a new session`() {
         configService = FakeConfigService()
         createOrchestrator(AppState.BACKGROUND)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -536,6 +536,7 @@ internal class SessionOrchestratorTest {
                 maxDurationSecs = TimeUnit.MILLISECONDS.toSeconds(maxDurationMs),
                 inactivityTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(inactivityMs),
                 partNumber = 1,
+                lastActivityMs = clock.now(),
             )
         )
 
@@ -591,6 +592,7 @@ internal class SessionOrchestratorTest {
                 maxDurationSecs = TimeUnit.MILLISECONDS.toSeconds(maxDurationMs),
                 inactivityTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(inactivityMs),
                 partNumber = 1,
+                lastActivityMs = 0L,
             )
         )
 
@@ -600,6 +602,66 @@ internal class SessionOrchestratorTest {
         // Expired session is discarded; a fresh user session is created instead
         val session = checkNotNull(orchestrator.currentUserSession())
         assertNotEquals("old-id", session.userSessionId)
+    }
+
+    @Test
+    fun `process killed in background after inactivity timeout - new user session on restart`() {
+        configService = FakeConfigService(
+            sessionBehavior = FakeUserSessionBehavior(
+                maxSessionDurationMs = maxDurationMs,
+                sessionInactivityTimeoutMs = inactivityMs,
+            )
+        )
+        val store = UserSessionMetadataStore(FakeKeyValueStore())
+        val backgroundTime = clock.now()
+        store.save(
+            UserSessionMetadata(
+                startTimeMs = backgroundTime,
+                userSessionId = "bg-killed-id",
+                userSessionNumber = 2L,
+                maxDurationSecs = TimeUnit.MILLISECONDS.toSeconds(maxDurationMs),
+                inactivityTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(inactivityMs),
+                partNumber = 2,
+                lastActivityMs = backgroundTime,
+            )
+        )
+
+        // simulate process restart after inactivity timeout
+        clock.tick(inactivityMs)
+        createOrchestrator(AppState.FOREGROUND, metadataStoreOverride = store)
+
+        val session = checkNotNull(orchestrator.currentUserSession())
+        assertNotEquals("bg-killed-id", session.userSessionId)
+    }
+
+    @Test
+    fun `process killed in background before inactivity timeout - session is restored`() {
+        configService = FakeConfigService(
+            sessionBehavior = FakeUserSessionBehavior(
+                maxSessionDurationMs = maxDurationMs,
+                sessionInactivityTimeoutMs = inactivityMs,
+            )
+        )
+        val store = UserSessionMetadataStore(FakeKeyValueStore())
+        val backgroundTime = clock.now()
+        store.save(
+            UserSessionMetadata(
+                startTimeMs = backgroundTime,
+                userSessionId = "bg-killed-id",
+                userSessionNumber = 2L,
+                maxDurationSecs = TimeUnit.MILLISECONDS.toSeconds(maxDurationMs),
+                inactivityTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(inactivityMs),
+                partNumber = 2,
+                lastActivityMs = backgroundTime,
+            )
+        )
+
+        // simulate process restart before inactivity timeout
+        clock.tick(inactivityMs - 1)
+        createOrchestrator(AppState.FOREGROUND, metadataStoreOverride = store)
+
+        val session = checkNotNull(orchestrator.currentUserSession())
+        assertEquals("bg-killed-id", session.userSessionId)
     }
 
     @Test
@@ -676,6 +738,7 @@ internal class SessionOrchestratorTest {
                 maxDurationSecs = persistedMaxSecs,
                 inactivityTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(inactivityMs),
                 partNumber = 1,
+                lastActivityMs = clock.now(),
             )
         )
 
@@ -711,6 +774,7 @@ internal class SessionOrchestratorTest {
                 maxDurationSecs = TimeUnit.MILLISECONDS.toSeconds(maxDurationMs),
                 inactivityTimeoutSecs = persistedInactivitySecs,
                 partNumber = 1,
+                lastActivityMs = clock.now(),
             )
         )
 
@@ -746,6 +810,7 @@ internal class SessionOrchestratorTest {
                 maxDurationSecs = TimeUnit.MILLISECONDS.toSeconds(maxDurationMs),
                 inactivityTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(inactivityMs),
                 partNumber = 1,
+                lastActivityMs = clock.now() + 1_000L,
             )
         )
 
@@ -1022,6 +1087,7 @@ internal class SessionOrchestratorTest {
                 maxDurationSecs = TimeUnit.MILLISECONDS.toSeconds(maxDurationMs),
                 inactivityTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(inactivityMs),
                 partNumber = 1,
+                lastActivityMs = clock.now(),
             )
         )
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
@@ -23,6 +23,7 @@ internal class SessionPartSpanAttrPopulatorImplTest {
         maxDurationSecs = 43200L,
         inactivityTimeoutSecs = 1800L,
         partNumber = 2,
+        lastActivityMs = 1000L,
     )
     private lateinit var populator: SessionPartSpanAttrPopulatorImpl
     private lateinit var destination: FakeTelemetryDestination

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalLoggerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalLoggerTest.kt
@@ -154,7 +154,7 @@ internal class ExternalLoggerTest {
                 clock.tick()
                 logTime = clock.now().millisToNanos()
                 embrace.addUserSessionProperty("bg-attr", "blah", PropertyScope.PERMANENT)
-                sessionId = checkNotNull(embrace.currentUserSessionId)
+                sessionId = checkNotNull(testRule.bootstrapper.userSessionOrchestrationModule.sessionIdProvider.getCurrentSessionPartId())
                 val span = embOpenTelemetry.getTracer("").startSpan("my-span")
                 parentContext = span.spanContext
                 embLogger.emit(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalOtelJavaLoggerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalOtelJavaLoggerTest.kt
@@ -150,7 +150,7 @@ internal class ExternalOtelJavaLoggerTest {
                 clock.tick()
                 logTime = clock.now().millisToNanos()
                 embrace.addUserSessionProperty("bg-attr", "blah", PropertyScope.PERMANENT)
-                sessionId = checkNotNull(embrace.currentUserSessionId)
+                sessionId = checkNotNull(testRule.bootstrapper.userSessionOrchestrationModule.sessionIdProvider.getCurrentSessionPartId())
                 val span = embOpenTelemetry.getTracer("").spanBuilder("my-span").startSpan()
                 val logContext = span.storeInContext(OtelJavaContext.root())
                 parentContext = span.spanContext

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
@@ -8,7 +8,6 @@ import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRe
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -80,7 +79,30 @@ internal class PublicApiTest {
             },
             assertAction = {
                 assertNotNull(backgroundSessionId)
-                assertNotEquals(foregroundSessionId, backgroundSessionId)
+                assertEquals(foregroundSessionId, backgroundSessionId)
+            }
+        )
+    }
+
+    @Test
+    fun `currentUserSessionId is stable across FG to BG to FG transition`() {
+        val ids = mutableListOf<String?>()
+        testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
+            testCaseAction = {
+                recordSession {
+                    ids.add(embrace.currentUserSessionId)
+                }
+                ids.add(embrace.currentUserSessionId)
+                recordSession {
+                    ids.add(embrace.currentUserSessionId)
+                }
+            },
+            assertAction = {
+                assertEquals(3, ids.size)
+                assertTrue(ids.all { it != null })
+                assertEquals(ids[0], ids[1])
+                assertEquals(ids[1], ids[2])
             }
         )
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NativeCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NativeCrashFeatureTest.kt
@@ -360,7 +360,7 @@ internal class NativeCrashFeatureTest {
         nativeSessionMetadata: MutableList<Pair<String?, String?>>,
     ) {
         sessions.add(currentSessionId ?: "null")
-        nativeSessionMetadata.add(Pair(sessionId, reportPath))
+        nativeSessionMetadata.add(Pair(userSessionId, reportPath))
     }
 
     private fun findMatchingSessionId(it: Envelope<LogPayload>, data: StoredNativeCrashData): Boolean {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
@@ -53,7 +53,7 @@ internal class BackgroundActivityDisabledTest {
 
                 // Check what should and shouldn't be logged when there is no background activity and the app is in the background
                 assertTrue(embrace.isStarted)
-                assertTrue(embrace.currentUserSessionId.isNullOrBlank())
+                assertFalse(embrace.currentUserSessionId.isNullOrBlank())
                 assertTrue(embrace.deviceId.isNotBlank())
                 assertEquals(NoopEmbraceSdkSpan, embrace.startSpan("test"))
                 embrace.logError("error")

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegate.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegate.kt
@@ -34,7 +34,7 @@ internal class SdkStateApiDelegate(
         get() {
             val localSessionIdProvider = sessionIdProvider
             if (localSessionIdProvider != null && sdkCallChecker.check("get_current_session_id")) {
-                return localSessionIdProvider.getCurrentSessionPartId()
+                return localSessionIdProvider.getCurrentUserSessionId()
             }
             return null
         }

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegateTest.kt
@@ -78,7 +78,7 @@ internal class SdkStateApiDelegateTest {
 
     @Test
     fun getCurrentSessionId() {
-        sessionIdProvider.sessionPartId = "test"
+        sessionIdProvider.userSessionId = "test"
         assertEquals("test", delegate.currentUserSessionId)
     }
 


### PR DESCRIPTION
## Goal

Returns the correct ID in `SdkStateApiDelegate`. The user session ID should be returned rather than the session part ID.

## Testing

Updated unit tests.
