### PR TITLE
Always record activity load as a new navigation state

### DIFF
--- a/embrace-android-instrumentation-navigation/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/ActivityNavigationTracker.kt
+++ b/embrace-android-instrumentation-navigation/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/ActivityNavigationTracker.kt
@@ -73,12 +73,14 @@ internal class ActivityNavigationTracker(
     override fun onForeground() {}
 
     private fun handleActivityStarted(activity: Activity) {
-        navigationTrackingService.trackNavigation(activity)
         onEvent(ActivityStarted(activity, clock.now()))
     }
 
     private fun handleActivityResumed(activity: Activity) {
         onEvent(ActivityResumed(activity, clock.now()))
+
+        // Add NavController tracking after the resume event is fired to mimic how the rememberNavController Composable will do it.
+        navigationTrackingService.trackNavigation(activity)
     }
 
     private fun handleActivityPaused(activity: Activity) {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NavigationComplexDestinationAndRouteTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NavigationComplexDestinationAndRouteTest.kt
@@ -13,6 +13,7 @@ import io.embrace.android.embracesdk.fakes.SerializableRouteNavHostFragmentActiv
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.AppExecutionTimestamps
+import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface.Companion.LIFECYCLE_EVENT_GAP
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface.Companion.POST_ACTIVITY_ACTION_DWELL
 import org.junit.Rule
 import org.junit.Test
@@ -33,11 +34,13 @@ internal class NavigationComplexDestinationAndRouteTest {
     @Test
     fun `routes with argument templates use the template not the resolved value`() {
         var timestamps: AppExecutionTimestamps? = null
+        val activityController = Robolectric.buildActivity(ArgTemplateNavHostFragmentActivity::class.java)
         testRule.runTest(
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
-                timestamps = simulateNavHostFragmentActivityNavigation<ArgTemplateNavHostFragmentActivity>(
-                    routes = listOf("profile/123", "order/456/details")
+                timestamps = simulateNavHostFragmentActivityNavigation(
+                    routes = listOf("profile/123", "order/456/details"),
+                    activityController = activityController,
                 )
             },
             assertAction = {
@@ -47,11 +50,17 @@ internal class NavigationComplexDestinationAndRouteTest {
                 stateSpan.assertNavigationStateSpan(
                     transitionTimesMs = listOf(
                         timestamps.firstForegroundTimeMs,
+                        timestamps.firstForegroundTimeMs + LIFECYCLE_EVENT_GAP,
                         timestamps.firstActionTimeMs + POST_ACTIVITY_ACTION_DWELL,
                         timestamps.firstActionTimeMs + POST_ACTIVITY_ACTION_DWELL * 2,
                         timestamps.lastBackgroundTimeMs,
                     ),
-                    newStateValues = listOf("home", "profile/{userId}", "order/{orderId}/details"),
+                    newStateValues = listOf(
+                        activityController.get().localClassName,
+                        "home",
+                        "profile/{userId}",
+                        "order/{orderId}/details",
+                    ),
                 )
             },
         )
@@ -60,11 +69,13 @@ internal class NavigationComplexDestinationAndRouteTest {
     @Test
     fun `dialog destinations tracked like fragment destinations`() {
         var timestamps: AppExecutionTimestamps? = null
+        val activityController = Robolectric.buildActivity(DialogNavHostFragmentActivity::class.java)
         testRule.runTest(
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
-                timestamps = simulateNavHostFragmentActivityNavigation<DialogNavHostFragmentActivity>(
-                    routes = listOf("confirm_dialog")
+                timestamps = simulateNavHostFragmentActivityNavigation(
+                    routes = listOf("confirm_dialog"),
+                    activityController = activityController,
                 )
             },
             assertAction = {
@@ -73,10 +84,11 @@ internal class NavigationComplexDestinationAndRouteTest {
                 stateSpan.assertNavigationStateSpan(
                     transitionTimesMs = listOf(
                         timestamps.firstForegroundTimeMs,
+                        timestamps.firstForegroundTimeMs + LIFECYCLE_EVENT_GAP,
                         timestamps.firstActionTimeMs + POST_ACTIVITY_ACTION_DWELL,
                         timestamps.lastBackgroundTimeMs,
                     ),
-                    newStateValues = listOf("home", "confirm_dialog"),
+                    newStateValues = listOf(activityController.get().localClassName, "home", "confirm_dialog"),
                 )
             },
         )
@@ -85,11 +97,13 @@ internal class NavigationComplexDestinationAndRouteTest {
     @Test
     fun `nested graph destinations use inner destination route`() {
         var timestamps: AppExecutionTimestamps? = null
+        val activityController = Robolectric.buildActivity(NestedGraphNavHostFragmentActivity::class.java)
         testRule.runTest(
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
-                timestamps = simulateNavHostFragmentActivityNavigation<NestedGraphNavHostFragmentActivity>(
-                    routes = listOf("general")
+                timestamps = simulateNavHostFragmentActivityNavigation(
+                    routes = listOf("general"),
+                    activityController = activityController,
                 )
             },
             assertAction = {
@@ -99,10 +113,11 @@ internal class NavigationComplexDestinationAndRouteTest {
                 stateSpan.assertNavigationStateSpan(
                     transitionTimesMs = listOf(
                         timestamps.firstForegroundTimeMs,
+                        timestamps.firstForegroundTimeMs + LIFECYCLE_EVENT_GAP,
                         timestamps.firstActionTimeMs + POST_ACTIVITY_ACTION_DWELL,
                         timestamps.lastBackgroundTimeMs,
                     ),
-                    newStateValues = listOf("home", "general"),
+                    newStateValues = listOf(activityController.get().localClassName, "home", "general"),
                 )
             },
         )
@@ -111,10 +126,10 @@ internal class NavigationComplexDestinationAndRouteTest {
     @Test
     fun `back navigation triggers destination change`() {
         var timestamps: AppExecutionTimestamps? = null
+        val activityController = Robolectric.buildActivity(BasicNavHostFragmentActivity::class.java)
         testRule.runTest(
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
-                val activityController = Robolectric.buildActivity(BasicNavHostFragmentActivity::class.java)
                 timestamps = simulateOpeningActivities(
                     addStartupActivity = false,
                     startInBackground = true,
@@ -139,6 +154,7 @@ internal class NavigationComplexDestinationAndRouteTest {
                 stateSpan.assertNavigationStateSpan(
                     transitionTimesMs = listOf(
                         timestamps.firstForegroundTimeMs,
+                        timestamps.firstForegroundTimeMs + LIFECYCLE_EVENT_GAP,
                         timestamps.firstActionTimeMs + POST_ACTIVITY_ACTION_DWELL,
                         timestamps.firstActionTimeMs + POST_ACTIVITY_ACTION_DWELL * 2,
                         timestamps.firstActionTimeMs + POST_ACTIVITY_ACTION_DWELL * 3,
@@ -146,7 +162,14 @@ internal class NavigationComplexDestinationAndRouteTest {
                         timestamps.lastBackgroundTimeMs,
                     ),
                     // state should update to the previous destination when the nav stack is popped
-                    newStateValues = listOf("home", "about", "contacts", "about", "home"),
+                    newStateValues = listOf(
+                        activityController.get().localClassName,
+                        "home",
+                        "about",
+                        "contacts",
+                        "about",
+                        "home",
+                    ),
                 )
             },
         )
@@ -155,10 +178,10 @@ internal class NavigationComplexDestinationAndRouteTest {
     @Test
     fun `Serializable routes with SerialName use the serial name template not resolved args`() {
         var timestamps: AppExecutionTimestamps? = null
+        val activityController = Robolectric.buildActivity(SerializableRouteNavHostFragmentActivity::class.java)
         testRule.runTest(
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
-                val activityController = Robolectric.buildActivity(SerializableRouteNavHostFragmentActivity::class.java)
                 timestamps = simulateOpeningActivities(
                     addStartupActivity = false,
                     startInBackground = true,
@@ -178,10 +201,11 @@ internal class NavigationComplexDestinationAndRouteTest {
                 stateSpan.assertNavigationStateSpan(
                     transitionTimesMs = listOf(
                         timestamps.firstForegroundTimeMs,
+                        timestamps.firstForegroundTimeMs + LIFECYCLE_EVENT_GAP,
                         timestamps.firstActionTimeMs + POST_ACTIVITY_ACTION_DWELL,
                         timestamps.lastBackgroundTimeMs,
                     ),
-                    newStateValues = listOf("home", "profile/{userId}"),
+                    newStateValues = listOf(activityController.get().localClassName, "home", "profile/{userId}"),
                 )
             },
         )
@@ -190,10 +214,10 @@ internal class NavigationComplexDestinationAndRouteTest {
     @Test
     fun `Serializable routes without SerialName use fully qualified class name with template not resolved as state value`() {
         var timestamps: AppExecutionTimestamps? = null
+        val activityController = Robolectric.buildActivity(FqcnRouteActivityNavHost::class.java)
         testRule.runTest(
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
-                val activityController = Robolectric.buildActivity(FqcnRouteActivityNavHost::class.java)
                 timestamps = simulateOpeningActivities(
                     addStartupActivity = false,
                     startInBackground = true,
@@ -215,10 +239,11 @@ internal class NavigationComplexDestinationAndRouteTest {
                 stateSpan.assertNavigationStateSpan(
                     transitionTimesMs = listOf(
                         timestamps.firstForegroundTimeMs,
+                        timestamps.firstForegroundTimeMs + LIFECYCLE_EVENT_GAP,
                         timestamps.firstActionTimeMs + POST_ACTIVITY_ACTION_DWELL,
                         timestamps.lastBackgroundTimeMs,
                     ),
-                    newStateValues = listOf(fqcnHome, fqcnDetail),
+                    newStateValues = listOf(activityController.get().localClassName, fqcnHome, fqcnDetail),
                 )
             },
         )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NavigationStateFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NavigationStateFeatureTest.kt
@@ -179,26 +179,31 @@ internal class NavigationStateFeatureTest {
     fun `FragmentActivity navigation recorded as state span`() {
         val navRoutes = listOf("contacts", "about", "home")
         var timestamps: AppExecutionTimestamps? = null
+        val activityController = Robolectric.buildActivity(BasicNavHostFragmentActivity::class.java)
 
         testRule.runTest(
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
-                timestamps = simulateNavHostFragmentActivityNavigation<BasicNavHostFragmentActivity>(routes = navRoutes)
+                timestamps = simulateNavHostFragmentActivityNavigation(
+                    routes = navRoutes,
+                    activityController = activityController,
+                )
             },
             assertAction = {
                 val stateSpan = checkNotNull(getSingleSessionEnvelope().getNavigationStateSpan())
                 checkNotNull(timestamps)
                 val eventTimes = mutableListOf(
                     timestamps.firstForegroundTimeMs,
+                    timestamps.firstForegroundTimeMs + LIFECYCLE_EVENT_GAP,
                     timestamps.firstActionTimeMs + POST_ACTIVITY_ACTION_DWELL,
                     timestamps.firstActionTimeMs + POST_ACTIVITY_ACTION_DWELL * 2,
                     timestamps.firstActionTimeMs + POST_ACTIVITY_ACTION_DWELL * 3,
                     timestamps.lastBackgroundTimeMs,
                 )
-                val expectedRoutes = listOf("home") + navRoutes + listOf("Backgrounded")
+                val expectedStateValues = listOf(activityController.get().localClassName, "home") + navRoutes + listOf("Backgrounded")
                 stateSpan.assertNavigationStateSpan(
                     transitionTimesMs = eventTimes,
-                    newStateValues = expectedRoutes
+                    newStateValues = expectedStateValues
                 )
             },
         )
@@ -261,11 +266,13 @@ internal class NavigationStateFeatureTest {
                     transitionTimesMs = listOf(
                         timestamps.firstForegroundTimeMs,
                         navigationTime - POST_ACTIVITY_ACTION_DWELL - 2 * LIFECYCLE_EVENT_GAP,
+                        navigationTime - POST_ACTIVITY_ACTION_DWELL - LIFECYCLE_EVENT_GAP,
                         navigationTime,
                         timestamps.lastBackgroundTimeMs
                     ),
                     newStateValues = listOf(
                         startupActivity.get().localClassName,
+                        navActivity.get().localClassName,
                         "home",
                         "about",
                         "Backgrounded"
@@ -279,7 +286,7 @@ internal class NavigationStateFeatureTest {
     fun `navigation of NavController tracked using public observeNavigation API creates state span`() {
         var timestamps: AppExecutionTimestamps? = null
         val activityController = Robolectric.buildActivity(TestNavControllerActivity::class.java)
-        val expectedStateValues = listOf("home", "contacts", "about", "Backgrounded")
+        val expectedStateValues = listOf(activityController.get().localClassName, "home", "contacts", "about", "Backgrounded")
         testRule.runTest(
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
@@ -293,6 +300,7 @@ internal class NavigationStateFeatureTest {
                 checkNotNull(timestamps)
                 val expectedTransitionTimes = listOf(
                     timestamps.firstForegroundTimeMs,
+                    timestamps.firstForegroundTimeMs + LIFECYCLE_EVENT_GAP,
                     timestamps.firstForegroundTimeMs + POST_ACTIVITY_ACTION_DWELL + LIFECYCLE_EVENT_GAP * 2,
                     timestamps.firstForegroundTimeMs + POST_ACTIVITY_ACTION_DWELL * 2 + LIFECYCLE_EVENT_GAP * 2,
                     timestamps.lastBackgroundTimeMs,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
@@ -143,7 +143,7 @@ internal class EmbraceActionInterface(
         endInBackground: Boolean = true,
         createFirstActivity: Boolean = true,
         invokeManualEnd: Boolean = false,
-        postOnStart: (Activity) -> Unit = {},
+        postOnResume: (Activity) -> Unit = {},
         activitiesAndActions: List<Pair<ActivityController<*>, () -> Unit>> = listOf(
             Robolectric.buildActivity(Activity::class.java) to {},
         ),
@@ -182,9 +182,9 @@ internal class EmbraceActionInterface(
                 onForeground()
             }
             invokeWithMainLooperUnblock(activityController::start)
-            invokeWithMainLooperUnblock { postOnStart(activityController.get()) }
             setup.getClock().tick(LIFECYCLE_EVENT_GAP)
             invokeWithMainLooperUnblock(activityController::resume)
+            invokeWithMainLooperUnblock { postOnResume(activityController.get()) }
             setup.getClock().tick(LIFECYCLE_EVENT_GAP)
 
             if (invokeManualEnd) {
@@ -237,8 +237,8 @@ internal class EmbraceActionInterface(
 
     /**
      * Simulates opening the given [Activity] and navigating through the given destinations using the NavController provided
-     * by the [HasNavController] interface. The public API for tracking NavControllers will be called after
-     * onStart to register the given NavControlle for navigation tracking.
+     * by the [HasNavController] interface. The public API for tracking NavControllers will be called after onResume
+     * to register the given NavController for navigation tracking.
      */
     inline fun <reified T> simulateNavControllerTrackingAndNavigation(
         routes: List<String>,
@@ -264,12 +264,12 @@ internal class EmbraceActionInterface(
     private inline fun <reified T> simulateNavControllerNavigation(
         routes: List<String>,
         activityController: ActivityController<T>,
-        crossinline postStart: (Activity) -> Unit = {},
+        crossinline postResume: (Activity) -> Unit = {},
     ): AppExecutionTimestamps where T : Activity, T : HasNavController =
         simulateOpeningActivities(
             addStartupActivity = false,
             startInBackground = true,
-            postOnStart = { activity -> postStart(activity) },
+            postOnResume = { activity -> postResume(activity) },
             activitiesAndActions = listOf(
                 activityController to {
                     routes.forEach { route ->


### PR DESCRIPTION
Always update the nav state when an activity becomes visible. If a `NavController` associated with the activity is being tracked, let the destination change update go after that. This changes enables the Compose and non-Compose usage of NavControllers to log uniform state changes, as in the Compose case, the NavController is not created until after resume when the first composition happens.