### PR TITLE
Public API for tracking NavControllers

### DIFF
--- a/embrace-android-api/api/embrace-android-api.api
+++ b/embrace-android-api/api/embrace-android-api.api
@@ -55,6 +55,7 @@ public abstract interface class io/embrace/android/embracesdk/internal/api/Instr
 	public abstract fun addStartupTraceChildSpan (Ljava/lang/String;JJLjava/util/Map;Ljava/util/List;Lio/embrace/android/embracesdk/spans/ErrorCode;)V
 	public abstract fun appReady ()V
 	public abstract fun getSdkCurrentTimeMs ()J
+	public abstract fun observeNavigation (Landroid/app/Activity;Ljava/lang/Object;)V
 }
 
 public final class io/embrace/android/embracesdk/internal/api/InstrumentationApi$DefaultImpls {

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/InstrumentationApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/InstrumentationApi.kt
@@ -86,7 +86,7 @@ public interface InstrumentationApi {
     )
 
     /**
-     * Add a completed child span to the app startup trace with the given  attributes and span events.
+     * Add a completed child span to the app startup trace with the given attributes and span events.
      * Specify an [ErrorCode] if the span didn't complete successfully.
      */
     public fun addStartupTraceChildSpan(
@@ -97,4 +97,12 @@ public interface InstrumentationApi {
         events: List<EmbraceSpanEvent>,
         errorCode: ErrorCode?,
     )
+
+    /**
+     * Observe navigation within the given [Activity] that is controlled by the given [navigationController].
+     *
+     * [navigationController] is intentionally typeless so the SDK can introspect about its capabilities and do the required
+     * wiring in order to observe and track navigation
+     */
+    public fun observeNavigation(activity: Activity, navigationController: Any)
 }

--- a/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationApi.kt
+++ b/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationApi.kt
@@ -42,4 +42,7 @@ class FakeInstrumentationApi(
         errorCode: ErrorCode?,
     ) {
     }
+
+    override fun observeNavigation(activity: Activity, navigationController: Any) {
+    }
 }

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -44,6 +44,7 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun logMessage (Ljava/lang/String;Lio/embrace/android/embracesdk/Severity;Ljava/util/Map;[B)V
 	public fun logPushNotification (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
 	public fun logWarning (Ljava/lang/String;)V
+	public fun observeNavigation (Landroid/app/Activity;Ljava/lang/Object;)V
 	public fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Ljava/util/Map;Ljava/util/List;)Z
 	public fun recordNetworkRequest (Lio/embrace/android/embracesdk/network/EmbraceNetworkRequest;)V
 	public fun recordSpan (Ljava/lang/String;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Ljava/util/Map;Ljava/util/List;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NavigationStateFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NavigationStateFeatureTest.kt
@@ -276,7 +276,7 @@ internal class NavigationStateFeatureTest {
     }
 
     @Test
-    fun `navigation of NavController tracked using internal API creates state span`() {
+    fun `navigation of NavController tracked using public observeNavigation API creates state span`() {
         var timestamps: AppExecutionTimestamps? = null
         val activityController = Robolectric.buildActivity(TestNavControllerActivity::class.java)
         val expectedStateValues = listOf("home", "contacts", "about", "Backgrounded")

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.testframework.actions
 
 import android.app.Activity
 import androidx.lifecycle.Lifecycle
-import androidx.navigation.NavController
 import io.embrace.android.embracesdk.Embrace
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.HasNavController
@@ -144,7 +143,7 @@ internal class EmbraceActionInterface(
         endInBackground: Boolean = true,
         createFirstActivity: Boolean = true,
         invokeManualEnd: Boolean = false,
-        toBeRegisteredNavControllerProvider: () -> NavController? = { null },
+        postOnStart: (Activity) -> Unit = {},
         activitiesAndActions: List<Pair<ActivityController<*>, () -> Unit>> = listOf(
             Robolectric.buildActivity(Activity::class.java) to {},
         ),
@@ -183,11 +182,7 @@ internal class EmbraceActionInterface(
                 onForeground()
             }
             invokeWithMainLooperUnblock(activityController::start)
-            toBeRegisteredNavControllerProvider()?.let {
-                invokeWithMainLooperUnblock {
-                    bootstrapper.essentialServiceModule.navigationTrackingService.trackNavigation(activityController.get(), it)
-                }
-            }
+            invokeWithMainLooperUnblock { postOnStart(activityController.get()) }
             setup.getClock().tick(LIFECYCLE_EVENT_GAP)
             invokeWithMainLooperUnblock(activityController::resume)
             setup.getClock().tick(LIFECYCLE_EVENT_GAP)
@@ -233,21 +228,25 @@ internal class EmbraceActionInterface(
 
     /**
      * Simulates opening a [TestNavHostFragmentActivity] and navigating through the given routes.
-     * The tracking of the underlying [NavController] is handled automatically by the SDK. No explicit [NavController] tracking is done
+     * The tracking of the navigation will be handled automatically by the SDK.
      */
     inline fun <reified T : TestNavHostFragmentActivity> simulateNavHostFragmentActivityNavigation(
         routes: List<String>,
         activityController: ActivityController<T> = Robolectric.buildActivity(T::class.java),
-    ) = simulateNavControllerNavigation(routes, false, activityController)
+    ) = simulateNavControllerNavigation(routes, activityController)
 
     /**
-     * Simulates opening the given [Activity] and navigating through the destinations [routes] defined on the [NavController] provided by
-     * the [HasNavController] interface. The [NavController] will be accessed during onStart, so its initialization has to be done by then.
+     * Simulates opening the given [Activity] and navigating through the given destinations using the NavController provided
+     * by the [HasNavController] interface. The public API for tracking NavControllers will be called after
+     * onStart to register the given NavControlle for navigation tracking.
      */
     inline fun <reified T> simulateNavControllerTrackingAndNavigation(
         routes: List<String>,
         activityController: ActivityController<T>,
-    ) where T : Activity, T : HasNavController = simulateNavControllerNavigation(routes, true, activityController)
+    ): AppExecutionTimestamps where T : Activity, T : HasNavController =
+        simulateNavControllerNavigation(routes, activityController) { activity ->
+            embrace.observeNavigation(activity, activityController.get().getNavController())
+        }
 
     fun simulateJvmUncaughtException(exc: Throwable) {
         Thread.getDefaultUncaughtExceptionHandler()?.uncaughtException(Thread.currentThread(), exc)
@@ -264,19 +263,13 @@ internal class EmbraceActionInterface(
 
     private inline fun <reified T> simulateNavControllerNavigation(
         routes: List<String>,
-        registerNavController: Boolean,
         activityController: ActivityController<T>,
+        crossinline postStart: (Activity) -> Unit = {},
     ): AppExecutionTimestamps where T : Activity, T : HasNavController =
         simulateOpeningActivities(
             addStartupActivity = false,
             startInBackground = true,
-            toBeRegisteredNavControllerProvider = {
-                if (registerNavController) {
-                    activityController.get().getNavController()
-                } else {
-                    null
-                }
-            },
+            postOnStart = { activity -> postStart(activity) },
             activitiesAndActions = listOf(
                 activityController to {
                     routes.forEach { route ->

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/InstrumentationApiDelegate.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/InstrumentationApiDelegate.kt
@@ -25,6 +25,9 @@ internal class InstrumentationApiDelegate(
     private val appStartupDataCollector by embraceImplInject(sdkCallChecker) {
         bootstrapper.dataCaptureServiceModule.appStartupDataCollector
     }
+    private val navigationTrackingService by embraceImplInject(sdkCallChecker) {
+        bootstrapper.essentialServiceModule.navigationTrackingService
+    }
 
     override fun appReady() {
         if (sdkCallChecker.check("app_ready")) {
@@ -91,6 +94,12 @@ internal class InstrumentationApiDelegate(
                 events = events.map(::toSpanEvent),
                 errorCode = errorCode?.toErrorCodeAttribute()
             )
+        }
+    }
+
+    override fun observeNavigation(activity: Activity, navigationController: Any) {
+        if (sdkCallChecker.check("observe_navigation")) {
+            navigationTrackingService?.trackNavigation(activity, navigationController)
         }
     }
 


### PR DESCRIPTION
Create a public API method to track objects that direct navigation change. The interface doesn't specify a type so the main Embrace SDK doesn't need to take a dependency, instead deferring to one of the optional modules to handle the resolution, which currently supports Jetpack Navigation's`NavController` only.

The integration tests that used to test the internal API for registering `NavController` tracking has been modified to use the public API method instead, so no additional tests need to be added