### PR TITLE
Add integration tests for session sequence number

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SessionOrchestratorSupplier.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SessionOrchestratorSupplier.kt
@@ -27,7 +27,6 @@ fun createSessionOrchestrator(
     val payloadMessageCollator = PayloadMessageCollatorImpl(
         EmbTrace.trace("sessionEnvelopeSource") { payloadSourceModule.sessionPartEnvelopeSource },
         openTelemetryModule.currentSessionPartSpan,
-        coreModule.ordinalStore,
     )
 
     val payloadFactory = PayloadFactoryImpl(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
@@ -34,7 +34,6 @@ class UserSessionOrchestrationModuleImpl(
         val payloadMessageCollator = PayloadMessageCollatorImpl(
             EmbTrace.trace("sessionEnvelopeSource") { payloadSourceModule.sessionPartEnvelopeSource },
             openTelemetryModule.currentSessionPartSpan,
-            coreModule.ordinalStore,
         )
 
         val payloadFactory = PayloadFactoryImpl(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/InitialEnvelopeParams.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/InitialEnvelopeParams.kt
@@ -11,4 +11,5 @@ class InitialEnvelopeParams(
     val startType: LifeEventType,
     val startTime: Long,
     val appState: AppState,
+    val partNumber: Int,
 )

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactory.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactory.kt
@@ -14,7 +14,12 @@ interface PayloadFactory {
     /**
      * Starts a session in response to a state event.
      */
-    fun startPayloadWithState(state: AppState, timestamp: Long, coldStart: Boolean): SessionPartToken?
+    fun startPayloadWithState(
+        state: AppState,
+        timestamp: Long,
+        coldStart: Boolean,
+        partNumber: Int
+    ): SessionPartToken?
 
     /**
      * Ends a session in response to a state event.
@@ -43,7 +48,7 @@ interface PayloadFactory {
     /**
      * Starts a session manually.
      */
-    fun startSessionWithManual(timestamp: Long): SessionPartToken
+    fun startSessionWithManual(timestamp: Long, partNumber: Int): SessionPartToken
 
     /**
      * Ends a session manually.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImpl.kt
@@ -18,10 +18,10 @@ internal class PayloadFactoryImpl(
     private val logger: InternalLogger,
 ) : PayloadFactory {
 
-    override fun startPayloadWithState(state: AppState, timestamp: Long, coldStart: Boolean): SessionPartToken? =
+    override fun startPayloadWithState(state: AppState, timestamp: Long, coldStart: Boolean, partNumber: Int): SessionPartToken? =
         when (state) {
-            AppState.FOREGROUND -> startSessionWithState(timestamp, coldStart)
-            AppState.BACKGROUND -> startBackgroundActivityWithState(timestamp, coldStart)
+            AppState.FOREGROUND -> startSessionWithState(timestamp, coldStart, partNumber)
+            AppState.BACKGROUND -> startBackgroundActivityWithState(timestamp, coldStart, partNumber)
         }
 
     override fun endPayloadWithState(
@@ -54,13 +54,14 @@ internal class PayloadFactoryImpl(
             AppState.BACKGROUND -> snapshotBackgroundActivity(initial)
         }
 
-    override fun startSessionWithManual(timestamp: Long): SessionPartToken {
+    override fun startSessionWithManual(timestamp: Long, partNumber: Int): SessionPartToken {
         return payloadMessageCollator.buildInitialPart(
             InitialEnvelopeParams(
                 false,
                 LifeEventType.MANUAL,
                 timestamp,
-                AppState.FOREGROUND
+                AppState.FOREGROUND,
+                partNumber,
             )
         )
     }
@@ -80,18 +81,19 @@ internal class PayloadFactoryImpl(
         return logEnvelopeSource.getEmptySingleLogEnvelope()
     }
 
-    private fun startSessionWithState(timestamp: Long, coldStart: Boolean): SessionPartToken {
+    private fun startSessionWithState(timestamp: Long, coldStart: Boolean, partNumber: Int): SessionPartToken {
         return payloadMessageCollator.buildInitialPart(
             InitialEnvelopeParams(
                 coldStart,
                 LifeEventType.STATE,
                 timestamp,
-                AppState.FOREGROUND
+                AppState.FOREGROUND,
+                partNumber,
             )
         )
     }
 
-    private fun startBackgroundActivityWithState(timestamp: Long, coldStart: Boolean): SessionPartToken? {
+    private fun startBackgroundActivityWithState(timestamp: Long, coldStart: Boolean, partNumber: Int): SessionPartToken? {
         if (!isBackgroundActivityEnabled()) {
             return null
         }
@@ -107,7 +109,8 @@ internal class PayloadFactoryImpl(
                 coldStart = coldStart,
                 startType = LifeEventType.BKGND_STATE,
                 startTime = time,
-                AppState.BACKGROUND
+                AppState.BACKGROUND,
+                partNumber,
             )
         )
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImpl.kt
@@ -5,8 +5,6 @@ import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
 import io.embrace.android.embracesdk.internal.session.SessionPartToken
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionPartSpan
-import io.embrace.android.embracesdk.internal.store.Ordinal
-import io.embrace.android.embracesdk.internal.store.OrdinalStore
 
 /**
  * Generates a payload
@@ -14,7 +12,6 @@ import io.embrace.android.embracesdk.internal.store.OrdinalStore
 internal class PayloadMessageCollatorImpl(
     private val sessionPartEnvelopeSource: SessionPartEnvelopeSource,
     private val currentSessionPartSpan: CurrentSessionPartSpan,
-    private val store: OrdinalStore,
 ) : PayloadMessageCollator {
 
     override fun buildInitialPart(params: InitialEnvelopeParams): SessionPartToken = with(params) {
@@ -25,7 +22,7 @@ internal class PayloadMessageCollatorImpl(
             isColdStart = coldStart,
             appState = appState,
             startType = startType,
-            sessionPartNumber = store.incrementAndGet(Ordinal.USER_SESSION_PART),
+            sessionPartNumber = partNumber,
         )
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -118,7 +118,7 @@ internal class SessionOrchestratorImpl(
             transitionType = TransitionType.INITIAL,
             timestamp = timestamp,
             newSessionAction = {
-                payloadFactory.startPayloadWithState(state, timestamp, true)
+                payloadFactory.startPayloadWithState(state, timestamp, true, incrementPartNumber())
             }
         )
     }
@@ -147,7 +147,7 @@ internal class SessionOrchestratorImpl(
                 payloadFactory.endPayloadWithState(AppState.BACKGROUND, timestamp, initial)
             },
             newSessionAction = {
-                payloadFactory.startPayloadWithState(AppState.FOREGROUND, timestamp, coldStart)
+                payloadFactory.startPayloadWithState(AppState.FOREGROUND, timestamp, coldStart, incrementPartNumber())
             },
             earlyTerminationCondition = {
                 return@transitionState shouldRunOnForeground(state)
@@ -165,7 +165,7 @@ internal class SessionOrchestratorImpl(
                 payloadFactory.endPayloadWithState(AppState.FOREGROUND, timestamp, initial)
             },
             newSessionAction = {
-                payloadFactory.startPayloadWithState(AppState.BACKGROUND, timestamp, false)
+                payloadFactory.startPayloadWithState(AppState.BACKGROUND, timestamp, false, incrementPartNumber())
             },
             earlyTerminationCondition = {
                 return@transitionState shouldRunOnBackground(state)
@@ -184,7 +184,7 @@ internal class SessionOrchestratorImpl(
             },
             newSessionAction = {
                 lastManualEndMs = timestamp
-                payloadFactory.startSessionWithManual(timestamp)
+                payloadFactory.startSessionWithManual(timestamp, incrementPartNumber())
             },
             earlyTerminationCondition = {
                 return@transitionState shouldEndManualSession(
@@ -332,6 +332,11 @@ internal class SessionOrchestratorImpl(
             // update newly created session
             val userSession = currentUserSession()
             if (newSession != null && userSession != null) {
+                // persist partNumber to handle user session restoration in new process
+                val updatedUserSession = userSession.copy(partNumber = newSession.sessionPartNumber)
+                metadataStore.save(updatedUserSession)
+                userSessionState = UserSessionState.Active(updatedUserSession)
+
                 if (endAppState == AppState.FOREGROUND) {
                     sessionTracker.setProcessStateSummary(newSession.sessionPartId, userSession.userSessionId)
                 }
@@ -396,7 +401,7 @@ internal class SessionOrchestratorImpl(
                     payloadFactory.endPayloadWithState(currentAppState, timestamp, initial)
                 },
                 newSessionAction = {
-                    payloadFactory.startPayloadWithState(currentAppState, timestamp, false)
+                    payloadFactory.startPayloadWithState(currentAppState, timestamp, false, incrementPartNumber())
                 },
             )
         }
@@ -416,13 +421,20 @@ internal class SessionOrchestratorImpl(
                         payloadFactory.endPayloadWithState(AppState.BACKGROUND, timestamp, initial)
                     },
                     newSessionAction = {
-                        payloadFactory.startPayloadWithState(AppState.BACKGROUND, timestamp, false)
+                        payloadFactory.startPayloadWithState(
+                            AppState.BACKGROUND,
+                            timestamp,
+                            false,
+                            incrementPartNumber()
+                        )
                     },
                     earlyTerminationCondition = { state != AppState.BACKGROUND },
                 )
             }
         }
     }
+
+    private fun incrementPartNumber(): Int = (currentUserSession()?.partNumber ?: 0) + 1
 
     private fun processEndMessage(envelope: Envelope<SessionPartPayload>?, transitionType: TransitionType) {
         envelope?.let {
@@ -455,10 +467,7 @@ internal class SessionOrchestratorImpl(
                 terminateUserSession(current)
                 startNewUserSession(timestamp)
             } else {
-                val updatedMetadata = current.metadata.copy(
-                    partNumber = current.metadata.partNumber + 1,
-                    lastActivityMs = timestamp,
-                )
+                val updatedMetadata = current.metadata.copy(lastActivityMs = timestamp)
                 metadataStore.save(updatedMetadata)
                 userSessionState = UserSessionState.Active(updatedMetadata)
             }
@@ -488,7 +497,7 @@ internal class SessionOrchestratorImpl(
             userSessionNumber = ordinalStore.incrementAndGet(Ordinal.USER_SESSION).toLong(),
             maxDurationSecs = maxDurationMs / 1_000L,
             inactivityTimeoutSecs = inactivityTimeoutMs / 1_000L,
-            partNumber = 1,
+            partNumber = 0,
             lastActivityMs = startTimeMs,
         )
         metadataStore.save(newMetadata)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadMessageCollator.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadMessageCollator.kt
@@ -28,6 +28,7 @@ class FakePayloadMessageCollator(
             isColdStart = coldStart,
             appState = appState,
             startType = startType,
+            sessionPartNumber = partNumber,
         )
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/PayloadFactoryBaTest.kt
@@ -5,7 +5,6 @@ import io.embrace.android.embracesdk.fakes.FakeAppStateTracker
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
-import io.embrace.android.embracesdk.fakes.FakeOrdinalStore
 import io.embrace.android.embracesdk.fakes.FakeOtelPayloadMapper
 import io.embrace.android.embracesdk.fakes.FakeSessionPartTracker
 import io.embrace.android.embracesdk.fakes.FakeUserService
@@ -45,7 +44,6 @@ internal class PayloadFactoryBaTest {
     private lateinit var currentSessionPartSpan: CurrentSessionPartSpan
     private lateinit var spanService: SpanService
     private lateinit var blockingExecutorService: BlockingScheduledExecutorService
-    private lateinit var store: FakeOrdinalStore
 
     @Before
     fun init() {
@@ -65,7 +63,6 @@ internal class PayloadFactoryBaTest {
             )
         )
         blockingExecutorService = BlockingScheduledExecutorService(blockingMode = false)
-        store = FakeOrdinalStore()
     }
 
     @Test
@@ -125,11 +122,10 @@ internal class PayloadFactoryBaTest {
         val collator = PayloadMessageCollatorImpl(
             payloadSourceModule.sessionPartEnvelopeSource,
             currentSessionPartSpan,
-            store,
         )
         return PayloadFactoryImpl(collator, payloadSourceModule.logEnvelopeSource, configService, logger).apply {
             if (createInitialSession) {
-                startPayloadWithState(AppState.BACKGROUND, clock.now(), true)
+                startPayloadWithState(AppState.BACKGROUND, clock.now(), true, 1)
             }
         }
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/PayloadFactorySessionPartTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/PayloadFactorySessionPartTest.kt
@@ -5,7 +5,6 @@ import io.embrace.android.embracesdk.fakes.FakeAppStateTracker
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
-import io.embrace.android.embracesdk.fakes.FakeOrdinalStore
 import io.embrace.android.embracesdk.fakes.FakeSessionPartTracker
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
@@ -46,7 +45,6 @@ internal class PayloadFactorySessionPartTest {
     private lateinit var currentSessionPartSpan: CurrentSessionPartSpan
     private lateinit var spanService: SpanService
     private lateinit var blockingExecutorService: BlockingScheduledExecutorService
-    private lateinit var store: FakeOrdinalStore
 
     companion object {
 
@@ -80,7 +78,6 @@ internal class PayloadFactorySessionPartTest {
         currentSessionPartSpan = initModule.openTelemetryModule.currentSessionPartSpan
         spanService = initModule.openTelemetryModule.spanService
         blockingExecutorService = BlockingScheduledExecutorService(blockingMode = false)
-        store = FakeOrdinalStore()
     }
 
     @After
@@ -102,7 +99,6 @@ internal class PayloadFactorySessionPartTest {
         val collator = PayloadMessageCollatorImpl(
             payloadSourceModule.sessionPartEnvelopeSource,
             currentSessionPartSpan,
-            store,
         )
         service = PayloadFactoryImpl(collator, payloadSourceModule.logEnvelopeSource, FakeConfigService(), logger)
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionHandlerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionHandlerTest.kt
@@ -7,7 +7,6 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
-import io.embrace.android.embracesdk.fakes.FakeOrdinalStore
 import io.embrace.android.embracesdk.fakes.FakeOtelPayloadMapper
 import io.embrace.android.embracesdk.fakes.FakeSessionPartTracker
 import io.embrace.android.embracesdk.fakes.FakeUserService
@@ -60,7 +59,6 @@ internal class UserSessionHandlerTest {
     private lateinit var spanRepository: SpanRepository
     private lateinit var currentSessionPartSpan: CurrentSessionPartSpan
     private lateinit var userSessionPropertiesService: UserSessionPropertiesService
-    private lateinit var store: FakeOrdinalStore
 
     @Before
     fun before() {
@@ -79,7 +77,6 @@ internal class UserSessionHandlerTest {
         spanService = initModule.openTelemetryModule.spanService
         spanRepository = initModule.openTelemetryModule.spanRepository
         currentSessionPartSpan = initModule.openTelemetryModule.currentSessionPartSpan
-        store = FakeOrdinalStore()
         val partPayloadSource = SessionPartPayloadSourceImpl(
             null,
             spanSink,
@@ -100,7 +97,6 @@ internal class UserSessionHandlerTest {
                 payloadSource = partPayloadSource
             ),
             currentSessionPartSpan,
-            store,
         )
         payloadFactory = PayloadFactoryImpl(collator, payloadSourceModule.logEnvelopeSource, configService, logger)
     }
@@ -183,7 +179,8 @@ internal class UserSessionHandlerTest {
             payloadFactory.startPayloadWithState(
                 AppState.FOREGROUND,
                 NOW,
-                true
+                true,
+                1
             )
         )
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImplTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.internal.session.message
 
 import io.embrace.android.embracesdk.fakes.FakeConfigService
-import io.embrace.android.embracesdk.fakes.FakeOrdinalStore
 import io.embrace.android.embracesdk.fakes.FakeSessionPartPayloadSource
 import io.embrace.android.embracesdk.fakes.createBackgroundActivityBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
@@ -35,7 +34,6 @@ internal class PayloadFactoryImplTest {
         val collator = PayloadMessageCollatorImpl(
             sessionPartEnvelopeSource = payloadSourceModule.sessionPartEnvelopeSource,
             currentSessionPartSpan = initModule.openTelemetryModule.currentSessionPartSpan,
-            store = FakeOrdinalStore(),
         )
         factory = PayloadFactoryImpl(
             payloadMessageCollator = collator,
@@ -47,7 +45,7 @@ internal class PayloadFactoryImplTest {
 
     @Test
     fun `payload generated`() {
-        val session = checkNotNull(factory.startPayloadWithState(FOREGROUND, 0, false))
+        val session = checkNotNull(factory.startPayloadWithState(FOREGROUND, 0, false, 1))
         checkNotNull(factory.endPayloadWithState(FOREGROUND, 0, session))
     }
 
@@ -72,7 +70,7 @@ internal class PayloadFactoryImplTest {
     }
 
     private fun verifyPayloadWithState(state: AppState, zygoteCreated: Boolean, startNewSession: Boolean) {
-        val zygote = factory.startPayloadWithState(state, 0, false)
+        val zygote = factory.startPayloadWithState(state, 0, false, 1)
         if (zygoteCreated) {
             assertTrue(checkNotNull(zygote).sessionPartId.isNotBlank())
             assertNotNull(factory.endPayloadWithState(state, 0, zygote))
@@ -83,7 +81,7 @@ internal class PayloadFactoryImplTest {
     }
 
     private fun verifyPayloadWithManual() {
-        val zygote = factory.startSessionWithManual(0)
+        val zygote = factory.startSessionWithManual(0, 1)
         assertTrue(zygote.sessionPartId.isNotBlank())
         assertNotNull(factory.endSessionWithManual(0, zygote))
         assertEquals(true, partPayloadSource.lastStartNewSession)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImplTest.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.internal.session.message
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
-import io.embrace.android.embracesdk.fakes.FakeOrdinalStore
 import io.embrace.android.embracesdk.fakes.FakeSessionPartPayloadSource
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.arch.state.AppState
@@ -45,7 +44,6 @@ internal class PayloadMessageCollatorImplTest {
         collator = PayloadMessageCollatorImpl(
             sessionPartEnvelopeSource = sessionPartEnvelopeSource,
             currentSessionPartSpan = currentSessionPartSpan,
-            store = FakeOrdinalStore(),
         )
     }
 
@@ -56,7 +54,8 @@ internal class PayloadMessageCollatorImplTest {
                 false,
                 LifeEventType.BKGND_STATE,
                 5,
-                AppState.BACKGROUND
+                AppState.BACKGROUND,
+                1
             )
         )
         msg.verifyInitialFieldsPopulated()
@@ -69,7 +68,8 @@ internal class PayloadMessageCollatorImplTest {
                 false,
                 LifeEventType.STATE,
                 5,
-                AppState.FOREGROUND
+                AppState.FOREGROUND,
+                1
             )
         )
         msg.verifyInitialFieldsPopulated()
@@ -83,7 +83,8 @@ internal class PayloadMessageCollatorImplTest {
                 false,
                 LifeEventType.BKGND_STATE,
                 5,
-                AppState.BACKGROUND
+                AppState.BACKGROUND,
+                1
             )
         )
         startMsg.verifyInitialFieldsPopulated()
@@ -109,7 +110,8 @@ internal class PayloadMessageCollatorImplTest {
                 false,
                 LifeEventType.STATE,
                 5,
-                AppState.FOREGROUND
+                AppState.FOREGROUND,
+                1
             )
         )
         startMsg.verifyInitialFieldsPopulated()
@@ -138,7 +140,8 @@ internal class PayloadMessageCollatorImplTest {
                             coldStart = startupTemperature,
                             startType = lifeEventType,
                             startTime = 5L,
-                            appState = previousState
+                            appState = previousState,
+                            partNumber = 1
                         )
                     ).verifyInitialFieldsPopulated()
                 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -428,6 +428,9 @@ internal class SessionOrchestratorTest {
     @Test
     fun `user session max duration boundary`() {
         configService = FakeConfigService(
+            backgroundActivityBehavior = createBackgroundActivityBehavior(
+                remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 100f))
+            ),
             sessionBehavior = FakeUserSessionBehavior(
                 maxSessionDurationMs = maxDurationMs,
                 sessionInactivityTimeoutMs = inactivityMs,
@@ -486,6 +489,9 @@ internal class SessionOrchestratorTest {
     @Test
     fun `part number increments within user session`() {
         configService = FakeConfigService(
+            backgroundActivityBehavior = createBackgroundActivityBehavior(
+                remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 100f))
+            ),
             sessionBehavior = FakeUserSessionBehavior(
                 maxSessionDurationMs = maxDurationMs,
                 sessionInactivityTimeoutMs = inactivityMs,
@@ -856,6 +862,9 @@ internal class SessionOrchestratorTest {
     @Test
     fun `clock shifted backwards during new session part terminates and restarts user session`() {
         configService = FakeConfigService(
+            backgroundActivityBehavior = createBackgroundActivityBehavior(
+                remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 100f))
+            ),
             sessionBehavior = FakeUserSessionBehavior(
                 maxSessionDurationMs = maxDurationMs,
                 sessionInactivityTimeoutMs = inactivityMs,

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/store/OrdinalStoreImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/store/OrdinalStoreImplTest.kt
@@ -18,7 +18,7 @@ class OrdinalStoreImplTest {
 
     @Test
     fun `test ordinal numbers are saved`() {
-        Ordinal.entries.filter { it != Ordinal.USER_SESSION && it != Ordinal.USER_SESSION_PART }.forEach { ordinal ->
+        Ordinal.entries.filter { it != Ordinal.USER_SESSION }.forEach { ordinal ->
             repeat(4) { k ->
                 assertEquals(k + 1, store.incrementAndGet(ordinal))
             }

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/store/Ordinal.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/store/Ordinal.kt
@@ -36,11 +36,5 @@ enum class Ordinal(val key: String) {
      * Increments at the start of every user session. This allows us to check the % of user sessions
      * that didn't get delivered to the backend.
      */
-    USER_SESSION("io.embrace.usersessionnumber"),
-
-    /**
-     * Global monotonic counter for session parts. Replaces emb.session_number.
-     * Seeds from the SESSION counter on first use for consecutive numbering on upgrade.
-     */
-    USER_SESSION_PART("io.embrace.usersessionpartnumber")
+    USER_SESSION("io.embrace.usersessionnumber")
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionLifecycleTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionLifecycleTest.kt
@@ -1,0 +1,288 @@
+package io.embrace.android.embracesdk.testcases.session
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.assertions.findSessionSpan
+import io.embrace.android.embracesdk.assertions.getSessionId
+import io.embrace.android.embracesdk.assertions.getUserSessionId
+import io.embrace.android.embracesdk.internal.arch.state.AppState
+import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.UserSessionRemoteConfig
+import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_IS_FINAL_SESSION_PART
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_NUMBER
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_TERMINATION_REASON
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbUserSessionTerminationReasonValues.INACTIVITY
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbUserSessionTerminationReasonValues.MANUAL
+import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Asserts that the user session obeys rules about its lifecycle
+ */
+@RunWith(AndroidJUnit4::class)
+internal class UserSessionLifecycleTest {
+
+    @Rule
+    @JvmField
+    val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule()
+
+    @Test
+    fun `user session created only once the app enters the foreground`() {
+        testRule.runTest(
+            persistedRemoteConfig = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(100f)),
+            testCaseAction = { recordSession() },
+            assertAction = {
+                val bgSession = getSingleSessionEnvelope(AppState.BACKGROUND)
+                val fgSession = getSingleSessionEnvelope(AppState.FOREGROUND)
+                assertEquals(bgSession.getUserSessionId(), fgSession.getUserSessionId())
+
+                val fgSessionSpan = fgSession.findSessionSpan()
+                assertEquals("1", fgSessionSpan.attributes?.findAttributeValue(EMB_USER_SESSION_NUMBER))
+                assertNull(fgSessionSpan.attributes?.findAttributeValue(EMB_IS_FINAL_SESSION_PART))
+                assertNull(fgSessionSpan.attributes?.findAttributeValue(EMB_USER_SESSION_TERMINATION_REASON))
+            }
+        )
+    }
+
+    @Test
+    fun `new user session can be manually created`() {
+        testRule.runTest(
+            testCaseAction = {
+                recordSession {
+                    clock.tick(10_000)
+                    embrace.endUserSession()
+                }
+            },
+            assertAction = {
+                val sessions = getSessionEnvelopes(2)
+                val firstSessionSpan = sessions[0].findSessionSpan()
+                val secondSessionSpan = sessions[1].findSessionSpan()
+
+                assertNotEquals(sessions[0].getUserSessionId(), sessions[1].getUserSessionId())
+                assertEquals("1", firstSessionSpan.attributes?.findAttributeValue(EMB_IS_FINAL_SESSION_PART))
+                assertEquals(MANUAL, firstSessionSpan.attributes?.findAttributeValue(EMB_USER_SESSION_TERMINATION_REASON))
+                assertNull(secondSessionSpan.attributes?.findAttributeValue(EMB_IS_FINAL_SESSION_PART))
+                assertNull(secondSessionSpan.attributes?.findAttributeValue(EMB_USER_SESSION_TERMINATION_REASON))
+            }
+        )
+    }
+
+    @Test
+    fun `new user session can be created via inactivity timeout with background activity disabled`() {
+        testRule.runTest(
+            persistedRemoteConfig = RemoteConfig(
+                userSession = UserSessionRemoteConfig(inactivityTimeoutSeconds = 30)
+            ),
+            testCaseAction = {
+                val inactivityMs = 30L * 1_000L
+                recordSession()
+                clock.tick(inactivityMs + 1_000L)
+                recordSession()
+            },
+            assertAction = {
+                val sessions = getSessionEnvelopes(2)
+                val firstSessionSpan = sessions[0].findSessionSpan()
+                val secondSessionSpan = sessions[1].findSessionSpan()
+
+                assertNotEquals(sessions[0].getUserSessionId(), sessions[1].getUserSessionId())
+
+                // session orchestrator cannot be sure of final session reason, so does not set it
+                assertNull(firstSessionSpan.attributes?.findAttributeValue(EMB_IS_FINAL_SESSION_PART))
+                assertNull(firstSessionSpan.attributes?.findAttributeValue(EMB_USER_SESSION_TERMINATION_REASON))
+                assertNull(secondSessionSpan.attributes?.findAttributeValue(EMB_IS_FINAL_SESSION_PART))
+                assertNull(secondSessionSpan.attributes?.findAttributeValue(EMB_USER_SESSION_TERMINATION_REASON))
+            }
+        )
+    }
+
+    @Test
+    fun `new user session can be created via inactivity timeout with background activity enabled`() {
+        testRule.runTest(
+            persistedRemoteConfig = RemoteConfig(
+                backgroundActivityConfig = BackgroundActivityRemoteConfig(100f),
+                userSession = UserSessionRemoteConfig(inactivityTimeoutSeconds = 30),
+            ),
+            testCaseAction = {
+                val inactivityMs = 30L * 1_000L
+                recordSession()
+                clock.tick(inactivityMs + 1_000L)
+                recordSession()
+            },
+            assertAction = {
+                val fgSessions = getSessionEnvelopes(2, AppState.FOREGROUND)
+                val bgSessions = getSessionEnvelopes(2, AppState.BACKGROUND)
+
+                assertNotEquals(fgSessions[0].getUserSessionId(), fgSessions[1].getUserSessionId())
+                assertEquals("1", bgSessions[1].findSessionSpan().attributes?.findAttributeValue(EMB_IS_FINAL_SESSION_PART))
+                assertEquals(INACTIVITY, bgSessions[1].findSessionSpan().attributes?.findAttributeValue(EMB_USER_SESSION_TERMINATION_REASON))
+                assertNull(bgSessions[0].findSessionSpan().attributes?.findAttributeValue(EMB_IS_FINAL_SESSION_PART))
+                assertNull(fgSessions[0].findSessionSpan().attributes?.findAttributeValue(EMB_IS_FINAL_SESSION_PART))
+                assertNull(fgSessions[0].findSessionSpan().attributes?.findAttributeValue(EMB_USER_SESSION_TERMINATION_REASON))
+                assertNull(fgSessions[1].findSessionSpan().attributes?.findAttributeValue(EMB_IS_FINAL_SESSION_PART))
+                assertNull(fgSessions[1].findSessionSpan().attributes?.findAttributeValue(EMB_USER_SESSION_TERMINATION_REASON))
+            }
+        )
+    }
+
+    @Test
+    fun `user session recovers from inactivity timeout with background activity disabled`() {
+        testRule.runTest(
+            persistedRemoteConfig = RemoteConfig(
+                userSession = UserSessionRemoteConfig(inactivityTimeoutSeconds = 30)
+            ),
+            testCaseAction = {
+                val inactivityMs = 30L * 1_000L
+                recordSession()
+                clock.tick(inactivityMs - 1_000L)
+                recordSession()
+            },
+            assertAction = {
+                val sessions = getSessionEnvelopes(2)
+                val firstSessionSpan = sessions[0].findSessionSpan()
+                val secondSessionSpan = sessions[1].findSessionSpan()
+
+                assertEquals(sessions[0].getUserSessionId(), sessions[1].getUserSessionId())
+                assertNull(firstSessionSpan.attributes?.findAttributeValue(EMB_IS_FINAL_SESSION_PART))
+                assertNull(firstSessionSpan.attributes?.findAttributeValue(EMB_USER_SESSION_TERMINATION_REASON))
+                assertNull(secondSessionSpan.attributes?.findAttributeValue(EMB_IS_FINAL_SESSION_PART))
+                assertNull(secondSessionSpan.attributes?.findAttributeValue(EMB_USER_SESSION_TERMINATION_REASON))
+            }
+        )
+    }
+
+    @Test
+    fun `user session recovers from inactivity timeout with background activity enabled`() {
+        testRule.runTest(
+            persistedRemoteConfig = RemoteConfig(
+                backgroundActivityConfig = BackgroundActivityRemoteConfig(100f),
+                userSession = UserSessionRemoteConfig(inactivityTimeoutSeconds = 30),
+            ),
+            testCaseAction = {
+                val inactivityMs = 30L * 1_000L
+                recordSession()
+                clock.tick(inactivityMs - 1_000L)
+                recordSession()
+            },
+            assertAction = {
+                val sessions = getSessionEnvelopes(2, AppState.FOREGROUND)
+                val firstSessionSpan = sessions[0].findSessionSpan()
+                val secondSessionSpan = sessions[1].findSessionSpan()
+
+                assertEquals(sessions[0].getUserSessionId(), sessions[1].getUserSessionId())
+                assertNull(firstSessionSpan.attributes?.findAttributeValue(EMB_IS_FINAL_SESSION_PART))
+                assertNull(firstSessionSpan.attributes?.findAttributeValue(EMB_USER_SESSION_TERMINATION_REASON))
+                assertNull(secondSessionSpan.attributes?.findAttributeValue(EMB_IS_FINAL_SESSION_PART))
+                assertNull(secondSessionSpan.attributes?.findAttributeValue(EMB_USER_SESSION_TERMINATION_REASON))
+            }
+        )
+    }
+
+    @Test
+    fun `load persisted user session in foreground state`() {
+        val persistedId = "aabbccdd11223344aabbccdd11223344"
+        val startMs = SdkIntegrationTestRule.DEFAULT_SDK_START_TIME_MS - 1_000L
+        val lastActivityMs = SdkIntegrationTestRule.DEFAULT_SDK_START_TIME_MS - 100L
+        testRule.runTest(
+            setupAction = {
+                persistUserSession(sessionId = persistedId, startMs = startMs, lastActivityMs = lastActivityMs)
+            },
+            testCaseAction = { recordSession() },
+            assertAction = {
+                val session = getSingleSessionEnvelope()
+                val sessionSpan = session.findSessionSpan()
+                assertEquals(persistedId, session.getUserSessionId())
+                assertEquals(persistedId, session.getSessionId())
+                assertNull(sessionSpan.attributes?.findAttributeValue(EMB_IS_FINAL_SESSION_PART))
+                assertNull(sessionSpan.attributes?.findAttributeValue(EMB_USER_SESSION_TERMINATION_REASON))
+            }
+        )
+    }
+
+    @Test
+    fun `load persisted user session in inactivity timeout state`() {
+        val persistedId = "aabbccdd11223344aabbccdd11223344"
+        val startMs = SdkIntegrationTestRule.DEFAULT_SDK_START_TIME_MS - 3_000_000L
+        // lastActivityMs more than inactivity timeout before clock.now(), so the session is inactive
+        val defaultInactivityMs = 1800L * 1_000L
+        val lastActivityMs = SdkIntegrationTestRule.DEFAULT_SDK_START_TIME_MS - defaultInactivityMs - 1L
+        testRule.runTest(
+            setupAction = {
+                persistUserSession(sessionId = persistedId, startMs = startMs, lastActivityMs = lastActivityMs)
+            },
+            testCaseAction = { recordSession() },
+            assertAction = {
+                val session = getSingleSessionEnvelope()
+                val sessionSpan = session.findSessionSpan()
+                assertNotEquals(persistedId, session.getUserSessionId())
+                assertNotEquals(persistedId, session.getSessionId())
+                assertNull(sessionSpan.attributes?.findAttributeValue(EMB_IS_FINAL_SESSION_PART))
+                assertNull(sessionSpan.attributes?.findAttributeValue(EMB_USER_SESSION_TERMINATION_REASON))
+            }
+        )
+    }
+
+    @Test
+    fun `load persisted user session that exceeds max duration`() {
+        val persistedId = "aabbccdd11223344aabbccdd11223344"
+        // startMs more than max duration before clock.now(), so the session exceeds max duration
+        val defaultMaxDurationMs = 43200L * 1_000L
+        val startMs = SdkIntegrationTestRule.DEFAULT_SDK_START_TIME_MS - defaultMaxDurationMs - 1L
+        // lastActivityMs is recent so inactivity check does not fire first
+        val lastActivityMs = SdkIntegrationTestRule.DEFAULT_SDK_START_TIME_MS - 1_000L
+        testRule.runTest(
+            setupAction = {
+                persistUserSession(sessionId = persistedId, startMs = startMs, lastActivityMs = lastActivityMs)
+            },
+            testCaseAction = { recordSession() },
+            assertAction = {
+                val session = getSingleSessionEnvelope()
+                val sessionSpan = session.findSessionSpan()
+                assertNotEquals(persistedId, session.getUserSessionId())
+                assertNotEquals(persistedId, session.getSessionId())
+                assertNull(sessionSpan.attributes?.findAttributeValue(EMB_IS_FINAL_SESSION_PART))
+                assertNull(sessionSpan.attributes?.findAttributeValue(EMB_USER_SESSION_TERMINATION_REASON))
+            }
+        )
+    }
+
+    @Test
+    fun `new user session can be created via max duration`() {
+        val cfg = UserSessionRemoteConfig(
+            maxDurationSeconds = 3600,
+            inactivityTimeoutSeconds = 3600,
+        )
+        testRule.runTest(
+            persistedRemoteConfig = RemoteConfig(
+                backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 100.0f),
+                userSession = cfg
+            ),
+            testCaseAction = {
+                recordSession()
+                val seconds = checkNotNull(cfg.maxDurationSeconds) * 5
+                clock.tick(seconds * 1000L)
+                recordSession()
+            },
+            assertAction = {
+                val sessions = getSessionEnvelopes(2)
+                val bgActivities = getSessionEnvelopes(2, state = AppState.BACKGROUND)
+                val firstBg = bgActivities[0].findSessionSpan()
+                val secondBg = bgActivities[1].findSessionSpan()
+                val firstSession = sessions[0].findSessionSpan()
+                val secondSession = sessions[1].findSessionSpan()
+
+                assertNotEquals(sessions[0].getUserSessionId(), sessions[1].getUserSessionId())
+                assertEquals("1", firstBg.attributes?.findAttributeValue(EMB_USER_SESSION_NUMBER))
+                assertEquals("1", firstSession.attributes?.findAttributeValue(EMB_USER_SESSION_NUMBER))
+                assertEquals("1", secondBg.attributes?.findAttributeValue(EMB_USER_SESSION_NUMBER))
+                assertEquals("2", secondSession.attributes?.findAttributeValue(EMB_USER_SESSION_NUMBER))
+            }
+        )
+    }
+
+}

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionLifecycleTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionLifecycleTest.kt
@@ -120,7 +120,10 @@ internal class UserSessionLifecycleTest {
 
                 assertNotEquals(fgSessions[0].getUserSessionId(), fgSessions[1].getUserSessionId())
                 assertEquals("1", bgSessions[1].findSessionSpan().attributes?.findAttributeValue(EMB_IS_FINAL_SESSION_PART))
-                assertEquals(INACTIVITY, bgSessions[1].findSessionSpan().attributes?.findAttributeValue(EMB_USER_SESSION_TERMINATION_REASON))
+                assertEquals(
+                    INACTIVITY,
+                    bgSessions[1].findSessionSpan().attributes?.findAttributeValue(EMB_USER_SESSION_TERMINATION_REASON)
+                )
                 assertNull(bgSessions[0].findSessionSpan().attributes?.findAttributeValue(EMB_IS_FINAL_SESSION_PART))
                 assertNull(fgSessions[0].findSessionSpan().attributes?.findAttributeValue(EMB_IS_FINAL_SESSION_PART))
                 assertNull(fgSessions[0].findSessionSpan().attributes?.findAttributeValue(EMB_USER_SESSION_TERMINATION_REASON))
@@ -284,5 +287,4 @@ internal class UserSessionLifecycleTest {
             }
         )
     }
-
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionPartNumberTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionPartNumberTest.kt
@@ -1,0 +1,92 @@
+package io.embrace.android.embracesdk.testcases.session
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.assertions.findSessionSpan
+import io.embrace.android.embracesdk.assertions.getUserSessionId
+import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_NUMBER
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_PART_NUMBER
+import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class UserSessionPartNumberTest {
+
+    @Rule
+    @JvmField
+    val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule()
+
+    @Test
+    fun `user session sequence numbers`() {
+        testRule.runTest(
+            testCaseAction = {
+                recordSession()
+                recordSession {
+                    clock.tick(10_000)
+                    embrace.endUserSession()
+                }
+                recordSession()
+            },
+            assertAction = {
+                val sessions = getSessionEnvelopes(4)
+                val us1p1 = sessions[0].findSessionSpan().attributes
+                val us1p2 = sessions[1].findSessionSpan().attributes
+                val us2p1 = sessions[2].findSessionSpan().attributes
+                val us2p2 = sessions[3].findSessionSpan().attributes
+
+                assertEquals("1", us1p1?.findAttributeValue(EMB_USER_SESSION_NUMBER))
+                assertEquals("1", us1p1?.findAttributeValue(EMB_USER_SESSION_PART_NUMBER))
+
+                assertEquals("1", us1p2?.findAttributeValue(EMB_USER_SESSION_NUMBER))
+                assertEquals("2", us1p2?.findAttributeValue(EMB_USER_SESSION_PART_NUMBER))
+
+                assertEquals("2", us2p1?.findAttributeValue(EMB_USER_SESSION_NUMBER))
+                assertEquals("1", us2p1?.findAttributeValue(EMB_USER_SESSION_PART_NUMBER))
+
+                assertEquals("2", us2p2?.findAttributeValue(EMB_USER_SESSION_NUMBER))
+                assertEquals("2", us2p2?.findAttributeValue(EMB_USER_SESSION_PART_NUMBER))
+            },
+        )
+    }
+
+    @Test
+    fun `load existing user session results in using existing session part number`() {
+        val persistedId = "aabbccdd11223344aabbccdd11223344"
+        val startMs = SdkIntegrationTestRule.DEFAULT_SDK_START_TIME_MS - 1_000L
+        val lastActivityMs = SdkIntegrationTestRule.DEFAULT_SDK_START_TIME_MS - 100L
+        testRule.runTest(
+            setupAction = {
+                persistUserSession(sessionId = persistedId, startMs = startMs, lastActivityMs = lastActivityMs, partNumber = 2)
+            },
+            testCaseAction = { recordSession() },
+            assertAction = {
+                val session = getSingleSessionEnvelope()
+                assertEquals(persistedId, session.getUserSessionId())
+                assertEquals("3", session.findSessionSpan().attributes?.findAttributeValue(EMB_USER_SESSION_PART_NUMBER))
+            }
+        )
+    }
+
+    @Test
+    fun `load expired user session results in resetting session part number`() {
+        val persistedId = "aabbccdd11223344aabbccdd11223344"
+        val startMs = SdkIntegrationTestRule.DEFAULT_SDK_START_TIME_MS - 3_000_000L
+        val defaultInactivityMs = 1800L * 1_000L
+        val lastActivityMs = SdkIntegrationTestRule.DEFAULT_SDK_START_TIME_MS - defaultInactivityMs - 1L
+        testRule.runTest(
+            setupAction = {
+                persistUserSession(sessionId = persistedId, startMs = startMs, lastActivityMs = lastActivityMs, partNumber = 5)
+            },
+            testCaseAction = { recordSession() },
+            assertAction = {
+                val session = getSingleSessionEnvelope()
+                assertNotEquals(persistedId, session.getUserSessionId())
+                assertEquals("1", session.findSessionSpan().attributes?.findAttributeValue(EMB_USER_SESSION_PART_NUMBER))
+            }
+        )
+    }
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadFactory.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadFactory.kt
@@ -24,6 +24,7 @@ class FakePayloadFactory : PayloadFactory {
         state: AppState,
         timestamp: Long,
         coldStart: Boolean,
+        partNumber: Int,
     ): SessionPartToken {
         return when (state) {
             AppState.FOREGROUND -> startSessionWithState(timestamp)
@@ -93,7 +94,7 @@ class FakePayloadFactory : PayloadFactory {
         return checkNotNull(activeSession)
     }
 
-    override fun startSessionWithManual(timestamp: Long): SessionPartToken {
+    override fun startSessionWithManual(timestamp: Long, partNumber: Int): SessionPartToken {
         manualSessionStartCount++
         activeSession = fakeSessionPartToken()
         return checkNotNull(activeSession)


### PR DESCRIPTION
## Goal

Adds integration tests that check the sequence of the session part number is correct between user sessions, and corrects the existing implementation that made it a continuously incrementing number.
