### PR TITLE
Reset sdkStartChecker state when SDK disabled

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/DisableSdkFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/DisableSdkFeatureTest.kt
@@ -50,6 +50,7 @@ internal class DisableSdkFeatureTest {
     fun `disabling SDK stops data export`() {
         testRule.runTest(
             setupAction = {
+                getEmbLogger().throwOnInternalError = false
                 // create some dummy values in embrace directories to see if they get deleted
                 embraceDirs.forEach {
                     File(it, TEST_FILE_NAME).writeText(DUMMY_CONTENT)
@@ -60,16 +61,16 @@ internal class DisableSdkFeatureTest {
                     assertEquals(DUMMY_CONTENT, File(it, TEST_FILE_NAME).readText())
                 }
                 recordSession {
-                    embrace.startSpan(SPAN_1)?.stop()
+                    embrace.startSpan(SPAN_1).stop()
                     embrace.logInfo(LOG_1)
-                    embrace.startSpan(SPAN_2)?.stop()
+                    embrace.startSpan(SPAN_2).stop()
                     embrace.logInfo(LOG_2)
 
                     // disable SDK at this point
                     embrace.disable()
 
                     // log some more data
-                    embrace.startSpan(SPAN_3)?.stop()
+                    embrace.startSpan(SPAN_3).stop()
                     embrace.logInfo(LOG_3)
                 }
             },
@@ -101,6 +102,47 @@ internal class DisableSdkFeatureTest {
                 }
                 assertEquals(listOf(LOG_1, LOG_2), logData.map { it.bodyValue?.value })
             }
+        )
+    }
+
+    @Test
+    fun `calling public methods is safe after SDK disabling`() {
+        lateinit var logger: FakeInternalLogger
+        testRule.runTest(
+            setupAction = {
+                logger = getEmbLogger().apply {
+                    throwOnInternalError = false
+                }
+            },
+            testCaseAction = {
+                recordSession {
+                    embrace.disable()
+                    embrace.startSpan(SPAN_3).stop()
+                    embrace.addBreadcrumb("foo")
+                    embrace.logInfo(LOG_1)
+                }
+                recordSession {
+                    embrace.addBreadcrumb("foo")
+                    embrace.logInfo(LOG_1)
+                }
+            },
+            assertAction = {
+                returnIfConditionMet(
+                    desiredValueSupplier = { true },
+                    dataProvider = {
+                        embraceDirs.all {
+                            !File(it, TEST_FILE_NAME).exists()
+                        }
+                    },
+                    condition = { true },
+                )
+
+                assertEquals(0, getLogEnvelopes(0).size)
+                assertEquals(0, getSessionEnvelopes(0).size)
+                assertEquals(4, logger.sdkNotInitializedMessages.size)
+                assertEquals(2, logger.sdkNotInitializedMessages.filter { it.msg == "add_breadcrumb" }.size)
+                assertEquals(2, logger.sdkNotInitializedMessages.filter { it.msg == "log_message" }.size)
+            },
         )
     }
 }

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -165,20 +165,23 @@ internal class EmbraceImpl(
      * Shuts down the Embrace SDK.
      */
     fun stop() {
+        sdkCallChecker.started.set(false)
         bootstrapper.stop()
     }
 
     override fun disable() {
         if (sdkCallChecker.started.get()) {
             bootstrapper.openTelemetryModule.otelSdkConfig.disableDataExport()
+            val rootDir = bootstrapper.coreModule.context.filesDir
+            val fallbackDir = bootstrapper.coreModule.context.cacheDir
             stop()
             Executors.newSingleThreadExecutor().execute {
                 runCatching {
                     StorageLocation.entries.map {
                         it.asFile(
-                            logger = logger,
-                            rootDirSupplier = { bootstrapper.coreModule.context.filesDir },
-                            fallbackDirSupplier = { bootstrapper.coreModule.context.cacheDir }
+                            logger = null,
+                            rootDirSupplier = { rootDir },
+                            fallbackDirSupplier = { fallbackDir }
                         ).value
                     }.forEach {
                         it.deleteRecursively()

--- a/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/StorageLocationExt.kt
+++ b/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/StorageLocationExt.kt
@@ -8,14 +8,14 @@ import java.io.File
  * Get the directory as a [File] object
  */
 fun StorageLocation.asFile(
-    logger: InternalLogger,
+    logger: InternalLogger?,
     rootDirSupplier: () -> File,
     fallbackDirSupplier: () -> File,
 ): Lazy<File> = lazy {
     try {
         File(rootDirSupplier(), dir).apply(File::mkdirs)
     } catch (exc: Throwable) {
-        logger.trackInternalError(InternalErrorType.PAYLOAD_STORAGE_FAIL, exc)
+        logger?.trackInternalError(InternalErrorType.PAYLOAD_STORAGE_FAIL, exc)
         File(fallbackDirSupplier(), dir).apply(File::mkdirs)
     }
 }


### PR DESCRIPTION
Reset the SdkCallChecker when the SDK is disabled so API methods don't get invoked.