### PR TITLE
Add session index

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/SessionPartToken.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/SessionPartToken.kt
@@ -41,5 +41,10 @@ data class SessionPartToken(
     /**
      * Monotonic index of this part of the user session.
      */
+    val userSessionPartIndex: Int = 0,
+
+    /**
+     * Monotonic index of all session parts ever created on this device
+     */
     val sessionPartNumber: Int = 0,
 )

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadata.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadata.kt
@@ -13,7 +13,7 @@ data class UserSessionMetadata(
     val userSessionNumber: Long,
     val maxDurationSecs: Long,
     val inactivityTimeoutSecs: Long,
-    val partNumber: Int,
+    val partIndex: Int,
     val lastActivityMs: Long,
 ) {
     fun isOverMaxDuration(clock: Clock): Boolean =

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStore.kt
@@ -19,7 +19,7 @@ internal class UserSessionMetadataStore(private val store: KeyValueStore) {
     fun save(metadata: UserSessionMetadata) {
         store.edit {
             val map = metadata.attributes.mapValues { it.value.toString() }.toMutableMap()
-            map[EmbSessionAttributes.EMB_USER_SESSION_PART_NUMBER] = metadata.partNumber.toString()
+            map[EmbSessionAttributes.EMB_USER_SESSION_PART_INDEX] = metadata.partIndex.toString()
             map[KEY_LAST_ACTIVITY_TS] = metadata.lastActivityMs.toString()
             putStringMap(KEY_SESSION, map)
         }
@@ -45,7 +45,7 @@ internal class UserSessionMetadataStore(private val store: KeyValueStore) {
         val number = attrs[EmbSessionAttributes.EMB_USER_SESSION_NUMBER]?.toLongOrNull() ?: return null
         val maxDurationSecs = attrs[EmbSessionAttributes.EMB_USER_SESSION_MAX_DURATION_SECONDS]?.toLongOrNull() ?: return null
         val inactivityTimeoutSecs = attrs[EmbSessionAttributes.EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS]?.toLongOrNull() ?: return null
-        val partNumber = attrs[EmbSessionAttributes.EMB_USER_SESSION_PART_NUMBER]?.toIntOrNull() ?: return null
+        val partIndex = attrs[EmbSessionAttributes.EMB_USER_SESSION_PART_INDEX]?.toIntOrNull() ?: return null
         val lastActivityMs = attrs[KEY_LAST_ACTIVITY_TS]?.toLongOrNull() ?: return null
         return UserSessionMetadata(
             startTimeMs = startMs,
@@ -53,7 +53,7 @@ internal class UserSessionMetadataStore(private val store: KeyValueStore) {
             userSessionNumber = number,
             maxDurationSecs = maxDurationSecs,
             inactivityTimeoutSecs = inactivityTimeoutSecs,
-            partNumber = partNumber,
+            partIndex = partIndex,
             lastActivityMs = lastActivityMs,
         )
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/InitialEnvelopeParams.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/InitialEnvelopeParams.kt
@@ -11,5 +11,6 @@ class InitialEnvelopeParams(
     val startType: LifeEventType,
     val startTime: Long,
     val appState: AppState,
-    val partNumber: Int,
+    val userSessionPartIndex: Int,
+    val sessionPartNumber: Int,
 )

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactory.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactory.kt
@@ -18,7 +18,8 @@ interface PayloadFactory {
         state: AppState,
         timestamp: Long,
         coldStart: Boolean,
-        partNumber: Int,
+        userSessionPartIndex: () -> Int,
+        sessionPartNumber: () -> Int,
     ): SessionPartToken?
 
     /**
@@ -48,7 +49,12 @@ interface PayloadFactory {
     /**
      * Starts a session manually.
      */
-    fun startSessionWithManual(state: AppState, timestamp: Long, partNumber: Int): SessionPartToken?
+    fun startSessionWithManual(
+        state: AppState,
+        timestamp: Long,
+        userSessionPartIndex: () -> Int,
+        sessionPartNumber: () -> Int,
+    ): SessionPartToken?
 
     /**
      * Ends a session manually.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImpl.kt
@@ -22,11 +22,12 @@ internal class PayloadFactoryImpl(
         state: AppState,
         timestamp: Long,
         coldStart: Boolean,
-        partNumber: Int,
+        userSessionPartIndex: () -> Int,
+        sessionPartNumber: () -> Int,
     ): SessionPartToken? =
         when (state) {
-            AppState.FOREGROUND -> startSessionWithState(timestamp, coldStart, partNumber)
-            AppState.BACKGROUND -> startBackgroundActivityWithState(timestamp, coldStart, partNumber)
+            AppState.FOREGROUND -> startSessionWithState(timestamp, coldStart, userSessionPartIndex, sessionPartNumber)
+            AppState.BACKGROUND -> startBackgroundActivityWithState(timestamp, coldStart, userSessionPartIndex, sessionPartNumber)
         }
 
     override fun endPayloadWithState(
@@ -59,7 +60,12 @@ internal class PayloadFactoryImpl(
             AppState.BACKGROUND -> snapshotBackgroundActivity(initial)
         }
 
-    override fun startSessionWithManual(state: AppState, timestamp: Long, partNumber: Int): SessionPartToken? {
+    override fun startSessionWithManual(
+        state: AppState,
+        timestamp: Long,
+        userSessionPartIndex: () -> Int,
+        sessionPartNumber: () -> Int,
+    ): SessionPartToken? {
         if (state == AppState.BACKGROUND && !isBackgroundActivityEnabled()) {
             return null
         }
@@ -73,7 +79,8 @@ internal class PayloadFactoryImpl(
                 startType = startType,
                 startTime = timestamp,
                 appState = state,
-                partNumber = partNumber,
+                userSessionPartIndex = userSessionPartIndex(),
+                sessionPartNumber = sessionPartNumber(),
             )
         )
     }
@@ -96,7 +103,8 @@ internal class PayloadFactoryImpl(
     private fun startSessionWithState(
         timestamp: Long,
         coldStart: Boolean,
-        partNumber: Int,
+        userSessionPartIndex: () -> Int,
+        sessionPartNumber: () -> Int,
     ): SessionPartToken {
         return payloadMessageCollator.buildInitialPart(
             InitialEnvelopeParams(
@@ -104,7 +112,8 @@ internal class PayloadFactoryImpl(
                 startType = LifeEventType.STATE,
                 startTime = timestamp,
                 appState = AppState.FOREGROUND,
-                partNumber = partNumber,
+                userSessionPartIndex = userSessionPartIndex(),
+                sessionPartNumber = sessionPartNumber(),
             )
         )
     }
@@ -112,7 +121,8 @@ internal class PayloadFactoryImpl(
     private fun startBackgroundActivityWithState(
         timestamp: Long,
         coldStart: Boolean,
-        partNumber: Int,
+        userSessionPartIndex: () -> Int,
+        sessionPartNumber: () -> Int,
     ): SessionPartToken? {
         if (!isBackgroundActivityEnabled()) {
             return null
@@ -130,7 +140,8 @@ internal class PayloadFactoryImpl(
                 startType = LifeEventType.BKGND_STATE,
                 startTime = time,
                 appState = AppState.BACKGROUND,
-                partNumber = partNumber,
+                userSessionPartIndex = userSessionPartIndex(),
+                sessionPartNumber = sessionPartNumber(),
             )
         )
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImpl.kt
@@ -25,7 +25,8 @@ internal class PayloadMessageCollatorImpl(
             appState = appState,
             isColdStart = coldStart,
             startType = startType,
-            sessionPartNumber = partNumber,
+            userSessionPartIndex = userSessionPartIndex,
+            sessionPartNumber = sessionPartNumber,
         )
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -126,7 +126,8 @@ internal class SessionOrchestratorImpl(
                     state = state,
                     timestamp = timestamp,
                     coldStart = true,
-                    partNumber = incrementPartNumber(),
+                    userSessionPartIndex = ::incrementPartIndex,
+                    sessionPartNumber = ::incrementSessionPartNumber,
                 )
             }
         )
@@ -160,7 +161,8 @@ internal class SessionOrchestratorImpl(
                     state = AppState.FOREGROUND,
                     timestamp = timestamp,
                     coldStart = coldStart,
-                    partNumber = incrementPartNumber(),
+                    userSessionPartIndex = ::incrementPartIndex,
+                    sessionPartNumber = ::incrementSessionPartNumber,
                 )
             },
             earlyTerminationCondition = {
@@ -183,7 +185,8 @@ internal class SessionOrchestratorImpl(
                     state = AppState.BACKGROUND,
                     timestamp = timestamp,
                     coldStart = false,
-                    partNumber = incrementPartNumber(),
+                    userSessionPartIndex = ::incrementPartIndex,
+                    sessionPartNumber = ::incrementSessionPartNumber,
                 )
             },
             earlyTerminationCondition = {
@@ -203,7 +206,12 @@ internal class SessionOrchestratorImpl(
             },
             newSessionAction = {
                 lastManualEndMs = timestamp
-                payloadFactory.startSessionWithManual(state, timestamp, incrementPartNumber())
+                payloadFactory.startSessionWithManual(
+                    state = state,
+                    timestamp = timestamp,
+                    userSessionPartIndex = ::incrementPartIndex,
+                    sessionPartNumber = ::incrementSessionPartNumber,
+                )
             },
             earlyTerminationCondition = {
                 return@transitionState shouldEndManualSession(
@@ -341,8 +349,8 @@ internal class SessionOrchestratorImpl(
             val userSession = currentUserSession()
             if (newSession != null) {
                 if (userSession != null) {
-                    // persist partNumber to handle user session restoration in new process
-                    val updatedUserSession = userSession.copy(partNumber = newSession.sessionPartNumber)
+                    // persist partIndex to handle user session restoration in new process
+                    val updatedUserSession = userSession.copy(partIndex = newSession.userSessionPartIndex)
                     metadataStore.save(updatedUserSession)
                     userSessionState = UserSessionState.Active(updatedUserSession)
 
@@ -415,7 +423,8 @@ internal class SessionOrchestratorImpl(
                         state = currentAppState,
                         timestamp = timestamp,
                         coldStart = false,
-                        partNumber = incrementPartNumber(),
+                        userSessionPartIndex = ::incrementPartIndex,
+                        sessionPartNumber = ::incrementSessionPartNumber,
                     )
                 },
             )
@@ -437,7 +446,8 @@ internal class SessionOrchestratorImpl(
                             state = AppState.BACKGROUND,
                             timestamp = timestamp,
                             coldStart = false,
-                            partNumber = incrementPartNumber(),
+                            userSessionPartIndex = ::incrementPartIndex,
+                            sessionPartNumber = ::incrementSessionPartNumber,
                         )
                     } else {
                         null
@@ -448,7 +458,13 @@ internal class SessionOrchestratorImpl(
         }
     }
 
-    private fun incrementPartNumber(): Int = (currentUserSession()?.partNumber ?: 0) + 1
+    private fun incrementPartIndex(): Int = (currentUserSession()?.partIndex ?: 0) + 1
+
+    private fun incrementSessionPartNumber(): Int {
+        return ordinalStore.incrementAndGet(Ordinal.SESSION_PART) {
+            currentUserSession()?.userSessionNumber?.toInt() ?: 1
+        }
+    }
 
     private fun processEndMessage(envelope: Envelope<SessionPartPayload>?, transitionType: TransitionType) {
         envelope?.let {
@@ -540,13 +556,14 @@ internal class SessionOrchestratorImpl(
     private fun startNewUserSession(startTimeMs: Long) {
         val maxDurationMs = configService.sessionBehavior.getMaxSessionDurationMs()
         val inactivityTimeoutMs = configService.sessionBehavior.getSessionInactivityTimeoutMs()
+        val userSessionNumber = ordinalStore.incrementAndGet(Ordinal.USER_SESSION).toLong()
         val newMetadata = UserSessionMetadata(
             startTimeMs = startTimeMs,
             userSessionId = uuidSource.createUuid(),
-            userSessionNumber = ordinalStore.incrementAndGet(Ordinal.USER_SESSION).toLong(),
+            userSessionNumber = userSessionNumber,
             maxDurationSecs = maxDurationMs / 1_000L,
             inactivityTimeoutSecs = inactivityTimeoutMs / 1_000L,
-            partNumber = 0,
+            partIndex = 0,
             lastActivityMs = startTimeMs,
         )
         metadataStore.save(newMetadata)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImpl.kt
@@ -29,9 +29,10 @@ internal class SessionPartSpanAttrPopulatorImpl(
                 addSessionPartAttribute(EmbSessionAttributes.EMB_SESSION_START_TYPE, it)
             }
 
+            addSessionPartAttribute(EmbSessionAttributes.EMB_SESSION_PART_NUMBER, sessionPart.sessionPartNumber.toString())
             if (userSession != null) {
                 addSessionPartAttribute(EmbSessionAttributes.EMB_SESSION_PART_ID, sessionPart.sessionPartId)
-                addSessionPartAttribute(EmbSessionAttributes.EMB_USER_SESSION_PART_NUMBER, sessionPart.sessionPartNumber.toString())
+                addSessionPartAttribute(EmbSessionAttributes.EMB_USER_SESSION_PART_INDEX, sessionPart.userSessionPartIndex.toString())
                 userSession.attributes.forEach { (key, value) ->
                     addSessionPartAttribute(key, value.toString())
                 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadMessageCollator.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadMessageCollator.kt
@@ -30,7 +30,8 @@ class FakePayloadMessageCollator(
             isColdStart = coldStart,
             appState = appState,
             startType = startType,
-            sessionPartNumber = partNumber,
+            userSessionPartIndex = userSessionPartIndex,
+            sessionPartNumber = sessionPartNumber,
         )
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/PayloadFactoryBaTest.kt
@@ -127,7 +127,7 @@ internal class PayloadFactoryBaTest {
         )
         return PayloadFactoryImpl(collator, payloadSourceModule.logEnvelopeSource, configService, logger).apply {
             if (createInitialSession) {
-                startPayloadWithState(AppState.BACKGROUND, clock.now(), true, 1)
+                startPayloadWithState(AppState.BACKGROUND, clock.now(), true, { 1 }, { 1 })
             }
         }
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionHandlerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionHandlerTest.kt
@@ -182,7 +182,8 @@ internal class UserSessionHandlerTest {
                 AppState.FOREGROUND,
                 NOW,
                 true,
-                1
+                { 1 },
+                { 1 },
             )
         )
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStoreTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStoreTest.kt
@@ -18,7 +18,7 @@ internal class UserSessionMetadataStoreTest {
         userSessionNumber = 3L,
         maxDurationSecs = 3600L,
         inactivityTimeoutSecs = 1800L,
-        partNumber = 1,
+        partIndex = 1,
         lastActivityMs = 5000L,
     )
     private val metadata2 = UserSessionMetadata(
@@ -27,7 +27,7 @@ internal class UserSessionMetadataStoreTest {
         userSessionNumber = 5L,
         maxDurationSecs = 7200L,
         inactivityTimeoutSecs = 3600L,
-        partNumber = 2,
+        partIndex = 2,
         lastActivityMs = 9000L,
     )
 
@@ -52,7 +52,7 @@ internal class UserSessionMetadataStoreTest {
         assertEquals(metadata.userSessionNumber, loaded.userSessionNumber)
         assertEquals(metadata.maxDurationSecs, loaded.maxDurationSecs)
         assertEquals(metadata.inactivityTimeoutSecs, loaded.inactivityTimeoutSecs)
-        assertEquals(metadata.partNumber, loaded.partNumber)
+        assertEquals(metadata.partIndex, loaded.partIndex)
         assertEquals(metadata.lastActivityMs, loaded.lastActivityMs)
     }
 
@@ -67,7 +67,7 @@ internal class UserSessionMetadataStoreTest {
         assertEquals(metadata2.userSessionNumber, loaded.userSessionNumber)
         assertEquals(metadata2.maxDurationSecs, loaded.maxDurationSecs)
         assertEquals(metadata2.inactivityTimeoutSecs, loaded.inactivityTimeoutSecs)
-        assertEquals(metadata2.partNumber, loaded.partNumber)
+        assertEquals(metadata2.partIndex, loaded.partIndex)
         assertEquals(metadata2.lastActivityMs, loaded.lastActivityMs)
     }
 
@@ -129,10 +129,10 @@ internal class UserSessionMetadataStoreTest {
     }
 
     @Test
-    fun `load returns null when part number is missing`() {
+    fun `load returns null when part index is missing`() {
         metadataStore.save(metadata)
         val stored = checkNotNull(kvStore.getStringMap("embrace.user_session")).toMutableMap()
-        stored.remove(EmbSessionAttributes.EMB_USER_SESSION_PART_NUMBER)
+        stored.remove(EmbSessionAttributes.EMB_USER_SESSION_PART_INDEX)
         kvStore.edit { putStringMap("embrace.user_session", stored) }
 
         assertNull(metadataStore.load())

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionIdProviderImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionIdProviderImplTest.kt
@@ -42,7 +42,7 @@ internal class SessionIdProviderImplTest {
             userSessionNumber = 1L,
             maxDurationSecs = 3600L,
             inactivityTimeoutSecs = 300L,
-            partNumber = 1,
+            partIndex = 1,
             lastActivityMs = 1000L,
         )
         assertEquals("user-session-uuid", provider.getCurrentUserSessionId())
@@ -58,7 +58,7 @@ internal class SessionIdProviderImplTest {
             userSessionNumber = 2,
             maxDurationSecs = 3600L,
             inactivityTimeoutSecs = 300L,
-            partNumber = token.sessionPartNumber + 1,
+            partIndex = token.userSessionPartIndex + 1,
             lastActivityMs = token.startTime + 10_000L,
         )
         assertEquals(SessionIdsSnapshot(token.userSessionId, token.sessionPartId), provider.getActiveSessionIds())
@@ -73,7 +73,7 @@ internal class SessionIdProviderImplTest {
             userSessionNumber = 1L,
             maxDurationSecs = 3600L,
             inactivityTimeoutSecs = 300L,
-            partNumber = 1,
+            partIndex = 1,
             lastActivityMs = 1000L,
         )
         assertEquals(

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImplTest.kt
@@ -47,7 +47,7 @@ internal class PayloadFactoryImplTest {
 
     @Test
     fun `payload generated`() {
-        val session = checkNotNull(factory.startPayloadWithState(FOREGROUND, 0, false, 1))
+        val session = checkNotNull(factory.startPayloadWithState(FOREGROUND, 0, false, { 1 }, { 1 }))
         checkNotNull(factory.endPayloadWithState(FOREGROUND, 0, session))
     }
 
@@ -72,7 +72,7 @@ internal class PayloadFactoryImplTest {
     }
 
     private fun verifyPayloadWithState(state: AppState, zygoteCreated: Boolean, startNewSession: Boolean) {
-        val zygote = factory.startPayloadWithState(state, 0, false, 1)
+        val zygote = factory.startPayloadWithState(state, 0, false, { 1 }, { 1 })
         if (zygoteCreated) {
             assertTrue(checkNotNull(zygote).sessionPartId.isNotBlank())
             assertNotNull(factory.endPayloadWithState(state, 0, zygote))
@@ -83,7 +83,7 @@ internal class PayloadFactoryImplTest {
     }
 
     private fun verifyPayloadWithManual() {
-        val zygote = checkNotNull(factory.startSessionWithManual(FOREGROUND, 0, 1))
+        val zygote = checkNotNull(factory.startSessionWithManual(FOREGROUND, 0, { 1 }, { 1 }))
         assertTrue(zygote.sessionPartId.isNotBlank())
         assertNotNull(factory.endSessionWithManual(0, zygote))
         assertEquals(true, partPayloadSource.lastStartNewSession)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImplTest.kt
@@ -57,7 +57,8 @@ internal class PayloadMessageCollatorImplTest {
                 LifeEventType.BKGND_STATE,
                 5,
                 AppState.BACKGROUND,
-                1
+                1,
+                1,
             )
         )
         msg.verifyInitialFieldsPopulated()
@@ -71,7 +72,8 @@ internal class PayloadMessageCollatorImplTest {
                 LifeEventType.STATE,
                 5,
                 AppState.FOREGROUND,
-                1
+                1,
+                1,
             )
         )
         msg.verifyInitialFieldsPopulated()
@@ -86,7 +88,8 @@ internal class PayloadMessageCollatorImplTest {
                 LifeEventType.BKGND_STATE,
                 5,
                 AppState.BACKGROUND,
-                1
+                1,
+                1,
             )
         )
         startMsg.verifyInitialFieldsPopulated()
@@ -113,7 +116,8 @@ internal class PayloadMessageCollatorImplTest {
                 LifeEventType.STATE,
                 5,
                 AppState.FOREGROUND,
-                1
+                1,
+                1,
             )
         )
         startMsg.verifyInitialFieldsPopulated()
@@ -143,7 +147,8 @@ internal class PayloadMessageCollatorImplTest {
                             lifeEventType,
                             5L,
                             previousState,
-                            1
+                            1,
+                            1,
                         )
                     ).verifyInitialFieldsPopulated()
                 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorListenerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorListenerTest.kt
@@ -220,7 +220,7 @@ internal class SessionOrchestratorListenerTest {
                 userSessionNumber = 7L,
                 maxDurationSecs = TimeUnit.MILLISECONDS.toSeconds(maxDurationMs),
                 inactivityTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(inactivityMs),
-                partNumber = 1,
+                partIndex = 1,
                 lastActivityMs = clock.now(),
             )
         )

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -466,7 +466,7 @@ internal class SessionOrchestratorTest {
 
         val first = checkNotNull(orchestrator.currentUserSession())
         assertEquals(1L, first.userSessionNumber)
-        assertEquals(1, first.partNumber)
+        assertEquals(1, first.partIndex)
         assertEquals(TimeUnit.MILLISECONDS.toSeconds(maxDurationMs), first.maxDurationSecs)
         assertEquals(TimeUnit.MILLISECONDS.toSeconds(inactivityMs), first.inactivityTimeoutSecs)
         assertNotNull(first.userSessionId)
@@ -477,7 +477,7 @@ internal class SessionOrchestratorTest {
         orchestrator.onForeground()
         val repeat = checkNotNull(orchestrator.currentUserSession())
         assertEquals(first.userSessionId, repeat.userSessionId)
-        assertEquals(3, repeat.partNumber)
+        assertEquals(3, repeat.partIndex)
 
         // at/past max duration — new user session starts
         clock.tick(1)
@@ -486,7 +486,7 @@ internal class SessionOrchestratorTest {
         val second = checkNotNull(orchestrator.currentUserSession())
         assertNotEquals(first.userSessionId, second.userSessionId)
         assertEquals(2L, second.userSessionNumber)
-        assertEquals(2, second.partNumber)
+        assertEquals(2, second.partIndex)
     }
 
     @Test
@@ -501,7 +501,7 @@ internal class SessionOrchestratorTest {
 
         val first = checkNotNull(orchestrator.currentUserSession())
         assertEquals(1L, first.userSessionNumber)
-        assertEquals(1, first.partNumber)
+        assertEquals(1, first.partIndex)
 
         // manual end always terminates and starts a new user session
         clock.tick(10000)
@@ -509,11 +509,11 @@ internal class SessionOrchestratorTest {
         val second = checkNotNull(orchestrator.currentUserSession())
         assertEquals(2L, second.userSessionNumber)
         assertNotEquals(first.userSessionId, second.userSessionId)
-        assertEquals(1, second.partNumber)
+        assertEquals(1, second.partIndex)
     }
 
     @Test
-    fun `part number increments within user session`() {
+    fun `part index increments within user session`() {
         configService = FakeConfigService(
             backgroundActivityBehavior = createBackgroundActivityBehavior(
                 remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 100f))
@@ -525,18 +525,18 @@ internal class SessionOrchestratorTest {
         )
         createOrchestrator(AppState.FOREGROUND)
 
-        assertEquals(1, checkNotNull(orchestrator.currentUserSession()).partNumber)
+        assertEquals(1, checkNotNull(orchestrator.currentUserSession()).partIndex)
 
         orchestrator.onBackground()
-        assertEquals(2, checkNotNull(orchestrator.currentUserSession()).partNumber)
+        assertEquals(2, checkNotNull(orchestrator.currentUserSession()).partIndex)
 
         orchestrator.onForeground()
-        assertEquals(3, checkNotNull(orchestrator.currentUserSession()).partNumber)
+        assertEquals(3, checkNotNull(orchestrator.currentUserSession()).partIndex)
 
-        // new user session resets part number to 1
+        // new user session resets part index to 1
         clock.tick(10000)
         orchestrator.endSessionWithManual()
-        assertEquals(1, checkNotNull(orchestrator.currentUserSession()).partNumber)
+        assertEquals(1, checkNotNull(orchestrator.currentUserSession()).partIndex)
     }
 
     @Test
@@ -596,7 +596,7 @@ internal class SessionOrchestratorTest {
                 userSessionNumber = 7L,
                 maxDurationSecs = TimeUnit.MILLISECONDS.toSeconds(maxDurationMs),
                 inactivityTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(inactivityMs),
-                partNumber = 1,
+                partIndex = 1,
                 lastActivityMs = clock.now(),
             )
         )
@@ -606,7 +606,7 @@ internal class SessionOrchestratorTest {
         val session = checkNotNull(orchestrator.currentUserSession())
         assertEquals("restored-id", session.userSessionId)
         assertEquals(7L, session.userSessionNumber)
-        assertEquals(2, session.partNumber)
+        assertEquals(2, session.partIndex)
     }
 
     @Test
@@ -652,7 +652,7 @@ internal class SessionOrchestratorTest {
                 userSessionNumber = 3L,
                 maxDurationSecs = TimeUnit.MILLISECONDS.toSeconds(maxDurationMs),
                 inactivityTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(inactivityMs),
-                partNumber = 1,
+                partIndex = 1,
                 lastActivityMs = 0L,
             )
         )
@@ -682,7 +682,7 @@ internal class SessionOrchestratorTest {
                 userSessionNumber = 2L,
                 maxDurationSecs = TimeUnit.MILLISECONDS.toSeconds(maxDurationMs),
                 inactivityTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(inactivityMs),
-                partNumber = 2,
+                partIndex = 2,
                 lastActivityMs = backgroundTime,
             )
         )
@@ -712,7 +712,7 @@ internal class SessionOrchestratorTest {
                 userSessionNumber = 2L,
                 maxDurationSecs = TimeUnit.MILLISECONDS.toSeconds(maxDurationMs),
                 inactivityTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(inactivityMs),
-                partNumber = 2,
+                partIndex = 2,
                 lastActivityMs = backgroundTime,
             )
         )
@@ -798,7 +798,7 @@ internal class SessionOrchestratorTest {
                 userSessionNumber = 5L,
                 maxDurationSecs = persistedMaxSecs,
                 inactivityTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(inactivityMs),
-                partNumber = 1,
+                partIndex = 1,
                 lastActivityMs = clock.now(),
             )
         )
@@ -834,7 +834,7 @@ internal class SessionOrchestratorTest {
                 userSessionNumber = 3L,
                 maxDurationSecs = TimeUnit.MILLISECONDS.toSeconds(maxDurationMs),
                 inactivityTimeoutSecs = persistedInactivitySecs,
-                partNumber = 1,
+                partIndex = 1,
                 lastActivityMs = clock.now(),
             )
         )
@@ -870,7 +870,7 @@ internal class SessionOrchestratorTest {
                 userSessionNumber = 5L,
                 maxDurationSecs = TimeUnit.MILLISECONDS.toSeconds(maxDurationMs),
                 inactivityTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(inactivityMs),
-                partNumber = 1,
+                partIndex = 1,
                 lastActivityMs = clock.now() + 1_000L,
             )
         )
@@ -907,7 +907,7 @@ internal class SessionOrchestratorTest {
         val second = checkNotNull(orchestrator.currentUserSession())
         assertNotEquals(first.userSessionId, second.userSessionId)
         assertEquals(2L, second.userSessionNumber)
-        assertEquals(1, second.partNumber)
+        assertEquals(1, second.partIndex)
 
         val errors = logger.internalErrorMessages
         assertEquals(1, errors.size)
@@ -1213,7 +1213,7 @@ internal class SessionOrchestratorTest {
                 userSessionNumber = 4L,
                 maxDurationSecs = TimeUnit.MILLISECONDS.toSeconds(maxDurationMs),
                 inactivityTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(inactivityMs),
-                partNumber = 1,
+                partIndex = 1,
                 lastActivityMs = clock.now(),
             )
         )

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
@@ -24,7 +24,8 @@ internal class SessionPartSpanAttrPopulatorImplTest {
         appState = AppState.FOREGROUND,
         isColdStart = false,
         startType = LifeEventType.STATE,
-        sessionPartNumber = 5
+        userSessionPartIndex = 5,
+        sessionPartNumber = 12,
     )
     private val userSession = UserSessionMetadata(
         startTimeMs = 1000L,
@@ -32,7 +33,7 @@ internal class SessionPartSpanAttrPopulatorImplTest {
         userSessionNumber = 3L,
         maxDurationSecs = 43200L,
         inactivityTimeoutSecs = 1800L,
-        partNumber = 2,
+        partIndex = 2,
         lastActivityMs = 1000L,
     )
     private lateinit var populator: SessionPartSpanAttrPopulatorImpl
@@ -55,7 +56,8 @@ internal class SessionPartSpanAttrPopulatorImplTest {
 
         val attrs = destination.attributes
         assertEquals("false", attrs[EmbSessionAttributes.EMB_COLD_START])
-        assertEquals("5", attrs[EmbSessionAttributes.EMB_USER_SESSION_PART_NUMBER])
+        assertEquals("5", attrs[EmbSessionAttributes.EMB_USER_SESSION_PART_INDEX])
+        assertEquals("12", attrs[EmbSessionAttributes.EMB_SESSION_PART_NUMBER])
         assertEquals("foreground", attrs[EmbSessionAttributes.EMB_STATE])
         assertEquals("false", attrs[EmbSessionAttributes.EMB_CLEAN_EXIT])
         assertEquals("true", attrs[EmbSessionAttributes.EMB_TERMINATED])
@@ -75,6 +77,7 @@ internal class SessionPartSpanAttrPopulatorImplTest {
 
         val attrs = destination.attributes
         assertEquals("false", attrs[EmbSessionAttributes.EMB_COLD_START])
+        assertEquals("12", attrs[EmbSessionAttributes.EMB_SESSION_PART_NUMBER])
         assertEquals("foreground", attrs[EmbSessionAttributes.EMB_STATE])
         assertEquals("false", attrs[EmbSessionAttributes.EMB_CLEAN_EXIT])
         assertEquals("true", attrs[EmbSessionAttributes.EMB_TERMINATED])
@@ -83,7 +86,7 @@ internal class SessionPartSpanAttrPopulatorImplTest {
         assertEquals("", attrs[EmbSessionAttributes.EMB_USER_SESSION_ID])
         assertEquals("", attrs[SessionAttributes.SESSION_ID])
 
-        assertFalse(attrs.containsKey(EmbSessionAttributes.EMB_USER_SESSION_PART_NUMBER))
+        assertFalse(attrs.containsKey(EmbSessionAttributes.EMB_USER_SESSION_PART_INDEX))
         assertFalse(attrs.containsKey(EmbSessionAttributes.EMB_USER_SESSION_NUMBER))
         assertFalse(attrs.containsKey(EmbSessionAttributes.EMB_USER_SESSION_START_TS))
         assertFalse(attrs.containsKey(EmbSessionAttributes.EMB_USER_SESSION_MAX_DURATION_SECONDS))

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/store/OrdinalStoreImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/store/OrdinalStoreImplTest.kt
@@ -37,4 +37,24 @@ class OrdinalStoreImplTest {
         assertEquals(1, store.incrementAndGet(Ordinal.USER_SESSION))
         assertEquals(2, store.incrementAndGet(Ordinal.USER_SESSION))
     }
+
+    @Test
+    fun `seed lambda only fires on the first call for an ordinal`() {
+        var seedCalls = 0
+        val seed = {
+            seedCalls++
+            5
+        }
+        assertEquals(5, store.incrementAndGet(Ordinal.SESSION_PART, seed))
+        assertEquals(6, store.incrementAndGet(Ordinal.SESSION_PART, seed))
+        // Even with a different seed value, subsequent calls just increment.
+        assertEquals(7, store.incrementAndGet(Ordinal.SESSION_PART) { 100 })
+        assertEquals(1, seedCalls)
+    }
+
+    @Test
+    fun `default seed makes indices start at 1`() {
+        assertEquals(1, store.incrementAndGet(Ordinal.SESSION_PART))
+        assertEquals(2, store.incrementAndGet(Ordinal.SESSION_PART))
+    }
 }

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/store/Ordinal.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/store/Ordinal.kt
@@ -36,5 +36,12 @@ enum class Ordinal(val key: String) {
      * Increments at the start of every user session. This allows us to check the % of user sessions
      * that didn't get delivered to the backend.
      */
-    USER_SESSION("io.embrace.usersessionnumber")
+    USER_SESSION("io.embrace.usersessionnumber"),
+
+    /**
+     * Monotonically increments on each session part created. Persisted across SDK install
+     * lifetime; seeded from [USER_SESSION] the first time it is read. Surfaced as
+     * `emb.session_part_number`.
+     */
+    SESSION_PART("io.embrace.sessionpartnumber")
 }

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/store/OrdinalStore.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/store/OrdinalStore.kt
@@ -3,7 +3,8 @@ package io.embrace.android.embracesdk.internal.store
 interface OrdinalStore {
 
     /**
-     * Increments and returns the ordinal.
+     * Increments and returns the ordinal. An ordinal that has never been written returns the value
+     * supplied by [seed] on its first read; subsequent calls increment by 1. [seed] returns 1 by default.
      */
-    fun incrementAndGet(ordinal: Ordinal): Int
+    fun incrementAndGet(ordinal: Ordinal, seed: () -> Int = { 1 }): Int
 }

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/store/OrdinalStoreImpl.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/store/OrdinalStoreImpl.kt
@@ -4,11 +4,20 @@ class OrdinalStoreImpl(
     private val impl: KeyValueStore,
 ) : OrdinalStore {
 
-    override fun incrementAndGet(ordinal: Ordinal): Int {
-        val sanitizedOrdinal = when (ordinal) {
-            Ordinal.USER_SESSION -> Ordinal.SESSION
-            else -> ordinal
+    override fun incrementAndGet(ordinal: Ordinal, seed: () -> Int): Int {
+        val key = sanitize(ordinal).key
+        seedIfAbsent(key, seed)
+        return impl.incrementAndGet(key)
+    }
+
+    private fun seedIfAbsent(key: String, seed: () -> Int) {
+        if (impl.getInt(key) == null) {
+            impl.edit { putInt(key, seed() - 1) }
         }
-        return impl.incrementAndGet(sanitizedOrdinal.key)
+    }
+
+    private fun sanitize(ordinal: Ordinal): Ordinal = when (ordinal) {
+        Ordinal.USER_SESSION -> Ordinal.SESSION
+        else -> ordinal
     }
 }

--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOrdinalStore.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOrdinalStore.kt
@@ -2,13 +2,15 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.store.Ordinal
 import io.embrace.android.embracesdk.internal.store.OrdinalStore
-import java.util.concurrent.atomic.AtomicInteger
 
 class FakeOrdinalStore : OrdinalStore {
 
-    private val counts = Ordinal.entries.associateWith { AtomicInteger(0) }
+    private val lock = Any()
+    private val values = mutableMapOf<Ordinal, Int>()
 
-    override fun incrementAndGet(ordinal: Ordinal): Int {
-        return checkNotNull(counts[ordinal]).incrementAndGet()
+    override fun incrementAndGet(ordinal: Ordinal, seed: () -> Int): Int = synchronized(lock) {
+        val next = values[ordinal]?.plus(1) ?: seed()
+        values[ordinal] = next
+        next
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionApiTest.kt
@@ -113,7 +113,8 @@ internal class UserSessionApiTest {
             EmbSessionAttributes.EMB_USER_SESSION_NUMBER,
             EmbSessionAttributes.EMB_USER_SESSION_MAX_DURATION_SECONDS,
             EmbSessionAttributes.EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS,
-            EmbSessionAttributes.EMB_USER_SESSION_PART_NUMBER,
+            EmbSessionAttributes.EMB_USER_SESSION_PART_INDEX,
+            EmbSessionAttributes.EMB_SESSION_PART_NUMBER,
             EmbSessionAttributes.EMB_USER_SESSION_START_TS,
         ).plus(validateExistenceOnly)
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionPartNumberTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionPartNumberTest.kt
@@ -1,0 +1,82 @@
+package io.embrace.android.embracesdk.testcases.session
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.assertions.findSessionSpan
+import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_SESSION_PART_NUMBER
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_NUMBER
+import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Asserts that `emb.session_part_number` is monotonic across user sessions and across SDK install
+ * lifetime (seeded from `emb.session_number` on first creation).
+ */
+@RunWith(AndroidJUnit4::class)
+internal class SessionPartNumberTest {
+
+    @Rule
+    @JvmField
+    val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule()
+
+    @Test
+    fun `session_part_number seeds from session_number and increments monotonically across user sessions`() {
+        testRule.runTest(
+            testCaseAction = {
+                recordSession()
+                recordSession {
+                    clock.tick(10_000)
+                    embrace.endUserSession()
+                }
+                recordSession()
+            },
+            assertAction = {
+                val sessions = getSessionEnvelopes(4)
+                val us1p1 = sessions[0].findSessionSpan().attributes
+                val us1p2 = sessions[1].findSessionSpan().attributes
+                val us2p1 = sessions[2].findSessionSpan().attributes
+                val us2p2 = sessions[3].findSessionSpan().attributes
+
+                assertEquals("1", us1p1?.findAttributeValue(EMB_USER_SESSION_NUMBER))
+                assertEquals("1", us1p1?.findAttributeValue(EMB_SESSION_PART_NUMBER))
+
+                assertEquals("1", us1p2?.findAttributeValue(EMB_USER_SESSION_NUMBER))
+                assertEquals("2", us1p2?.findAttributeValue(EMB_SESSION_PART_NUMBER))
+
+                assertEquals("2", us2p1?.findAttributeValue(EMB_USER_SESSION_NUMBER))
+                assertEquals("3", us2p1?.findAttributeValue(EMB_SESSION_PART_NUMBER))
+
+                assertEquals("2", us2p2?.findAttributeValue(EMB_USER_SESSION_NUMBER))
+                assertEquals("4", us2p2?.findAttributeValue(EMB_SESSION_PART_NUMBER))
+            },
+        )
+    }
+
+    @Test
+    fun `session_part_number seeds from existing user session number on upgrade`() {
+        val persistedId = "aabbccdd11223344aabbccdd11223344"
+        val startMs = SdkIntegrationTestRule.DEFAULT_SDK_START_TIME_MS - 1_000L
+        val lastActivityMs = SdkIntegrationTestRule.DEFAULT_SDK_START_TIME_MS - 100L
+        testRule.runTest(
+            setupAction = {
+                persistUserSession(
+                    userSessionId = persistedId,
+                    startMs = startMs,
+                    lastActivityMs = lastActivityMs,
+                    sessionNumber = 7,
+                    partIndex = 2,
+                )
+            },
+            testCaseAction = { recordSession() },
+            assertAction = {
+                val session = getSingleSessionEnvelope()
+                val attrs = session.findSessionSpan().attributes
+                assertEquals("7", attrs?.findAttributeValue(EMB_USER_SESSION_NUMBER))
+                assertEquals("7", attrs?.findAttributeValue(EMB_SESSION_PART_NUMBER))
+            }
+        )
+    }
+}

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionIdKeysTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionIdKeysTest.kt
@@ -11,7 +11,7 @@ import io.embrace.android.embracesdk.internal.toStringMap
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_MAX_DURATION_SECONDS
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_NUMBER
-import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_PART_NUMBER
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_PART_INDEX
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_START_TS
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_TERMINATION_REASON
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
@@ -53,7 +53,7 @@ internal class UserSessionIdKeysTest {
     private fun assertFirstSessionSpanAttributes(attrs: Map<String, String>) {
         attrs.assertSessionIds()
         assertEquals("1", attrs[EMB_USER_SESSION_NUMBER])
-        assertEquals("1", attrs[EMB_USER_SESSION_PART_NUMBER])
+        assertEquals("1", attrs[EMB_USER_SESSION_PART_INDEX])
         assertFalse(attrs[EMB_USER_SESSION_START_TS].isNullOrBlank())
         assertFalse(attrs[EMB_USER_SESSION_MAX_DURATION_SECONDS].isNullOrBlank())
         assertFalse(attrs[EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS].isNullOrBlank())
@@ -81,7 +81,7 @@ internal class UserSessionIdKeysTest {
     private fun assertLogSessionAttributes(attrs: Map<String, String?>) {
         attrs.assertSessionIds()
         assertNull(attrs[EMB_USER_SESSION_NUMBER])
-        assertNull(attrs[EMB_USER_SESSION_PART_NUMBER])
+        assertNull(attrs[EMB_USER_SESSION_PART_INDEX])
         assertNull(attrs[EMB_USER_SESSION_START_TS])
         assertNull(attrs[EMB_USER_SESSION_MAX_DURATION_SECONDS])
         assertNull(attrs[EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS])

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionLifecycleTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionLifecycleTest.kt
@@ -18,7 +18,7 @@ import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_SESSION_PART_ID
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_ID
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_NUMBER
-import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_PART_NUMBER
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_PART_INDEX
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_START_TS
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbUserSessionTerminationReasonValues.INACTIVITY
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbUserSessionTerminationReasonValues.MANUAL
@@ -66,7 +66,7 @@ internal class UserSessionLifecycleTest {
                 assertEquals("", bgAttrs?.findAttributeValue(EMB_USER_SESSION_ID))
                 assertEquals("", bgAttrs?.findAttributeValue(EMB_SESSION_PART_ID))
                 assertNull(bgAttrs?.findAttributeValue(EMB_USER_SESSION_NUMBER))
-                assertNull(bgAttrs?.findAttributeValue(EMB_USER_SESSION_PART_NUMBER))
+                assertNull(bgAttrs?.findAttributeValue(EMB_USER_SESSION_PART_INDEX))
                 assertNull(bgAttrs?.findAttributeValue(EMB_USER_SESSION_START_TS))
 
                 // entering foreground creates the first user session

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionPartIndexTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionPartIndexTest.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.assertions.findSessionSpan
 import io.embrace.android.embracesdk.assertions.getUserSessionId
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_NUMBER
-import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_PART_NUMBER
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_PART_INDEX
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
@@ -14,7 +14,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-internal class UserSessionPartNumberTest {
+internal class UserSessionPartIndexTest {
 
     @Rule
     @JvmField
@@ -39,53 +39,53 @@ internal class UserSessionPartNumberTest {
                 val us2p2 = sessions[3].findSessionSpan().attributes
 
                 assertEquals("1", us1p1?.findAttributeValue(EMB_USER_SESSION_NUMBER))
-                assertEquals("1", us1p1?.findAttributeValue(EMB_USER_SESSION_PART_NUMBER))
+                assertEquals("1", us1p1?.findAttributeValue(EMB_USER_SESSION_PART_INDEX))
 
                 assertEquals("1", us1p2?.findAttributeValue(EMB_USER_SESSION_NUMBER))
-                assertEquals("2", us1p2?.findAttributeValue(EMB_USER_SESSION_PART_NUMBER))
+                assertEquals("2", us1p2?.findAttributeValue(EMB_USER_SESSION_PART_INDEX))
 
                 assertEquals("2", us2p1?.findAttributeValue(EMB_USER_SESSION_NUMBER))
-                assertEquals("1", us2p1?.findAttributeValue(EMB_USER_SESSION_PART_NUMBER))
+                assertEquals("1", us2p1?.findAttributeValue(EMB_USER_SESSION_PART_INDEX))
 
                 assertEquals("2", us2p2?.findAttributeValue(EMB_USER_SESSION_NUMBER))
-                assertEquals("2", us2p2?.findAttributeValue(EMB_USER_SESSION_PART_NUMBER))
+                assertEquals("2", us2p2?.findAttributeValue(EMB_USER_SESSION_PART_INDEX))
             },
         )
     }
 
     @Test
-    fun `load existing user session results in using existing session part number`() {
+    fun `load existing user session results in using existing session part index`() {
         val persistedId = "aabbccdd11223344aabbccdd11223344"
         val startMs = SdkIntegrationTestRule.DEFAULT_SDK_START_TIME_MS - 1_000L
         val lastActivityMs = SdkIntegrationTestRule.DEFAULT_SDK_START_TIME_MS - 100L
         testRule.runTest(
             setupAction = {
-                persistUserSession(userSessionId = persistedId, startMs = startMs, lastActivityMs = lastActivityMs, partNumber = 2)
+                persistUserSession(userSessionId = persistedId, startMs = startMs, lastActivityMs = lastActivityMs, partIndex = 2)
             },
             testCaseAction = { recordSession() },
             assertAction = {
                 val session = getSingleSessionEnvelope()
                 assertEquals(persistedId, session.getUserSessionId())
-                assertEquals("3", session.findSessionSpan().attributes?.findAttributeValue(EMB_USER_SESSION_PART_NUMBER))
+                assertEquals("3", session.findSessionSpan().attributes?.findAttributeValue(EMB_USER_SESSION_PART_INDEX))
             }
         )
     }
 
     @Test
-    fun `load expired user session results in resetting session part number`() {
+    fun `load expired user session results in resetting session part index`() {
         val persistedId = "aabbccdd11223344aabbccdd11223344"
         val startMs = SdkIntegrationTestRule.DEFAULT_SDK_START_TIME_MS - 3_000_000L
         val defaultInactivityMs = 1800L * 1_000L
         val lastActivityMs = SdkIntegrationTestRule.DEFAULT_SDK_START_TIME_MS - defaultInactivityMs - 1L
         testRule.runTest(
             setupAction = {
-                persistUserSession(userSessionId = persistedId, startMs = startMs, lastActivityMs = lastActivityMs, partNumber = 5)
+                persistUserSession(userSessionId = persistedId, startMs = startMs, lastActivityMs = lastActivityMs, partIndex = 5)
             },
             testCaseAction = { recordSession() },
             assertAction = {
                 val session = getSingleSessionEnvelope()
                 assertNotEquals(persistedId, session.getUserSessionId())
-                assertEquals("1", session.findSessionSpan().attributes?.findAttributeValue(EMB_USER_SESSION_PART_NUMBER))
+                assertEquals("1", session.findSessionSpan().attributes?.findAttributeValue(EMB_USER_SESSION_PART_INDEX))
             }
         )
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -242,7 +242,7 @@ internal class EmbraceSetupInterface(
         startMs: Long,
         lastActivityMs: Long,
         sessionNumber: Int = 1,
-        partNumber: Int = 1,
+        partIndex: Int = 1,
         maxDurationSeconds: Int = 43200,
         inactivityTimeoutSeconds: Int = 1800,
     ) {
@@ -256,7 +256,7 @@ internal class EmbraceSetupInterface(
                     EmbSessionAttributes.EMB_USER_SESSION_MAX_DURATION_SECONDS to maxDurationSeconds.toString(),
                     EmbSessionAttributes.EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS to inactivityTimeoutSeconds.toString(),
                     SessionAttributes.SESSION_ID to userSessionId,
-                    EmbSessionAttributes.EMB_USER_SESSION_PART_NUMBER to partNumber.toString(),
+                    EmbSessionAttributes.EMB_USER_SESSION_PART_INDEX to partIndex.toString(),
                     "emb.user_session_last_activity_ts" to lastActivityMs.toString(),
                 )
             )

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_basic_span.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_basic_span.json
@@ -60,6 +60,11 @@
       "key": "emb.session_part_id",
       "value": "__EMBRACE_TEST_SESSION_PART_ID__"
     },
+
+    {
+      "key": "emb.session_part_number",
+      "value": "1"
+    },
     {
       "key": "emb.session_start_type",
       "value": "state"
@@ -101,7 +106,7 @@
       "value": "1"
     },
     {
-      "key": "emb.user_session_part_number",
+      "key": "emb.user_session_part_index",
       "value": "1"
     },
     {

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_1.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_1.json
@@ -60,6 +60,11 @@
       "key": "emb.session_part_id",
       "value": "__EMBRACE_TEST_SESSION_PART_ID__"
     },
+
+    {
+      "key": "emb.session_part_number",
+      "value": "1"
+    },
     {
       "key": "emb.session_start_type",
       "value": "bkgnd_state"

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_2.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_2.json
@@ -60,6 +60,11 @@
       "key": "emb.session_part_id",
       "value": "__EMBRACE_TEST_SESSION_PART_ID__"
     },
+
+    {
+      "key": "emb.session_part_number",
+      "value": "2"
+    },
     {
       "key": "emb.session_start_type",
       "value": "state"
@@ -97,7 +102,7 @@
       "value": "1"
     },
     {
-      "key": "emb.user_session_part_number",
+      "key": "emb.user_session_part_index",
       "value": "1"
     },
     {

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_3.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_3.json
@@ -64,6 +64,11 @@
       "key": "emb.session_part_id",
       "value": "__EMBRACE_TEST_SESSION_PART_ID__"
     },
+
+    {
+      "key": "emb.session_part_number",
+      "value": "3"
+    },
     {
       "key": "emb.session_start_type",
       "value": "bkgnd_state"
@@ -97,7 +102,7 @@
       "value": "1"
     },
     {
-      "key": "emb.user_session_part_number",
+      "key": "emb.user_session_part_index",
       "value": "2"
     },
     {

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_4.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_4.json
@@ -64,6 +64,11 @@
       "key": "emb.session_part_id",
       "value": "__EMBRACE_TEST_SESSION_PART_ID__"
     },
+
+    {
+      "key": "emb.session_part_number",
+      "value": "4"
+    },
     {
       "key": "emb.session_start_type",
       "value": "bkgnd_state"
@@ -97,7 +102,7 @@
       "value": "2"
     },
     {
-      "key": "emb.user_session_part_number",
+      "key": "emb.user_session_part_index",
       "value": "1"
     },
     {

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_5.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_5.json
@@ -60,6 +60,11 @@
       "key": "emb.session_part_id",
       "value": "__EMBRACE_TEST_SESSION_PART_ID__"
     },
+
+    {
+      "key": "emb.session_part_number",
+      "value": "5"
+    },
     {
       "key": "emb.session_start_type",
       "value": "state"
@@ -93,7 +98,7 @@
       "value": "3"
     },
     {
-      "key": "emb.user_session_part_number",
+      "key": "emb.user_session_part_index",
       "value": "1"
     },
     {

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_custom_timeouts.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_custom_timeouts.json
@@ -60,6 +60,11 @@
       "key": "emb.session_part_id",
       "value": "__EMBRACE_TEST_SESSION_PART_ID__"
     },
+
+    {
+      "key": "emb.session_part_number",
+      "value": "1"
+    },
     {
       "key": "emb.session_start_type",
       "value": "state"
@@ -97,7 +102,7 @@
       "value": "1"
     },
     {
-      "key": "emb.user_session_part_number",
+      "key": "emb.user_session_part_index",
       "value": "1"
     },
     {

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_jvm_crash_span.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_jvm_crash_span.json
@@ -68,6 +68,11 @@
       "key": "emb.session_part_id",
       "value": "__EMBRACE_TEST_SESSION_PART_ID__"
     },
+
+    {
+      "key": "emb.session_part_number",
+      "value": "1"
+    },
     {
       "key": "emb.session_start_type",
       "value": "state"
@@ -109,7 +114,7 @@
       "value": "1"
     },
     {
-      "key": "emb.user_session_part_number",
+      "key": "emb.user_session_part_index",
       "value": "1"
     },
     {

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_manual_end_1.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_manual_end_1.json
@@ -64,6 +64,11 @@
       "key": "emb.session_part_id",
       "value": "__EMBRACE_TEST_SESSION_PART_ID__"
     },
+
+    {
+      "key": "emb.session_part_number",
+      "value": "1"
+    },
     {
       "key": "emb.session_start_type",
       "value": "state"
@@ -105,7 +110,7 @@
       "value": "1"
     },
     {
-      "key": "emb.user_session_part_number",
+      "key": "emb.user_session_part_index",
       "value": "1"
     },
     {

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_manual_end_2.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_manual_end_2.json
@@ -60,6 +60,11 @@
       "key": "emb.session_part_id",
       "value": "__EMBRACE_TEST_SESSION_PART_ID__"
     },
+
+    {
+      "key": "emb.session_part_number",
+      "value": "2"
+    },
     {
       "key": "emb.session_start_type",
       "value": "manual"
@@ -93,7 +98,7 @@
       "value": "2"
     },
     {
-      "key": "emb.user_session_part_number",
+      "key": "emb.user_session_part_index",
       "value": "1"
     },
     {

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_max_duration_1.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_max_duration_1.json
@@ -64,6 +64,11 @@
       "key": "emb.session_part_id",
       "value": "__EMBRACE_TEST_SESSION_PART_ID__"
     },
+
+    {
+      "key": "emb.session_part_number",
+      "value": "1"
+    },
     {
       "key": "emb.session_start_type",
       "value": "state"
@@ -101,7 +106,7 @@
       "value": "1"
     },
     {
-      "key": "emb.user_session_part_number",
+      "key": "emb.user_session_part_index",
       "value": "1"
     },
     {

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_max_duration_2.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_max_duration_2.json
@@ -60,6 +60,11 @@
       "key": "emb.session_part_id",
       "value": "__EMBRACE_TEST_SESSION_PART_ID__"
     },
+
+    {
+      "key": "emb.session_part_number",
+      "value": "2"
+    },
     {
       "key": "emb.session_start_type",
       "value": "state"
@@ -93,7 +98,7 @@
       "value": "2"
     },
     {
-      "key": "emb.user_session_part_number",
+      "key": "emb.user_session_part_index",
       "value": "1"
     },
     {

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_part_1.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_part_1.json
@@ -60,6 +60,11 @@
       "key": "emb.session_part_id",
       "value": "__EMBRACE_TEST_SESSION_PART_ID__"
     },
+
+    {
+      "key": "emb.session_part_number",
+      "value": "1"
+    },
     {
       "key": "emb.session_start_type",
       "value": "state"
@@ -97,7 +102,7 @@
       "value": "1"
     },
     {
-      "key": "emb.user_session_part_number",
+      "key": "emb.user_session_part_index",
       "value": "1"
     },
     {

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_part_2.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_part_2.json
@@ -60,6 +60,11 @@
       "key": "emb.session_part_id",
       "value": "__EMBRACE_TEST_SESSION_PART_ID__"
     },
+
+    {
+      "key": "emb.session_part_number",
+      "value": "2"
+    },
     {
       "key": "emb.session_start_type",
       "value": "state"
@@ -93,7 +98,7 @@
       "value": "1"
     },
     {
-      "key": "emb.user_session_part_number",
+      "key": "emb.user_session_part_index",
       "value": "2"
     },
     {

--- a/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSessionAttributes.kt
+++ b/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSessionAttributes.kt
@@ -89,6 +89,12 @@ object EmbSessionAttributes {
     const val EMB_SESSION_PART_ID: String = "emb.session_part_id"
 
     /**
+     * Monotonically incrementing counter of session parts since SDK install. Seeded from emb.session_number when first created; increments by 1 on each new session part. Never resets across process or session boundaries.
+     */
+    @ExperimentalSemconv
+    const val EMB_SESSION_PART_NUMBER: String = "emb.session_part_number"
+
+    /**
      * The session start type.
      */
     @ExperimentalSemconv
@@ -146,7 +152,7 @@ object EmbSessionAttributes {
      * The index of the part within the session. 1-indexed, matching the behavior of session_number.
      */
     @ExperimentalSemconv
-    const val EMB_USER_SESSION_PART_NUMBER: String = "emb.user_session_part_number"
+    const val EMB_USER_SESSION_PART_INDEX: String = "emb.user_session_part_index"
 
     /**
      * Session start timestamp (milliseconds since epoch).

--- a/embrace-android-semconv/src/main/semconv/embrace_android.yaml
+++ b/embrace-android-semconv/src/main/semconv/embrace_android.yaml
@@ -462,7 +462,12 @@ groups:
         brief: "UUID identifying the session part."
         stability: development
         examples: ["3a1c2b4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"]
-      - id: emb.user_session_part_number
+      - id: emb.session_part_number
+        type: string
+        brief: "Monotonically incrementing counter of session parts since SDK install. Seeded from emb.session_number when first created; increments by 1 on each new session part. Never resets across process or session boundaries."
+        stability: development
+        examples: ["1", "2", "42"]
+      - id: emb.user_session_part_index
         type: string
         brief: "The index of the part within the session. 1-indexed, matching the behavior of session_number."
         stability: development

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionPart.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionPart.kt
@@ -16,6 +16,7 @@ fun fakeSessionPartToken(): SessionPartToken = SessionPartToken(
     appState = AppState.FOREGROUND,
     isColdStart = true,
     startType = LifeEventType.STATE,
+    userSessionPartIndex = 1,
     sessionPartNumber = 1,
 )
 


### PR DESCRIPTION
## Goal

Renames `emb.user_session_part_number` to `emb.user_session_part_index` and additionally adds `emb.session_part_number` which increments monotonically for session parts.

## Testing

Updated existing test coverage.
