### PR TITLE
Allow apiTokens that are longer than 32 chars

### DIFF
--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/variant/VariantConfigurationValidator.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/variant/VariantConfigurationValidator.kt
@@ -2,7 +2,7 @@ package io.embrace.android.gradle.plugin.config.variant
 
 import io.embrace.android.gradle.plugin.instrumentation.config.model.EmbraceVariantConfig
 
-private const val API_TOKEN_LENGTH = 32
+private const val API_TOKEN_MIN_LENGTH = 32
 private const val APP_ID_LENGTH = 5
 
 /**
@@ -36,8 +36,8 @@ internal object VariantConfigurationValidator {
      */
     private fun validateApiToken(configuration: EmbraceVariantConfig) {
         if (!configuration.apiToken.isNullOrEmpty()) {
-            require(configuration.apiToken.length == API_TOKEN_LENGTH) {
-                "api_token must contain exactly $API_TOKEN_LENGTH characters."
+            require(configuration.apiToken.length >= API_TOKEN_MIN_LENGTH) {
+                "api_token must contain at least $API_TOKEN_MIN_LENGTH characters."
             }
         }
     }

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/config/variant/VariantConfigValidatorTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/config/variant/VariantConfigValidatorTest.kt
@@ -20,9 +20,15 @@ class VariantConfigValidatorTest {
     }
 
     @Test
-    fun `fail if apiToken length is not valid`() {
+    fun `fail if apiToken length is too short`() {
         val configuration = getVariantConfiguration(appId = "abcde", apiToken = "asdf")
-        assertValidationFailure(configuration, "api_token must contain exactly")
+        assertValidationFailure(configuration, "api_token must contain at least 32 characters.")
+    }
+
+    @Test
+    fun `apiTokens longer than 32 characters is fine`() {
+        val configuration = getVariantConfiguration(appId = "abcde", apiToken = "a".repeat(50))
+        VariantConfigurationValidator.validate(configuration)
     }
 
     private fun getVariantConfiguration(


### PR DESCRIPTION
New versions of the apiToken can be longer than 32 characters. Change teh validation to account for that.