### PR TITLE
Allow manual ending of user sessions in background

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactory.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactory.kt
@@ -48,7 +48,7 @@ interface PayloadFactory {
     /**
      * Starts a session manually.
      */
-    fun startSessionWithManual(timestamp: Long, partNumber: Int): SessionPartToken
+    fun startSessionWithManual(state: AppState, timestamp: Long, partNumber: Int): SessionPartToken?
 
     /**
      * Ends a session manually.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImpl.kt
@@ -54,14 +54,21 @@ internal class PayloadFactoryImpl(
             AppState.BACKGROUND -> snapshotBackgroundActivity(initial)
         }
 
-    override fun startSessionWithManual(timestamp: Long, partNumber: Int): SessionPartToken {
+    override fun startSessionWithManual(state: AppState, timestamp: Long, partNumber: Int): SessionPartToken? {
+        if (state == AppState.BACKGROUND && !isBackgroundActivityEnabled()) {
+            return null
+        }
+        val startType = when (state) {
+            AppState.FOREGROUND -> LifeEventType.MANUAL
+            AppState.BACKGROUND -> LifeEventType.BKGND_MANUAL
+        }
         return payloadMessageCollator.buildInitialPart(
             InitialEnvelopeParams(
-                false,
-                LifeEventType.MANUAL,
-                timestamp,
-                AppState.FOREGROUND,
-                partNumber,
+                coldStart = false,
+                startType = startType,
+                startTime = timestamp,
+                appState = state,
+                partNumber = partNumber,
             )
         )
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/OrchestratorTerminationConditions.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/OrchestratorTerminationConditions.kt
@@ -9,9 +9,8 @@ internal fun shouldEndManualSession(
     clock: Clock,
     userSessionStartTimeMs: Long?,
     lastManualEndMs: Long?,
-    state: AppState,
 ): Boolean {
-    if (state == AppState.BACKGROUND || configService.sessionBehavior.isSessionControlEnabled() || userSessionStartTimeMs == null) {
+    if (configService.sessionBehavior.isSessionControlEnabled() || userSessionStartTimeMs == null) {
         return true
     }
     if (lastManualEndMs == null) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -185,7 +185,7 @@ internal class SessionOrchestratorImpl(
             },
             newSessionAction = {
                 lastManualEndMs = timestamp
-                payloadFactory.startSessionWithManual(timestamp, incrementPartNumber())
+                payloadFactory.startSessionWithManual(state, timestamp, incrementPartNumber())
             },
             earlyTerminationCondition = {
                 return@transitionState shouldEndManualSession(
@@ -193,7 +193,6 @@ internal class SessionOrchestratorImpl(
                     clock,
                     currentUserSession()?.startTimeMs,
                     lastManualEndMs,
-                    state
                 )
             }
         )

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImplTest.kt
@@ -81,7 +81,7 @@ internal class PayloadFactoryImplTest {
     }
 
     private fun verifyPayloadWithManual() {
-        val zygote = factory.startSessionWithManual(0, 1)
+        val zygote = checkNotNull(factory.startSessionWithManual(FOREGROUND, 0, 1))
         assertTrue(zygote.sessionPartId.isNotBlank())
         assertNotNull(factory.endSessionWithManual(0, zygote))
         assertEquals(true, partPayloadSource.lastStartNewSession)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -220,12 +220,29 @@ internal class SessionOrchestratorTest {
     }
 
     @Test
-    fun `end session with manual in background`() {
-        createOrchestrator(AppState.BACKGROUND)
-        appStateTracker.state = AppState.BACKGROUND
+    fun `end session with manual in background rotates user session and stores payload`() {
+        configService = FakeConfigService(
+            backgroundActivityBehavior = createBackgroundActivityBehavior(
+                remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 100f))
+            ),
+            sessionBehavior = FakeUserSessionBehavior(
+                maxSessionDurationMs = maxDurationMs,
+                sessionInactivityTimeoutMs = inactivityMs,
+            )
+        )
+        createOrchestrator(AppState.FOREGROUND)
+        val firstUserSession = checkNotNull(orchestrator.currentUserSession())
+
+        clock.tick(1000)
+        orchestrator.onBackground()
+        val storedBefore = store.storedSessionPartPayloads.size
+
+        clock.tick(10000)
         orchestrator.endSessionWithManual()
-        assertTrue(store.storedSessionPartPayloads.isEmpty())
-        assertTrue(store.cachedEmptyCrashPayloads.isEmpty())
+
+        assertEquals(storedBefore + 1, store.storedSessionPartPayloads.size)
+        val secondUserSession = checkNotNull(orchestrator.currentUserSession())
+        assertNotEquals(firstUserSession.userSessionId, secondUserSession.userSessionId)
     }
 
     @Test

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadFactory.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadFactory.kt
@@ -94,9 +94,9 @@ class FakePayloadFactory : PayloadFactory {
         return checkNotNull(activeSession)
     }
 
-    override fun startSessionWithManual(timestamp: Long, partNumber: Int): SessionPartToken {
+    override fun startSessionWithManual(state: AppState, timestamp: Long, partNumber: Int): SessionPartToken {
         manualSessionStartCount++
-        activeSession = fakeSessionPartToken()
+        activeSession = fakeSessionPartToken().copy(appState = state)
         return checkNotNull(activeSession)
     }
 


### PR DESCRIPTION
## Goal

Allows the manual ending of user sessions in the background, which was previously disallowed.

## Testing

Updated existing tests.
