### PR TITLE
Allow state transitions to record attributes

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/TelemetryDestinationImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/TelemetryDestinationImpl.kt
@@ -244,8 +244,9 @@ class TelemetryDestinationImpl(
         private val transitionCount = AtomicInteger(0)
 
         override fun update(
-            updateDetectedTimeMs: Long,
             newValue: T,
+            transitionTimeMs: Long,
+            transitionAttributes: Map<String, String>,
             unrecordedTransitions: UnrecordedTransitions,
         ): Boolean {
             if (!spanToken.isRecording()) {
@@ -253,9 +254,10 @@ class TelemetryDestinationImpl(
             }
             spanToken.addSystemEvent(
                 name = "transition",
-                eventTimeMs = updateDetectedTimeMs,
-                attributes = mutableMapOf(EmbStateTransitionAttributes.EMB_STATE_NEW_VALUE to newValue.toString())
+                eventTimeMs = transitionTimeMs,
+                attributes = transitionAttributes.toMutableMap()
                     .apply {
+                        put(EmbStateTransitionAttributes.EMB_STATE_NEW_VALUE, newValue.toString())
                         if (unrecordedTransitions.notInSession > 0) {
                             setEmbraceAttribute(EmbStateTransitionAttributes.EMB_STATE_NOT_IN_SESSION, unrecordedTransitions.notInSession)
                         }

--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionPartStateToken.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionPartStateToken.kt
@@ -6,11 +6,18 @@ import io.embrace.android.embracesdk.internal.clock.Clock
 
 class FakeSessionPartStateToken<T>(
     val transitions: MutableList<Pair<Long, T>> = mutableListOf(),
+    val transitionAttributes: MutableList<Map<String, String>> = mutableListOf(),
     private val clock: Clock = FakeClock(),
 ) : SessionPartStateToken<T> {
     var endTimeMs = 0L
-    override fun update(updateDetectedTimeMs: Long, newValue: T, unrecordedTransitions: UnrecordedTransitions): Boolean {
-        transitions.add(Pair(updateDetectedTimeMs, newValue))
+    override fun update(
+        newValue: T,
+        transitionTimeMs: Long,
+        transitionAttributes: Map<String, String>,
+        unrecordedTransitions: UnrecordedTransitions,
+    ): Boolean {
+        transitions.add(Pair(transitionTimeMs, newValue))
+        this.transitionAttributes.add(transitionAttributes)
         return true
     }
 

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/SessionPartStateToken.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/SessionPartStateToken.kt
@@ -16,9 +16,10 @@ interface SessionPartStateToken<T> {
      * avoid including into the timestamp the delay between when the transition happened to when instrumentation recorded it.
      */
     fun update(
-        updateDetectedTimeMs: Long,
         newValue: T,
-        unrecordedTransitions: UnrecordedTransitions = noUnrecordedTransitions
+        transitionTimeMs: Long,
+        transitionAttributes: Map<String, String> = emptyMap(),
+        unrecordedTransitions: UnrecordedTransitions = noUnrecordedTransitions,
     ): Boolean
 
     /**

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/StateDataSource.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/StateDataSource.kt
@@ -30,9 +30,14 @@ abstract class StateDataSource<T : Any>(
 
     /**
      * Notify that the state has changed at the given time to the given value, with the given number of transitions dropped by the
-     * since the last time this data source was notified of a state change.
+     * instrumentation since the last time this data source was notified of a state change.
      */
-    fun onStateChange(updateDetectedTimeMs: Long, newState: T, droppedTransitions: Int = 0) {
+    fun onStateChange(
+        newState: T,
+        transitionTimeMs: Long,
+        transitionAttributes: Map<String, String> = emptyMap(),
+        droppedTransitions: Int = 0,
+    ) {
         val oldState = currentState.getAndSet(newState)
         val currentStateToken = partStateToken.get()
         // Track the number of transitions dropped by instrumentation that didn't cause this to be invoked
@@ -47,9 +52,10 @@ abstract class StateDataSource<T : Any>(
             ) {
                 val droppedTransitions = unrecordedTransitions.getAndSet(noUnrecordedTransitions)
                 val transitionRecorded = currentStateToken.update(
-                    updateDetectedTimeMs = updateDetectedTimeMs,
                     newValue = newState,
-                    unrecordedTransitions = droppedTransitions
+                    transitionTimeMs = transitionTimeMs,
+                    transitionAttributes = transitionAttributes,
+                    unrecordedTransitions = droppedTransitions,
                 )
                 // If the transition was not recorded by the token, it means the associated session has ended.
                 // Add that transition as occurring outside of a session and also add back unrecorded transitions we tried to record.

--- a/embrace-android-instrumentation-navigation/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/NavigationStateDataSource.kt
+++ b/embrace-android-instrumentation-navigation/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/NavigationStateDataSource.kt
@@ -49,7 +49,7 @@ class NavigationStateDataSource(
     }
 
     fun onScreenLoad(loadTimeMs: Long, screenName: String) {
-        onStateChange(loadTimeMs, Screen(name = screenName))
+        onStateChange(newState = Screen(name = screenName), transitionTimeMs = loadTimeMs)
     }
 
     companion object {

--- a/embrace-android-instrumentation-network-status/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkStateDataSource.kt
+++ b/embrace-android-instrumentation-network-status/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkStateDataSource.kt
@@ -16,7 +16,7 @@ class NetworkStateDataSource(
     maxTransitions = MAX_CAPTURED_NETWORK_STATE_TRANSITIONS,
 ) {
     override fun onNetworkConnectivityStatusChanged(status: ConnectivityStatus) {
-        onStateChange(clock.now(), status.toState())
+        onStateChange(status.toState(), clock.now())
     }
 
     private fun ConnectivityStatus.toState(): Status =

--- a/embrace-android-instrumentation-power-save/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/powersave/PowerStateDataSource.kt
+++ b/embrace-android-instrumentation-power-save/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/powersave/PowerStateDataSource.kt
@@ -40,6 +40,6 @@ class PowerStateDataSource(
         } else {
             PowerMode.NORMAL
         }
-        onStateChange(timestamp, newState)
+        onStateChange(newState, timestamp)
     }
 }

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SpanEventAssertions.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SpanEventAssertions.kt
@@ -1,10 +1,10 @@
 package io.embrace.android.embracesdk.assertions
 
-import io.embrace.android.embracesdk.semconv.EmbStateTransitionAttributes
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttributeKey
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttributeValue
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
+import io.embrace.android.embracesdk.semconv.EmbStateTransitionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -14,6 +14,7 @@ fun <T: Any> SpanEvent.assertStateTransition(
     newStateValue: T,
     notInSession: Int = 0,
     droppedByInstrumentation: Int = 0,
+    transitionAttributes: Map<String, String> = emptyMap(),
 ) {
     assertEquals("transition", name)
     assertEquals(timestampMs.millisToNanos(), timestampNanos)
@@ -29,6 +30,10 @@ fun <T: Any> SpanEvent.assertStateTransition(
             assertTrue(hasEmbraceAttributeValue(EmbStateTransitionAttributes.EMB_STATE_DROPPED_BY_INSTRUMENTATION, droppedByInstrumentation.toString()))
         } else {
             assertFalse(hasEmbraceAttributeKey(EmbStateTransitionAttributes.EMB_STATE_DROPPED_BY_INSTRUMENTATION))
+        }
+
+        transitionAttributes.forEach { (key, value) ->
+            assertTrue("Expected attribute $key=$value on transition event", hasEmbraceAttributeValue(key, value))
         }
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/StateFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/StateFeatureTest.kt
@@ -15,6 +15,7 @@ import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
+import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttributeKey
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttributeValue
 import io.embrace.android.embracesdk.internal.otel.spans.hasEmbraceAttributeValue
 import io.embrace.android.embracesdk.internal.session.getSessionSpan
@@ -183,8 +184,8 @@ internal class StateFeatureTest {
                 recordSession {
                     repeat(101) { i ->
                         findDataSource<TestStateDataSource>().onStateChange(
-                            updateDetectedTimeMs = clock.tick(),
                             newState = i.toString(),
+                            transitionTimeMs = clock.tick(),
                         )
                     }
                 }
@@ -390,17 +391,129 @@ internal class StateFeatureTest {
         )
     }
 
+    @Test
+    fun `each transition event can have its set of attributes`() {
+        val attrsA = mapOf("testAttr" to "blah", "derp" to "1")
+        val attrsB = mapOf("testAttr" to "orf", "derp" to "2", "id" to "123")
+        val attrsC = mapOf("testAttr" to "barf", "derp" to "3")
+        val transitionAttributes = listOf(attrsA, attrsB, attrsC)
+        var transitions: List<Pair<Long, String>> = listOf()
+        testRule.runTest(
+            persistedRemoteConfig = stateEnabledRemoteConfig,
+            testCaseAction = {
+                recordSession {
+                    transitions = executeTransitions(
+                        updates = listOf("first", "second", "C"),
+                        transitionAttributes = transitionAttributes,
+                    )
+                }
+            },
+            assertAction = {
+                val events = checkNotNull(getSingleSessionEnvelope().getStateSpan("emb-state-test")?.events)
+                assertEquals(3, events.size)
+
+                // Each event carries exactly its own attrs, verified with all keys/values
+                repeat(events.size) { i ->
+                    events[i].assertStateTransition(
+                        timestampMs = transitions[i].first,
+                        newStateValue = transitions[i].second,
+                        transitionAttributes = transitionAttributes[i],
+                    )
+                }
+
+                assertTrue(!checkNotNull(events[0].attributes).hasEmbraceAttributeKey("id"))
+                assertTrue(!checkNotNull(events[2].attributes).hasEmbraceAttributeKey("id"))
+
+                assertTrue(checkNotNull(events[0].attributes).hasEmbraceAttributeValue("testAttr", "blah"))
+                assertTrue(checkNotNull(events[1].attributes).hasEmbraceAttributeValue("testAttr", "orf"))
+                assertTrue(checkNotNull(events[2].attributes).hasEmbraceAttributeValue("testAttr", "barf"))
+            }
+        )
+    }
+
+    @Test
+    fun `transition attributes cannot override built-in state attributes`() {
+        var transitions: List<Pair<Long, String>> = listOf()
+        testRule.runTest(
+            persistedRemoteConfig = stateEnabledRemoteConfig,
+            testCaseAction = {
+                recordSession {
+                    transitions = executeTransitions(
+                        updates = listOf("real"),
+                        transitionDrops = 3,
+                        transitionAttributes = listOf(
+                            mapOf(
+                                EmbStateTransitionAttributes.EMB_STATE_NEW_VALUE to "hacked",
+                                EmbStateTransitionAttributes.EMB_STATE_DROPPED_BY_INSTRUMENTATION to "99"
+                            )
+                        ),
+                    )
+                }
+            },
+            assertAction = {
+                val events = checkNotNull(getSingleSessionEnvelope().getStateSpan("emb-state-test")?.events)
+                events.single().assertStateTransition(
+                    timestampMs = transitions[0].first,
+                    newStateValue = "real",
+                    droppedByInstrumentation = 3,
+                )
+            }
+        )
+    }
+
+    @Test
+    fun `transition attributes discarded when transition dropped`() {
+        val attrsFirst = mapOf("foo" to "first")
+        val attrsSecond = mapOf("foo" to "second")
+        val attrsThird = mapOf("foo" to "third")
+        val timestamps = mutableListOf<Long>()
+        testRule.runTest(
+            persistedRemoteConfig = stateEnabledRemoteConfig,
+            testCaseAction = {
+                recordSession {
+                    val dataSource = findDataSource<TestStateDataSource>()
+                    timestamps.add(clock.tick(100L))
+                    dataSource.onStateChange("first", clock.now(), attrsFirst)
+                    timestamps.add(clock.tick(100L))
+                    // This is dropped so the attributes of the dropped transition are lost
+                    dataSource.onStateChange("first", clock.now(), attrsSecond)
+                    timestamps.add(clock.tick(100L))
+                    dataSource.onStateChange("second", clock.now(), attrsThird)
+                }
+            },
+            assertAction = {
+                val events = checkNotNull(getSingleSessionEnvelope().getStateSpan("emb-state-test")?.events)
+                assertEquals(2, events.size)
+
+                events[0].assertStateTransition(
+                    timestampMs = timestamps[0],
+                    newStateValue = "first",
+                    transitionAttributes = attrsFirst,
+                )
+                
+                events[1].assertStateTransition(
+                    timestampMs = timestamps[2],
+                    newStateValue = "second",
+                    droppedByInstrumentation = 1,
+                    transitionAttributes = attrsThird,
+                )
+            }
+        )
+    }
+
     private fun EmbraceActionInterface.executeTransitions(
         updates: List<String>,
         transitionDrops: Int = 0,
+        transitionAttributes: List<Map<String, String>> = emptyList(),
     ): List<Pair<Long, String>> {
         val transitions: MutableList<Pair<Long, String>> = mutableListOf()
         val dataSource = findDataSource<TestStateDataSource>()
         repeat(updates.size) { i ->
             transitions.add(Pair(clock.tick(100L), updates[i]))
             dataSource.onStateChange(
-                updateDetectedTimeMs = clock.now(),
                 newState = updates[i],
+                transitionTimeMs = clock.now(),
+                transitionAttributes = transitionAttributes.getOrNull(i) ?: emptyMap(),
                 droppedTransitions = transitionDrops,
             )
         }


### PR DESCRIPTION
Allow state transition events senders to attach a set of arbitrary attributes to an event. These will not be aggregated as of yet but can show up in the timeline to give additional context to the transition