### PR TITLE
Add realistic app navigation samples to ExampleApp

### DIFF
--- a/examples/ExampleApp/app/src/main/AndroidManifest.xml
+++ b/examples/ExampleApp/app/src/main/AndroidManifest.xml
@@ -62,6 +62,69 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".paradigms.social.a2a.SocialA2ATimelineActivity"
+            android:theme="@style/Theme.ExampleApp" />
+        <activity
+            android:name=".paradigms.social.a2a.SocialA2APostDetailActivity"
+            android:theme="@style/Theme.ExampleApp" />
+        <activity
+            android:name=".paradigms.social.a2a.SocialA2AProfileActivity"
+            android:theme="@style/Theme.ExampleApp" />
+        <activity
+            android:name=".paradigms.social.a2a.SocialA2AComposeActivity"
+            android:theme="@style/Theme.ExampleApp" />
+        <activity
+            android:name=".paradigms.social.fragments.SocialFragmentsActivity"
+            android:theme="@style/Theme.ExampleApp" />
+        <activity
+            android:name=".paradigms.social.navcompose.SocialNavComposeActivity"
+            android:theme="@style/Theme.ExampleApp" />
+        <activity
+            android:name=".paradigms.social.nav3.SocialNav3Activity"
+            android:theme="@style/Theme.ExampleApp" />
+
+        <activity
+            android:name=".paradigms.news.a2a.NewsA2ASectionsActivity"
+            android:theme="@style/Theme.ExampleApp" />
+        <activity
+            android:name=".paradigms.news.a2a.NewsA2AArticleListActivity"
+            android:theme="@style/Theme.ExampleApp" />
+        <activity
+            android:name=".paradigms.news.a2a.NewsA2AArticleDetailActivity"
+            android:theme="@style/Theme.ExampleApp" />
+        <activity
+            android:name=".paradigms.news.fragments.NewsFragmentsActivity"
+            android:theme="@style/Theme.ExampleApp" />
+        <activity
+            android:name=".paradigms.news.navcompose.NewsNavComposeActivity"
+            android:theme="@style/Theme.ExampleApp" />
+        <activity
+            android:name=".paradigms.news.nav3.NewsNav3Activity"
+            android:theme="@style/Theme.ExampleApp" />
+
+        <activity
+            android:name=".paradigms.ecommerce.a2a.EcommerceA2ACategoriesActivity"
+            android:theme="@style/Theme.ExampleApp" />
+        <activity
+            android:name=".paradigms.ecommerce.a2a.EcommerceA2AProductListActivity"
+            android:theme="@style/Theme.ExampleApp" />
+        <activity
+            android:name=".paradigms.ecommerce.a2a.EcommerceA2AProductDetailActivity"
+            android:theme="@style/Theme.ExampleApp" />
+        <activity
+            android:name=".paradigms.ecommerce.a2a.EcommerceA2ACartActivity"
+            android:theme="@style/Theme.ExampleApp" />
+        <activity
+            android:name=".paradigms.ecommerce.fragments.EcommerceFragmentsActivity"
+            android:theme="@style/Theme.ExampleApp" />
+        <activity
+            android:name=".paradigms.ecommerce.navcompose.EcommerceNavComposeActivity"
+            android:theme="@style/Theme.ExampleApp" />
+        <activity
+            android:name=".paradigms.ecommerce.nav3.EcommerceNav3Activity"
+            android:theme="@style/Theme.ExampleApp" />
+
         <service android:name=".ui.examples.bytecode.ExamplePushNotificationService" />
     </application>
 

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/NavParadigm.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/NavParadigm.kt
@@ -1,0 +1,7 @@
+package io.embrace.android.exampleapp.paradigms
+
+enum class NavParadigm(val displayName: String) {
+    SOCIAL("Doom Scrolling"),
+    NEWS("News Reader"),
+    ECOMMERCE("Stuff-Buying"),
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/NavStyle.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/NavStyle.kt
@@ -1,0 +1,8 @@
+package io.embrace.android.exampleapp.paradigms
+
+enum class NavStyle(val displayName: String) {
+    ACTIVITY_TO_ACTIVITY("Activity → Activity"),
+    FRAGMENTS_PRE_24("Fragments + NavController (pre-2.4)"),
+    NAV_COMPOSE_28("Nav-Compose 2.8+"),
+    NAV3("Navigation 3"),
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ParadigmCatalog.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ParadigmCatalog.kt
@@ -1,0 +1,77 @@
+package io.embrace.android.exampleapp.paradigms
+
+import android.content.Context
+import io.embrace.android.exampleapp.paradigms.ecommerce.a2a.EcommerceA2ACategoriesActivity
+import io.embrace.android.exampleapp.paradigms.ecommerce.fragments.EcommerceFragmentsActivity
+import io.embrace.android.exampleapp.paradigms.ecommerce.nav3.EcommerceNav3Activity
+import io.embrace.android.exampleapp.paradigms.ecommerce.navcompose.EcommerceNavComposeActivity
+import io.embrace.android.exampleapp.paradigms.news.a2a.NewsA2ASectionsActivity
+import io.embrace.android.exampleapp.paradigms.news.fragments.NewsFragmentsActivity
+import io.embrace.android.exampleapp.paradigms.news.nav3.NewsNav3Activity
+import io.embrace.android.exampleapp.paradigms.news.navcompose.NewsNavComposeActivity
+import io.embrace.android.exampleapp.paradigms.social.a2a.SocialA2ATimelineActivity
+import io.embrace.android.exampleapp.paradigms.social.fragments.SocialFragmentsActivity
+import io.embrace.android.exampleapp.paradigms.social.nav3.SocialNav3Activity
+import io.embrace.android.exampleapp.paradigms.social.navcompose.SocialNavComposeActivity
+
+object ParadigmCatalog {
+
+    val runs: List<ParadigmRun> = NavParadigm.entries.flatMap { paradigm ->
+        NavStyle.entries.map { style ->
+            ParadigmRun(paradigm, style, launchFor(paradigm, style))
+        }
+    }
+
+    fun runsFor(paradigm: NavParadigm): List<ParadigmRun> = runs.filter { it.paradigm == paradigm }
+
+    private fun launchFor(paradigm: NavParadigm, style: NavStyle): (Context) -> Unit = when (paradigm) {
+        NavParadigm.SOCIAL -> socialLauncher(style)
+        NavParadigm.NEWS -> newsLauncher(style)
+        NavParadigm.ECOMMERCE -> ecommerceLauncher(style)
+    }
+
+    private fun socialLauncher(style: NavStyle): (Context) -> Unit = when (style) {
+        NavStyle.ACTIVITY_TO_ACTIVITY -> { ctx ->
+            ctx.startActivity(SocialA2ATimelineActivity.newIntent(ctx))
+        }
+        NavStyle.FRAGMENTS_PRE_24 -> { ctx ->
+            ctx.startActivity(SocialFragmentsActivity.newIntent(ctx))
+        }
+        NavStyle.NAV_COMPOSE_28 -> { ctx ->
+            ctx.startActivity(SocialNavComposeActivity.newIntent(ctx))
+        }
+        NavStyle.NAV3 -> { ctx ->
+            ctx.startActivity(SocialNav3Activity.newIntent(ctx))
+        }
+    }
+
+    private fun newsLauncher(style: NavStyle): (Context) -> Unit = when (style) {
+        NavStyle.ACTIVITY_TO_ACTIVITY -> { ctx ->
+            ctx.startActivity(NewsA2ASectionsActivity.newIntent(ctx))
+        }
+        NavStyle.FRAGMENTS_PRE_24 -> { ctx ->
+            ctx.startActivity(NewsFragmentsActivity.newIntent(ctx))
+        }
+        NavStyle.NAV_COMPOSE_28 -> { ctx ->
+            ctx.startActivity(NewsNavComposeActivity.newIntent(ctx))
+        }
+        NavStyle.NAV3 -> { ctx ->
+            ctx.startActivity(NewsNav3Activity.newIntent(ctx))
+        }
+    }
+
+    private fun ecommerceLauncher(style: NavStyle): (Context) -> Unit = when (style) {
+        NavStyle.ACTIVITY_TO_ACTIVITY -> { ctx ->
+            ctx.startActivity(EcommerceA2ACategoriesActivity.newIntent(ctx))
+        }
+        NavStyle.FRAGMENTS_PRE_24 -> { ctx ->
+            ctx.startActivity(EcommerceFragmentsActivity.newIntent(ctx))
+        }
+        NavStyle.NAV_COMPOSE_28 -> { ctx ->
+            ctx.startActivity(EcommerceNavComposeActivity.newIntent(ctx))
+        }
+        NavStyle.NAV3 -> { ctx ->
+            ctx.startActivity(EcommerceNav3Activity.newIntent(ctx))
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ParadigmHubContent.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ParadigmHubContent.kt
@@ -1,0 +1,93 @@
+package io.embrace.android.exampleapp.paradigms
+
+import android.app.Activity
+import android.content.Intent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import io.embrace.android.exampleapp.ComplexDestinationActivity
+import io.embrace.android.exampleapp.MainFragmentActivity
+import io.embrace.android.exampleapp.ObservedBackStackActivity
+import io.embrace.android.exampleapp.ObservedNavControllerActivity
+
+private data class NavigationTestingEntry(
+    val label: String,
+    val activityClass: Class<out Activity>,
+)
+
+private val NAVIGATION_TESTING_ENTRIES: List<NavigationTestingEntry> = listOf(
+    NavigationTestingEntry("Compose Fragment Navigation", MainFragmentActivity::class.java),
+    NavigationTestingEntry("Complex Fragment Navigation", ComplexDestinationActivity::class.java),
+    NavigationTestingEntry(
+        "Observed NavController (Compose Nav 2.x)",
+        ObservedNavControllerActivity::class.java,
+    ),
+    NavigationTestingEntry("Observed BackStack (Nav 3)", ObservedBackStackActivity::class.java),
+)
+
+@Composable
+fun ParadigmHubContent() {
+    val context = LocalContext.current
+    LazyColumn(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        item(key = "header_navigation_testing") {
+            Column(modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
+                Text(
+                    text = "Navigation Testing",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp),
+                )
+                HorizontalDivider()
+            }
+        }
+        items(
+            items = NAVIGATION_TESTING_ENTRIES,
+            key = { it.label },
+        ) { entry ->
+            Button(
+                onClick = {
+                    context.startActivity(Intent(context, entry.activityClass))
+                },
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp),
+            ) {
+                Text(text = entry.label)
+            }
+        }
+        NavParadigm.entries.forEach { paradigm ->
+            item(key = "header_${paradigm.name}") {
+                Column(modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
+                    Text(
+                        text = paradigm.displayName,
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp),
+                    )
+                    HorizontalDivider()
+                }
+            }
+            items(
+                items = ParadigmCatalog.runsFor(paradigm),
+                key = { it.key },
+            ) { run ->
+                Button(
+                    onClick = { run.launch(context) },
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp),
+                ) {
+                    Text(text = run.style.displayName)
+                }
+            }
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ParadigmRun.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ParadigmRun.kt
@@ -1,0 +1,11 @@
+package io.embrace.android.exampleapp.paradigms
+
+import android.content.Context
+
+class ParadigmRun(
+    val paradigm: NavParadigm,
+    val style: NavStyle,
+    val launch: (Context) -> Unit,
+) {
+    val key: String = "${paradigm.name.lowercase()}_${style.name.lowercase()}"
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/data/Article.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/data/Article.kt
@@ -1,0 +1,15 @@
+package io.embrace.android.exampleapp.paradigms.data
+
+data class Article(
+    val id: String,
+    val sectionId: String,
+    val headline: String,
+    val byline: String,
+    val summary: String,
+    val body: String,
+)
+
+data class NewsSection(
+    val id: String,
+    val title: String,
+)

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/data/Post.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/data/Post.kt
@@ -1,0 +1,19 @@
+package io.embrace.android.exampleapp.paradigms.data
+
+data class Post(
+    val id: String,
+    val authorHandle: String,
+    val authorDisplayName: String,
+    val body: String,
+    val likeCount: Int,
+    val replyCount: Int,
+    val repostCount: Int,
+)
+
+data class PostAuthor(
+    val handle: String,
+    val displayName: String,
+    val bio: String,
+    val followerCount: Int,
+    val followingCount: Int,
+)

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/data/Product.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/data/Product.kt
@@ -1,0 +1,21 @@
+package io.embrace.android.exampleapp.paradigms.data
+
+data class Product(
+    val id: String,
+    val categoryId: String,
+    val title: String,
+    val priceCents: Long,
+    val rating: Double,
+    val reviewCount: Int,
+    val description: String,
+)
+
+data class ProductCategory(
+    val id: String,
+    val title: String,
+)
+
+data class CartLine(
+    val product: Product,
+    val quantity: Int,
+)

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/data/SampleData.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/data/SampleData.kt
@@ -1,0 +1,134 @@
+package io.embrace.android.exampleapp.paradigms.data
+
+object SampleData {
+
+    val postAuthors: List<PostAuthor> = listOf(
+        PostAuthor(
+            handle = "ada",
+            displayName = "Ada Lovelace",
+            bio = "Notes on the Analytical Engine. Mostly correct.",
+            followerCount = 21_345,
+            followingCount = 184,
+        ),
+        PostAuthor(
+            handle = "linus",
+            displayName = "Linus T.",
+            bio = "Kernel hacker. Opinions own, code GPL.",
+            followerCount = 982_133,
+            followingCount = 12,
+        ),
+        PostAuthor(
+            handle = "grace",
+            displayName = "Grace Hopper",
+            bio = "Compilers. Nanoseconds. Ships.",
+            followerCount = 56_421,
+            followingCount = 311,
+        ),
+    )
+
+    val posts: List<Post> = listOf(
+        Post("t1", "ada", "Ada Lovelace", "Wrote a loop that finally terminates. Big day.", 412, 17, 88),
+        Post("t2", "linus", "Linus T.", "Reverted that patch. Again.", 9_812, 504, 1_233),
+        Post("t3", "grace", "Grace Hopper", "It's easier to ask forgiveness than permission.", 7_344, 22, 412),
+        Post("t4", "ada", "Ada Lovelace", "Counter-counterfactual: what if we just didn't?", 188, 9, 21),
+        Post("t5", "linus", "Linus T.", "Talk is cheap. Show me the diff.", 22_104, 871, 4_002),
+    )
+
+    val newsSections: List<NewsSection> = listOf(
+        NewsSection("world", "World"),
+        NewsSection("tech", "Technology"),
+        NewsSection("opinion", "Opinion"),
+    )
+
+    val articles: List<Article> = listOf(
+        Article(
+            id = "a1",
+            sectionId = "world",
+            headline = "Treaty Signed After Decade of Talks",
+            byline = "By Staff",
+            summary = "Negotiators reached agreement on a long-disputed clause.",
+            body = "After ten rounds of negotiation, delegates announced a final text on Tuesday. " +
+                "The agreement, if ratified, would reshape regional trade and immigration rules.",
+        ),
+        Article(
+            id = "a2",
+            sectionId = "tech",
+            headline = "On-Device AI Models Hit New Memory Lows",
+            byline = "By J. Reporter",
+            summary = "Quantization advances push 7B-parameter models below 2GB.",
+            body = "Researchers presented a quantization scheme that maintains accuracy while " +
+                "halving memory footprint. Phone vendors are reportedly already integrating it.",
+        ),
+        Article(
+            id = "a3",
+            sectionId = "opinion",
+            headline = "Why Navigation APIs Keep Getting Reinvented",
+            byline = "By A Columnist",
+            summary = "Each generation of UI framework rediscovers the back stack.",
+            body = "From Activities to Fragments to Composables to typed key navigation, " +
+                "the industry seems unable to stop reinventing how a user gets from one screen to the next.",
+        ),
+        Article(
+            id = "a4",
+            sectionId = "tech",
+            headline = "Gradle 9 Lands With Faster Configuration",
+            byline = "By Staff",
+            summary = "Configuration cache becomes default; some plugins still incompatible.",
+            body = "The new release prioritizes incremental builds and configuration cache adoption.",
+        ),
+    )
+
+    val productCategories: List<ProductCategory> = listOf(
+        ProductCategory("electronics", "Electronics"),
+        ProductCategory("books", "Books"),
+        ProductCategory("kitchen", "Kitchen"),
+    )
+
+    val products: List<Product> = listOf(
+        Product(
+            id = "p1",
+            categoryId = "electronics",
+            title = "USB-C Hub, 7-in-1",
+            priceCents = 3499,
+            rating = 4.4,
+            reviewCount = 2_104,
+            description = "HDMI, Ethernet, SD/microSD, two USB-A, USB-C PD passthrough.",
+        ),
+        Product(
+            id = "p2",
+            categoryId = "electronics",
+            title = "Mechanical Keyboard, 75%",
+            priceCents = 12999,
+            rating = 4.7,
+            reviewCount = 814,
+            description = "Hot-swappable, wireless, RGB, with knob.",
+        ),
+        Product(
+            id = "p3",
+            categoryId = "books",
+            title = "Effective Kotlin",
+            priceCents = 4500,
+            rating = 4.8,
+            reviewCount = 312,
+            description = "Best practices for writing clean, idiomatic Kotlin.",
+        ),
+        Product(
+            id = "p4",
+            categoryId = "kitchen",
+            title = "Cast Iron Skillet, 12\"",
+            priceCents = 5499,
+            rating = 4.6,
+            reviewCount = 9_302,
+            description = "Pre-seasoned, made in the USA, lasts forever.",
+        ),
+    )
+
+    fun post(id: String): Post? = posts.firstOrNull { it.id == id }
+    fun author(handle: String): PostAuthor? = postAuthors.firstOrNull { it.handle == handle }
+    fun article(id: String): Article? = articles.firstOrNull { it.id == id }
+    fun section(id: String): NewsSection? = newsSections.firstOrNull { it.id == id }
+    fun product(id: String): Product? = products.firstOrNull { it.id == id }
+    fun category(id: String): ProductCategory? = productCategories.firstOrNull { it.id == id }
+    fun articlesIn(sectionId: String): List<Article> = articles.filter { it.sectionId == sectionId }
+    fun productsIn(categoryId: String): List<Product> = products.filter { it.categoryId == categoryId }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/EcommerceCartStore.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/EcommerceCartStore.kt
@@ -1,0 +1,33 @@
+package io.embrace.android.exampleapp.paradigms.ecommerce
+
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import io.embrace.android.exampleapp.paradigms.data.CartLine
+import io.embrace.android.exampleapp.paradigms.data.Product
+
+object EcommerceCartStore {
+
+    private val backing: SnapshotStateList<CartLine> = mutableStateListOf()
+
+    val items: List<CartLine> get() = backing
+    val itemCount: Int get() = backing.sumOf { it.quantity }
+    val totalCents: Long get() = backing.sumOf { it.product.priceCents * it.quantity }
+
+    fun add(product: Product) {
+        val existingIndex = backing.indexOfFirst { it.product.id == product.id }
+        if (existingIndex >= 0) {
+            val current = backing[existingIndex]
+            backing[existingIndex] = current.copy(quantity = current.quantity + 1)
+        } else {
+            backing.add(CartLine(product = product, quantity = 1))
+        }
+    }
+
+    fun remove(productId: String) {
+        backing.removeAll { it.product.id == productId }
+    }
+
+    fun clear() {
+        backing.clear()
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/a2a/EcommerceA2ACartActivity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/a2a/EcommerceA2ACartActivity.kt
@@ -1,0 +1,44 @@
+package io.embrace.android.exampleapp.paradigms.ecommerce.a2a
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import io.embrace.android.exampleapp.paradigms.ecommerce.EcommerceCartStore
+import io.embrace.android.exampleapp.paradigms.ecommerce.ui.EcommerceCartUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class EcommerceA2ACartActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ExampleAppTheme {
+                EcommerceCartUi(
+                    items = EcommerceCartStore.items,
+                    totalCents = EcommerceCartStore.totalCents,
+                    onRemove = { id -> EcommerceCartStore.remove(id) },
+                    onPlaceOrder = {
+                        val total = EcommerceCartStore.totalCents
+                        EcommerceCartStore.clear()
+                        setResult(
+                            Activity.RESULT_OK,
+                            Intent().putExtra(EXTRA_ORDER_TOTAL_CENTS, total),
+                        )
+                        finish()
+                    },
+                    onBack = { finish() },
+                )
+            }
+        }
+    }
+
+    companion object {
+        const val EXTRA_ORDER_TOTAL_CENTS: String = "order_total_cents"
+
+        fun newIntent(context: Context): Intent =
+            Intent(context, EcommerceA2ACartActivity::class.java)
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/a2a/EcommerceA2ACategoriesActivity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/a2a/EcommerceA2ACategoriesActivity.kt
@@ -1,0 +1,56 @@
+package io.embrace.android.exampleapp.paradigms.ecommerce.a2a
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.paradigms.ecommerce.EcommerceCartStore
+import io.embrace.android.exampleapp.paradigms.ecommerce.ui.EcommerceCategoriesUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class EcommerceA2ACategoriesActivity : ComponentActivity() {
+
+    private var orderPlacedTotalCents by mutableStateOf<Long?>(null)
+
+    private val cartLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            orderPlacedTotalCents = result.data
+                ?.getLongExtra(EcommerceA2ACartActivity.EXTRA_ORDER_TOTAL_CENTS, 0L)
+                ?.takeIf { it >= 0 }
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ExampleAppTheme {
+                EcommerceCategoriesUi(
+                    title = "Categories (A2A)",
+                    categories = SampleData.productCategories,
+                    onCategoryClick = { id ->
+                        startActivity(EcommerceA2AProductListActivity.newIntent(this, id))
+                    },
+                    cartItemCount = EcommerceCartStore.itemCount,
+                    onCartClick = {
+                        cartLauncher.launch(EcommerceA2ACartActivity.newIntent(this))
+                    },
+                    orderPlacedTotalCents = orderPlacedTotalCents,
+                )
+            }
+        }
+    }
+
+    companion object {
+        fun newIntent(context: Context): Intent =
+            Intent(context, EcommerceA2ACategoriesActivity::class.java)
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/a2a/EcommerceA2AProductDetailActivity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/a2a/EcommerceA2AProductDetailActivity.kt
@@ -1,0 +1,43 @@
+package io.embrace.android.exampleapp.paradigms.ecommerce.a2a
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.paradigms.ecommerce.EcommerceCartStore
+import io.embrace.android.exampleapp.paradigms.ecommerce.ui.EcommerceProductDetailUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class EcommerceA2AProductDetailActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val productId = intent.getStringExtra(EXTRA_PRODUCT_ID)
+        val product = productId?.let(SampleData::product)
+        if (product == null) {
+            Toast.makeText(this, "Unknown product", Toast.LENGTH_SHORT).show()
+            finish()
+            return
+        }
+        setContent {
+            ExampleAppTheme {
+                EcommerceProductDetailUi(
+                    product = product,
+                    onBack = { finish() },
+                    onAddToCart = { EcommerceCartStore.add(product) },
+                )
+            }
+        }
+    }
+
+    companion object {
+        private const val EXTRA_PRODUCT_ID = "product_id"
+
+        fun newIntent(context: Context, productId: String): Intent =
+            Intent(context, EcommerceA2AProductDetailActivity::class.java)
+                .putExtra(EXTRA_PRODUCT_ID, productId)
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/a2a/EcommerceA2AProductListActivity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/a2a/EcommerceA2AProductListActivity.kt
@@ -1,0 +1,46 @@
+package io.embrace.android.exampleapp.paradigms.ecommerce.a2a
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.paradigms.ecommerce.ui.EcommerceProductListUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class EcommerceA2AProductListActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val categoryId = intent.getStringExtra(EXTRA_CATEGORY_ID)
+        val category = categoryId?.let(SampleData::category)
+        if (category == null) {
+            Toast.makeText(this, "Unknown category", Toast.LENGTH_SHORT).show()
+            finish()
+            return
+        }
+        val products = SampleData.productsIn(category.id)
+        setContent {
+            ExampleAppTheme {
+                EcommerceProductListUi(
+                    categoryTitle = category.title,
+                    products = products,
+                    onProductClick = { id ->
+                        startActivity(EcommerceA2AProductDetailActivity.newIntent(this, id))
+                    },
+                    onBack = { finish() },
+                )
+            }
+        }
+    }
+
+    companion object {
+        private const val EXTRA_CATEGORY_ID = "category_id"
+
+        fun newIntent(context: Context, categoryId: String): Intent =
+            Intent(context, EcommerceA2AProductListActivity::class.java)
+                .putExtra(EXTRA_CATEGORY_ID, categoryId)
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/fragments/EcommerceCartFragment.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/fragments/EcommerceCartFragment.kt
@@ -1,0 +1,47 @@
+package io.embrace.android.exampleapp.paradigms.ecommerce.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.setFragmentResult
+import androidx.navigation.fragment.findNavController
+import io.embrace.android.exampleapp.paradigms.ecommerce.EcommerceCartStore
+import io.embrace.android.exampleapp.paradigms.ecommerce.ui.EcommerceCartUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class EcommerceCartFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View = ComposeView(requireContext()).apply {
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        setContent {
+            ExampleAppTheme {
+                EcommerceCartUi(
+                    items = EcommerceCartStore.items,
+                    totalCents = EcommerceCartStore.totalCents,
+                    onRemove = { id -> EcommerceCartStore.remove(id) },
+                    onPlaceOrder = {
+                        val total = EcommerceCartStore.totalCents
+                        EcommerceCartStore.clear()
+                        val result = Bundle().apply {
+                            putLong(EcommerceFragmentsActivity.FRAGMENT_RESULT_KEY_TOTAL_CENTS, total)
+                        }
+                        setFragmentResult(
+                            EcommerceFragmentsActivity.FRAGMENT_RESULT_ORDER_PLACED,
+                            result,
+                        )
+                        findNavController().popBackStack()
+                    },
+                    onBack = { findNavController().popBackStack() },
+                )
+            }
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/fragments/EcommerceCategoriesFragment.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/fragments/EcommerceCategoriesFragment.kt
@@ -1,0 +1,59 @@
+package io.embrace.android.exampleapp.paradigms.ecommerce.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.setFragmentResultListener
+import androidx.navigation.fragment.findNavController
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.paradigms.ecommerce.EcommerceCartStore
+import io.embrace.android.exampleapp.paradigms.ecommerce.ui.EcommerceCategoriesUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class EcommerceCategoriesFragment : Fragment() {
+
+    private var orderPlacedTotalCents by mutableStateOf<Long?>(null)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setFragmentResultListener(
+            EcommerceFragmentsActivity.FRAGMENT_RESULT_ORDER_PLACED,
+        ) { _, bundle ->
+            orderPlacedTotalCents = bundle.getLong(
+                EcommerceFragmentsActivity.FRAGMENT_RESULT_KEY_TOTAL_CENTS,
+                0L,
+            )
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View = ComposeView(requireContext()).apply {
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        setContent {
+            ExampleAppTheme {
+                EcommerceCategoriesUi(
+                    title = "Categories (Fragments)",
+                    categories = SampleData.productCategories,
+                    onCategoryClick = { id ->
+                        findNavController().navigate("category/$id")
+                    },
+                    cartItemCount = EcommerceCartStore.itemCount,
+                    onCartClick = {
+                        findNavController().navigate(EcommerceFragmentsActivity.ROUTE_CART)
+                    },
+                    orderPlacedTotalCents = orderPlacedTotalCents,
+                )
+            }
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/fragments/EcommerceFragmentsActivity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/fragments/EcommerceFragmentsActivity.kt
@@ -1,0 +1,55 @@
+package io.embrace.android.exampleapp.paradigms.ecommerce.fragments
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.widget.FrameLayout
+import androidx.fragment.app.FragmentActivity
+import androidx.navigation.createGraph
+import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.fragment.fragment
+
+class EcommerceFragmentsActivity : FragmentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val containerId = View.generateViewId()
+        setContentView(
+            FrameLayout(this).apply {
+                id = containerId
+                layoutParams = FrameLayout.LayoutParams(
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                )
+            },
+        )
+        if (savedInstanceState != null) {
+            return
+        }
+        val navHostFragment = NavHostFragment()
+        supportFragmentManager.beginTransaction()
+            .replace(containerId, navHostFragment)
+            .commitNow()
+
+        val navController = navHostFragment.navController
+        navController.graph = navController.createGraph(startDestination = ROUTE_CATEGORIES) {
+            fragment<EcommerceCategoriesFragment>(ROUTE_CATEGORIES)
+            fragment<EcommerceProductListFragment>("category/{$ARG_CATEGORY_ID}")
+            fragment<EcommerceProductDetailFragment>("product/{$ARG_PRODUCT_ID}")
+            fragment<EcommerceCartFragment>(ROUTE_CART)
+        }
+    }
+
+    companion object {
+        internal const val ROUTE_CATEGORIES: String = "categories"
+        internal const val ROUTE_CART: String = "cart"
+        internal const val ARG_CATEGORY_ID: String = "categoryId"
+        internal const val ARG_PRODUCT_ID: String = "productId"
+        internal const val FRAGMENT_RESULT_ORDER_PLACED: String = "ecommerce_fragments_order_placed"
+        internal const val FRAGMENT_RESULT_KEY_TOTAL_CENTS: String = "totalCents"
+
+        fun newIntent(context: Context): Intent =
+            Intent(context, EcommerceFragmentsActivity::class.java)
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/fragments/EcommerceProductDetailFragment.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/fragments/EcommerceProductDetailFragment.kt
@@ -1,0 +1,42 @@
+package io.embrace.android.exampleapp.paradigms.ecommerce.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.paradigms.ecommerce.EcommerceCartStore
+import io.embrace.android.exampleapp.paradigms.ecommerce.ui.EcommerceProductDetailUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class EcommerceProductDetailFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        val productId = arguments?.getString(EcommerceFragmentsActivity.ARG_PRODUCT_ID)
+        val product = productId?.let(SampleData::product)
+        if (product == null) {
+            findNavController().popBackStack()
+            return ComposeView(requireContext())
+        }
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                ExampleAppTheme {
+                    EcommerceProductDetailUi(
+                        product = product,
+                        onBack = { findNavController().popBackStack() },
+                        onAddToCart = { EcommerceCartStore.add(product) },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/fragments/EcommerceProductListFragment.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/fragments/EcommerceProductListFragment.kt
@@ -1,0 +1,45 @@
+package io.embrace.android.exampleapp.paradigms.ecommerce.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.paradigms.ecommerce.ui.EcommerceProductListUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class EcommerceProductListFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        val categoryId = arguments?.getString(EcommerceFragmentsActivity.ARG_CATEGORY_ID)
+        val category = categoryId?.let(SampleData::category)
+        if (category == null) {
+            findNavController().popBackStack()
+            return ComposeView(requireContext())
+        }
+        val products = SampleData.productsIn(category.id)
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                ExampleAppTheme {
+                    EcommerceProductListUi(
+                        categoryTitle = category.title,
+                        products = products,
+                        onProductClick = { id ->
+                            findNavController().navigate("product/$id")
+                        },
+                        onBack = { findNavController().popBackStack() },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/nav3/EcommerceNav3Activity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/nav3/EcommerceNav3Activity.kt
@@ -1,0 +1,99 @@
+package io.embrace.android.exampleapp.paradigms.ecommerce.nav3
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.ui.NavDisplay
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.paradigms.ecommerce.EcommerceCartStore
+import io.embrace.android.exampleapp.paradigms.ecommerce.ui.EcommerceCartUi
+import io.embrace.android.exampleapp.paradigms.ecommerce.ui.EcommerceCategoriesUi
+import io.embrace.android.exampleapp.paradigms.ecommerce.ui.EcommerceProductDetailUi
+import io.embrace.android.exampleapp.paradigms.ecommerce.ui.EcommerceProductListUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class EcommerceNav3Activity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ExampleAppTheme {
+                val backStack = remember { mutableStateListOf<EcommerceNav3Key>(EcommerceNav3Key.Categories) }
+                var orderPlacedTotalCents by remember { mutableStateOf<Long?>(null) }
+                NavDisplay(
+                    backStack = backStack,
+                    onBack = { backStack.removeLastOrNull() },
+                    entryProvider = { key ->
+                        when (key) {
+                            is EcommerceNav3Key.Categories -> NavEntry(key) {
+                                EcommerceCategoriesUi(
+                                    title = "Categories (Nav3)",
+                                    categories = SampleData.productCategories,
+                                    onCategoryClick = { id ->
+                                        backStack.add(EcommerceNav3Key.ProductList(id))
+                                    },
+                                    cartItemCount = EcommerceCartStore.itemCount,
+                                    onCartClick = { backStack.add(EcommerceNav3Key.Cart) },
+                                    orderPlacedTotalCents = orderPlacedTotalCents,
+                                )
+                            }
+                            is EcommerceNav3Key.ProductList -> NavEntry(key) {
+                                val category = SampleData.category(key.categoryId)
+                                if (category == null) {
+                                    backStack.removeLastOrNull()
+                                } else {
+                                    EcommerceProductListUi(
+                                        categoryTitle = category.title,
+                                        products = SampleData.productsIn(category.id),
+                                        onProductClick = { id ->
+                                            backStack.add(EcommerceNav3Key.ProductDetail(id))
+                                        },
+                                        onBack = { backStack.removeLastOrNull() },
+                                    )
+                                }
+                            }
+                            is EcommerceNav3Key.ProductDetail -> NavEntry(key) {
+                                val product = SampleData.product(key.productId)
+                                if (product == null) {
+                                    backStack.removeLastOrNull()
+                                } else {
+                                    EcommerceProductDetailUi(
+                                        product = product,
+                                        onBack = { backStack.removeLastOrNull() },
+                                        onAddToCart = { EcommerceCartStore.add(product) },
+                                    )
+                                }
+                            }
+                            is EcommerceNav3Key.Cart -> NavEntry(key) {
+                                EcommerceCartUi(
+                                    items = EcommerceCartStore.items,
+                                    totalCents = EcommerceCartStore.totalCents,
+                                    onRemove = { id -> EcommerceCartStore.remove(id) },
+                                    onPlaceOrder = {
+                                        orderPlacedTotalCents = EcommerceCartStore.totalCents
+                                        EcommerceCartStore.clear()
+                                        backStack.removeLastOrNull()
+                                    },
+                                    onBack = { backStack.removeLastOrNull() },
+                                )
+                            }
+                        }
+                    },
+                )
+            }
+        }
+    }
+
+    companion object {
+        fun newIntent(context: Context): Intent =
+            Intent(context, EcommerceNav3Activity::class.java)
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/nav3/EcommerceNav3Keys.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/nav3/EcommerceNav3Keys.kt
@@ -1,0 +1,8 @@
+package io.embrace.android.exampleapp.paradigms.ecommerce.nav3
+
+internal sealed interface EcommerceNav3Key {
+    data object Categories : EcommerceNav3Key
+    data class ProductList(val categoryId: String) : EcommerceNav3Key
+    data class ProductDetail(val productId: String) : EcommerceNav3Key
+    data object Cart : EcommerceNav3Key
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/navcompose/EcommerceNavComposeActivity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/navcompose/EcommerceNavComposeActivity.kt
@@ -1,0 +1,105 @@
+package io.embrace.android.exampleapp.paradigms.ecommerce.navcompose
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.toRoute
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.paradigms.ecommerce.EcommerceCartStore
+import io.embrace.android.exampleapp.paradigms.ecommerce.ui.EcommerceCartUi
+import io.embrace.android.exampleapp.paradigms.ecommerce.ui.EcommerceCategoriesUi
+import io.embrace.android.exampleapp.paradigms.ecommerce.ui.EcommerceProductDetailUi
+import io.embrace.android.exampleapp.paradigms.ecommerce.ui.EcommerceProductListUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class EcommerceNavComposeActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ExampleAppTheme {
+                val navController = rememberNavController()
+                NavHost(
+                    navController = navController,
+                    startDestination = EcommerceRoute.Categories,
+                ) {
+                    composable<EcommerceRoute.Categories> { entry ->
+                        val savedHandle = entry.savedStateHandle
+                        val orderPlacedTotal by savedHandle
+                            .getStateFlow<Long?>(SAVED_STATE_ORDER_PLACED_TOTAL_CENTS, null)
+                            .collectAsState()
+                        EcommerceCategoriesUi(
+                            title = "Categories (Nav-Compose)",
+                            categories = SampleData.productCategories,
+                            onCategoryClick = { id ->
+                                navController.navigate(EcommerceRoute.ProductList(id))
+                            },
+                            cartItemCount = EcommerceCartStore.itemCount,
+                            onCartClick = {
+                                navController.navigate(EcommerceRoute.Cart)
+                            },
+                            orderPlacedTotalCents = orderPlacedTotal,
+                        )
+                    }
+                    composable<EcommerceRoute.ProductList> { entry ->
+                        val route: EcommerceRoute.ProductList = entry.toRoute()
+                        val category = SampleData.category(route.categoryId)
+                        if (category == null) {
+                            navController.popBackStack()
+                        } else {
+                            EcommerceProductListUi(
+                                categoryTitle = category.title,
+                                products = SampleData.productsIn(category.id),
+                                onProductClick = { id ->
+                                    navController.navigate(EcommerceRoute.ProductDetail(id))
+                                },
+                                onBack = { navController.popBackStack() },
+                            )
+                        }
+                    }
+                    composable<EcommerceRoute.ProductDetail> { entry ->
+                        val route: EcommerceRoute.ProductDetail = entry.toRoute()
+                        val product = SampleData.product(route.productId)
+                        if (product == null) {
+                            navController.popBackStack()
+                        } else {
+                            EcommerceProductDetailUi(
+                                product = product,
+                                onBack = { navController.popBackStack() },
+                                onAddToCart = { EcommerceCartStore.add(product) },
+                            )
+                        }
+                    }
+                    composable<EcommerceRoute.Cart> {
+                        EcommerceCartUi(
+                            items = EcommerceCartStore.items,
+                            totalCents = EcommerceCartStore.totalCents,
+                            onRemove = { id -> EcommerceCartStore.remove(id) },
+                            onPlaceOrder = {
+                                val total = EcommerceCartStore.totalCents
+                                EcommerceCartStore.clear()
+                                navController.previousBackStackEntry
+                                    ?.savedStateHandle
+                                    ?.set(SAVED_STATE_ORDER_PLACED_TOTAL_CENTS, total)
+                                navController.popBackStack()
+                            },
+                            onBack = { navController.popBackStack() },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        fun newIntent(context: Context): Intent =
+            Intent(context, EcommerceNavComposeActivity::class.java)
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/navcompose/EcommerceNavComposeRoutes.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/navcompose/EcommerceNavComposeRoutes.kt
@@ -1,0 +1,20 @@
+package io.embrace.android.exampleapp.paradigms.ecommerce.navcompose
+
+import kotlinx.serialization.Serializable
+
+internal sealed interface EcommerceRoute {
+
+    @Serializable
+    object Categories : EcommerceRoute
+
+    @Serializable
+    data class ProductList(val categoryId: String) : EcommerceRoute
+
+    @Serializable
+    data class ProductDetail(val productId: String) : EcommerceRoute
+
+    @Serializable
+    object Cart : EcommerceRoute
+}
+
+internal const val SAVED_STATE_ORDER_PLACED_TOTAL_CENTS: String = "ecommerce_navcompose_order_placed_total_cents"

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/ui/EcommerceCartUi.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/ui/EcommerceCartUi.kt
@@ -1,0 +1,126 @@
+package io.embrace.android.exampleapp.paradigms.ecommerce.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import io.embrace.android.exampleapp.paradigms.data.CartLine
+import io.embrace.android.exampleapp.ui.appBarColors
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EcommerceCartUi(
+    items: List<CartLine>,
+    totalCents: Long,
+    onRemove: (productId: String) -> Unit,
+    onPlaceOrder: () -> Unit,
+    onBack: () -> Unit,
+) {
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text("Cart") },
+                colors = appBarColors(),
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            tint = Color.White,
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            if (items.isEmpty()) {
+                Column(
+                    modifier = Modifier.fillMaxSize().padding(32.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    Text(
+                        text = "Your cart is empty",
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                }
+            } else {
+                LazyColumn(modifier = Modifier.weight(1f)) {
+                    items(items = items, key = { it.product.id }) { line ->
+                        CartRow(line = line, onRemove = onRemove)
+                        HorizontalDivider()
+                    }
+                }
+                CheckoutFooter(totalCents = totalCents, onPlaceOrder = onPlaceOrder)
+            }
+        }
+    }
+}
+
+@Composable
+private fun CartRow(line: CartLine, onRemove: (String) -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(text = line.product.title, style = MaterialTheme.typography.titleSmall)
+            Text(
+                text = "${line.quantity} × ${formatPrice(line.product.priceCents)}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Text(
+            text = formatPrice(line.product.priceCents * line.quantity),
+            style = MaterialTheme.typography.titleSmall,
+            modifier = Modifier.padding(end = 12.dp),
+        )
+        IconButton(onClick = { onRemove(line.product.id) }) {
+            Icon(
+                imageVector = Icons.Filled.Delete,
+                contentDescription = "Remove ${line.product.title}",
+            )
+        }
+    }
+}
+
+@Composable
+private fun CheckoutFooter(totalCents: Long, onPlaceOrder: () -> Unit) {
+    HorizontalDivider()
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(text = "Total", style = MaterialTheme.typography.labelMedium)
+            Text(text = formatPrice(totalCents), style = MaterialTheme.typography.headlineSmall)
+        }
+        Button(onClick = onPlaceOrder) {
+            Text("Place Order")
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/ui/EcommerceCategoriesUi.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/ui/EcommerceCategoriesUi.kt
@@ -1,0 +1,103 @@
+package io.embrace.android.exampleapp.paradigms.ecommerce.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ShoppingCart
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import io.embrace.android.exampleapp.paradigms.data.ProductCategory
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.ui.appBarColors
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EcommerceCategoriesUi(
+    title: String,
+    categories: List<ProductCategory>,
+    onCategoryClick: (categoryId: String) -> Unit,
+    cartItemCount: Int = 0,
+    onCartClick: (() -> Unit)? = null,
+    orderPlacedTotalCents: Long? = null,
+) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    LaunchedEffect(orderPlacedTotalCents) {
+        if (orderPlacedTotalCents != null) {
+            snackbarHostState.showSnackbar("Order placed: ${formatPrice(orderPlacedTotalCents)}")
+        }
+    }
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text(title) },
+                colors = appBarColors(),
+                actions = {
+                    if (onCartClick != null) {
+                        IconButton(onClick = onCartClick) {
+                            BadgedBox(
+                                badge = {
+                                    if (cartItemCount > 0) {
+                                        Badge { Text(cartItemCount.toString()) }
+                                    }
+                                },
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Filled.ShoppingCart,
+                                    contentDescription = "Cart",
+                                    tint = Color.White,
+                                )
+                            }
+                        }
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) { Snackbar(it) } },
+    ) { padding ->
+        LazyColumn(modifier = Modifier.fillMaxSize().padding(padding)) {
+            items(items = categories, key = { it.id }) { category ->
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onCategoryClick(category.id) },
+                ) {
+                    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp)) {
+                        Text(text = category.title, style = MaterialTheme.typography.titleMedium)
+                        val count = SampleData.productsIn(category.id).size
+                        Text(
+                            text = "$count items",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(top = 4.dp),
+                        )
+                    }
+                }
+                HorizontalDivider()
+            }
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/ui/EcommerceProductDetailUi.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/ui/EcommerceProductDetailUi.kt
@@ -1,0 +1,105 @@
+package io.embrace.android.exampleapp.paradigms.ecommerce.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import io.embrace.android.exampleapp.paradigms.data.Product
+import io.embrace.android.exampleapp.ui.appBarColors
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EcommerceProductDetailUi(
+    product: Product,
+    onBack: () -> Unit,
+    onAddToCart: (() -> Unit)? = null,
+) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text("Product") },
+                colors = appBarColors(),
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            tint = Color.White,
+                        )
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) { Snackbar(it) } },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            Text(text = product.title, style = MaterialTheme.typography.headlineSmall)
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Text(
+                    text = formatPrice(product.priceCents),
+                    style = MaterialTheme.typography.titleLarge,
+                )
+                Text(
+                    text = "★ ${product.rating}  (${product.reviewCount} reviews)",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+            Text(text = product.description, style = MaterialTheme.typography.bodyLarge)
+            if (onAddToCart != null) {
+                Spacer(modifier = Modifier.height(24.dp))
+                Button(
+                    onClick = {
+                        onAddToCart()
+                        scope.launch {
+                            snackbarHostState.showSnackbar("Added to cart: ${product.title}")
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text("Add to Cart")
+                }
+            }
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/ui/EcommerceProductListUi.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/ui/EcommerceProductListUi.kt
@@ -1,0 +1,83 @@
+package io.embrace.android.exampleapp.paradigms.ecommerce.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import io.embrace.android.exampleapp.paradigms.data.Product
+import io.embrace.android.exampleapp.ui.appBarColors
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EcommerceProductListUi(
+    categoryTitle: String,
+    products: List<Product>,
+    onProductClick: (productId: String) -> Unit,
+    onBack: () -> Unit,
+) {
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text(categoryTitle) },
+                colors = appBarColors(),
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            tint = Color.White,
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        LazyColumn(modifier = Modifier.fillMaxSize().padding(padding)) {
+            items(items = products, key = { it.id }) { product ->
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onProductClick(product.id) }
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                ) {
+                    Text(text = product.title, style = MaterialTheme.typography.titleMedium)
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    ) {
+                        Text(
+                            text = formatPrice(product.priceCents),
+                            style = MaterialTheme.typography.titleSmall,
+                        )
+                        Text(
+                            text = "★ ${product.rating}  (${product.reviewCount})",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                HorizontalDivider()
+            }
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/ui/PriceFormat.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/ecommerce/ui/PriceFormat.kt
@@ -1,0 +1,7 @@
+package io.embrace.android.exampleapp.paradigms.ecommerce.ui
+
+internal fun formatPrice(priceCents: Long): String {
+    val dollars = priceCents / 100
+    val cents = priceCents % 100
+    return "$%d.%02d".format(dollars, cents)
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/a2a/NewsA2AArticleDetailActivity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/a2a/NewsA2AArticleDetailActivity.kt
@@ -1,0 +1,41 @@
+package io.embrace.android.exampleapp.paradigms.news.a2a
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.paradigms.news.ui.NewsArticleDetailUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class NewsA2AArticleDetailActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val articleId = intent.getStringExtra(EXTRA_ARTICLE_ID)
+        val article = articleId?.let(SampleData::article)
+        if (article == null) {
+            Toast.makeText(this, "Unknown article", Toast.LENGTH_SHORT).show()
+            finish()
+            return
+        }
+        setContent {
+            ExampleAppTheme {
+                NewsArticleDetailUi(
+                    article = article,
+                    onBack = { finish() },
+                )
+            }
+        }
+    }
+
+    companion object {
+        private const val EXTRA_ARTICLE_ID = "article_id"
+
+        fun newIntent(context: Context, articleId: String): Intent =
+            Intent(context, NewsA2AArticleDetailActivity::class.java)
+                .putExtra(EXTRA_ARTICLE_ID, articleId)
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/a2a/NewsA2AArticleListActivity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/a2a/NewsA2AArticleListActivity.kt
@@ -1,0 +1,46 @@
+package io.embrace.android.exampleapp.paradigms.news.a2a
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.paradigms.news.ui.NewsArticleListUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class NewsA2AArticleListActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val sectionId = intent.getStringExtra(EXTRA_SECTION_ID)
+        val section = sectionId?.let(SampleData::section)
+        if (section == null) {
+            Toast.makeText(this, "Unknown section", Toast.LENGTH_SHORT).show()
+            finish()
+            return
+        }
+        val articles = SampleData.articlesIn(section.id)
+        setContent {
+            ExampleAppTheme {
+                NewsArticleListUi(
+                    sectionTitle = section.title,
+                    articles = articles,
+                    onArticleClick = { id ->
+                        startActivity(NewsA2AArticleDetailActivity.newIntent(this, id))
+                    },
+                    onBack = { finish() },
+                )
+            }
+        }
+    }
+
+    companion object {
+        private const val EXTRA_SECTION_ID = "section_id"
+
+        fun newIntent(context: Context, sectionId: String): Intent =
+            Intent(context, NewsA2AArticleListActivity::class.java)
+                .putExtra(EXTRA_SECTION_ID, sectionId)
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/a2a/NewsA2ASectionsActivity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/a2a/NewsA2ASectionsActivity.kt
@@ -1,0 +1,43 @@
+package io.embrace.android.exampleapp.paradigms.news.a2a
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.core.app.TaskStackBuilder
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.paradigms.news.ui.NewsSectionsUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class NewsA2ASectionsActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ExampleAppTheme {
+                NewsSectionsUi(
+                    title = "Sections (A2A)",
+                    sections = SampleData.newsSections,
+                    onSectionClick = { id ->
+                        startActivity(NewsA2AArticleListActivity.newIntent(this, id))
+                    },
+                    onDeeplinkRandom = {
+                        val article = SampleData.articles.random()
+                        TaskStackBuilder.create(this)
+                            .addNextIntent(newIntent(this))
+                            .addNextIntent(NewsA2AArticleListActivity.newIntent(this, article.sectionId))
+                            .addNextIntent(NewsA2AArticleDetailActivity.newIntent(this, article.id))
+                            .startActivities()
+                        finish()
+                    },
+                )
+            }
+        }
+    }
+
+    companion object {
+        fun newIntent(context: Context): Intent =
+            Intent(context, NewsA2ASectionsActivity::class.java)
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/fragments/NewsArticleDetailFragment.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/fragments/NewsArticleDetailFragment.kt
@@ -1,0 +1,40 @@
+package io.embrace.android.exampleapp.paradigms.news.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.paradigms.news.ui.NewsArticleDetailUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class NewsArticleDetailFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        val articleId = arguments?.getString(NewsFragmentsActivity.ARG_ARTICLE_ID)
+        val article = articleId?.let(SampleData::article)
+        if (article == null) {
+            findNavController().popBackStack()
+            return ComposeView(requireContext())
+        }
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                ExampleAppTheme {
+                    NewsArticleDetailUi(
+                        article = article,
+                        onBack = { findNavController().popBackStack() },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/fragments/NewsArticleListFragment.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/fragments/NewsArticleListFragment.kt
@@ -1,0 +1,45 @@
+package io.embrace.android.exampleapp.paradigms.news.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.paradigms.news.ui.NewsArticleListUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class NewsArticleListFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        val sectionId = arguments?.getString(NewsFragmentsActivity.ARG_SECTION_ID)
+        val section = sectionId?.let(SampleData::section)
+        if (section == null) {
+            findNavController().popBackStack()
+            return ComposeView(requireContext())
+        }
+        val articles = SampleData.articlesIn(section.id)
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                ExampleAppTheme {
+                    NewsArticleListUi(
+                        sectionTitle = section.title,
+                        articles = articles,
+                        onArticleClick = { id ->
+                            findNavController().navigate("article/$id")
+                        },
+                        onBack = { findNavController().popBackStack() },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/fragments/NewsFragmentsActivity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/fragments/NewsFragmentsActivity.kt
@@ -1,0 +1,51 @@
+package io.embrace.android.exampleapp.paradigms.news.fragments
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.widget.FrameLayout
+import androidx.fragment.app.FragmentActivity
+import androidx.navigation.createGraph
+import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.fragment.fragment
+
+class NewsFragmentsActivity : FragmentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val containerId = View.generateViewId()
+        setContentView(
+            FrameLayout(this).apply {
+                id = containerId
+                layoutParams = FrameLayout.LayoutParams(
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                )
+            },
+        )
+        if (savedInstanceState != null) {
+            return
+        }
+        val navHostFragment = NavHostFragment()
+        supportFragmentManager.beginTransaction()
+            .replace(containerId, navHostFragment)
+            .commitNow()
+
+        val navController = navHostFragment.navController
+        navController.graph = navController.createGraph(startDestination = ROUTE_SECTIONS) {
+            fragment<NewsSectionsFragment>(ROUTE_SECTIONS)
+            fragment<NewsArticleListFragment>("section/{$ARG_SECTION_ID}")
+            fragment<NewsArticleDetailFragment>("article/{$ARG_ARTICLE_ID}")
+        }
+    }
+
+    companion object {
+        internal const val ROUTE_SECTIONS: String = "sections"
+        internal const val ARG_SECTION_ID: String = "sectionId"
+        internal const val ARG_ARTICLE_ID: String = "articleId"
+
+        fun newIntent(context: Context): Intent =
+            Intent(context, NewsFragmentsActivity::class.java)
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/fragments/NewsSectionsFragment.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/fragments/NewsSectionsFragment.kt
@@ -1,0 +1,41 @@
+package io.embrace.android.exampleapp.paradigms.news.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.paradigms.news.ui.NewsSectionsUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class NewsSectionsFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View = ComposeView(requireContext()).apply {
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        setContent {
+            ExampleAppTheme {
+                NewsSectionsUi(
+                    title = "Sections (Fragments)",
+                    sections = SampleData.newsSections,
+                    onSectionClick = { id ->
+                        findNavController().navigate("section/$id")
+                    },
+                    onDeeplinkRandom = {
+                        val article = SampleData.articles.random()
+                        val navController = findNavController()
+                        navController.navigate("section/${article.sectionId}")
+                        navController.navigate("article/${article.id}")
+                    },
+                )
+            }
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/nav3/NewsNav3Activity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/nav3/NewsNav3Activity.kt
@@ -1,0 +1,85 @@
+package io.embrace.android.exampleapp.paradigms.news.nav3
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.ui.NavDisplay
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.paradigms.news.ui.NewsArticleDetailUi
+import io.embrace.android.exampleapp.paradigms.news.ui.NewsArticleListUi
+import io.embrace.android.exampleapp.paradigms.news.ui.NewsSectionsUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class NewsNav3Activity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ExampleAppTheme {
+                val backStack = remember { mutableStateListOf<NewsNav3Key>(NewsNav3Key.Sections) }
+                NavDisplay(
+                    backStack = backStack,
+                    onBack = { backStack.removeLastOrNull() },
+                    entryProvider = { key ->
+                        when (key) {
+                            is NewsNav3Key.Sections -> NavEntry(key) {
+                                NewsSectionsUi(
+                                    title = "Sections (Nav3)",
+                                    sections = SampleData.newsSections,
+                                    onSectionClick = { id ->
+                                        backStack.add(NewsNav3Key.ArticleList(id))
+                                    },
+                                    onDeeplinkRandom = {
+                                        val article = SampleData.articles.random()
+                                        backStack.addAll(
+                                            listOf(
+                                                NewsNav3Key.ArticleList(article.sectionId),
+                                                NewsNav3Key.ArticleDetail(article.id),
+                                            ),
+                                        )
+                                    },
+                                )
+                            }
+                            is NewsNav3Key.ArticleList -> NavEntry(key) {
+                                val section = SampleData.section(key.sectionId)
+                                if (section == null) {
+                                    backStack.removeLastOrNull()
+                                } else {
+                                    NewsArticleListUi(
+                                        sectionTitle = section.title,
+                                        articles = SampleData.articlesIn(section.id),
+                                        onArticleClick = { id ->
+                                            backStack.add(NewsNav3Key.ArticleDetail(id))
+                                        },
+                                        onBack = { backStack.removeLastOrNull() },
+                                    )
+                                }
+                            }
+                            is NewsNav3Key.ArticleDetail -> NavEntry(key) {
+                                val article = SampleData.article(key.articleId)
+                                if (article == null) {
+                                    backStack.removeLastOrNull()
+                                } else {
+                                    NewsArticleDetailUi(
+                                        article = article,
+                                        onBack = { backStack.removeLastOrNull() },
+                                    )
+                                }
+                            }
+                        }
+                    },
+                )
+            }
+        }
+    }
+
+    companion object {
+        fun newIntent(context: Context): Intent =
+            Intent(context, NewsNav3Activity::class.java)
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/nav3/NewsNav3Keys.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/nav3/NewsNav3Keys.kt
@@ -1,0 +1,7 @@
+package io.embrace.android.exampleapp.paradigms.news.nav3
+
+internal sealed interface NewsNav3Key {
+    data object Sections : NewsNav3Key
+    data class ArticleList(val sectionId: String) : NewsNav3Key
+    data class ArticleDetail(val articleId: String) : NewsNav3Key
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/navcompose/NewsNavComposeActivity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/navcompose/NewsNavComposeActivity.kt
@@ -1,0 +1,80 @@
+package io.embrace.android.exampleapp.paradigms.news.navcompose
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.toRoute
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.paradigms.news.ui.NewsArticleDetailUi
+import io.embrace.android.exampleapp.paradigms.news.ui.NewsArticleListUi
+import io.embrace.android.exampleapp.paradigms.news.ui.NewsSectionsUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class NewsNavComposeActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ExampleAppTheme {
+                val navController = rememberNavController()
+                NavHost(
+                    navController = navController,
+                    startDestination = NewsRoute.Sections,
+                ) {
+                    composable<NewsRoute.Sections> {
+                        NewsSectionsUi(
+                            title = "Sections (Nav-Compose)",
+                            sections = SampleData.newsSections,
+                            onSectionClick = { id ->
+                                navController.navigate(NewsRoute.ArticleList(id))
+                            },
+                            onDeeplinkRandom = {
+                                val article = SampleData.articles.random()
+                                navController.navigate(NewsRoute.ArticleList(article.sectionId))
+                                navController.navigate(NewsRoute.ArticleDetail(article.id))
+                            },
+                        )
+                    }
+                    composable<NewsRoute.ArticleList> { entry ->
+                        val route: NewsRoute.ArticleList = entry.toRoute()
+                        val section = SampleData.section(route.sectionId)
+                        if (section == null) {
+                            navController.popBackStack()
+                        } else {
+                            NewsArticleListUi(
+                                sectionTitle = section.title,
+                                articles = SampleData.articlesIn(section.id),
+                                onArticleClick = { id ->
+                                    navController.navigate(NewsRoute.ArticleDetail(id))
+                                },
+                                onBack = { navController.popBackStack() },
+                            )
+                        }
+                    }
+                    composable<NewsRoute.ArticleDetail> { entry ->
+                        val route: NewsRoute.ArticleDetail = entry.toRoute()
+                        val article = SampleData.article(route.articleId)
+                        if (article == null) {
+                            navController.popBackStack()
+                        } else {
+                            NewsArticleDetailUi(
+                                article = article,
+                                onBack = { navController.popBackStack() },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        fun newIntent(context: Context): Intent =
+            Intent(context, NewsNavComposeActivity::class.java)
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/navcompose/NewsNavComposeRoutes.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/navcompose/NewsNavComposeRoutes.kt
@@ -1,0 +1,15 @@
+package io.embrace.android.exampleapp.paradigms.news.navcompose
+
+import kotlinx.serialization.Serializable
+
+internal sealed interface NewsRoute {
+
+    @Serializable
+    object Sections : NewsRoute
+
+    @Serializable
+    data class ArticleList(val sectionId: String) : NewsRoute
+
+    @Serializable
+    data class ArticleDetail(val articleId: String) : NewsRoute
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/ui/NewsArticleDetailUi.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/ui/NewsArticleDetailUi.kt
@@ -1,0 +1,72 @@
+package io.embrace.android.exampleapp.paradigms.news.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import io.embrace.android.exampleapp.paradigms.data.Article
+import io.embrace.android.exampleapp.ui.appBarColors
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NewsArticleDetailUi(
+    article: Article,
+    onBack: () -> Unit,
+) {
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text("Article") },
+                colors = appBarColors(),
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            tint = Color.White,
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            Text(text = article.headline, style = MaterialTheme.typography.headlineSmall)
+            Text(
+                text = article.byline,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 6.dp),
+            )
+            HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+            Text(text = article.summary, style = MaterialTheme.typography.titleMedium)
+            Text(
+                text = article.body,
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.padding(top = 12.dp),
+            )
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/ui/NewsArticleListUi.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/ui/NewsArticleListUi.kt
@@ -1,0 +1,78 @@
+package io.embrace.android.exampleapp.paradigms.news.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import io.embrace.android.exampleapp.paradigms.data.Article
+import io.embrace.android.exampleapp.ui.appBarColors
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NewsArticleListUi(
+    sectionTitle: String,
+    articles: List<Article>,
+    onArticleClick: (articleId: String) -> Unit,
+    onBack: () -> Unit,
+) {
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text(sectionTitle) },
+                colors = appBarColors(),
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            tint = Color.White,
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        LazyColumn(modifier = Modifier.fillMaxSize().padding(padding)) {
+            items(items = articles, key = { it.id }) { article ->
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onArticleClick(article.id) }
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                ) {
+                    Text(text = article.headline, style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        text = article.byline,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                    Text(
+                        text = article.summary,
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(top = 6.dp),
+                    )
+                }
+                HorizontalDivider()
+            }
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/ui/NewsSectionsUi.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/news/ui/NewsSectionsUi.kt
@@ -1,0 +1,63 @@
+package io.embrace.android.exampleapp.paradigms.news.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.embrace.android.exampleapp.paradigms.data.NewsSection
+import io.embrace.android.exampleapp.ui.appBarColors
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NewsSectionsUi(
+    title: String,
+    sections: List<NewsSection>,
+    onSectionClick: (sectionId: String) -> Unit,
+    onDeeplinkRandom: (() -> Unit)? = null,
+) {
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(title = { Text(title) }, colors = appBarColors())
+        },
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            if (onDeeplinkRandom != null) {
+                Button(
+                    onClick = onDeeplinkRandom,
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+                ) {
+                    Text("Deeplink: open a random article")
+                }
+                HorizontalDivider()
+            }
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(items = sections, key = { it.id }) { section ->
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onSectionClick(section.id) }
+                            .padding(horizontal = 16.dp, vertical = 16.dp),
+                    ) {
+                        Text(text = section.title, style = MaterialTheme.typography.titleMedium)
+                    }
+                    HorizontalDivider()
+                }
+            }
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/a2a/SocialA2AComposeActivity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/a2a/SocialA2AComposeActivity.kt
@@ -1,0 +1,35 @@
+package io.embrace.android.exampleapp.paradigms.social.a2a
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import io.embrace.android.exampleapp.paradigms.social.ui.ComposePostUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class SocialA2AComposeActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ExampleAppTheme {
+                ComposePostUi(
+                    onPost = { body ->
+                        setResult(Activity.RESULT_OK, Intent().putExtra(EXTRA_BODY, body))
+                        finish()
+                    },
+                    onCancel = { finish() },
+                )
+            }
+        }
+    }
+
+    companion object {
+        const val EXTRA_BODY: String = "body"
+
+        fun newIntent(context: Context): Intent =
+            Intent(context, SocialA2AComposeActivity::class.java)
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/a2a/SocialA2APostDetailActivity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/a2a/SocialA2APostDetailActivity.kt
@@ -1,0 +1,44 @@
+package io.embrace.android.exampleapp.paradigms.social.a2a
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.paradigms.social.ui.PostDetailUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class SocialA2APostDetailActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val postId = intent.getStringExtra(EXTRA_POST_ID)
+        val post = postId?.let(SampleData::post)
+        if (post == null) {
+            Toast.makeText(this, "Unknown post", Toast.LENGTH_SHORT).show()
+            finish()
+            return
+        }
+        setContent {
+            ExampleAppTheme {
+                PostDetailUi(
+                    post = post,
+                    onAuthorClick = { handle ->
+                        startActivity(SocialA2AProfileActivity.newIntent(this, handle))
+                    },
+                    onBack = { finish() },
+                )
+            }
+        }
+    }
+
+    companion object {
+        private const val EXTRA_POST_ID = "post_id"
+
+        fun newIntent(context: Context, postId: String): Intent =
+            Intent(context, SocialA2APostDetailActivity::class.java)
+                .putExtra(EXTRA_POST_ID, postId)
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/a2a/SocialA2AProfileActivity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/a2a/SocialA2AProfileActivity.kt
@@ -1,0 +1,46 @@
+package io.embrace.android.exampleapp.paradigms.social.a2a
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.paradigms.social.ui.ProfileUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class SocialA2AProfileActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val handle = intent.getStringExtra(EXTRA_HANDLE)
+        val author = handle?.let(SampleData::author)
+        if (author == null) {
+            Toast.makeText(this, "Unknown author", Toast.LENGTH_SHORT).show()
+            finish()
+            return
+        }
+        val authorPosts = SampleData.posts.filter { it.authorHandle == author.handle }
+        setContent {
+            ExampleAppTheme {
+                ProfileUi(
+                    author = author,
+                    authorPosts = authorPosts,
+                    onPostClick = { id ->
+                        startActivity(SocialA2APostDetailActivity.newIntent(this, id))
+                    },
+                    onBack = { finish() },
+                )
+            }
+        }
+    }
+
+    companion object {
+        private const val EXTRA_HANDLE = "handle"
+
+        fun newIntent(context: Context, handle: String): Intent =
+            Intent(context, SocialA2AProfileActivity::class.java)
+                .putExtra(EXTRA_HANDLE, handle)
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/a2a/SocialA2ATimelineActivity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/a2a/SocialA2ATimelineActivity.kt
@@ -1,0 +1,55 @@
+package io.embrace.android.exampleapp.paradigms.social.a2a
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.paradigms.social.ui.TimelineUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class SocialA2ATimelineActivity : ComponentActivity() {
+
+    private var postedBody by mutableStateOf<String?>(null)
+
+    private val composeLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            postedBody = result.data?.getStringExtra(SocialA2AComposeActivity.EXTRA_BODY)
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ExampleAppTheme {
+                TimelineUi(
+                    title = "Home (A2A)",
+                    posts = SampleData.posts,
+                    onPostClick = { id ->
+                        startActivity(SocialA2APostDetailActivity.newIntent(this, id))
+                    },
+                    onAuthorClick = { handle ->
+                        startActivity(SocialA2AProfileActivity.newIntent(this, handle))
+                    },
+                    onCompose = {
+                        composeLauncher.launch(SocialA2AComposeActivity.newIntent(this))
+                    },
+                    postedBody = postedBody,
+                )
+            }
+        }
+    }
+
+    companion object {
+        fun newIntent(context: Context): Intent =
+            Intent(context, SocialA2ATimelineActivity::class.java)
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/fragments/ComposePostFragment.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/fragments/ComposePostFragment.kt
@@ -1,0 +1,38 @@
+package io.embrace.android.exampleapp.paradigms.social.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.setFragmentResult
+import androidx.navigation.fragment.findNavController
+import io.embrace.android.exampleapp.paradigms.social.ui.ComposePostUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class ComposePostFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View = ComposeView(requireContext()).apply {
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        setContent {
+            ExampleAppTheme {
+                ComposePostUi(
+                    onPost = { body ->
+                        val result = Bundle().apply {
+                            putString(SocialFragmentsActivity.FRAGMENT_RESULT_KEY_BODY, body)
+                        }
+                        setFragmentResult(SocialFragmentsActivity.FRAGMENT_RESULT_COMPOSE, result)
+                        findNavController().popBackStack()
+                    },
+                    onCancel = { findNavController().popBackStack() },
+                )
+            }
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/fragments/PostDetailFragment.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/fragments/PostDetailFragment.kt
@@ -1,0 +1,43 @@
+package io.embrace.android.exampleapp.paradigms.social.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.paradigms.social.ui.PostDetailUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class PostDetailFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        val postId = arguments?.getString(SocialFragmentsActivity.ARG_POST_ID)
+        val post = postId?.let(SampleData::post)
+        if (post == null) {
+            findNavController().popBackStack()
+            return ComposeView(requireContext())
+        }
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                ExampleAppTheme {
+                    PostDetailUi(
+                        post = post,
+                        onAuthorClick = { handle ->
+                            findNavController().navigate("profile/$handle")
+                        },
+                        onBack = { findNavController().popBackStack() },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/fragments/ProfileFragment.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/fragments/ProfileFragment.kt
@@ -1,0 +1,45 @@
+package io.embrace.android.exampleapp.paradigms.social.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.paradigms.social.ui.ProfileUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class ProfileFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        val handle = arguments?.getString(SocialFragmentsActivity.ARG_HANDLE)
+        val author = handle?.let(SampleData::author)
+        if (author == null) {
+            findNavController().popBackStack()
+            return ComposeView(requireContext())
+        }
+        val authorPosts = SampleData.posts.filter { it.authorHandle == author.handle }
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                ExampleAppTheme {
+                    ProfileUi(
+                        author = author,
+                        authorPosts = authorPosts,
+                        onPostClick = { id ->
+                            findNavController().navigate("post/$id")
+                        },
+                        onBack = { findNavController().popBackStack() },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/fragments/SocialFragmentsActivity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/fragments/SocialFragmentsActivity.kt
@@ -1,0 +1,55 @@
+package io.embrace.android.exampleapp.paradigms.social.fragments
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.widget.FrameLayout
+import androidx.fragment.app.FragmentActivity
+import androidx.navigation.createGraph
+import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.fragment.fragment
+
+class SocialFragmentsActivity : FragmentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val containerId = View.generateViewId()
+        setContentView(
+            FrameLayout(this).apply {
+                id = containerId
+                layoutParams = FrameLayout.LayoutParams(
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                )
+            },
+        )
+        if (savedInstanceState != null) {
+            return
+        }
+        val navHostFragment = NavHostFragment()
+        supportFragmentManager.beginTransaction()
+            .replace(containerId, navHostFragment)
+            .commitNow()
+
+        val navController = navHostFragment.navController
+        navController.graph = navController.createGraph(startDestination = ROUTE_TIMELINE) {
+            fragment<TimelineFragment>(ROUTE_TIMELINE)
+            fragment<PostDetailFragment>("post/{$ARG_POST_ID}")
+            fragment<ProfileFragment>("profile/{$ARG_HANDLE}")
+            fragment<ComposePostFragment>(ROUTE_COMPOSE)
+        }
+    }
+
+    companion object {
+        internal const val ROUTE_TIMELINE: String = "timeline"
+        internal const val ROUTE_COMPOSE: String = "compose"
+        internal const val ARG_POST_ID: String = "postId"
+        internal const val ARG_HANDLE: String = "handle"
+        internal const val FRAGMENT_RESULT_COMPOSE: String = "social_fragments_compose_result"
+        internal const val FRAGMENT_RESULT_KEY_BODY: String = "body"
+
+        fun newIntent(context: Context): Intent =
+            Intent(context, SocialFragmentsActivity::class.java)
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/fragments/TimelineFragment.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/fragments/TimelineFragment.kt
@@ -1,0 +1,55 @@
+package io.embrace.android.exampleapp.paradigms.social.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.setFragmentResultListener
+import androidx.navigation.fragment.findNavController
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.paradigms.social.ui.TimelineUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class TimelineFragment : Fragment() {
+
+    private var postedBody by mutableStateOf<String?>(null)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setFragmentResultListener(SocialFragmentsActivity.FRAGMENT_RESULT_COMPOSE) { _, bundle ->
+            postedBody = bundle.getString(SocialFragmentsActivity.FRAGMENT_RESULT_KEY_BODY)
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View = ComposeView(requireContext()).apply {
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        setContent {
+            ExampleAppTheme {
+                TimelineUi(
+                    title = "Home (Fragments)",
+                    posts = SampleData.posts,
+                    onPostClick = { id ->
+                        findNavController().navigate("post/$id")
+                    },
+                    onAuthorClick = { handle ->
+                        findNavController().navigate("profile/$handle")
+                    },
+                    onCompose = {
+                        findNavController().navigate(SocialFragmentsActivity.ROUTE_COMPOSE)
+                    },
+                    postedBody = postedBody,
+                )
+            }
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/nav3/SocialNav3Activity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/nav3/SocialNav3Activity.kt
@@ -1,0 +1,99 @@
+package io.embrace.android.exampleapp.paradigms.social.nav3
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.ui.NavDisplay
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.paradigms.social.ui.ComposePostUi
+import io.embrace.android.exampleapp.paradigms.social.ui.ProfileUi
+import io.embrace.android.exampleapp.paradigms.social.ui.TimelineUi
+import io.embrace.android.exampleapp.paradigms.social.ui.PostDetailUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class SocialNav3Activity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ExampleAppTheme {
+                val backStack = remember { mutableStateListOf<SocialNav3Keys>(SocialNav3Keys.Timeline) }
+                var postedBody by remember { mutableStateOf<String?>(null) }
+                NavDisplay(
+                    backStack = backStack,
+                    onBack = { backStack.removeLastOrNull() },
+                    entryProvider = { key ->
+                        when (key) {
+                            is SocialNav3Keys.Timeline -> NavEntry(key) {
+                                TimelineUi(
+                                    title = "Home (Nav3)",
+                                    posts = SampleData.posts,
+                                    onPostClick = { id ->
+                                        backStack.add(SocialNav3Keys.PostDetails(id))
+                                    },
+                                    onAuthorClick = { handle ->
+                                        backStack.add(SocialNav3Keys.Profile(handle))
+                                    },
+                                    onCompose = { backStack.add(SocialNav3Keys.Compose) },
+                                    postedBody = postedBody,
+                                )
+                            }
+                            is SocialNav3Keys.PostDetails -> NavEntry(key) {
+                                val post = SampleData.post(key.postId)
+                                if (post == null) {
+                                    backStack.removeLastOrNull()
+                                } else {
+                                    PostDetailUi(
+                                        post = post,
+                                        onAuthorClick = { handle ->
+                                            backStack.add(SocialNav3Keys.Profile(handle))
+                                        },
+                                        onBack = { backStack.removeLastOrNull() },
+                                    )
+                                }
+                            }
+                            is SocialNav3Keys.Profile -> NavEntry(key) {
+                                val author = SampleData.author(key.handle)
+                                if (author == null) {
+                                    backStack.removeLastOrNull()
+                                } else {
+                                    val authorPosts = SampleData.posts.filter { it.authorHandle == author.handle }
+                                    ProfileUi(
+                                        author = author,
+                                        authorPosts = authorPosts,
+                                        onPostClick = { id ->
+                                            backStack.add(SocialNav3Keys.PostDetails(id))
+                                        },
+                                        onBack = { backStack.removeLastOrNull() },
+                                    )
+                                }
+                            }
+                            is SocialNav3Keys.Compose -> NavEntry(key) {
+                                ComposePostUi(
+                                    onPost = { body ->
+                                        postedBody = body
+                                        backStack.removeLastOrNull()
+                                    },
+                                    onCancel = { backStack.removeLastOrNull() },
+                                )
+                            }
+                        }
+                    },
+                )
+            }
+        }
+    }
+
+    companion object {
+        fun newIntent(context: Context): Intent =
+            Intent(context, SocialNav3Activity::class.java)
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/nav3/SocialNav3Keys.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/nav3/SocialNav3Keys.kt
@@ -1,0 +1,8 @@
+package io.embrace.android.exampleapp.paradigms.social.nav3
+
+internal sealed interface SocialNav3Keys {
+    data object Timeline : SocialNav3Keys
+    data class PostDetails(val postId: String) : SocialNav3Keys
+    data class Profile(val handle: String) : SocialNav3Keys
+    data object Compose : SocialNav3Keys
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/navcompose/SocialNavComposeActivity.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/navcompose/SocialNavComposeActivity.kt
@@ -1,0 +1,104 @@
+package io.embrace.android.exampleapp.paradigms.social.navcompose
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.toRoute
+import io.embrace.android.exampleapp.paradigms.data.SampleData
+import io.embrace.android.exampleapp.paradigms.social.ui.ComposePostUi
+import io.embrace.android.exampleapp.paradigms.social.ui.ProfileUi
+import io.embrace.android.exampleapp.paradigms.social.ui.TimelineUi
+import io.embrace.android.exampleapp.paradigms.social.ui.PostDetailUi
+import io.embrace.android.exampleapp.ui.theme.ExampleAppTheme
+
+class SocialNavComposeActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ExampleAppTheme {
+                val navController = rememberNavController()
+                NavHost(
+                    navController = navController,
+                    startDestination = SocialRoute.Timeline,
+                ) {
+                    composable<SocialRoute.Timeline> { entry ->
+                        val savedHandle = entry.savedStateHandle
+                        val postedBody by savedHandle
+                            .getStateFlow<String?>(SAVED_STATE_POSTED_BODY, null)
+                            .collectAsState()
+                        TimelineUi(
+                            title = "Home (Nav-Compose)",
+                            posts = SampleData.posts,
+                            onPostClick = { id ->
+                                navController.navigate(SocialRoute.PostDetail(id))
+                            },
+                            onAuthorClick = { handle ->
+                                navController.navigate(SocialRoute.Profile(handle))
+                            },
+                            onCompose = {
+                                navController.navigate(SocialRoute.Compose)
+                            },
+                            postedBody = postedBody,
+                        )
+                    }
+                    composable<SocialRoute.PostDetail> { entry ->
+                        val route: SocialRoute.PostDetail = entry.toRoute()
+                        val post = SampleData.post(route.postId)
+                        if (post == null) {
+                            navController.popBackStack()
+                        } else {
+                            PostDetailUi(
+                                post = post,
+                                onAuthorClick = { handle ->
+                                    navController.navigate(SocialRoute.Profile(handle))
+                                },
+                                onBack = { navController.popBackStack() },
+                            )
+                        }
+                    }
+                    composable<SocialRoute.Profile> { entry ->
+                        val route: SocialRoute.Profile = entry.toRoute()
+                        val author = SampleData.author(route.handle)
+                        if (author == null) {
+                            navController.popBackStack()
+                        } else {
+                            val authorPosts = SampleData.posts.filter { it.authorHandle == author.handle }
+                            ProfileUi(
+                                author = author,
+                                authorPosts = authorPosts,
+                                onPostClick = { id ->
+                                    navController.navigate(SocialRoute.PostDetail(id))
+                                },
+                                onBack = { navController.popBackStack() },
+                            )
+                        }
+                    }
+                    composable<SocialRoute.Compose> {
+                        ComposePostUi(
+                            onPost = { body ->
+                                navController.previousBackStackEntry
+                                    ?.savedStateHandle
+                                    ?.set(SAVED_STATE_POSTED_BODY, body)
+                                navController.popBackStack()
+                            },
+                            onCancel = { navController.popBackStack() },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        fun newIntent(context: Context): Intent =
+            Intent(context, SocialNavComposeActivity::class.java)
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/navcompose/SocialNavComposeRoutes.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/navcompose/SocialNavComposeRoutes.kt
@@ -1,0 +1,20 @@
+package io.embrace.android.exampleapp.paradigms.social.navcompose
+
+import kotlinx.serialization.Serializable
+
+internal sealed interface SocialRoute {
+
+    @Serializable
+    object Timeline : SocialRoute
+
+    @Serializable
+    data class PostDetail(val postId: String) : SocialRoute
+
+    @Serializable
+    data class Profile(val handle: String) : SocialRoute
+
+    @Serializable
+    object Compose : SocialRoute
+}
+
+internal const val SAVED_STATE_POSTED_BODY: String = "social_navcompose_posted_body"

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/ui/ComposePostUi.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/ui/ComposePostUi.kt
@@ -1,0 +1,73 @@
+package io.embrace.android.exampleapp.paradigms.social.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import io.embrace.android.exampleapp.ui.appBarColors
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ComposePostUi(
+    onPost: (body: String) -> Unit,
+    onCancel: () -> Unit,
+) {
+    var body by rememberSaveable { mutableStateOf("") }
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text("Compose Post") },
+                colors = appBarColors(),
+                navigationIcon = {
+                    IconButton(onClick = onCancel) {
+                        Icon(
+                            imageVector = Icons.Filled.Close,
+                            contentDescription = "Cancel",
+                            tint = Color.White,
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier.fillMaxSize().padding(padding).padding(16.dp),
+            horizontalAlignment = Alignment.End,
+        ) {
+            OutlinedTextField(
+                value = body,
+                onValueChange = { body = it },
+                modifier = Modifier.fillMaxWidth().height(180.dp),
+                placeholder = { Text("What's happening?") },
+            )
+            Button(
+                onClick = { onPost(body) },
+                enabled = body.isNotBlank(),
+                modifier = Modifier.padding(top = 12.dp),
+            ) {
+                Text("Post")
+            }
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/ui/PostDetailUi.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/ui/PostDetailUi.kt
@@ -1,0 +1,82 @@
+package io.embrace.android.exampleapp.paradigms.social.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import io.embrace.android.exampleapp.paradigms.data.Post
+import io.embrace.android.exampleapp.ui.appBarColors
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PostDetailUi(
+    post: Post,
+    onAuthorClick: (handle: String) -> Unit,
+    onBack: () -> Unit,
+) {
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text("Post") },
+                colors = appBarColors(),
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            tint = Color.White,
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier.fillMaxSize().padding(padding).padding(16.dp),
+        ) {
+            Row(modifier = Modifier.fillMaxWidth().clickable { onAuthorClick(post.authorHandle) }) {
+                Text(
+                    text = post.authorDisplayName,
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Text(
+                    text = " @${post.authorHandle}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Text(
+                text = post.body,
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.padding(top = 12.dp),
+            )
+            HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(24.dp),
+            ) {
+                Text(text = "↺ ${post.repostCount} reposts", style = MaterialTheme.typography.labelMedium)
+                Text(text = "♡ ${post.likeCount} likes", style = MaterialTheme.typography.labelMedium)
+                Text(text = "↩ ${post.replyCount} replies", style = MaterialTheme.typography.labelMedium)
+            }
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/ui/ProfileUi.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/ui/ProfileUi.kt
@@ -1,0 +1,94 @@
+package io.embrace.android.exampleapp.paradigms.social.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import io.embrace.android.exampleapp.paradigms.data.Post
+import io.embrace.android.exampleapp.paradigms.data.PostAuthor
+import io.embrace.android.exampleapp.ui.appBarColors
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileUi(
+    author: PostAuthor,
+    authorPosts: List<Post>,
+    onPostClick: (postId: String) -> Unit,
+    onBack: () -> Unit,
+) {
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text("@${author.handle}") },
+                colors = appBarColors(),
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            tint = Color.White,
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+                Text(text = author.displayName, style = MaterialTheme.typography.titleLarge)
+                Text(
+                    text = "@${author.handle}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = author.bio,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(top = 8.dp),
+                )
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(24.dp),
+                ) {
+                    Text(text = "${author.followingCount} following", style = MaterialTheme.typography.labelMedium)
+                    Text(text = "${author.followerCount} followers", style = MaterialTheme.typography.labelMedium)
+                }
+            }
+            HorizontalDivider()
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(items = authorPosts, key = { it.id }) { post ->
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onPostClick(post.id) }
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                    ) {
+                        Text(text = post.body, style = MaterialTheme.typography.bodyMedium)
+                    }
+                    HorizontalDivider()
+                }
+            }
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/ui/TimelineUi.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/paradigms/social/ui/TimelineUi.kt
@@ -1,0 +1,132 @@
+package io.embrace.android.exampleapp.paradigms.social.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import io.embrace.android.exampleapp.paradigms.data.Post
+import io.embrace.android.exampleapp.ui.appBarColors
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TimelineUi(
+    title: String,
+    posts: List<Post>,
+    onPostClick: (postId: String) -> Unit,
+    onAuthorClick: (handle: String) -> Unit,
+    onCompose: () -> Unit,
+    onBack: (() -> Unit)? = null,
+    postedBody: String? = null,
+) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    LaunchedEffect(postedBody) {
+        if (postedBody != null) {
+            snackbarHostState.showSnackbar("Posted: $postedBody")
+        }
+    }
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text(title) },
+                colors = appBarColors(),
+                navigationIcon = {
+                    if (onBack != null) {
+                        IconButton(onClick = onBack) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = "Back",
+                                tint = Color.White,
+                            )
+                        }
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = onCompose) {
+                Icon(imageVector = Icons.Filled.Add, contentDescription = "Compose post")
+            }
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) { Snackbar(it) } },
+    ) { padding ->
+        LazyColumn(modifier = Modifier.fillMaxSize().padding(padding)) {
+            items(items = posts, key = { it.id }) { post ->
+                PostRow(
+                    post = post,
+                    onPostClick = onPostClick,
+                    onAuthorClick = onAuthorClick,
+                )
+                HorizontalDivider()
+            }
+        }
+    }
+}
+
+@Composable
+private fun PostRow(
+    post: Post,
+    onPostClick: (String) -> Unit,
+    onAuthorClick: (String) -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onPostClick(post.id) }
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+    ) {
+        Column {
+            Row(modifier = Modifier.fillMaxWidth().clickable { onAuthorClick(post.authorHandle) }) {
+                Text(
+                    text = post.authorDisplayName,
+                    style = MaterialTheme.typography.titleSmall,
+                )
+                Text(
+                    text = " @${post.authorHandle}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Text(
+                text = post.body,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(top = 6.dp),
+                horizontalArrangement = Arrangement.spacedBy(20.dp),
+            ) {
+                Text(text = "↺ ${post.repostCount}", style = MaterialTheme.typography.labelSmall)
+                Text(text = "♡ ${post.likeCount}", style = MaterialTheme.typography.labelSmall)
+                Text(text = "↩ ${post.replyCount}", style = MaterialTheme.typography.labelSmall)
+            }
+        }
+    }
+}

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ui/CodeExample.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ui/CodeExample.kt
@@ -3,6 +3,7 @@ package io.embrace.android.exampleapp.ui
 enum class CodeExample(
     val desc: String,
 ) {
+    NAV_PARADIGMS("Navigation Paradigms"),
     JVM_CRASH("JVM Uncaught Exception"),
     NDK_CRASH("NDK crash"),
     ANR_DETECTION("ANR detection"),
@@ -16,11 +17,7 @@ enum class CodeExample(
     ALTER_USER("Alter User"),
     VIEW_TRACKING("View Tracking"),
     SDK_STATE_API("SDK State API"),
-    BYTECODE_INSTRUMENTATION_SAMPLES("Bytecode Instrumentation"),
-    FRAGMENT_NAVIGATION("Compose Fragment Navigation"),
-    COMPLEX_FRAGMENT_NAVIGATION("Complex Fragment Navigation"),
-    OBSERVED_NAV_CONTROLLER("Observed NavController (Compose Nav 2.x)"),
-    OBSERVED_BACK_STACK("Observed BackStack (Nav 3)");
+    BYTECODE_INSTRUMENTATION_SAMPLES("Bytecode Instrumentation");
 
     val route: String = name.lowercase()
 }

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ui/ExampleContent.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/ui/ExampleContent.kt
@@ -1,24 +1,21 @@
 package io.embrace.android.exampleapp.ui
 
 import androidx.compose.runtime.Composable
+import io.embrace.android.exampleapp.paradigms.ParadigmHubContent
 import io.embrace.android.exampleapp.ui.examples.AddBreadcrumbExample
 import io.embrace.android.exampleapp.ui.examples.AnrDetectionExample
-import io.embrace.android.exampleapp.ui.examples.ComplexFragmentNavigationExample
-import io.embrace.android.exampleapp.ui.examples.ComposeFragmentNavigationExample
-import io.embrace.android.exampleapp.ui.examples.ObservedBackStackExample
-import io.embrace.android.exampleapp.ui.examples.ObservedNavControllerExample
-import io.embrace.android.exampleapp.ui.examples.bytecode.BytecodeInstrumentationExample
 import io.embrace.android.exampleapp.ui.examples.EndSessionExample
 import io.embrace.android.exampleapp.ui.examples.JvmCrashExample
 import io.embrace.android.exampleapp.ui.examples.LogMessageAttachmentsExample
-import io.embrace.android.exampleapp.ui.examples.NdkCrashExample
 import io.embrace.android.exampleapp.ui.examples.LogMessageExample
+import io.embrace.android.exampleapp.ui.examples.NdkCrashExample
 import io.embrace.android.exampleapp.ui.examples.NetworkRequestExample
 import io.embrace.android.exampleapp.ui.examples.SdkStateApiExample
-import io.embrace.android.exampleapp.ui.examples.UserSessionPropertiesExample
 import io.embrace.android.exampleapp.ui.examples.TracingApiExample
 import io.embrace.android.exampleapp.ui.examples.UserExample
+import io.embrace.android.exampleapp.ui.examples.UserSessionPropertiesExample
 import io.embrace.android.exampleapp.ui.examples.ViewTrackingExample
+import io.embrace.android.exampleapp.ui.examples.bytecode.BytecodeInstrumentationExample
 
 @Composable
 fun ExampleContent(example: CodeExample) {
@@ -37,9 +34,6 @@ fun ExampleContent(example: CodeExample) {
         CodeExample.NDK_CRASH -> NdkCrashExample()
         CodeExample.ANR_DETECTION -> AnrDetectionExample()
         CodeExample.BYTECODE_INSTRUMENTATION_SAMPLES -> BytecodeInstrumentationExample()
-        CodeExample.FRAGMENT_NAVIGATION -> ComposeFragmentNavigationExample()
-        CodeExample.COMPLEX_FRAGMENT_NAVIGATION -> ComplexFragmentNavigationExample()
-        CodeExample.OBSERVED_NAV_CONTROLLER -> ObservedNavControllerExample()
-        CodeExample.OBSERVED_BACK_STACK -> ObservedBackStackExample()
+        CodeExample.NAV_PARADIGMS -> ParadigmHubContent()
     }
 }


### PR DESCRIPTION
Add simulations of some realistic app styles and how they would implement navigation, specifically something that is like a social media doomscrolling app, a news reader, and a e-commerce example. This adds the scaffolding and general structure, and additional data and complexity will be added later.