### PR TITLE
rememberNavController wrapper that tracks navigation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     kotlin("jvm") apply false
     alias(libs.plugins.google.ksp) apply false
+    alias(libs.plugins.kotlin.compose) apply false
     id("com.android.library") apply false
     id("org.jetbrains.dokka")
     id("org.jetbrains.kotlinx.kover")

--- a/buildSrc/src/main/kotlin/embrace-test-kotlin-compiler-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/embrace-test-kotlin-compiler-conventions.gradle.kts
@@ -1,0 +1,7 @@
+// Add Kotlin compiler plugins so they exist only in the test classpath
+configurations.matching {
+    it.name.startsWith("kotlinCompilerPluginClasspath") && it.name.endsWith("UnitTest")
+}.configureEach {
+    dependencies.add(project.dependencies.create(findLibrary("kotlin.compose.compiler.plugin")))
+    dependencies.add(project.dependencies.create(findLibrary("kotlin.serialization.compiler.plugin")))
+}

--- a/embrace-android-instrumentation-compose-navigation/api/embrace-android-instrumentation-compose-navigation.api
+++ b/embrace-android-instrumentation-compose-navigation/api/embrace-android-instrumentation-compose-navigation.api
@@ -1,0 +1,4 @@
+public final class io/embrace/android/embracesdk/internal/instrumentation/compose/navigation/NavigationTrackersKt {
+	public static final fun rememberObservedNavController ([Landroidx/navigation/Navigator;Landroidx/compose/runtime/Composer;I)Landroidx/navigation/NavHostController;
+}
+

--- a/embrace-android-instrumentation-compose-navigation/build.gradle.kts
+++ b/embrace-android-instrumentation-compose-navigation/build.gradle.kts
@@ -1,19 +1,29 @@
 plugins {
-    id("embrace-prod-android-conventions")
+    id("embrace-public-api-conventions")
+    alias(libs.plugins.kotlin.compose)
 }
 
 description = "Embrace Android SDK: Compose Navigation Support"
 
 android {
-    namespace = "io.embrace.android.embracesdk.instrumentation.compose.navigation"
+    defaultConfig {
+        namespace = "io.embrace.android.embracesdk.instrumentation.compose.navigation"
+    }
+    buildFeatures {
+        compose = true
+    }
 }
 
 dependencies {
     implementation(project(":embrace-android-instrumentation-api"))
     implementation(project(":embrace-android-instrumentation-navigation"))
     implementation(libs.androidx.navigation.fragment)
-    implementation(libs.androidx.navigation.common)
+    compileOnly(libs.androidx.navigation.compose)
+
     testImplementation(project(":embrace-android-instrumentation-api-fakes"))
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.navigation.testing)
+    testCompileOnly(libs.compose.runtime)
+
+    add("kotlinCompilerPluginClasspath", libs.kotlin.compose.compiler.plugin)
 }

--- a/embrace-android-instrumentation-compose-navigation/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/navigation/ComposeNavigationInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-compose-navigation/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/navigation/ComposeNavigationInstrumentationProvider.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.instrumentation.compose.navigation
 
+import android.app.Activity
 import io.embrace.android.embracesdk.internal.arch.InstrumentationArgs
 import io.embrace.android.embracesdk.internal.arch.InstrumentationProvider
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
@@ -8,11 +9,18 @@ import io.embrace.android.embracesdk.internal.arch.navigation.NavigationTracking
 /**
  * Instrumentation provider that creates and registers [NavControllerTracker] with the [NavigationTrackingService].
  */
-class ComposeNavigationInstrumentationProvider : InstrumentationProvider {
+public class ComposeNavigationInstrumentationProvider : InstrumentationProvider {
 
     override fun register(args: InstrumentationArgs): DataSourceState<*>? {
         args.navigationTrackingService.navigationTrackingInitListener =
             NavControllerTracker(args.navigationTrackingService, args.clock, args.logger)
+        trackNavigation = args.navigationTrackingService::trackNavigation
         return null
     }
 }
+
+/**
+ * Function to call to track a component that controls navigation
+ */
+internal var trackNavigation: (Activity, Any?) -> Unit = { _, _ -> }
+    private set

--- a/embrace-android-instrumentation-compose-navigation/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/navigation/NavigationTrackers.kt
+++ b/embrace-android-instrumentation-compose-navigation/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/navigation/NavigationTrackers.kt
@@ -1,0 +1,44 @@
+package io.embrace.android.embracesdk.internal.instrumentation.compose.navigation
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalContext
+import androidx.navigation.NavDestination
+import androidx.navigation.NavHostController
+import androidx.navigation.Navigator
+import androidx.navigation.compose.rememberNavController
+
+/**
+ * Wrapper for [androidx.navigation.compose.rememberNavController] that registers the returned [NavHostController] with the
+ * Embrace SDK so navigations are observed.
+ *
+ * Simply replace uses of [rememberNavController] with this Composable to get this functionality.
+ */
+@Composable
+public fun rememberObservedNavController(
+    vararg navigators: Navigator<out NavDestination>,
+): NavHostController {
+    val navController = rememberNavController(*navigators)
+    val context = LocalContext.current
+    DisposableEffect(navController) {
+        context.findActivity()?.let { activity ->
+            trackNavigation(activity, navController)
+        }
+        onDispose { }
+    }
+    return navController
+}
+
+private fun Context.findActivity(): Activity? {
+    var current: Context = this
+    while (current is ContextWrapper) {
+        if (current is Activity) {
+            return current
+        }
+        current = current.baseContext
+    }
+    return null
+}

--- a/embrace-android-sdk/build.gradle.kts
+++ b/embrace-android-sdk/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("embrace-public-api-conventions")
+    id("embrace-test-kotlin-compiler-conventions")
     id("com.google.devtools.ksp")
 }
 
@@ -79,11 +80,10 @@ dependencies {
     testImplementation(libs.opentelemetry.sdk)
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.navigation.fragment)
-    testImplementation(libs.androidx.navigation.common)
+    testImplementation(libs.androidx.navigation.compose)
     testImplementation(libs.androidx.navigation.testing)
     testImplementation(libs.opentelemetry.kotlin.compat)
     testImplementation(libs.kotlinx.serialization.core)
-    add("kotlinCompilerPluginClasspath", libs.kotlin.serialization.compiler.plugin)
 
     lintChecks(project(":embrace-lint"))
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/fakes/ComposeNavHostActivity.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/fakes/ComposeNavHostActivity.kt
@@ -1,0 +1,31 @@
+package io.embrace.android.embracesdk.fakes
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.navigation.NavController
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import io.embrace.android.embracesdk.internal.instrumentation.compose.navigation.rememberObservedNavController
+
+class ComposeNavHostActivity : ComponentActivity(), HasNavController {
+
+    @Volatile
+    private var capturedNavController: NavHostController? = null
+
+    override fun getNavController(): NavController = checkNotNull(capturedNavController) { "NavController not yet created" }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            val navController = rememberObservedNavController()
+            capturedNavController = navController
+            NavHost(navController = navController, startDestination = "home") {
+                composable("home") { }
+                composable("about") { }
+                composable("contacts") { }
+            }
+        }
+    }
+}

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/fakes/WrappedContextComposeNavHostActivity.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/fakes/WrappedContextComposeNavHostActivity.kt
@@ -1,0 +1,38 @@
+package io.embrace.android.embracesdk.fakes
+
+import android.content.ContextWrapper
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.navigation.NavController
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import io.embrace.android.embracesdk.internal.instrumentation.compose.navigation.rememberObservedNavController
+
+class WrappedContextComposeNavHostActivity : ComponentActivity(), HasNavController {
+
+    @Volatile
+    private var capturedNavController: NavHostController? = null
+
+    override fun getNavController(): NavController = checkNotNull(capturedNavController) { "NavController not yet created" }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            val wrapped = remember(this) { ContextWrapper(this) }
+            CompositionLocalProvider(LocalContext provides wrapped) {
+                val navController = rememberObservedNavController()
+                capturedNavController = navController
+                NavHost(navController = navController, startDestination = "home") {
+                    composable("home") { }
+                    composable("about") { }
+                    composable("contacts") { }
+                }
+            }
+        }
+    }
+}

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NavigationComplexDestinationAndRouteTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NavigationComplexDestinationAndRouteTest.kt
@@ -38,7 +38,7 @@ internal class NavigationComplexDestinationAndRouteTest {
         testRule.runTest(
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
-                timestamps = simulateNavHostFragmentActivityNavigation(
+                timestamps = simulateNavControllerActivityNavigation(
                     routes = listOf("profile/123", "order/456/details"),
                     activityController = activityController,
                 )
@@ -73,7 +73,7 @@ internal class NavigationComplexDestinationAndRouteTest {
         testRule.runTest(
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
-                timestamps = simulateNavHostFragmentActivityNavigation(
+                timestamps = simulateNavControllerActivityNavigation(
                     routes = listOf("confirm_dialog"),
                     activityController = activityController,
                 )
@@ -101,7 +101,7 @@ internal class NavigationComplexDestinationAndRouteTest {
         testRule.runTest(
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
-                timestamps = simulateNavHostFragmentActivityNavigation(
+                timestamps = simulateNavControllerActivityNavigation(
                     routes = listOf("general"),
                     activityController = activityController,
                 )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NavigationStateFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NavigationStateFeatureTest.kt
@@ -6,7 +6,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.assertNavigationStateSpan
 import io.embrace.android.embracesdk.assertions.getNavigationStateSpan
 import io.embrace.android.embracesdk.fakes.BasicNavHostFragmentActivity
+import io.embrace.android.embracesdk.fakes.ComposeNavHostActivity
 import io.embrace.android.embracesdk.fakes.TestNavControllerActivity
+import io.embrace.android.embracesdk.fakes.WrappedContextComposeNavHostActivity
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.internal.arch.state.AppState
@@ -184,7 +186,7 @@ internal class NavigationStateFeatureTest {
         testRule.runTest(
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
-                timestamps = simulateNavHostFragmentActivityNavigation(
+                timestamps = simulateNavControllerActivityNavigation(
                     routes = navRoutes,
                     activityController = activityController,
                 )
@@ -200,7 +202,7 @@ internal class NavigationStateFeatureTest {
                     timestamps.firstActionTimeMs + POST_ACTIVITY_ACTION_DWELL * 3,
                     timestamps.lastBackgroundTimeMs,
                 )
-                val expectedStateValues = listOf(activityController.get().localClassName, "home") + navRoutes + listOf("Backgrounded")
+                val expectedStateValues = listOf(activityController.get().localClassName, "home") + navRoutes
                 stateSpan.assertNavigationStateSpan(
                     transitionTimesMs = eventTimes,
                     newStateValues = expectedStateValues
@@ -215,7 +217,7 @@ internal class NavigationStateFeatureTest {
         testRule.runTest(
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {
-                simulateNavHostFragmentActivityNavigation(
+                simulateNavControllerActivityNavigation(
                     routes = listOf("about"),
                     activityController = navActivity
                 )
@@ -275,8 +277,69 @@ internal class NavigationStateFeatureTest {
                         navActivity.get().localClassName,
                         "home",
                         "about",
-                        "Backgrounded"
                     )
+                )
+            },
+        )
+    }
+
+    @Test
+    fun `rememberObservedNavController registers created NavController and creates state span`() {
+        var timestamps: AppExecutionTimestamps? = null
+        val activityController = Robolectric.buildActivity(ComposeNavHostActivity::class.java)
+        val expectedStateValues = listOf(activityController.get().localClassName, "home", "contacts", "about")
+        testRule.runTest(
+            persistedRemoteConfig = enabledRemoteConfig,
+            testCaseAction = {
+                timestamps = simulateNavControllerActivityNavigation<ComposeNavHostActivity>(
+                    routes = listOf("contacts", "about"),
+                    activityController = activityController,
+                )
+            },
+            assertAction = {
+                val stateSpan = checkNotNull(getSingleSessionEnvelope().getNavigationStateSpan())
+                checkNotNull(timestamps)
+                val eventTimes = mutableListOf(
+                    timestamps.firstForegroundTimeMs,
+                    timestamps.firstActionTimeMs,
+                    timestamps.firstActionTimeMs + POST_ACTIVITY_ACTION_DWELL,
+                    timestamps.firstActionTimeMs + POST_ACTIVITY_ACTION_DWELL * 2,
+                    timestamps.lastBackgroundTimeMs,
+                )
+                stateSpan.assertNavigationStateSpan(
+                    transitionTimesMs = eventTimes,
+                    newStateValues = expectedStateValues
+                )
+            },
+        )
+    }
+
+    @Test
+    fun `rememberObservedNavController finds Activity associated with NavController through wrapped LocalContext`() {
+        var timestamps: AppExecutionTimestamps? = null
+        val activityController = Robolectric.buildActivity(WrappedContextComposeNavHostActivity::class.java)
+        val expectedStateValues = listOf(activityController.get().localClassName, "home", "about", "contacts")
+        testRule.runTest(
+            persistedRemoteConfig = enabledRemoteConfig,
+            testCaseAction = {
+                timestamps = simulateNavControllerActivityNavigation<WrappedContextComposeNavHostActivity>(
+                    routes = listOf("about", "contacts"),
+                    activityController = activityController,
+                )
+            },
+            assertAction = {
+                val stateSpan = checkNotNull(getSingleSessionEnvelope().getNavigationStateSpan())
+                checkNotNull(timestamps)
+                val eventTimes = mutableListOf(
+                    timestamps.firstForegroundTimeMs,
+                    timestamps.firstActionTimeMs,
+                    timestamps.firstActionTimeMs + POST_ACTIVITY_ACTION_DWELL,
+                    timestamps.firstActionTimeMs + POST_ACTIVITY_ACTION_DWELL * 2,
+                    timestamps.lastBackgroundTimeMs,
+                )
+                stateSpan.assertNavigationStateSpan(
+                    transitionTimesMs = eventTimes,
+                    newStateValues = expectedStateValues
                 )
             },
         )
@@ -286,7 +349,7 @@ internal class NavigationStateFeatureTest {
     fun `navigation of NavController tracked using public observeNavigation API creates state span`() {
         var timestamps: AppExecutionTimestamps? = null
         val activityController = Robolectric.buildActivity(TestNavControllerActivity::class.java)
-        val expectedStateValues = listOf(activityController.get().localClassName, "home", "contacts", "about", "Backgrounded")
+        val expectedStateValues = listOf(activityController.get().localClassName, "home", "contacts", "about")
         testRule.runTest(
             persistedRemoteConfig = enabledRemoteConfig,
             testCaseAction = {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceActionInterface.kt
@@ -228,12 +228,12 @@ internal class EmbraceActionInterface(
 
     /**
      * Simulates opening a [TestNavHostFragmentActivity] and navigating through the given routes.
-     * The tracking of the navigation will be handled automatically by the SDK.
+     * No explicit NavController tracking will be done by the test.
      */
-    inline fun <reified T : TestNavHostFragmentActivity> simulateNavHostFragmentActivityNavigation(
+    inline fun <reified T> simulateNavControllerActivityNavigation(
         routes: List<String>,
         activityController: ActivityController<T> = Robolectric.buildActivity(T::class.java),
-    ) = simulateNavControllerNavigation(routes, activityController)
+    ) where T : Activity, T : HasNavController = simulateNavControllerNavigation(routes, activityController)
 
     /**
      * Simulates opening the given [Activity] and navigating through the given destinations using the NavController provided
@@ -272,6 +272,7 @@ internal class EmbraceActionInterface(
             postOnResume = { activity -> postResume(activity) },
             activitiesAndActions = listOf(
                 activityController to {
+                    activityController.visible()
                     routes.forEach { route ->
                         clock.tick(POST_ACTIVITY_ACTION_DWELL)
                         activityController.get().getNavController().navigate(route)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,6 +55,7 @@ kover = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version.ref = "k
 agp = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinGradlePlugin" }
 kotlin-serialization-compiler-plugin = { module = "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin-embeddable", version.ref = "kotlinGradlePlugin" }
+kotlin-compose-compiler-plugin = { module = "org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable", version.ref = "kotlinGradlePlugin" }
 lifecycle-runtime = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
 lifecycle-compiler = { group = "androidx.lifecycle", name = "lifecycle-compiler", version.ref = "lifecycle" }
 lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycle" }
@@ -77,6 +78,7 @@ okhttp = { group = "com.squareup.okhttp3", name = "okhttp" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging", version.ref = "firebase" }
 compose = { group = "androidx.compose.ui", name = "ui", version.ref = "compose" }
+compose-runtime = { group = "androidx.compose.runtime", name = "runtime", version.ref = "compose" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidxTest" }
@@ -88,6 +90,7 @@ detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", 
 appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "navigation" }
 androidx-navigation-common = { module = "androidx.navigation:navigation-common-ktx", version.ref = "navigation" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation" }
 androidx-navigation-testing = { module = "androidx.navigation:navigation-testing", version.ref = "navigation" }
 asm-util = { module = "org.ow2.asm:asm-util", version.ref = "asmUtil" }
 gradle-test-kit = { module = "dev.gradleplugins:gradle-test-kit", version.ref = "gradleTestKit" }
@@ -115,5 +118,6 @@ dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlinGradlePlugin" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlinGradlePlugin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "koverGradlePlugin" }
 benchmark = { id = "androidx.benchmark", version.ref = "androidxBenchmark" }


### PR DESCRIPTION
Add Composable that wraps `rememberNavController`that will register the created controller navigation state tracking before returning it.

This makes the `compose-navigation` module export a public interface, which is necessary because it includes a dependency that the main SDK doesn't have -- `NavHostController` -- which requires `androidx.navigation` 2.4.0.