### PR TITLE
Add nav2 compose and nav3 examples to the sample app

### DIFF
--- a/examples/ExampleApp/app/build.gradle.kts
+++ b/examples/ExampleApp/app/build.gradle.kts
@@ -77,6 +77,8 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.navigation.fragment)
+    implementation(libs.androidx.navigation3.runtime)
+    implementation(libs.androidx.navigation3.ui)
     implementation(libs.kotlinx.serialization.core)
     add("kotlinCompilerPluginClasspath", libs.kotlin.serialization.compiler.plugin)
     implementation(platform(libs.androidx.compose.bom))
@@ -91,6 +93,7 @@ dependencies {
     implementation(libs.opentelemetry.sdk)
     implementation(libs.firebase.messaging)
     implementation(libs.embrace.android.otel.java)
+//    implementation(libs.embrace.android.instrumentation.androidx.navigation)
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
 
     // uncomment to enable debugging through source contained in those modules

--- a/examples/ExampleApp/app/build.gradle.kts
+++ b/examples/ExampleApp/app/build.gradle.kts
@@ -93,7 +93,6 @@ dependencies {
     implementation(libs.opentelemetry.sdk)
     implementation(libs.firebase.messaging)
     implementation(libs.embrace.android.otel.java)
-//    implementation(libs.embrace.android.instrumentation.androidx.navigation)
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
 
     // uncomment to enable debugging through source contained in those modules

--- a/examples/ExampleApp/app/src/main/AndroidManifest.xml
+++ b/examples/ExampleApp/app/src/main/AndroidManifest.xml
@@ -48,6 +48,12 @@
             android:name=".ComplexDestinationActivity"
             android:theme="@style/Theme.ExampleApp" />
         <activity
+            android:name=".ObservedNavControllerActivity"
+            android:theme="@style/Theme.ExampleApp" />
+        <activity
+            android:name=".ObservedBackStackActivity"
+            android:theme="@style/Theme.ExampleApp" />
+        <activity
             android:name=".TracingApiActivity"
             android:exported="true">
             <intent-filter>

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/MainActivity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/MainActivity.kt
@@ -20,7 +20,6 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             ExampleAppTheme {
-//                val navController = rememberObservedNavController()
                 val navController = rememberNavController()
                 NavHost(navController = navController, startDestination = "main") {
                     composable("main") {

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/MainActivity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/MainActivity.kt
@@ -20,6 +20,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             ExampleAppTheme {
+//                val navController = rememberObservedNavController()
                 val navController = rememberNavController()
                 NavHost(navController = navController, startDestination = "main") {
                     composable("main") {

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ObservedBackStackActivity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ObservedBackStackActivity.kt
@@ -1,0 +1,95 @@
+package io.embrace.android.exampleapp
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.ui.NavDisplay
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class ObservedBackStackActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ExampleAppTheme {
+//                val backStack = rememberObservedBackStack<Screen>(Screen.Home)
+                val backStack = remember { mutableStateListOf<Screen>(Screen.Home) }
+                NavDisplay(
+                    backStack = backStack,
+                    onBack = { backStack.removeLastOrNull() },
+                    entryProvider = { screen -> entryFor(screen, backStack) },
+                )
+            }
+        }
+    }
+
+    sealed class Screen: NavKey {
+        object Home : Screen() {
+            override fun toString(): String = "back-stack-home"
+        }
+
+        object About : Screen() {
+            override fun toString(): String = "back-stack-about"
+        }
+
+        object Contacts : Screen() {
+            override fun toString(): String = "back-stack-contacts"
+        }
+    }
+
+    private fun entryFor(screen: Screen, backStack: SnapshotStateList<Screen>): NavEntry<Screen> =
+        NavEntry(key = screen) {
+            ScreenContent(title = screen.toString(), backStack = backStack)
+        }
+}
+
+@Composable
+private fun ScreenContent(title: String, backStack: SnapshotStateList<ObservedBackStackActivity.Screen>) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = title.replaceFirstChar { it.titlecase() },
+            style = androidx.compose.material3.MaterialTheme.typography.headlineMedium,
+        )
+        Spacer(Modifier.height(24.dp))
+        Text("Push or pop entries — the SDK records each top-of-stack change as a navigation state.")
+        Spacer(Modifier.height(16.dp))
+        listOf(
+            ObservedBackStackActivity.Screen.Home,
+            ObservedBackStackActivity.Screen.About,
+            ObservedBackStackActivity.Screen.Contacts
+        ).filter {
+            it.toString() != title
+        }.forEach { screen ->
+            Button(onClick = { backStack.add(screen) }) {
+                Text("Push ${screen.toString().replaceFirstChar { it.titlecase() }}")
+            }
+            Spacer(Modifier.height(8.dp))
+        }
+        if (backStack.size > 1) {
+            Button(onClick = { backStack.removeLastOrNull() }) {
+                Text("Pop")
+            }
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ObservedBackStackActivity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ObservedBackStackActivity.kt
@@ -28,7 +28,6 @@ class ObservedBackStackActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             ExampleAppTheme {
-//                val backStack = rememberObservedBackStack<Screen>(Screen.Home)
                 val backStack = remember { mutableStateListOf<Screen>(Screen.Home) }
                 NavDisplay(
                     backStack = backStack,

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ObservedNavControllerActivity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ObservedNavControllerActivity.kt
@@ -26,7 +26,6 @@ class ObservedNavControllerActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             ExampleAppTheme {
-//                val navController = rememberObservedNavController()
                 val navController = rememberNavController()
                 NavHost(navController = navController, startDestination = "nav-controller-home") {
                     composable("nav-controller-home") { ScreenContent("Home", navController) }

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ObservedNavControllerActivity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ObservedNavControllerActivity.kt
@@ -1,0 +1,64 @@
+package io.embrace.android.exampleapp
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class ObservedNavControllerActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ExampleAppTheme {
+//                val navController = rememberObservedNavController()
+                val navController = rememberNavController()
+                NavHost(navController = navController, startDestination = "nav-controller-home") {
+                    composable("nav-controller-home") { ScreenContent("Home", navController) }
+                    composable("nav-controller-about") { ScreenContent("About", navController) }
+                    composable("nav-controller-contacts") { ScreenContent("Contacts", navController) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScreenContent(title: String, navController: NavHostController) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(text = title, style = androidx.compose.material3.MaterialTheme.typography.headlineMedium)
+        Spacer(Modifier.height(24.dp))
+        Text("Navigate to a different destination — the SDK records each transition as a state change.")
+        Spacer(Modifier.height(16.dp))
+        listOf("nav-controller-home", "nav-controller-about", "nav-controller-contacts")
+            .filter {
+                it != title.lowercase()
+            }
+            .forEach { route ->
+                Button(onClick = { navController.navigate(route) }) {
+                    Text("Go to ${route.replaceFirstChar { it.titlecase() }}")
+                }
+                Spacer(Modifier.height(8.dp))
+            }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ui/CodeExample.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ui/CodeExample.kt
@@ -18,7 +18,9 @@ enum class CodeExample(
     SDK_STATE_API("SDK State API"),
     BYTECODE_INSTRUMENTATION_SAMPLES("Bytecode Instrumentation"),
     FRAGMENT_NAVIGATION("Compose Fragment Navigation"),
-    COMPLEX_FRAGMENT_NAVIGATION("Complex Fragment Navigation");
+    COMPLEX_FRAGMENT_NAVIGATION("Complex Fragment Navigation"),
+    OBSERVED_NAV_CONTROLLER("Observed NavController (Compose Nav 2.x)"),
+    OBSERVED_BACK_STACK("Observed BackStack (Nav 3)");
 
     val route: String = name.lowercase()
 }

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ui/ExampleContent.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ui/ExampleContent.kt
@@ -5,6 +5,8 @@ import io.embrace.android.exampleapp.ui.examples.AddBreadcrumbExample
 import io.embrace.android.exampleapp.ui.examples.AnrDetectionExample
 import io.embrace.android.exampleapp.ui.examples.ComplexFragmentNavigationExample
 import io.embrace.android.exampleapp.ui.examples.ComposeFragmentNavigationExample
+import io.embrace.android.exampleapp.ui.examples.ObservedBackStackExample
+import io.embrace.android.exampleapp.ui.examples.ObservedNavControllerExample
 import io.embrace.android.exampleapp.ui.examples.bytecode.BytecodeInstrumentationExample
 import io.embrace.android.exampleapp.ui.examples.EndSessionExample
 import io.embrace.android.exampleapp.ui.examples.JvmCrashExample
@@ -37,5 +39,7 @@ fun ExampleContent(example: CodeExample) {
         CodeExample.BYTECODE_INSTRUMENTATION_SAMPLES -> BytecodeInstrumentationExample()
         CodeExample.FRAGMENT_NAVIGATION -> ComposeFragmentNavigationExample()
         CodeExample.COMPLEX_FRAGMENT_NAVIGATION -> ComplexFragmentNavigationExample()
+        CodeExample.OBSERVED_NAV_CONTROLLER -> ObservedNavControllerExample()
+        CodeExample.OBSERVED_BACK_STACK -> ObservedBackStackExample()
     }
 }

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ui/examples/ObservedBackStackExample.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ui/examples/ObservedBackStackExample.kt
@@ -1,0 +1,28 @@
+package io.embrace.android.exampleapp.ui.examples
+
+import android.content.Intent
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import io.embrace.android.exampleapp.ObservedBackStackActivity
+
+@Composable
+fun ObservedBackStackExample() {
+    val context = LocalContext.current
+    Text(
+        "Opens an Activity that uses `rememberObservedBackStack()` (Navigation 3). The hosted " +
+            "NavDisplay's back-stack mutations (push/pop) are captured as state-span transitions by " +
+            "the SDK."
+    )
+    Spacer(modifier = Modifier.height(16.dp))
+    Button(onClick = {
+        context.startActivity(Intent(context, ObservedBackStackActivity::class.java))
+    }) {
+        Text("Open rememberObservedBackStack Activity")
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ui/examples/ObservedNavControllerExample.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ui/examples/ObservedNavControllerExample.kt
@@ -1,0 +1,27 @@
+package io.embrace.android.exampleapp.ui.examples
+
+import android.content.Intent
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import io.embrace.android.exampleapp.ObservedNavControllerActivity
+
+@Composable
+fun ObservedNavControllerExample() {
+    val context = LocalContext.current
+    Text(
+        "Opens an Activity that uses `rememberObservedNavController()` (Compose Navigation 2.x). " +
+            "Each navigation in the hosted NavHost is captured as a state-span transition by the SDK."
+    )
+    Spacer(modifier = Modifier.height(16.dp))
+    Button(onClick = {
+        context.startActivity(Intent(context, ObservedNavControllerActivity::class.java))
+    }) {
+        Text("Open rememberObservedNavController Activity")
+    }
+}

--- a/examples/ExampleApp/gradle/libs.versions.toml
+++ b/examples/ExampleApp/gradle/libs.versions.toml
@@ -54,7 +54,6 @@ embrace-android-delivery = { group = "io.embrace", name = "embrace-android-deliv
 embrace-android-okhttp = { group = "io.embrace", name = "embrace-android-instrumentation-okhttp", version.ref = "embrace" }
 embrace-android-network-common = { group = "io.embrace", name = "embrace-android-instrumentation-network-common", version.ref = "embrace" }
 embrace-android-instrumentation-api = { group = "io.embrace", name = "embrace-android-instrumentation-api", version.ref = "embrace" }
-embrace-android-instrumentation-androidx-navigation = { group = "io.embrace", name = "embrace-android-instrumentation-androidx-navigation", version.ref = "embrace" }
 androidx-navigation3-runtime = { group = "androidx.navigation3", name = "navigation3-runtime", version.ref = "navigation3" }
 androidx-navigation3-ui = { group = "androidx.navigation3", name = "navigation3-ui", version.ref = "navigation3" }
 

--- a/examples/ExampleApp/gradle/libs.versions.toml
+++ b/examples/ExampleApp/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ activityCompose = "1.13.0"
 composeBom = "2026.05.00"
 embrace = "8.3.1"
 navigationCompose = "2.9.8"
+navigation3 = "1.1.1"
 okhttp = "5.3.2"
 otel = "1.61.0"
 firebase = "25.0.1"
@@ -53,6 +54,9 @@ embrace-android-delivery = { group = "io.embrace", name = "embrace-android-deliv
 embrace-android-okhttp = { group = "io.embrace", name = "embrace-android-instrumentation-okhttp", version.ref = "embrace" }
 embrace-android-network-common = { group = "io.embrace", name = "embrace-android-instrumentation-network-common", version.ref = "embrace" }
 embrace-android-instrumentation-api = { group = "io.embrace", name = "embrace-android-instrumentation-api", version.ref = "embrace" }
+embrace-android-instrumentation-androidx-navigation = { group = "io.embrace", name = "embrace-android-instrumentation-androidx-navigation", version.ref = "embrace" }
+androidx-navigation3-runtime = { group = "androidx.navigation3", name = "navigation3-runtime", version.ref = "navigation3" }
+androidx-navigation3-ui = { group = "androidx.navigation3", name = "navigation3-ui", version.ref = "navigation3" }
 
 embrace-android-otel-java = { group = "io.embrace", name = "embrace-android-otel-java", version.ref = "embrace" }
 androidx-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "uiautomator" }


### PR DESCRIPTION
Add trivial navigation samples to the test app to test various APIs being introduced in the next SDK release. Right now, the new APIs aren't used, but will be once we release a new version, at which time I will merge a PR to enable it.