### PR TITLE
Populate span termination attributes correctly

### DIFF
--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
@@ -24,6 +24,7 @@ import io.embrace.android.embracesdk.fakes.fakeLaterEnvelopeResource
 import io.embrace.android.embracesdk.fixtures.fakeCachedSessionStoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.arch.attrs.asPair
 import io.embrace.android.embracesdk.internal.arch.attrs.isEmbraceAttributeName
+import io.embrace.android.embracesdk.internal.arch.schema.AppTerminationCause
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.delivery.PayloadType
@@ -138,7 +139,8 @@ class PayloadResurrectionServiceImplTest {
             expectedParentId = OtelIds.INVALID_SPAN_ID,
             expectedErrorCode = ErrorCode.FAILURE,
             expectedCustomAttributes = mapOf(
-                EmbType.Ux.Session.asPair()
+                EmbType.Ux.Session.asPair(),
+                AppTerminationCause.Crash.asPair(),
             )
         )
     }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanExt.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanExt.kt
@@ -5,7 +5,6 @@ import io.embrace.android.embracesdk.internal.arch.schema.AppTerminationCause
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
-import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
 import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.sdk.setEmbraceAttribute
 import io.embrace.android.embracesdk.internal.payload.Attribute
@@ -20,9 +19,10 @@ fun Span.hasEmbraceAttributeValue(key: String, value: Any): Boolean {
 }
 
 fun Span.toFailedSpan(endTimeMs: Long): Span {
+    val isSessionSpan = hasEmbraceAttribute(EmbType.Ux.Session)
     val newAttributes = mutableMapOf<String, String>().apply {
         setEmbraceAttribute(ErrorCodeAttribute.Failure)
-        if (hasEmbraceAttribute(EmbType.Ux.Session)) {
+        if (isSessionSpan) {
             setEmbraceAttribute(AppTerminationCause.Crash)
         }
     }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/payload/SpanMapperTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/payload/SpanMapperTest.kt
@@ -5,16 +5,9 @@ import io.embrace.android.embracesdk.assertions.assertIsTypePerformance
 import io.embrace.android.embracesdk.assertions.assertNotPrivateSpan
 import io.embrace.android.embracesdk.assertions.assertSuccessful
 import io.embrace.android.embracesdk.fakes.FakeSpanData
-import io.embrace.android.embracesdk.internal.arch.schema.AppTerminationCause
-import io.embrace.android.embracesdk.internal.arch.schema.EmbType
-import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
-import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
-import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
-import io.embrace.android.embracesdk.internal.otel.sdk.setEmbraceAttribute
-import io.embrace.android.embracesdk.internal.otel.spans.hasEmbraceAttribute
+import io.embrace.android.embracesdk.internal.otel.spans.toFailedSpan
 import io.embrace.android.embracesdk.internal.otel.toEmbracePayload
-import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.toEmbraceSpanData
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -71,21 +64,5 @@ internal class SpanMapperTest {
         checkNotNull(snapshot.attributes).forEach {
             assertEquals(attributesOfFailedSpan[it.key], it.data)
         }
-    }
-
-    private fun Span.toFailedSpan(endTimeMs: Long): Span {
-        val newAttributes = mutableMapOf<String, String>().apply {
-            setEmbraceAttribute(ErrorCodeAttribute.Failure)
-            if (hasEmbraceAttribute(EmbType.Ux.Session)) {
-                setEmbraceAttribute(AppTerminationCause.Crash)
-            }
-        }
-
-        return copy(
-            endTimeNanos = endTimeMs.millisToNanos(),
-            parentSpanId = parentSpanId ?: OtelIds.INVALID_SPAN_ID,
-            status = Span.Status.ERROR,
-            attributes = newAttributes.map { Attribute(it.key, it.value) }.plus(attributes ?: emptyList())
-        )
     }
 }


### PR DESCRIPTION
## Goal

Alters the `Span.toFailedSpan` extension function so that it sets the termination reason. `hasEmbraceAttribute` had overloads for both `Span` and `Map<String, Any>`, which meant in the context of `toFailedSpan` the `mutableMapOf` was checked for attributes. 

## Testing

Enhanced unit test coverage.
