### PR TITLE
Prepare feature flags and defaults for nav state dark mode

### DIFF
--- a/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAutoDataCaptureBehavior.kt
+++ b/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAutoDataCaptureBehavior.kt
@@ -15,7 +15,7 @@ class FakeAutoDataCaptureBehavior(
     private val uiLoadTracingEnabled: Boolean = true,
     private val uiLoadTracingTraceAll: Boolean = true,
     private val endStartupWithAppReady: Boolean = false,
-    private val enableStateCapture: Boolean = false,
+    private val enableStateCapture: Boolean = true,
     private val networkCallbackConnectivityServiceEnabled: Boolean = false,
     private val navigationStateCaptureEnabled: Boolean = true,
 ) : AutoDataCaptureBehavior {

--- a/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeEnabledFeatureConfig.kt
+++ b/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeEnabledFeatureConfig.kt
@@ -31,7 +31,6 @@ class FakeEnabledFeatureConfig(
     private val uiLoadTracingTraceAll: Boolean = base.isUiLoadTracingTraceAll(),
     private val endStartupWithAppReady: Boolean = base.isEndStartupWithAppReadyEnabled(),
     private val otelKotlinSdkEnabled: Boolean = base.isOtelKotlinSdkEnabled(),
-    private val stateCaptureEnabled: Boolean = base.isStateCaptureEnabled(),
 ) : EnabledFeatureConfig {
 
     override fun isActivityBreadcrumbCaptureEnabled(): Boolean = activityBreadcrumbCapture
@@ -58,5 +57,4 @@ class FakeEnabledFeatureConfig(
     override fun isUiLoadTracingTraceAll(): Boolean = uiLoadTracingTraceAll
     override fun isEndStartupWithAppReadyEnabled(): Boolean = endStartupWithAppReady
     override fun isOtelKotlinSdkEnabled(): Boolean = otelKotlinSdkEnabled
-    override fun isStateCaptureEnabled(): Boolean = stateCaptureEnabled
 }

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImpl.kt
@@ -16,6 +16,8 @@ class AutoDataCaptureBehaviorImpl(
     private companion object {
         const val THERMAL_STATUS_ENABLED_DEFAULT = true
         const val UI_LOAD_REMOTE_ENABLED_DEFAULT = true
+        const val STATE_CAPTURE_ENABLED_DEFAULT = true
+        const val NAVIGATION_STATE_CAPTURE_ENABLED_DEFAULT = true
     }
 
     private val local = local.enabledFeatures
@@ -47,11 +49,11 @@ class AutoDataCaptureBehaviorImpl(
 
     override fun isEndStartupWithAppReadyEnabled(): Boolean = local.isEndStartupWithAppReadyEnabled()
     override fun isStateCaptureEnabled(): Boolean =
-        thresholdCheck.isBehaviorEnabled(remote?.pctStateCaptureEnabledV2) ?: local.isStateCaptureEnabled()
+        thresholdCheck.isBehaviorEnabled(remote?.pctStateCaptureEnabledV2) ?: STATE_CAPTURE_ENABLED_DEFAULT
 
     override fun isNetworkCallbackConnectivityServiceEnabled(): Boolean =
         thresholdCheck.isBehaviorEnabled(remote?.pctNetworkCallbackConnectivityServiceEnabled) ?: false
 
     override fun isNavigationStateCaptureEnabled(): Boolean =
-        thresholdCheck.isBehaviorEnabled(remote?.pctNavigationStateCaptureEnabled) ?: true
+        thresholdCheck.isBehaviorEnabled(remote?.pctNavigationStateCaptureEnabled) ?: NAVIGATION_STATE_CAPTURE_ENABLED_DEFAULT
 }

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
@@ -38,7 +38,7 @@ internal class AutoDataCaptureBehaviorImplTest {
             assertTrue(isUiLoadTracingTraceAll())
             assertTrue(isThermalStatusCaptureEnabled())
             assertFalse(isEndStartupWithAppReadyEnabled())
-            assertFalse(isStateCaptureEnabled())
+            assertTrue(isStateCaptureEnabled())
             assertFalse(isNetworkCallbackConnectivityServiceEnabled())
             assertTrue(isNavigationStateCaptureEnabled())
         }
@@ -130,23 +130,10 @@ internal class AutoDataCaptureBehaviorImplTest {
     }
 
     @Test
-    fun `enable state capture`() {
-        val behavior = createBehavior(
-            localUiLoadTracingEnabled = true,
-            localUiLoadTracingTraceAllEnabled = true,
-            stateCaptureEnabled = true,
-            remote = remote
-        )
-
-        assertTrue(behavior.isStateCaptureEnabled())
-    }
-
-    @Test
     fun `enable state capture remotely`() {
         val behavior = createBehavior(
             localUiLoadTracingEnabled = true,
             localUiLoadTracingTraceAllEnabled = true,
-            stateCaptureEnabled = false,
             remote = remote.copy(pctStateCaptureEnabledV2 = 100.0f)
         )
 
@@ -158,7 +145,6 @@ internal class AutoDataCaptureBehaviorImplTest {
         val behavior = createBehavior(
             localUiLoadTracingEnabled = true,
             localUiLoadTracingTraceAllEnabled = true,
-            stateCaptureEnabled = true,
             remote = remote.copy(pctStateCaptureEnabledV2 = 0.0f)
         )
 
@@ -189,13 +175,6 @@ internal class AutoDataCaptureBehaviorImplTest {
     }
 
     @Test
-    fun `navigation state capture enabled by default when remote pct is null`() {
-        assertTrue(
-            createBehavior(remote = RemoteConfig()).isNavigationStateCaptureEnabled()
-        )
-    }
-
-    @Test
     fun `navigation state capture enabled when pct is 100`() {
         assertTrue(
             createBehavior(
@@ -216,7 +195,6 @@ internal class AutoDataCaptureBehaviorImplTest {
     private fun createBehavior(
         localUiLoadTracingEnabled: Boolean = true,
         localUiLoadTracingTraceAllEnabled: Boolean = true,
-        stateCaptureEnabled: Boolean = false,
         remote: RemoteConfig,
     ) = AutoDataCaptureBehaviorImpl(
         thresholdCheck = BehaviorThresholdCheck { FAKE_DEVICE_ID },
@@ -224,7 +202,6 @@ internal class AutoDataCaptureBehaviorImplTest {
             enabledFeatures = FakeEnabledFeatureConfig(
                 uiLoadTracingTraceAll = localUiLoadTracingTraceAllEnabled,
                 uiLoadTracingEnabled = localUiLoadTracingEnabled,
-                stateCaptureEnabled = stateCaptureEnabled,
             )
         ),
         remote = remote

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
@@ -168,9 +168,4 @@ interface EnabledFeatureConfig {
      * sdk_config.otel.enable_otel_kotlin_sdk
      */
     fun isOtelKotlinSdkEnabled(): Boolean = false
-
-    /**
-     * Gates whether the state feature is enabled. This is never set to true in production.
-     */
-    fun isStateCaptureEnabled(): Boolean = false
 }

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/RemoteConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/RemoteConfig.kt
@@ -104,7 +104,7 @@ data class RemoteConfig(
     @Json(name = "pct_network_callback_connectivity_service_enabled")
     val pctNetworkCallbackConnectivityServiceEnabled: Float? = null,
 
-    @Json(name = "pct_navigation_state_capture_enabled")
+    @Json(name = "pct_screen_tracking_enabled")
     val pctNavigationStateCaptureEnabled: Float? = null,
 
     @Json(name = "user_session")

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalLoggerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalLoggerTest.kt
@@ -7,7 +7,6 @@ import io.embrace.android.embracesdk.fakes.FakeLogRecordExporter
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.config.FakeProjectConfig
-import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.internal.arch.attrs.toEmbraceAttributeName
 import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
@@ -15,6 +14,7 @@ import io.embrace.android.embracesdk.internal.config.remote.OtelKotlinSdkConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.otel.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.toStringMap
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface
 import io.embrace.android.embracesdk.testframework.actions.EmbraceOtelExportAssertionInterface
@@ -48,7 +48,6 @@ internal class ExternalLoggerTest {
     private val instrumentedConfig = FakeInstrumentedConfig(
         enabledFeatures = FakeEnabledFeatureConfig(
             bgActivityCapture = true,
-            stateCaptureEnabled = true
         ),
         project = FakeProjectConfig(
             appId = "abcde",

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalOtelJavaLoggerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalOtelJavaLoggerTest.kt
@@ -7,7 +7,6 @@ import io.embrace.android.embracesdk.fakes.FakeOtelJavaLogRecordExporter
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.config.FakeProjectConfig
-import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.internal.arch.attrs.toEmbraceAttributeName
 import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
@@ -17,6 +16,7 @@ import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.toStringMap
 import io.embrace.android.embracesdk.otel.java.addJavaLogRecordExporter
 import io.embrace.android.embracesdk.otel.java.getJavaOpenTelemetry
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface
 import io.embrace.android.embracesdk.testframework.actions.EmbracePreSdkStartInterface
@@ -49,7 +49,6 @@ internal class ExternalOtelJavaLoggerTest {
     private val instrumentedConfig = FakeInstrumentedConfig(
         enabledFeatures = FakeEnabledFeatureConfig(
             bgActivityCapture = true,
-            stateCaptureEnabled = true
         ),
         project = FakeProjectConfig(
             appId = "abcde",

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionApiTest.kt
@@ -4,10 +4,10 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.toMap
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
-import io.embrace.android.embracesdk.semconv.EmbTelemetryAttributes
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
+import io.embrace.android.embracesdk.semconv.EmbTelemetryAttributes
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
@@ -32,7 +32,12 @@ internal class UserSessionApiTest {
         var startTime: Long = -1
 
         testRule.runTest(
-            instrumentedConfig = FakeInstrumentedConfig(enabledFeatures = FakeEnabledFeatureConfig(diskUsageCapture = false, bgActivityCapture = true)),
+            instrumentedConfig = FakeInstrumentedConfig(
+                enabledFeatures = FakeEnabledFeatureConfig(
+                    diskUsageCapture = false,
+                    bgActivityCapture = true
+                )
+            ),
             testCaseAction = {
                 startTime = recordSession {
                     embrace.setUserIdentifier("some id")
@@ -80,7 +85,7 @@ internal class UserSessionApiTest {
                     "emb.usage.set_username" to "1",
                     "emb.usage.set_user_email" to "1",
                     "emb.usage.set_user_identifier" to "1",
-                    EmbSessionAttributes.EMB_PRIVATE_SEQUENCE_ID to "5",
+                    EmbSessionAttributes.EMB_PRIVATE_SEQUENCE_ID to "9",
                     EmbSessionAttributes.EMB_STARTUP_DURATION to "0"
                 ).toSortedMap()
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LowPowerFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LowPowerFeatureTest.kt
@@ -91,7 +91,6 @@ internal class LowPowerFeatureTest {
         testRule.runTest(
             instrumentedConfig = FakeInstrumentedConfig(
                 enabledFeatures = FakeEnabledFeatureConfig(
-                    stateCaptureEnabled = true,
                     bgActivityCapture = false,
                     powerSaveCapture = true
                 )
@@ -139,7 +138,6 @@ internal class LowPowerFeatureTest {
         testRule.runTest(
             instrumentedConfig = FakeInstrumentedConfig(
                 enabledFeatures = FakeEnabledFeatureConfig(
-                    stateCaptureEnabled = true,
                     powerSaveCapture = false
                 )
             ),

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NativeCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NativeCrashFeatureTest.kt
@@ -54,7 +54,6 @@ internal class NativeCrashFeatureTest {
     private val config = FakeInstrumentedConfig(
         enabledFeatures = FakeEnabledFeatureConfig(
             nativeCrashCapture = true,
-            stateCaptureEnabled = true
         ),
         symbols = createNativeSymbolsForCurrentArch(fakeSymbols)
     )
@@ -62,7 +61,6 @@ internal class NativeCrashFeatureTest {
     private val disabledConfig = FakeInstrumentedConfig(
         enabledFeatures = FakeEnabledFeatureConfig(
             nativeCrashCapture = false,
-            stateCaptureEnabled = true
         )
     )
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NavigationComplexDestinationAndRouteTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NavigationComplexDestinationAndRouteTest.kt
@@ -10,8 +10,6 @@ import io.embrace.android.embracesdk.fakes.DialogNavHostFragmentActivity
 import io.embrace.android.embracesdk.fakes.FqcnRouteActivityNavHost
 import io.embrace.android.embracesdk.fakes.NestedGraphNavHostFragmentActivity
 import io.embrace.android.embracesdk.fakes.SerializableRouteNavHostFragmentActivity
-import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
-import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.AppExecutionTimestamps
@@ -30,20 +28,12 @@ internal class NavigationComplexDestinationAndRouteTest {
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule()
 
-    private val enabledConfig = FakeInstrumentedConfig(
-        enabledFeatures = FakeEnabledFeatureConfig(
-            stateCaptureEnabled = true,
-            bgActivityCapture = false,
-        ),
-    )
-
     private val enabledRemoteConfig = RemoteConfig(pctNavigationStateCaptureEnabled = 100.0f)
 
     @Test
     fun `routes with argument templates use the template not the resolved value`() {
         var timestamps: AppExecutionTimestamps? = null
         testRule.runTest(
-            instrumentedConfig = enabledConfig,
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
                 timestamps = simulateNavHostFragmentActivityNavigation<ArgTemplateNavHostFragmentActivity>(
@@ -71,7 +61,6 @@ internal class NavigationComplexDestinationAndRouteTest {
     fun `dialog destinations tracked like fragment destinations`() {
         var timestamps: AppExecutionTimestamps? = null
         testRule.runTest(
-            instrumentedConfig = enabledConfig,
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
                 timestamps = simulateNavHostFragmentActivityNavigation<DialogNavHostFragmentActivity>(
@@ -97,7 +86,6 @@ internal class NavigationComplexDestinationAndRouteTest {
     fun `nested graph destinations use inner destination route`() {
         var timestamps: AppExecutionTimestamps? = null
         testRule.runTest(
-            instrumentedConfig = enabledConfig,
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
                 timestamps = simulateNavHostFragmentActivityNavigation<NestedGraphNavHostFragmentActivity>(
@@ -124,7 +112,6 @@ internal class NavigationComplexDestinationAndRouteTest {
     fun `back navigation triggers destination change`() {
         var timestamps: AppExecutionTimestamps? = null
         testRule.runTest(
-            instrumentedConfig = enabledConfig,
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
                 val activityController = Robolectric.buildActivity(BasicNavHostFragmentActivity::class.java)
@@ -169,7 +156,6 @@ internal class NavigationComplexDestinationAndRouteTest {
     fun `Serializable routes with SerialName use the serial name template not resolved args`() {
         var timestamps: AppExecutionTimestamps? = null
         testRule.runTest(
-            instrumentedConfig = enabledConfig,
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
                 val activityController = Robolectric.buildActivity(SerializableRouteNavHostFragmentActivity::class.java)
@@ -205,7 +191,6 @@ internal class NavigationComplexDestinationAndRouteTest {
     fun `Serializable routes without SerialName use fully qualified class name with template not resolved as state value`() {
         var timestamps: AppExecutionTimestamps? = null
         testRule.runTest(
-            instrumentedConfig = enabledConfig,
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
                 val activityController = Robolectric.buildActivity(FqcnRouteActivityNavHost::class.java)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NavigationStateFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NavigationStateFeatureTest.kt
@@ -32,24 +32,13 @@ internal class NavigationStateFeatureTest {
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule()
 
-    private val enabledConfig = FakeInstrumentedConfig(
-        enabledFeatures = FakeEnabledFeatureConfig(
-            stateCaptureEnabled = true,
-            bgActivityCapture = false,
-        ),
-    )
-
+    private val disabledRemoteConfig = RemoteConfig(pctNavigationStateCaptureEnabled = 0.0f)
     private val enabledRemoteConfig = RemoteConfig(pctNavigationStateCaptureEnabled = 100.0f)
 
     @Test
-    fun `navigation state feature disabled when state capture flag off`() {
+    fun `navigation state feature disabled when navigation flag off`() {
         testRule.runTest(
-            instrumentedConfig = FakeInstrumentedConfig(
-                enabledFeatures = FakeEnabledFeatureConfig(
-                    stateCaptureEnabled = false,
-                ),
-            ),
-            persistedRemoteConfig = enabledRemoteConfig,
+            persistedRemoteConfig = disabledRemoteConfig,
             testCaseAction = {
                 recordSession {}
             },
@@ -60,14 +49,9 @@ internal class NavigationStateFeatureTest {
     }
 
     @Test
-    fun `navigation state feature disabled when navigation flag off`() {
+    fun `navigation state feature disabled when state feature flag is off`() {
         testRule.runTest(
-            instrumentedConfig = FakeInstrumentedConfig(
-                enabledFeatures = FakeEnabledFeatureConfig(
-                    stateCaptureEnabled = true,
-                ),
-            ),
-            persistedRemoteConfig = RemoteConfig(pctNavigationStateCaptureEnabled = 0.0f),
+            persistedRemoteConfig = enabledRemoteConfig.copy(pctStateCaptureEnabledV2 = 0.0f),
             testCaseAction = {
                 recordSession {}
             },
@@ -88,7 +72,6 @@ internal class NavigationStateFeatureTest {
             Robolectric.buildActivity(ProfileActivity::class.java)
         )
         testRule.runTest(
-            instrumentedConfig = enabledConfig,
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
                 firstSessionTimestamps = simulateOpeningActivities(
@@ -141,7 +124,6 @@ internal class NavigationStateFeatureTest {
         testRule.runTest(
             instrumentedConfig = FakeInstrumentedConfig(
                 enabledFeatures = FakeEnabledFeatureConfig(
-                    stateCaptureEnabled = true,
                     bgActivityCapture = true
                 )
             ),
@@ -199,7 +181,6 @@ internal class NavigationStateFeatureTest {
         var timestamps: AppExecutionTimestamps? = null
 
         testRule.runTest(
-            instrumentedConfig = enabledConfig,
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
                 timestamps = simulateNavHostFragmentActivityNavigation<BasicNavHostFragmentActivity>(routes = navRoutes)
@@ -227,7 +208,6 @@ internal class NavigationStateFeatureTest {
     fun `NavController destination restored when same Activity returns from background`() {
         val navActivity = Robolectric.buildActivity(BasicNavHostFragmentActivity::class.java)
         testRule.runTest(
-            instrumentedConfig = enabledConfig,
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
                 simulateNavHostFragmentActivityNavigation(
@@ -260,7 +240,6 @@ internal class NavigationStateFeatureTest {
         val navActivity = Robolectric.buildActivity(BasicNavHostFragmentActivity::class.java)
         var navigationTime: Long = 0
         testRule.runTest(
-            instrumentedConfig = enabledConfig,
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
                 timestamps = simulateOpeningActivities(
@@ -302,7 +281,6 @@ internal class NavigationStateFeatureTest {
         val activityController = Robolectric.buildActivity(TestNavControllerActivity::class.java)
         val expectedStateValues = listOf("home", "contacts", "about", "Backgrounded")
         testRule.runTest(
-            instrumentedConfig = enabledConfig,
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
                 timestamps = simulateNavControllerTrackingAndNavigation(
@@ -330,7 +308,6 @@ internal class NavigationStateFeatureTest {
     @Test
     fun `transitions capped at limit`() {
         testRule.runTest(
-            instrumentedConfig = enabledConfig,
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
                 val activityController = Robolectric.buildActivity(BasicNavHostFragmentActivity::class.java)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NetworkStateFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NetworkStateFeatureTest.kt
@@ -4,7 +4,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.assertStateTransition
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
-import io.embrace.android.embracesdk.semconv.EmbStateTransitionAttributes
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType.NetworkState.Status
 import io.embrace.android.embracesdk.internal.capture.connectivity.ConnectionType
 import io.embrace.android.embracesdk.internal.capture.connectivity.ConnectivityStatus
@@ -12,6 +11,7 @@ import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkStateDataSource
 import io.embrace.android.embracesdk.internal.session.getSessionSpan
 import io.embrace.android.embracesdk.internal.session.getStateSpan
+import io.embrace.android.embracesdk.semconv.EmbStateTransitionAttributes
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface.Companion.LIFECYCLE_EVENT_GAP
 import org.junit.Assert.assertEquals
@@ -35,8 +35,6 @@ internal class NetworkStateFeatureTest {
 
     private val networkStateEnabledConfig = FakeInstrumentedConfig(
         enabledFeatures = FakeEnabledFeatureConfig(
-            stateCaptureEnabled = true,
-            bgActivityCapture = false,
             networkConnectivityCapture = true
         )
     )
@@ -150,7 +148,6 @@ internal class NetworkStateFeatureTest {
         testRule.runTest(
             instrumentedConfig = FakeInstrumentedConfig(
                 enabledFeatures = FakeEnabledFeatureConfig(
-                    stateCaptureEnabled = true,
                     networkConnectivityCapture = false
                 )
             ),

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/StateFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/StateFeatureTest.kt
@@ -39,67 +39,23 @@ internal class StateFeatureTest {
 
     val stateEnabledRemoteConfig = RemoteConfig(pctStateCaptureEnabledV2 = 100.0f)
     val stateDisabledRemoteConfig = RemoteConfig(pctStateCaptureEnabledV2 = 0.0f)
-    val stateEnabledLocalConfig = FakeInstrumentedConfig(
-        enabledFeatures = FakeEnabledFeatureConfig(
-            stateCaptureEnabled = true
-        )
-    )
-    val stateDisabledLocalConfig = FakeInstrumentedConfig(
-        enabledFeatures = FakeEnabledFeatureConfig(
-            stateCaptureEnabled = false
-        )
-    )
 
     @Test
-    fun `state feature off by default`() {
-        var throwable: Throwable? = null
+    fun `state feature on by default`() {
         testRule.runTest(
             testCaseAction = {
-                try {
-                    findDataSource<TestStateDataSource>()
-                } catch (e: IllegalStateException) {
-                    throwable = e
-                }
-                recordSession {}
+                recordSession()
             },
             assertAction = {
-                val message = getSingleSessionEnvelope()
-                assertEquals(0, message.findSpansOfType(EmbType.State).size)
-                assertTrue(throwable is IllegalStateException)
+                assertTrue(getSingleSessionEnvelope().findSpansOfType(EmbType.State).isNotEmpty())
             }
         )
     }
 
     @Test
-    fun `state feature off if disabled by local config`() {
+    fun `state feature off if disabled by remote config `() {
         var throwable: Throwable? = null
         testRule.runTest(
-            instrumentedConfig = FakeInstrumentedConfig(
-                enabledFeatures = FakeEnabledFeatureConfig(
-                    stateCaptureEnabled = false
-                )
-            ),
-            testCaseAction = {
-                try {
-                    findDataSource<TestStateDataSource>()
-                } catch (e: IllegalStateException) {
-                    throwable = e
-                }
-                recordSession {}
-            },
-            assertAction = {
-                val message = getSingleSessionEnvelope()
-                assertEquals(0, message.findSpansOfType(EmbType.State).size)
-                assertTrue(throwable is IllegalStateException)
-            }
-        )
-    }
-
-    @Test
-    fun `state feature off if disabled by remote config even if enabled local config`() {
-        var throwable: Throwable? = null
-        testRule.runTest(
-            instrumentedConfig = stateEnabledLocalConfig,
             persistedRemoteConfig = stateDisabledRemoteConfig,
             testCaseAction = {
                 try {
@@ -113,20 +69,6 @@ internal class StateFeatureTest {
                 val message = getSingleSessionEnvelope()
                 assertEquals(0, message.findSpansOfType(EmbType.State).size)
                 assertTrue(throwable is IllegalStateException)
-            }
-        )
-    }
-
-    @Test
-    fun `state feature on if enabled by remote config even if disabled by local config`() {
-        testRule.runTest(
-            instrumentedConfig = stateDisabledLocalConfig,
-            persistedRemoteConfig = stateEnabledRemoteConfig,
-            testCaseAction = {
-                recordSession {}
-            },
-            assertAction = {
-                assertTrue(getSingleSessionEnvelope().findSpansOfType(EmbType.State).isNotEmpty())
             }
         )
     }
@@ -490,7 +432,7 @@ internal class StateFeatureTest {
                     newStateValue = "first",
                     transitionAttributes = attrsFirst,
                 )
-                
+
                 events[1].assertStateTransition(
                     timestampMs = timestamps[2],
                     newStateValue = "second",

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
@@ -6,13 +6,13 @@ import io.embrace.android.embracesdk.assertions.findEventsOfType
 import io.embrace.android.embracesdk.assertions.findSessionSpan
 import io.embrace.android.embracesdk.assertions.getLogsOfType
 import io.embrace.android.embracesdk.assertions.getSessionId
-import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.otel.spans.NoopEmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.payload.Span
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.opentelemetry.kotlin.semconv.SessionAttributes
@@ -182,7 +182,7 @@ internal class BackgroundActivityDisabledTest {
                     startMs = session2StartMs,
                     endMs = session2EndMs,
                     sessionNumber = 2,
-                    sequenceId = 10,
+                    sequenceId = 14,
                     coldStart = false,
                 )
 


### PR DESCRIPTION
Look for and set the correct feature flags to ensure both the state and nav state features are on by default (data still recorded as private spans). I also removed a local config to control state which isn't necessary anymore as we have a remote flag we can flip for tests.   
  
Fix tests the account for the new defaults.