### PR TITLE
Create a golden file test for a log from the background

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -307,28 +307,7 @@ internal class SessionOrchestratorImpl(
 
                     // transition the user session before creating the new session part so that
                     // the user session is always ready
-                    if (transitionType != TransitionType.CRASH) {
-                        if (transitionType == TransitionType.END_MANUAL ||
-                            transitionType == TransitionType.INACTIVITY_TIMEOUT ||
-                            transitionType == TransitionType.INACTIVITY_FOREGROUND ||
-                            transitionType == TransitionType.MAX_DURATION
-                        ) {
-                            handleUserSessionEnd(timestamp)
-                        } else {
-                            handleNewSessionPart(timestamp)
-                            when (endAppState) {
-                                AppState.FOREGROUND -> if (maxDurationTimerState == null) {
-                                    (userSessionState as? UserSessionState.Active)?.metadata?.let {
-                                        scheduleMaxDurationTimeout(it)
-                                    }
-                                }
-                                AppState.BACKGROUND -> {
-                                    maxDurationTimerState?.cancel()
-                                    maxDurationTimerState = null
-                                }
-                            }
-                        }
-                    }
+                    transitionUserSession(transitionType, endAppState, timestamp)
 
                     // create the next session span if we should, and update the SDK state to reflect the transition
                     EmbTrace.trace("create-new-session") {
@@ -343,14 +322,16 @@ internal class SessionOrchestratorImpl(
 
             // update newly created session
             val userSession = currentUserSession()
-            if (newSession != null && userSession != null) {
-                // persist partNumber to handle user session restoration in new process
-                val updatedUserSession = userSession.copy(partNumber = newSession.sessionPartNumber)
-                metadataStore.save(updatedUserSession)
-                userSessionState = UserSessionState.Active(updatedUserSession)
+            if (newSession != null) {
+                if (userSession != null) {
+                    // persist partNumber to handle user session restoration in new process
+                    val updatedUserSession = userSession.copy(partNumber = newSession.sessionPartNumber)
+                    metadataStore.save(updatedUserSession)
+                    userSessionState = UserSessionState.Active(updatedUserSession)
 
-                if (endAppState == AppState.FOREGROUND) {
-                    sessionTracker.setProcessStateSummary(newSession.sessionPartId, userSession.userSessionId)
+                    if (endAppState == AppState.FOREGROUND) {
+                        sessionTracker.setProcessStateSummary(newSession.sessionPartId, userSession.userSessionId)
+                    }
                 }
                 boundaryDelegate.prepareForNewSession()
                 sessionSpanAttrPopulator.populateSessionSpanStartAttrs(newSession, userSession)
@@ -458,6 +439,41 @@ internal class SessionOrchestratorImpl(
         val now = clock.now().millisToNanos()
         destination.addSessionPartAttribute(EmbSessionAttributes.EMB_HEARTBEAT_TIME_UNIX_NANO, now.toString())
         destination.addSessionPartAttribute(EmbSessionAttributes.EMB_TERMINATED, true.toString())
+    }
+
+    /**
+     * Decides what to do with the user session at the start of a session-part transition.
+     * Crashes leave the user session untouched. INITIAL with state=BACKGROUND defers user-session
+     * creation to the first foreground entry — the first user session of a process must originate
+     * from a foreground transition.
+     */
+    private fun transitionUserSession(transitionType: TransitionType, endAppState: AppState, timestamp: Long) {
+        when {
+            transitionType == TransitionType.CRASH -> {}
+
+            transitionType == TransitionType.END_MANUAL ||
+                transitionType == TransitionType.INACTIVITY_TIMEOUT ||
+                transitionType == TransitionType.INACTIVITY_FOREGROUND ||
+                transitionType == TransitionType.MAX_DURATION ->
+                handleUserSessionEnd(timestamp)
+
+            transitionType == TransitionType.INITIAL && state == AppState.BACKGROUND -> {}
+
+            else -> {
+                handleNewSessionPart(timestamp)
+                when (endAppState) {
+                    AppState.FOREGROUND -> if (maxDurationTimerState == null) {
+                        (userSessionState as? UserSessionState.Active)?.metadata?.let {
+                            scheduleMaxDurationTimeout(it)
+                        }
+                    }
+                    AppState.BACKGROUND -> {
+                        maxDurationTimerState?.cancel()
+                        maxDurationTimerState = null
+                    }
+                }
+            }
+        }
     }
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulator.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulator.kt
@@ -12,7 +12,7 @@ interface SessionPartSpanAttrPopulator {
     /**
      * Populates session span attributes at the start of the session.
      */
-    fun populateSessionSpanStartAttrs(sessionPart: SessionPartToken, userSession: UserSessionMetadata)
+    fun populateSessionSpanStartAttrs(sessionPart: SessionPartToken, userSession: UserSessionMetadata?)
 
     /**
      * Populates session span attributes at the end of the session.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImpl.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.internal.session.LifeEventType
 import io.embrace.android.embracesdk.internal.session.SessionPartToken
 import io.embrace.android.embracesdk.internal.session.UserSessionMetadata
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
+import io.opentelemetry.kotlin.semconv.SessionAttributes
 import java.util.Locale
 
 internal class SessionPartSpanAttrPopulatorImpl(
@@ -17,10 +18,9 @@ internal class SessionPartSpanAttrPopulatorImpl(
     private val metadataService: MetadataService,
 ) : SessionPartSpanAttrPopulator {
 
-    override fun populateSessionSpanStartAttrs(sessionPart: SessionPartToken, userSession: UserSessionMetadata) {
+    override fun populateSessionSpanStartAttrs(sessionPart: SessionPartToken, userSession: UserSessionMetadata?) {
         with(destination) {
             addSessionPartAttribute(EmbSessionAttributes.EMB_COLD_START, sessionPart.isColdStart.toString())
-            addSessionPartAttribute(EmbSessionAttributes.EMB_USER_SESSION_PART_NUMBER, sessionPart.sessionPartNumber.toString())
             addSessionPartAttribute(EmbSessionAttributes.EMB_STATE, sessionPart.appState.name.lowercase(Locale.US))
             addSessionPartAttribute(EmbSessionAttributes.EMB_CLEAN_EXIT, false.toString())
             addSessionPartAttribute(EmbSessionAttributes.EMB_TERMINATED, true.toString())
@@ -29,12 +29,17 @@ internal class SessionPartSpanAttrPopulatorImpl(
                 addSessionPartAttribute(EmbSessionAttributes.EMB_SESSION_START_TYPE, it)
             }
 
-            userSession.attributes.forEach { (key, value) ->
-                addSessionPartAttribute(key, value.toString())
+            if (userSession != null) {
+                addSessionPartAttribute(EmbSessionAttributes.EMB_SESSION_PART_ID, sessionPart.sessionPartId)
+                addSessionPartAttribute(EmbSessionAttributes.EMB_USER_SESSION_PART_NUMBER, sessionPart.sessionPartNumber.toString())
+                userSession.attributes.forEach { (key, value) ->
+                    addSessionPartAttribute(key, value.toString())
+                }
+            } else {
+                addSessionPartAttribute(EmbSessionAttributes.EMB_SESSION_PART_ID, "")
+                addSessionPartAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID, "")
+                addSessionPartAttribute(SessionAttributes.SESSION_ID, "")
             }
-
-            // set a unique ID for this session part
-            addSessionPartAttribute(EmbSessionAttributes.EMB_SESSION_PART_ID, sessionPart.sessionPartId)
         }
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -49,6 +49,7 @@ import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -104,6 +105,8 @@ internal class SessionOrchestratorTest {
         assertTrue(store.storedSessionPartPayloads.isEmpty())
         assertTrue(store.cachedEmptyCrashPayloads.isEmpty())
         assertEquals(1, fakeDataSource.enableDataCaptureCount)
+        // starting in bg produces no user session.
+        assertNull(orchestrator.currentUserSession())
     }
 
     @Test
@@ -116,6 +119,8 @@ internal class SessionOrchestratorTest {
         assertTrue(store.storedSessionPartPayloads.isEmpty())
         assertTrue(store.cachedEmptyCrashPayloads.isEmpty())
         assertEquals(1, fakeDataSource.enableDataCaptureCount)
+        // starting in fg produces user session
+        assertNotNull(orchestrator.currentUserSession())
     }
 
     @Test
@@ -124,6 +129,7 @@ internal class SessionOrchestratorTest {
         clock.tick()
         val foregroundTime = clock.now()
         val sessionSpan = currentSessionPartSpan.sessionSpan
+        assertNull(orchestrator.currentUserSession())
         orchestrator.onForeground()
         assertEquals(1, fakeDataSource.enableDataCaptureCount)
         validateSession(
@@ -132,6 +138,7 @@ internal class SessionOrchestratorTest {
             endType = LifeEventType.BKGND_STATE
         )
         assertTrue(store.cachedEmptyCrashPayloads.isEmpty())
+        assertNotNull(orchestrator.currentUserSession())
     }
 
     @Test
@@ -1116,7 +1123,7 @@ internal class SessionOrchestratorTest {
     }
 
     @Test
-    fun `max duration timeout does not create new session in background`() {
+    fun `max duration timer not scheduled when starting in background`() {
         configService = FakeConfigService(
             backgroundActivityBehavior = createBackgroundActivityBehavior(
                 remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 100f))
@@ -1127,16 +1134,11 @@ internal class SessionOrchestratorTest {
             )
         )
         createOrchestrator(AppState.BACKGROUND)
-
-        val first = checkNotNull(orchestrator.currentUserSession())
-        assertEquals(1L, first.userSessionNumber)
+        assertNull(orchestrator.currentUserSession())
 
         clock.tick(maxDurationMs * 2)
         inactivityWorkerExecutor.runCurrentlyBlocked()
-
-        val current = checkNotNull(orchestrator.currentUserSession())
-        assertEquals(1L, current.userSessionNumber)
-        assertEquals(first.userSessionId, current.userSessionId)
+        assertNull(orchestrator.currentUserSession())
     }
 
     @Test

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
@@ -11,6 +11,7 @@ import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbUserSessionTerminationReasonValues
 import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Test
 
@@ -58,6 +59,27 @@ internal class SessionPartSpanAttrPopulatorImplTest {
         assertEquals("1800", attrs[EmbSessionAttributes.EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS])
         assertEquals("user-session-uuid", attrs[SessionAttributes.SESSION_ID])
         assertEquals("id", attrs[EmbSessionAttributes.EMB_SESSION_PART_ID])
+    }
+
+    @Test
+    fun `start attributes populated without user session`() {
+        populator.populateSessionSpanStartAttrs(zygote, userSession = null)
+
+        val attrs = destination.attributes
+        assertEquals("false", attrs[EmbSessionAttributes.EMB_COLD_START])
+        assertEquals("foreground", attrs[EmbSessionAttributes.EMB_STATE])
+        assertEquals("false", attrs[EmbSessionAttributes.EMB_CLEAN_EXIT])
+        assertEquals("true", attrs[EmbSessionAttributes.EMB_TERMINATED])
+        assertEquals("state", attrs[EmbSessionAttributes.EMB_SESSION_START_TYPE])
+        assertEquals("", attrs[EmbSessionAttributes.EMB_SESSION_PART_ID])
+        assertEquals("", attrs[EmbSessionAttributes.EMB_USER_SESSION_ID])
+        assertEquals("", attrs[SessionAttributes.SESSION_ID])
+
+        assertFalse(attrs.containsKey(EmbSessionAttributes.EMB_USER_SESSION_PART_NUMBER))
+        assertFalse(attrs.containsKey(EmbSessionAttributes.EMB_USER_SESSION_NUMBER))
+        assertFalse(attrs.containsKey(EmbSessionAttributes.EMB_USER_SESSION_START_TS))
+        assertFalse(attrs.containsKey(EmbSessionAttributes.EMB_USER_SESSION_MAX_DURATION_SECONDS))
+        assertFalse(attrs.containsKey(EmbSessionAttributes.EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS))
     }
 
     @Test

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/LogAssertions.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/LogAssertions.kt
@@ -43,7 +43,8 @@ fun assertOtelLogReceived(
         if (hasSession) {
             assertFalse(log.attributes?.findAttributeValue(SessionAttributes.SESSION_ID).isNullOrBlank())
         } else {
-            assertNull(log.attributes?.find { it.key == SessionAttributes.SESSION_ID })
+            val sessionId = log.attributes?.findAttributeValue(SessionAttributes.SESSION_ID)
+            assertEquals("", sessionId ?: "")
         }
         expectedType?.let { assertAttribute(log, EmbAndroidAttributes.EMB_EXCEPTION_HANDLING, it) }
         assertEquals(expectedState, log.attributes?.findAttributeValue(EmbSessionAttributes.EMB_STATE))

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionGoldenFileTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionGoldenFileTest.kt
@@ -2,12 +2,14 @@ package io.embrace.android.embracesdk.testcases
 
 import android.app.ApplicationExitInfo
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.fakes.TestAeiData
 import io.embrace.android.embracesdk.fakes.setupFakeAeiData
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.UserSessionRemoteConfig
 import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.NativeCrashDataSource
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.assertions.assertLogPayloadMatchesGoldenFile
 import io.embrace.android.embracesdk.testframework.assertions.assertSessionSpanMatchesGoldenFile
@@ -45,6 +47,24 @@ internal class UserSessionGoldenFileTest {
                 assertSessionSpanMatchesGoldenFile(
                     getSingleSessionEnvelope(),
                     "user_session_basic_span.json",
+                )
+            }
+        )
+    }
+
+    /**
+     * Asserts that a log without a user session contains empty attributes for the user session ID and session part ID.
+     */
+    @Test
+    fun `log without user session`() {
+        testRule.runTest(
+            testCaseAction = {
+                embrace.logMessage("Hi", Severity.INFO, mapOf(EmbSessionAttributes.EMB_PRIVATE_SEND_MODE to "immediate"))
+            },
+            assertAction = {
+                assertLogPayloadMatchesGoldenFile(
+                    getSingleLogEnvelope(),
+                    "log_without_user_session.json",
                 )
             }
         )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
@@ -89,6 +89,7 @@ internal class JvmCrashFeatureTest {
                 getSingleLogEnvelope().getLastLog().assertCrash(
                     crashIdFromSession = ba.getCrashedId(),
                     crashTimeMs = crashTimeMs,
+                    hasSession = false,
                 )
             }
         )
@@ -106,6 +107,7 @@ internal class JvmCrashFeatureTest {
                 getSingleLogEnvelope().getLastLog().assertCrash(
                     crashIdFromSession = null,
                     crashTimeMs = crashTimeMs,
+                    hasSession = false,
                 )
             }
         )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LogFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LogFeatureTest.kt
@@ -88,6 +88,7 @@ internal class LogFeatureTest {
                     expectedSeverityNumber = SeverityNumber.WARN,
                     expectedSeverityText = Severity.WARNING.name,
                     expectedTimeMs = logTimestamps.remove(),
+                    hasSession = false,
                 )
             }
         )
@@ -111,6 +112,7 @@ internal class LogFeatureTest {
                     expectedSeverityNumber = SeverityNumber.ERROR,
                     expectedSeverityText = Severity.ERROR.name,
                     expectedTimeMs = logTimestamps.remove(),
+                    hasSession = false,
                 )
             }
         )
@@ -139,6 +141,7 @@ internal class LogFeatureTest {
                         expectedSeverityNumber = getOtelSeverity(severity),
                         expectedSeverityText = severity.name,
                         expectedTimeMs = logTimestamps.remove(),
+                        hasSession = false,
                     )
                 }
             }
@@ -169,6 +172,7 @@ internal class LogFeatureTest {
                         expectedSeverityText = severity.name,
                         expectedTimeMs = logTimestamps.remove(),
                         expectedProperties = customProperties,
+                        hasSession = false,
                     )
                 }
             })
@@ -196,6 +200,7 @@ internal class LogFeatureTest {
                     expectedExceptionMessage = checkNotNull(testException.message),
                     expectedStacktrace = testException.getSafeStackTrace()?.toList(),
                     expectedEmbType = "sys.exception",
+                    hasSession = false,
                 )
             }
         )
@@ -223,6 +228,7 @@ internal class LogFeatureTest {
                     expectedExceptionMessage = checkNotNull(testException.message),
                     expectedStacktrace = testException.getSafeStackTrace()?.toList(),
                     expectedEmbType = "sys.exception",
+                    hasSession = false,
                 )
             }
         )
@@ -258,6 +264,7 @@ internal class LogFeatureTest {
                         expectedStacktrace = testException.getSafeStackTrace()?.toList(),
                         expectedProperties = customProperties,
                         expectedEmbType = "sys.exception",
+                        hasSession = false,
                     )
                 }
             }
@@ -293,6 +300,7 @@ internal class LogFeatureTest {
                         expectedStacktrace = testException.getSafeStackTrace()?.toList(),
                         expectedProperties = customProperties,
                         expectedEmbType = "sys.exception",
+                        hasSession = false,
                     )
                 }
             }
@@ -319,6 +327,7 @@ internal class LogFeatureTest {
                     expectedType = LogExceptionType.HANDLED.value,
                     expectedStacktrace = stacktrace.toList(),
                     expectedEmbType = "sys.exception",
+                    hasSession = false,
                 )
             }
         )
@@ -348,6 +357,7 @@ internal class LogFeatureTest {
                         expectedType = LogExceptionType.HANDLED.value,
                         expectedStacktrace = stacktrace.toList(),
                         expectedEmbType = "sys.exception",
+                        hasSession = false,
                     )
                 }
             }
@@ -379,6 +389,7 @@ internal class LogFeatureTest {
                         expectedStacktrace = stacktrace.toList(),
                         expectedProperties = customProperties,
                         expectedEmbType = "sys.exception",
+                        hasSession = false,
                     )
                 }
             }
@@ -417,6 +428,7 @@ internal class LogFeatureTest {
                         expectedStacktrace = stacktrace.toList(),
                         expectedProperties = customProperties,
                         expectedEmbType = "sys.exception",
+                        hasSession = false,
                     )
                 }
             }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionLifecycleTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionLifecycleTest.kt
@@ -10,13 +10,18 @@ import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.UserSessionRemoteConfig
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_IS_FINAL_SESSION_PART
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_SESSION_PART_ID
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_ID
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_NUMBER
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_PART_NUMBER
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_START_TS
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_TERMINATION_REASON
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbUserSessionTerminationReasonValues.INACTIVITY
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbUserSessionTerminationReasonValues.MANUAL
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.junit.Test
@@ -40,9 +45,19 @@ internal class UserSessionLifecycleTest {
             assertAction = {
                 val bgSession = getSingleSessionEnvelope(AppState.BACKGROUND)
                 val fgSession = getSingleSessionEnvelope(AppState.FOREGROUND)
-                assertEquals(bgSession.getUserSessionId(), fgSession.getUserSessionId())
 
+                val bgSessionSpan = bgSession.findSessionSpan()
+                val bgAttrs = bgSessionSpan.attributes
+                assertEquals("", bgAttrs?.findAttributeValue(EMB_USER_SESSION_ID))
+                assertEquals("", bgAttrs?.findAttributeValue(EMB_SESSION_PART_ID))
+                assertNull(bgAttrs?.findAttributeValue(EMB_USER_SESSION_NUMBER))
+                assertNull(bgAttrs?.findAttributeValue(EMB_USER_SESSION_PART_NUMBER))
+                assertNull(bgAttrs?.findAttributeValue(EMB_USER_SESSION_START_TS))
+
+                // entering foreground creates the first user session
                 val fgSessionSpan = fgSession.findSessionSpan()
+                assertNotNull(fgSession.getUserSessionId())
+                assertEquals(fgSession.getUserSessionId(), fgSession.getSessionId())
                 assertEquals("1", fgSessionSpan.attributes?.findAttributeValue(EMB_USER_SESSION_NUMBER))
                 assertNull(fgSessionSpan.attributes?.findAttributeValue(EMB_IS_FINAL_SESSION_PART))
                 assertNull(fgSessionSpan.attributes?.findAttributeValue(EMB_USER_SESSION_TERMINATION_REASON))
@@ -280,7 +295,8 @@ internal class UserSessionLifecycleTest {
                 val secondSession = sessions[1].findSessionSpan()
 
                 assertNotEquals(sessions[0].getUserSessionId(), sessions[1].getUserSessionId())
-                assertEquals("1", firstBg.attributes?.findAttributeValue(EMB_USER_SESSION_NUMBER))
+                // cold-start background session ends before any user session exists
+                assertNull(firstBg.attributes?.findAttributeValue(EMB_USER_SESSION_NUMBER))
                 assertEquals("1", firstSession.attributes?.findAttributeValue(EMB_USER_SESSION_NUMBER))
                 assertEquals("1", secondBg.attributes?.findAttributeValue(EMB_USER_SESSION_NUMBER))
                 assertEquals("2", secondSession.attributes?.findAttributeValue(EMB_USER_SESSION_NUMBER))

--- a/embrace-android-sdk/src/integrationTest/resources/log_without_user_session.json
+++ b/embrace-android-sdk/src/integrationTest/resources/log_without_user_session.json
@@ -1,34 +1,38 @@
 {
   "logs": [
     {
-      "time_unix_nano": 169220160030000000,
+      "time_unix_nano": 169220160000000000,
       "severity_number": 9,
       "severity_text": "INFO",
       "body": "Hi",
       "attributes": [
         {
+          "key": "emb.private.send_mode",
+          "value": "immediate"
+        },
+        {
           "key": "emb.session_part_id",
-          "value": "A8BAF9242FCC7BE7020B7F533060E8EF"
+          "value": ""
         },
         {
           "key": "emb.state",
-          "value": "foreground"
+          "value": "background"
         },
         {
           "key": "emb.state.network",
-          "value": "unverified"
+          "value": "__EMBRACE_TEST_IGNORE__"
         },
         {
           "key": "emb.state.power",
-          "value": "normal"
+          "value": "__EMBRACE_TEST_IGNORE__"
         },
         {
           "key": "emb.state.screen-automatic",
-          "value": "android.app.Activity"
+          "value": "__EMBRACE_TEST_IGNORE__"
         },
         {
           "key": "emb.state.test",
-          "value": "UNKNOWN"
+          "value": "__EMBRACE_TEST_IGNORE__"
         },
         {
           "key": "emb.type",
@@ -36,7 +40,7 @@
         },
         {
           "key": "emb.user_session_id",
-          "value": "F2C8F6640C62AF2F006929719CB0C468"
+          "value": ""
         },
         {
           "key": "log.record.uid",
@@ -44,7 +48,7 @@
         },
         {
           "key": "session.id",
-          "value": "F2C8F6640C62AF2F006929719CB0C468"
+          "value": ""
         }
       ]
     }

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_aei_log.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_aei_log.json
@@ -52,7 +52,7 @@
         },
         {
           "key": "emb.state.test",
-          "value": "UNKNOWN"
+          "value": "__EMBRACE_TEST_IGNORE__"
         },
         {
           "key": "emb.type",
@@ -60,7 +60,7 @@
         },
         {
           "key": "emb.user_session_id",
-          "value": "88D9EEC83BEF469DB111DAAF5D87FF09"
+          "value": ""
         },
         {
           "key": "exit_status",
@@ -88,7 +88,7 @@
         },
         {
           "key": "session.id",
-          "value": "88D9EEC83BEF469DB111DAAF5D87FF09"
+          "value": ""
         },
         {
           "key": "session_id_error",

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_basic_span.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_basic_span.json
@@ -86,7 +86,7 @@
     },
     {
       "key": "emb.user_session_id",
-      "value": "88D9EEC83BEF469DB111DAAF5D87FF09"
+      "value": "F2C8F6640C62AF2F006929719CB0C468"
     },
     {
       "key": "emb.user_session_inactivity_timeout_seconds",
@@ -106,11 +106,11 @@
     },
     {
       "key": "emb.user_session_start_ts",
-      "value": "169220160000"
+      "value": "169220160010"
     },
     {
       "key": "session.id",
-      "value": "88D9EEC83BEF469DB111DAAF5D87FF09"
+      "value": "F2C8F6640C62AF2F006929719CB0C468"
     }
   ],
   "links": "__EMBRACE_TEST_IGNORE__"

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_custom_timeouts.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_custom_timeouts.json
@@ -82,7 +82,7 @@
     },
     {
       "key": "emb.user_session_id",
-      "value": "88D9EEC83BEF469DB111DAAF5D87FF09"
+      "value": "F2C8F6640C62AF2F006929719CB0C468"
     },
     {
       "key": "emb.user_session_inactivity_timeout_seconds",
@@ -102,11 +102,11 @@
     },
     {
       "key": "emb.user_session_start_ts",
-      "value": "169220160000"
+      "value": "169220160010"
     },
     {
       "key": "session.id",
-      "value": "88D9EEC83BEF469DB111DAAF5D87FF09"
+      "value": "F2C8F6640C62AF2F006929719CB0C468"
     }
   ],
   "links": "__EMBRACE_TEST_IGNORE__"

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_jvm_crash_log.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_jvm_crash_log.json
@@ -52,7 +52,7 @@
         },
         {
           "key": "emb.user_session_id",
-          "value": "88D9EEC83BEF469DB111DAAF5D87FF09"
+          "value": "F2C8F6640C62AF2F006929719CB0C468"
         },
         {
           "key": "exception.message",
@@ -72,7 +72,7 @@
         },
         {
           "key": "session.id",
-          "value": "88D9EEC83BEF469DB111DAAF5D87FF09"
+          "value": "F2C8F6640C62AF2F006929719CB0C468"
         }
       ]
     }

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_jvm_crash_span.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_jvm_crash_span.json
@@ -94,7 +94,7 @@
     },
     {
       "key": "emb.user_session_id",
-      "value": "88D9EEC83BEF469DB111DAAF5D87FF09"
+      "value": "F2C8F6640C62AF2F006929719CB0C468"
     },
     {
       "key": "emb.user_session_inactivity_timeout_seconds",
@@ -114,11 +114,11 @@
     },
     {
       "key": "emb.user_session_start_ts",
-      "value": "169220160000"
+      "value": "169220160010"
     },
     {
       "key": "session.id",
-      "value": "88D9EEC83BEF469DB111DAAF5D87FF09"
+      "value": "F2C8F6640C62AF2F006929719CB0C468"
     }
   ],
   "links": "__EMBRACE_TEST_IGNORE__"

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_max_duration_1.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_max_duration_1.json
@@ -86,7 +86,7 @@
     },
     {
       "key": "emb.user_session_id",
-      "value": "88D9EEC83BEF469DB111DAAF5D87FF09"
+      "value": "F2C8F6640C62AF2F006929719CB0C468"
     },
     {
       "key": "emb.user_session_inactivity_timeout_seconds",
@@ -106,7 +106,7 @@
     },
     {
       "key": "emb.user_session_start_ts",
-      "value": "169220160000"
+      "value": "169220160010"
     },
     {
       "key": "emb.user_session_termination_reason",
@@ -114,7 +114,7 @@
     },
     {
       "key": "session.id",
-      "value": "88D9EEC83BEF469DB111DAAF5D87FF09"
+      "value": "F2C8F6640C62AF2F006929719CB0C468"
     }
   ],
   "links": "__EMBRACE_TEST_IGNORE__"

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_part_1.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_part_1.json
@@ -82,7 +82,7 @@
     },
     {
       "key": "emb.user_session_id",
-      "value": "88D9EEC83BEF469DB111DAAF5D87FF09"
+      "value": "F2C8F6640C62AF2F006929719CB0C468"
     },
     {
       "key": "emb.user_session_inactivity_timeout_seconds",
@@ -102,11 +102,11 @@
     },
     {
       "key": "emb.user_session_start_ts",
-      "value": "169220160000"
+      "value": "169220160010"
     },
     {
       "key": "session.id",
-      "value": "88D9EEC83BEF469DB111DAAF5D87FF09"
+      "value": "F2C8F6640C62AF2F006929719CB0C468"
     }
   ],
   "links": "__EMBRACE_TEST_IGNORE__"

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_part_2.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_part_2.json
@@ -78,7 +78,7 @@
     },
     {
       "key": "emb.user_session_id",
-      "value": "88D9EEC83BEF469DB111DAAF5D87FF09"
+      "value": "F2C8F6640C62AF2F006929719CB0C468"
     },
     {
       "key": "emb.user_session_inactivity_timeout_seconds",
@@ -98,11 +98,11 @@
     },
     {
       "key": "emb.user_session_start_ts",
-      "value": "169220160000"
+      "value": "169220160010"
     },
     {
       "key": "session.id",
-      "value": "88D9EEC83BEF469DB111DAAF5D87FF09"
+      "value": "F2C8F6640C62AF2F006929719CB0C468"
     }
   ],
   "links": "__EMBRACE_TEST_IGNORE__"

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionPartSpanAttrPopulator.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionPartSpanAttrPopulator.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.internal.session.orchestrator.SessionPartSp
 
 class FakeSessionPartSpanAttrPopulator : SessionPartSpanAttrPopulator {
 
-    override fun populateSessionSpanStartAttrs(sessionPart: SessionPartToken, userSession: UserSessionMetadata) {
+    override fun populateSessionSpanStartAttrs(sessionPart: SessionPartToken, userSession: UserSessionMetadata?) {
     }
 
     override fun populateSessionSpanEndAttrs(


### PR DESCRIPTION
## Goal

Create a golden file test for a log from the background without any user session. This fixes a bug where the initial session part created a short-lived user session.
