### PR TITLE
Add public API for manual screen tracking

### DIFF
--- a/embrace-android-api/api/embrace-android-api.api
+++ b/embrace-android-api/api/embrace-android-api.api
@@ -56,11 +56,14 @@ public abstract interface class io/embrace/android/embracesdk/internal/api/Instr
 	public abstract fun appReady ()V
 	public abstract fun getSdkCurrentTimeMs ()J
 	public abstract fun observeNavigation (Landroid/app/Activity;Ljava/lang/Object;)V
+	public abstract fun screenLoaded (Ljava/lang/String;)V
+	public abstract fun screenLoaded (Ljava/lang/String;Ljava/util/Map;)V
 }
 
 public final class io/embrace/android/embracesdk/internal/api/InstrumentationApi$DefaultImpls {
 	public static fun addLoadTraceChildSpan (Lio/embrace/android/embracesdk/internal/api/InstrumentationApi;Landroid/app/Activity;Ljava/lang/String;JJ)V
 	public static fun addStartupTraceChildSpan (Lio/embrace/android/embracesdk/internal/api/InstrumentationApi;Ljava/lang/String;JJ)V
+	public static fun screenLoaded (Lio/embrace/android/embracesdk/internal/api/InstrumentationApi;Ljava/lang/String;)V
 }
 
 public abstract interface class io/embrace/android/embracesdk/internal/api/LogsApi {
@@ -103,6 +106,7 @@ public abstract interface class io/embrace/android/embracesdk/internal/api/SdkAp
 public final class io/embrace/android/embracesdk/internal/api/SdkApi$DefaultImpls {
 	public static fun addLoadTraceChildSpan (Lio/embrace/android/embracesdk/internal/api/SdkApi;Landroid/app/Activity;Ljava/lang/String;JJ)V
 	public static fun addStartupTraceChildSpan (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;JJ)V
+	public static fun screenLoaded (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;)V
 }
 
 public abstract interface class io/embrace/android/embracesdk/internal/api/SdkStateApi {

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/InstrumentationApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/InstrumentationApi.kt
@@ -105,4 +105,16 @@ public interface InstrumentationApi {
      * wiring in order to observe and track navigation
      */
     public fun observeNavigation(activity: Activity, navigationController: Any)
+
+    /**
+     * Record the given [screen] has been loaded. Calling this does not affect automatic navigation tracking instrumentation.
+     */
+    public fun screenLoaded(screen: String): Unit = screenLoaded(screen, emptyMap())
+
+    /**
+     * Record the given [screen] has been loaded. Calling this does not affect automatic navigation tracking instrumentation.
+     *
+     * Optionally pass in [eventAttributes] to be recorded with the screen loading event.
+     */
+    public fun screenLoaded(screen: String, eventAttributes: Map<String, String>)
 }

--- a/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationApi.kt
+++ b/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationApi.kt
@@ -45,4 +45,7 @@ class FakeInstrumentationApi(
 
     override fun observeNavigation(activity: Activity, navigationController: Any) {
     }
+
+    override fun screenLoaded(screen: String, eventAttributes: Map<String, String>) {
+    }
 }

--- a/embrace-android-instrumentation-navigation/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/ScreenDataSource.kt
+++ b/embrace-android-instrumentation-navigation/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/ScreenDataSource.kt
@@ -1,0 +1,40 @@
+package io.embrace.android.embracesdk.internal.instrumentation.navigation
+
+import io.embrace.android.embracesdk.internal.arch.InstrumentationArgs
+import io.embrace.android.embracesdk.internal.arch.datasource.StateDataSource
+import io.embrace.android.embracesdk.internal.arch.schema.SchemaType.ScreenState
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Tracks app-driven screen changes reported through the public `Embrace.screenLoaded` API.
+ *
+ * This datasource is initialized lazily upon first use, i.e. the state span won't be created until the first state update is received.
+ */
+class ScreenDataSource(
+    args: InstrumentationArgs,
+) : StateDataSource<String>(
+    args = args,
+    stateTypeFactory = ::ScreenState,
+    defaultValue = INITIAL_VALUE,
+    maxTransitions = MAX_SCREEN_STATE_TRANSITIONS,
+) {
+
+    override val enableOnCreate: Boolean = false
+
+    private val lastScreen = AtomicReference<String?>(null)
+
+    fun onScreenLoaded(screen: String, attributes: Map<String, String> = emptyMap()) {
+        if (lastScreen.getAndSet(screen) != screen) {
+            onStateChange(
+                newState = screen,
+                transitionTimeMs = clock.now(),
+                transitionAttributes = attributes,
+            )
+        }
+    }
+
+    companion object {
+        private const val INITIAL_VALUE = "Uninitialized"
+        private const val MAX_SCREEN_STATE_TRANSITIONS = 1000
+    }
+}

--- a/embrace-android-instrumentation-navigation/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/ScreenDataSource.kt
+++ b/embrace-android-instrumentation-navigation/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/ScreenDataSource.kt
@@ -19,7 +19,7 @@ class ScreenDataSource(
     maxTransitions = MAX_SCREEN_STATE_TRANSITIONS,
 ) {
 
-    override val enableOnCreate: Boolean = false
+    override val captureStateOnCreation: Boolean = false
 
     private val lastScreen = AtomicReference<String?>(null)
 

--- a/embrace-android-instrumentation-navigation/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/ScreenInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-navigation/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/ScreenInstrumentationProvider.kt
@@ -1,0 +1,12 @@
+package io.embrace.android.embracesdk.internal.instrumentation.navigation
+
+import io.embrace.android.embracesdk.internal.arch.InstrumentationArgs
+import io.embrace.android.embracesdk.internal.arch.datasource.StateInstrumentationProvider
+
+class ScreenInstrumentationProvider :
+    StateInstrumentationProvider<ScreenDataSource, String>() {
+
+    override fun factoryProvider(args: InstrumentationArgs): () -> ScreenDataSource {
+        return { ScreenDataSource(args) }
+    }
+}

--- a/embrace-android-instrumentation-navigation/src/main/resources/META-INF/services/io.embrace.android.embracesdk.internal.arch.InstrumentationProvider
+++ b/embrace-android-instrumentation-navigation/src/main/resources/META-INF/services/io.embrace.android.embracesdk.internal.arch.InstrumentationProvider
@@ -1,1 +1,2 @@
 io.embrace.android.embracesdk.internal.instrumentation.navigation.NavigationStateInstrumentationProvider
+io.embrace.android.embracesdk.internal.instrumentation.navigation.ScreenInstrumentationProvider

--- a/embrace-android-instrumentation-navigation/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/ScreenDataSourceTest.kt
+++ b/embrace-android-instrumentation-navigation/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/ScreenDataSourceTest.kt
@@ -4,7 +4,6 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -26,7 +25,6 @@ internal class ScreenDataSourceTest {
 
     @Test
     fun `data source not initialized by default`() {
-        assertFalse(dataSource.isEnabled())
         assertTrue(args.destination.createdStateTokens.isEmpty())
         assertEquals("Uninitialized", dataSource.getCurrentStateValue())
     }
@@ -36,7 +34,7 @@ internal class ScreenDataSourceTest {
         val firstTime = args.clock.tick()
         dataSource.onScreenLoaded("home")
         assertEquals("home", dataSource.getCurrentStateValue())
-        assertTrue(dataSource.isEnabled())
+        assertTrue(args.destination.createdStateTokens.isNotEmpty())
 
         val secondTime = args.clock.tick()
         dataSource.onScreenLoaded("settings")

--- a/embrace-android-instrumentation-navigation/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/ScreenDataSourceTest.kt
+++ b/embrace-android-instrumentation-navigation/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/ScreenDataSourceTest.kt
@@ -1,0 +1,56 @@
+package io.embrace.android.embracesdk.internal.instrumentation.navigation
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class ScreenDataSourceTest {
+    private lateinit var dataSource: ScreenDataSource
+    private lateinit var args: FakeInstrumentationArgs
+
+    @Before
+    fun setUp() {
+        args = FakeInstrumentationArgs(
+            ApplicationProvider.getApplicationContext(),
+            sessionIdSupplier = { "test-session" },
+        )
+        dataSource = ScreenInstrumentationProvider().register(args).dataSource as ScreenDataSource
+    }
+
+    @Test
+    fun `data source not initialized by default`() {
+        assertFalse(dataSource.isEnabled())
+        assertTrue(args.destination.createdStateTokens.isEmpty())
+        assertEquals("Uninitialized", dataSource.getCurrentStateValue())
+    }
+
+    @Test
+    fun `onScreenLoaded updates the current state value and records each transition at the SDK clock time`() {
+        val firstTime = args.clock.tick()
+        dataSource.onScreenLoaded("home")
+        assertEquals("home", dataSource.getCurrentStateValue())
+        assertTrue(dataSource.isEnabled())
+
+        val secondTime = args.clock.tick()
+        dataSource.onScreenLoaded("settings")
+        assertEquals("settings", dataSource.getCurrentStateValue())
+
+        val stateSpanToken = args.destination.createdStateTokens.single()
+        assertEquals(listOf(firstTime to "home", secondTime to "settings"), stateSpanToken.transitions)
+    }
+
+    @Test
+    fun `repeated onScreenLoaded with the same screen is deduplicated`() {
+        dataSource.onScreenLoaded("home")
+        args.clock.tick()
+        dataSource.onScreenLoaded("home")
+        assertEquals("home", dataSource.getCurrentStateValue())
+    }
+}

--- a/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
+++ b/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
@@ -313,6 +313,9 @@ sealed class SchemaType(
         }
     }
 
+    class ScreenState(initialValue: String) :
+        State<String>(initialValue, "screen-manual")
+
     /**
      * A custom telemetry type. This allows the hybrid SDKs (and others) to pass in custom
      * telemetry schemas if required.

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
@@ -61,37 +61,34 @@ fun Span.assertNavigationStateSpan(
     stateUninitialized: Boolean = true,
     transitionTimesMs: List<Long> = listOf(),
     newStateValues: List<String> = listOf(),
-) = assertStateSpan(
-    startStateValue = if (stateUninitialized) {
+)  {
+    val startStateValue = if (stateUninitialized) {
         "Initializing"
     } else {
         "Backgrounded"
-    },
-    transitionTimesMs = transitionTimesMs,
-    newStateValues = newStateValues
-)
+    }
+    assertStateSpan(
+        initialValue = startStateValue,
+        transitionTimesMs = transitionTimesMs,
+        newStateValues = newStateValues + "Backgrounded",
+    )
+}
 
 /**
- * Validates a state span's initial value attribute and all transition events.
+ * Validate that a state span has the given initial value and transition times with the associated state values
  */
 fun Span.assertStateSpan(
-    startStateValue: String,
+    initialValue: String,
     transitionTimesMs: List<Long> = listOf(),
     newStateValues: List<String> = listOf(),
 ) {
-    assertTrue(hasEmbraceAttributeValue(EMB_STATE_INITIAL_VALUE, startStateValue))
+    assertTrue(hasEmbraceAttributeValue(EMB_STATE_INITIAL_VALUE, initialValue))
     with(checkNotNull(events)) {
         assertEquals(transitionTimesMs.size, size)
-        if (isNotEmpty()) {
-            (0..<transitionTimesMs.size - 1).forEach {
-                this[it].assertStateTransition(
-                    timestampMs = transitionTimesMs[it],
-                    newStateValue = newStateValues[it],
-                )
-            }
-            last().assertStateTransition(
-                timestampMs = transitionTimesMs.last(),
-                newStateValue = "Backgrounded",
+        transitionTimesMs.indices.forEach {
+            this[it].assertStateTransition(
+                timestampMs = transitionTimesMs[it],
+                newStateValue = newStateValues[it],
             )
         }
     }

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -49,6 +49,8 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun recordNetworkRequest (Lio/embrace/android/embracesdk/network/EmbraceNetworkRequest;)V
 	public fun recordSpan (Ljava/lang/String;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Ljava/util/Map;Ljava/util/List;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public fun removeSessionProperty (Ljava/lang/String;)Z
+	public fun screenLoaded (Ljava/lang/String;)V
+	public fun screenLoaded (Ljava/lang/String;Ljava/util/Map;)V
 	public fun setResourceAttribute (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setUserEmail (Ljava/lang/String;)V
 	public fun setUserIdentifier (Ljava/lang/String;)V

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ScreenStateFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ScreenStateFeatureTest.kt
@@ -1,0 +1,182 @@
+package io.embrace.android.embracesdk.testcases.features
+
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.assertions.assertStateSpan
+import io.embrace.android.embracesdk.assertions.assertStateTransition
+import io.embrace.android.embracesdk.assertions.getNavigationStateSpan
+import io.embrace.android.embracesdk.assertions.getScreenStateSpan
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+@RunWith(AndroidJUnit4::class)
+internal class ScreenStateFeatureTest {
+
+    @Rule
+    @JvmField
+    val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule()
+
+    @Test
+    fun `screen data source records no data if state feature flag is disabled`() {
+        testRule.runTest(
+            persistedRemoteConfig = RemoteConfig(pctStateCaptureEnabledV2 = 0.0f),
+            testCaseAction = {
+                recordSession {
+                    embrace.screenLoaded("home")
+                }
+            },
+            assertAction = {
+                assertNull(getSingleSessionEnvelope().getScreenStateSpan())
+            },
+        )
+    }
+
+    @Test
+    fun `no screen state span is created if screenLoaded is never invoked`() {
+        testRule.runTest(
+            testCaseAction = {
+                recordSession {}
+            },
+            assertAction = {
+                assertNull(getSingleSessionEnvelope().getScreenStateSpan())
+            },
+        )
+    }
+
+    @Test
+    fun `screenLoaded emits transitions on a span that starts with Uninitialized`() {
+        var firstTransitionTime: Long = 0
+        var secondTransitionTime: Long = 0
+        testRule.runTest(
+            testCaseAction = {
+                recordSession {
+                    firstTransitionTime = clock.now()
+                    embrace.screenLoaded("home")
+                    clock.tick(1000)
+                    secondTransitionTime = clock.now()
+                    embrace.screenLoaded("checkout")
+                }
+            },
+            assertAction = {
+                val stateSpan = checkNotNull(getSingleSessionEnvelope().getScreenStateSpan())
+                stateSpan.assertStateSpan(
+                    initialValue = "Uninitialized",
+                    transitionTimesMs = listOf(firstTransitionTime, secondTransitionTime),
+                    newStateValues = listOf("home", "checkout"),
+                )
+            },
+        )
+    }
+
+    @Test
+    fun `screen state value carries forward to the next session`() {
+        var session1FirstTransition: Long = 0
+        var session1SecondTransition: Long = 0
+        var session2TransitionTime: Long = 0
+        testRule.runTest(
+            testCaseAction = {
+                recordSession {
+                    session1FirstTransition = clock.now()
+                    embrace.screenLoaded("home")
+                    clock.tick(1000)
+                    session1SecondTransition = clock.now()
+                    embrace.screenLoaded("checkout")
+                }
+                recordSession {
+                    clock.tick(1000)
+                    session2TransitionTime = clock.now()
+                    embrace.screenLoaded("confirmation")
+                }
+            },
+            assertAction = {
+                val sessions = getSessionEnvelopes(2)
+                checkNotNull(sessions[0].getScreenStateSpan()).assertStateSpan(
+                    initialValue = "Uninitialized",
+                    transitionTimesMs = listOf(session1FirstTransition, session1SecondTransition),
+                    newStateValues = listOf("home", "checkout"),
+                )
+
+                checkNotNull(sessions[1].getScreenStateSpan()).assertStateSpan(
+                    initialValue = "checkout",
+                    transitionTimesMs = listOf(session2TransitionTime),
+                    newStateValues = listOf("confirmation"),
+                )
+            },
+        )
+    }
+
+    @Test
+    fun `screenLoaded attributes recorded on the transition event`() {
+        var transitionTime: Long = 0
+        val customAttributes = mapOf("cart_size" to "3", "promo" to "FALL")
+        testRule.runTest(
+            testCaseAction = {
+                recordSession {
+                    transitionTime = clock.now()
+                    embrace.screenLoaded("checkout", customAttributes)
+                }
+            },
+            assertAction = {
+                val stateSpan = checkNotNull(getSingleSessionEnvelope().getScreenStateSpan())
+                checkNotNull(stateSpan.events).single().assertStateTransition(
+                    timestampMs = transitionTime,
+                    newStateValue = "checkout",
+                    transitionAttributes = customAttributes,
+                )
+            },
+        )
+    }
+
+    @Test
+    fun `repeated screenLoaded with same screen is deduplicated`() {
+        var firstTransition: Long = 0
+        testRule.runTest(
+            testCaseAction = {
+                recordSession {
+                    firstTransition = clock.now()
+                    embrace.screenLoaded("home")
+                    clock.tick(1000)
+                    embrace.screenLoaded("home")
+                }
+            },
+            assertAction = {
+                val stateSpan = checkNotNull(getSingleSessionEnvelope().getScreenStateSpan())
+                stateSpan.assertStateSpan(
+                    initialValue = "Uninitialized",
+                    transitionTimesMs = listOf(firstTransition),
+                    newStateValues = listOf("home"),
+                )
+            },
+        )
+    }
+
+    @Test
+    fun `screen state coexists with automatic navigation state in the same session`() {
+        testRule.runTest(
+            testCaseAction = {
+                recordSession {
+                    embrace.screenLoaded("home")
+                    clock.tick(10_000L)
+                    embrace.screenLoaded("cart")
+                    clock.tick(10_000L)
+                    embrace.screenLoaded("checkout")
+                }
+            },
+            assertAction = {
+                val envelope = getSingleSessionEnvelope()
+                val screenStateSpan = checkNotNull(envelope.getScreenStateSpan())
+                val navigationStateSpan = checkNotNull(envelope.getNavigationStateSpan())
+
+                assertEquals(2, navigationStateSpan.events?.size)
+                assertEquals(3, screenStateSpan.events?.size)
+            },
+        )
+    }
+}

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/InstrumentationApiDelegate.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/InstrumentationApiDelegate.kt
@@ -7,12 +7,13 @@ import io.embrace.android.embracesdk.internal.arch.datasource.SpanEventImpl
 import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.injection.embraceImplInject
+import io.embrace.android.embracesdk.internal.instrumentation.navigation.ScreenDataSource
 import io.embrace.android.embracesdk.internal.instrumentation.startup.activity.traceInstanceId
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 
 internal class InstrumentationApiDelegate(
-    bootstrapper: ModuleInitBootstrapper,
+    private val bootstrapper: ModuleInitBootstrapper,
     private val sdkCallChecker: SdkCallChecker,
 ) : InstrumentationApi {
 
@@ -27,6 +28,9 @@ internal class InstrumentationApiDelegate(
     }
     private val navigationTrackingService by embraceImplInject(sdkCallChecker) {
         bootstrapper.essentialServiceModule.navigationTrackingService
+    }
+    private val screenDataSource by embraceImplInject(sdkCallChecker) {
+        bootstrapper.instrumentationModule.instrumentationRegistry.findByType(ScreenDataSource::class)
     }
 
     override fun appReady() {
@@ -100,6 +104,14 @@ internal class InstrumentationApiDelegate(
     override fun observeNavigation(activity: Activity, navigationController: Any) {
         if (sdkCallChecker.check("observe_navigation")) {
             navigationTrackingService?.trackNavigation(activity, navigationController)
+        }
+    }
+
+    override fun screenLoaded(screen: String, eventAttributes: Map<String, String>) {
+        if (sdkCallChecker.check("screen_loaded")) {
+            screenDataSource?.run {
+                onScreenLoaded(screen, eventAttributes)
+            }
         }
     }
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SessionPartPayloadAssertions.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SessionPartPayloadAssertions.kt
@@ -103,3 +103,5 @@ fun Envelope<SessionPartPayload>.hasSpanSnapshotsOfType(telemetryType: EmbType):
 }
 
 fun Envelope<SessionPartPayload>.getNavigationStateSpan() = getStateSpan("emb-state-screen-automatic")
+
+fun Envelope<SessionPartPayload>.getScreenStateSpan() = getStateSpan("emb-state-screen-manual")


### PR DESCRIPTION
Create new lazy-init state datasorce for maually tracking screen load. The state is independent from navigation state and semantically represents when a screen has been loaded. Therefore, while the load is happening, the state is still the previous screen that was loaded.