### PR TITLE
fix console log when no app ID is set

### DIFF
--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
@@ -170,7 +170,8 @@ internal fun ModuleGraph.markSdkInitComplete() {
     )
     end()
     val appId = configService.appId
-    val startMsg = "Embrace SDK version ${BuildConfig.VERSION_NAME} started" + appId?.run { " for appId = $this" }
+    val startMsg = "Embrace SDK version ${BuildConfig.VERSION_NAME} started" +
+        (appId?.let { " for appId = $it" } ?: " without an app ID")
     initModule.logger.logInfo(startMsg)
 }
 


### PR DESCRIPTION
## Goal

If not app ID was set, the startup console log emitted was

```
Embrace SDK version 8.4.0-SNAPSHOT startednull
```

This change emits it as

```
Embrace SDK version 8.4.0-SNAPSHOT started without an app ID
```
## Testing

<!-- Describe how this change has been tested -->
