### PR TITLE
Tweak codecov threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,10 @@ coverage:
   status:
     project:
       default:
+        target: 75%
+        threshold: 1%
         removed_code_behavior: adjust_base
     patch:
       default:
-        target: 50%
+        target: 75%
+        threshold: 1%


### PR DESCRIPTION
## Goal

Tweaks the threshold used for codecov so that the minimum target for the project is 75%, but fluctuations of <1% are allowed on PRs. This should reduce the number of PRs that have CI check failures related to codecov.