### PR TITLE
Improve Compose-Tap Instrumentation Performance

### DIFF
--- a/embrace-android-instrumentation-compose-tap/build.gradle.kts
+++ b/embrace-android-instrumentation-compose-tap/build.gradle.kts
@@ -12,4 +12,8 @@ dependencies {
     implementation(project(":embrace-android-instrumentation-api"))
     implementation(project(":embrace-android-instrumentation-taps"))
     compileOnly(libs.compose)
+
+    testImplementation(project(":embrace-android-instrumentation-api-fakes"))
+    testImplementation(libs.compose)
+    testImplementation(libs.robolectric)
 }

--- a/embrace-android-instrumentation-compose-tap/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/ComposeClickedTargetIterator.kt
+++ b/embrace-android-instrumentation-compose-tap/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/ComposeClickedTargetIterator.kt
@@ -1,11 +1,11 @@
 package io.embrace.android.embracesdk.internal.instrumentation.compose.tap
 
+import android.annotation.SuppressLint
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
-import java.util.LinkedList
-import java.util.Queue
+import java.util.ArrayDeque
 
 internal class ComposeClickedTargetIterator(
     private val logger: InternalLogger,
@@ -13,6 +13,7 @@ internal class ComposeClickedTargetIterator(
 ) : EmbraceClickedTargetIterator {
 
     private val nodeLocator = EmbraceNodeIterator(dataSource)
+    private val windowLocation = IntArray(2)
 
     override fun findTarget(
         decorView: View,
@@ -20,25 +21,42 @@ internal class ComposeClickedTargetIterator(
         y: Float,
     ) {
         try {
-            val queue: Queue<View> = LinkedList()
+            if (!containsWindowPoint(decorView, x, y)) {
+                return
+            }
+
+            val queue = ArrayDeque<View>()
             queue.add(decorView)
             while (queue.isNotEmpty()) {
-                val view = queue.poll()
-                view?.let {
-                    if (it is ViewGroup) {
-                        // TODO: define a limit of how many views we want to store and process to avoid processing ridiculously large view
-                        for (i in 0 until it.childCount) {
-                            queue.add(it.getChildAt(i))
+                val view = queue.removeFirst()
+                if (view is ViewGroup) {
+                    // scan the children in reverse (z-index) order
+                    for (i in view.childCount - 1 downTo 0) {
+                        val child = view.getChildAt(i)
+                        // ViewGroups that don't clipChildren need to be fully scanned
+                        if (!view.clipChildren || containsWindowPoint(child, x, y)) {
+                            queue.add(child)
                         }
                     }
-
-                    if (it.parent is ComposeView) { // this validation is to reduce the locate method execution to the proper view
-                        nodeLocator.findClickedElement(it, x, y)
-                    }
+                }
+                if (view.parent is ComposeView) {
+                    nodeLocator.findClickedElement(view, x, y)
                 }
             }
         } catch (e: Throwable) {
             logger.logError("Failed to find target", e)
         }
+    }
+
+    private fun containsWindowPoint(view: View, x: Float, y: Float): Boolean {
+        @SuppressLint("UseKtx") // core-ktx is not a dependency of this module
+        if (view.visibility != View.VISIBLE) {
+            return false
+        }
+
+        view.getLocationInWindow(windowLocation)
+        val (viewX, viewY) = windowLocation
+        return x >= viewX && x < viewX + view.width &&
+            y >= viewY && y < viewY + view.height
     }
 }

--- a/embrace-android-instrumentation-compose-tap/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/EmbraceGestureListener.kt
+++ b/embrace-android-instrumentation-compose-tap/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/EmbraceGestureListener.kt
@@ -22,11 +22,9 @@ internal class EmbraceGestureListener(
 
     override fun onSingleTapUp(event: MotionEvent): Boolean {
         try {
-            if (event.actionMasked == MotionEvent.ACTION_UP) {
-                activityRef.get()?.let { activity ->
-                    activity.window?.let {
-                        logTapUp(it.decorView, event)
-                    }
+            activityRef.get()?.let { activity ->
+                activity.window?.let {
+                    logTapUp(it.decorView, event)
                 }
             }
         } catch (e: Throwable) {

--- a/embrace-android-instrumentation-compose-tap/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/EmbraceNodeIterator.kt
+++ b/embrace-android-instrumentation-compose-tap/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/EmbraceNodeIterator.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
-import androidx.compose.ui.semantics.getAllSemanticsNodes
 import androidx.compose.ui.semantics.getOrNull
 
 private const val UNKNOWN_ELEMENT_NAME = "Unlabeled Compose element"
@@ -25,9 +24,8 @@ internal class EmbraceNodeIterator(
     @SuppressLint("VisibleForTests")
     fun findClickedElement(root: View, x: Float, y: Float) {
         val semanticsOwner = if (root is ViewRootForTest) root.semanticsOwner else return
-        val semanticsNodes = semanticsOwner.getAllSemanticsNodes(true)
 
-        findClickedElement(semanticsNodes, x, y)?.let {
+        findClickedElement(semanticsOwner.rootSemanticsNode, x, y)?.let {
             val clickedView = ClickedView(it, x, y)
             dataSource.logComposeTap(
                 Pair(clickedView.x, clickedView.y),
@@ -39,15 +37,20 @@ internal class EmbraceNodeIterator(
     /**
      * Iterates over the compose tree to find the clicked element and retrieve its tag
      * */
-    private fun findClickedElement(semanticsNodes: List<SemanticsNode>, x: Float, y: Float): String? {
-        for (node in semanticsNodes) {
-            if (isNodeInPosition(node, x, y)) {
-                val clickableElementName = getClickableElementName(node.config)
-                if (clickableElementName != null) {
-                    return clickableElementName
-                }
+    private fun findClickedElement(semanticsNode: SemanticsNode, x: Float, y: Float): String? {
+        val children = semanticsNode.children
+        for (i in children.indices) {
+            val childNode = children[i]
+            findClickedElement(childNode, x, y)?.let { return it }
+        }
+
+        if (isNodeInPosition(semanticsNode, x, y)) {
+            val clickableElementName = getClickableElementName(semanticsNode.config)
+            if (clickableElementName != null) {
+                return clickableElementName
             }
         }
+
         return null
     }
 
@@ -67,6 +70,14 @@ internal class EmbraceNodeIterator(
                 val contentDescription = contentDescriptionSemanticsConfiguration.getOrNull(0)
                 if (contentDescription != null) {
                     return contentDescription
+                }
+            }
+
+            val textSemanticsConfiguration = semanticsConfiguration.getOrNull(SemanticsProperties.Text)
+            if (textSemanticsConfiguration != null) {
+                val text = textSemanticsConfiguration.getOrNull(0)?.text
+                if (text != null) {
+                    return text
                 }
             }
 

--- a/embrace-android-instrumentation-compose-tap/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/ComposeActivityListenerTest.kt
+++ b/embrace-android-instrumentation-compose-tap/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/ComposeActivityListenerTest.kt
@@ -1,0 +1,53 @@
+package io.embrace.android.embracesdk.internal.instrumentation.compose.tap
+
+import android.app.Activity
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
+import io.embrace.android.embracesdk.internal.instrumentation.view.taps.TapDataSource
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric.buildActivity
+
+@RunWith(AndroidJUnit4::class)
+internal class ComposeActivityListenerTest {
+
+    private lateinit var args: FakeInstrumentationArgs
+    private lateinit var listener: ComposeActivityListener
+
+    @Before
+    fun setUp() {
+        val application: Application = ApplicationProvider.getApplicationContext()
+        args = FakeInstrumentationArgs(application)
+        val tapDataSource = TapDataSource(args)
+        val composeTapDataSource = ComposeTapDataSource(args) { tapDataSource }
+        listener = ComposeActivityListener(args.logger, composeTapDataSource)
+    }
+
+    @Test
+    fun `onActivityResumed wraps the window callback in EmbraceWindowCallback`() {
+        val activity = buildActivity(Activity::class.java).setup().get()
+
+        listener.onActivityResumed(activity)
+
+        assertTrue(activity.window.callback is EmbraceWindowCallback)
+        assertTrue(args.logger.errorMessages.isEmpty())
+    }
+
+    @Test
+    fun `onActivityResumed does not re-wrap an existing EmbraceWindowCallback`() {
+        val activity = buildActivity(Activity::class.java).setup().get()
+
+        listener.onActivityResumed(activity)
+        val firstCallback = activity.window.callback
+        listener.onActivityResumed(activity)
+        val secondCallback = activity.window.callback
+
+        assertSame(firstCallback, secondCallback)
+        assertTrue(args.logger.errorMessages.isEmpty())
+    }
+}

--- a/embrace-android-instrumentation-compose-tap/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/ComposeClickedTargetIteratorTest.kt
+++ b/embrace-android-instrumentation-compose-tap/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/ComposeClickedTargetIteratorTest.kt
@@ -1,0 +1,173 @@
+package io.embrace.android.embracesdk.internal.instrumentation.compose.tap
+
+import android.app.Application
+import android.content.Context
+import android.view.View
+import androidx.compose.ui.platform.ComposeView
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
+import io.embrace.android.embracesdk.internal.instrumentation.compose.tap.fakes.FakeScreenViewFactory
+import io.embrace.android.embracesdk.internal.instrumentation.compose.tap.fakes.PositionedFrameLayout
+import io.embrace.android.embracesdk.internal.instrumentation.compose.tap.fakes.PositionedView
+import io.embrace.android.embracesdk.internal.instrumentation.view.taps.TapDataSource
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class ComposeClickedTargetIteratorTest {
+
+    private lateinit var context: Context
+    private lateinit var args: FakeInstrumentationArgs
+    private lateinit var iterator: ComposeClickedTargetIterator
+
+    @Before
+    fun setUp() {
+        val application: Application = ApplicationProvider.getApplicationContext()
+        context = application
+        args = FakeInstrumentationArgs(application)
+        val tapDataSource = TapDataSource(args)
+        val composeTapDataSource = ComposeTapDataSource(args) { tapDataSource }
+        iterator = ComposeClickedTargetIterator(args.logger, composeTapDataSource)
+    }
+
+    @Test
+    fun `tap inside body is a no-op when there is no ComposeView`() {
+        val decor = FakeScreenViewFactory.createScreen(context)
+
+        iterator.findTarget(decor, x = 540f, y = 1200f)
+
+        assertTrue(args.logger.errorMessages.isEmpty())
+        assertTrue(args.destination.addedEvents.isEmpty())
+    }
+
+    @Test
+    fun `tap outside screen is a no-op`() {
+        val decor = FakeScreenViewFactory.createScreen(context)
+
+        iterator.findTarget(decor, x = 2000f, y = 3000f)
+
+        assertTrue(args.logger.errorMessages.isEmpty())
+        assertTrue(args.destination.addedEvents.isEmpty())
+    }
+
+    @Test
+    fun `tap at top-left corner of a child is treated as inside the child`() {
+        val inner = PositionedView(context, winX = 100, winY = 200, width = 50, height = 50)
+        val child = PositionedFrameLayout(context, winX = 100, winY = 200, width = 50, height = 50)
+        child.addView(inner)
+        val decor = PositionedFrameLayout(context, winX = 0, winY = 0, width = 1000, height = 1000)
+        decor.addView(child)
+
+        iterator.findTarget(decor, x = 100f, y = 200f)
+
+        // child was queued and popped — so its children's location was queried during the bounds check
+        assertEquals(1, inner.locationCheckCount)
+        assertTrue(args.logger.errorMessages.isEmpty())
+    }
+
+    @Test
+    fun `tap at the right edge of a child is treated as outside the child`() {
+        val inner = PositionedView(context, winX = 100, winY = 200, width = 50, height = 50)
+        val child = PositionedFrameLayout(context, winX = 100, winY = 200, width = 50, height = 50)
+        child.addView(inner)
+        val decor = PositionedFrameLayout(context, winX = 0, winY = 0, width = 1000, height = 1000)
+        decor.addView(child)
+
+        // x == child.winX + child.width: exclusive upper bound, should fall outside
+        iterator.findTarget(decor, x = 150f, y = 200f)
+
+        assertEquals(0, inner.locationCheckCount)
+        assertTrue(args.logger.errorMessages.isEmpty())
+    }
+
+    @Test
+    fun `tap on an invisible child is treated as outside`() {
+        val inner = PositionedView(context, winX = 100, winY = 200, width = 50, height = 50)
+        val child = PositionedFrameLayout(context, winX = 100, winY = 200, width = 50, height = 50)
+        child.visibility = View.GONE
+        child.addView(inner)
+        val decor = PositionedFrameLayout(context, winX = 0, winY = 0, width = 1000, height = 1000)
+        decor.addView(child)
+
+        iterator.findTarget(decor, x = 100f, y = 200f)
+
+        assertEquals(0, inner.locationCheckCount)
+        assertTrue(args.logger.errorMessages.isEmpty())
+    }
+
+    @Test
+    fun `clipChildren=false visits children that are outside parent bounds`() {
+        val inner = PositionedView(context, winX = 2000, winY = 0, width = 10, height = 10)
+        val outOfBoundsChild = PositionedFrameLayout(context, winX = 2000, winY = 0, width = 100, height = 100)
+        outOfBoundsChild.addView(inner)
+        val container = PositionedFrameLayout(context, winX = 0, winY = 0, width = 1000, height = 1000)
+        container.clipChildren = false
+        container.addView(outOfBoundsChild)
+        val decor = PositionedFrameLayout(context, winX = 0, winY = 0, width = 1000, height = 1000)
+        decor.addView(container)
+
+        iterator.findTarget(decor, x = 50f, y = 50f)
+
+        // outOfBoundsChild was added to the queue without a bounds check and processed,
+        // so its child's location was queried
+        assertEquals(1, inner.locationCheckCount)
+        assertTrue(args.logger.errorMessages.isEmpty())
+    }
+
+    @Test
+    fun `clipChildren=true skips children that are outside parent bounds`() {
+        val inner = PositionedView(context, winX = 2000, winY = 0, width = 10, height = 10)
+        val outOfBoundsChild = PositionedFrameLayout(context, winX = 2000, winY = 0, width = 100, height = 100)
+        outOfBoundsChild.addView(inner)
+        val container = PositionedFrameLayout(context, winX = 0, winY = 0, width = 1000, height = 1000)
+        // clipChildren defaults to true
+        container.addView(outOfBoundsChild)
+        val decor = PositionedFrameLayout(context, winX = 0, winY = 0, width = 1000, height = 1000)
+        decor.addView(container)
+
+        iterator.findTarget(decor, x = 50f, y = 50f)
+
+        assertEquals(0, inner.locationCheckCount)
+        assertTrue(args.logger.errorMessages.isEmpty())
+    }
+
+    @Test
+    fun `exception during traversal is caught and logged`() {
+        val throwingChild = object : View(context) {
+            init { layout(0, 0, 100, 100) }
+            override fun getLocationInWindow(outLocation: IntArray) {
+                error("boom")
+            }
+        }
+        val decor = PositionedFrameLayout(context, winX = 0, winY = 0, width = 1000, height = 1000)
+        decor.addView(throwingChild)
+
+        iterator.findTarget(decor, x = 50f, y = 50f)
+
+        assertEquals(1, args.logger.errorMessages.size)
+        assertEquals("Failed to find target", args.logger.errorMessages[0].msg)
+        assertTrue(args.destination.addedEvents.isEmpty())
+    }
+
+    @Test
+    fun `iterator handles an empty ComposeView in the hierarchy without crashing`() {
+        // wrap the ComposeView in a positioned, clipChildren=false parent so it's queued and
+        // popped regardless of its own (unmeasured) bounds — this exercises the iterator's
+        // ViewGroup branch on a real ComposeView with no children
+        val composeView = ComposeView(context)
+        val wrapper = PositionedFrameLayout(context, winX = 0, winY = 0, width = 100, height = 100)
+        wrapper.clipChildren = false
+        wrapper.addView(composeView)
+        val decor = PositionedFrameLayout(context, winX = 0, winY = 0, width = 100, height = 100)
+        decor.addView(wrapper)
+
+        iterator.findTarget(decor, x = 50f, y = 50f)
+
+        assertTrue(args.logger.errorMessages.isEmpty())
+        assertTrue(args.destination.addedEvents.isEmpty())
+    }
+}

--- a/embrace-android-instrumentation-compose-tap/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/EmbraceWindowCallbackTest.kt
+++ b/embrace-android-instrumentation-compose-tap/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/EmbraceWindowCallbackTest.kt
@@ -1,0 +1,73 @@
+package io.embrace.android.embracesdk.internal.instrumentation.compose.tap
+
+import android.app.Activity
+import android.app.Application
+import android.content.Context
+import android.view.GestureDetector
+import android.view.MotionEvent
+import android.view.Window
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric.buildActivity
+
+@RunWith(AndroidJUnit4::class)
+internal class EmbraceWindowCallbackTest {
+
+    private lateinit var context: Context
+    private lateinit var args: FakeInstrumentationArgs
+
+    @Before
+    fun setUp() {
+        val application: Application = ApplicationProvider.getApplicationContext()
+        context = application
+        args = FakeInstrumentationArgs(application)
+    }
+
+    @Test
+    fun `dispatchTouchEvent forwards original event to delegate, a copy to the gesture detector, and returns delegate's value`() {
+        val activity = buildActivity(Activity::class.java).setup().get()
+        val recordingDelegate = object : Window.Callback by activity.window.callback {
+            var lastTouchEvent: MotionEvent? = null
+            var touchEventCallCount: Int = 0
+
+            override fun dispatchTouchEvent(event: MotionEvent?): Boolean {
+                lastTouchEvent = event
+                touchEventCallCount++
+                return true
+            }
+        }
+        val recordingDetector = object : GestureDetector(context, SimpleOnGestureListener()) {
+            var lastEvent: MotionEvent? = null
+            var callCount: Int = 0
+
+            override fun onTouchEvent(ev: MotionEvent): Boolean {
+                lastEvent = ev
+                callCount++
+                return super.onTouchEvent(ev)
+            }
+        }
+        val callback = EmbraceWindowCallback(recordingDelegate, recordingDetector, args.logger)
+        val event = MotionEvent.obtain(0L, 0L, MotionEvent.ACTION_DOWN, 10f, 20f, 0)
+
+        try {
+            val result = callback.dispatchTouchEvent(event)
+
+            assertTrue(result)
+            assertEquals(1, recordingDelegate.touchEventCallCount)
+            assertSame(event, recordingDelegate.lastTouchEvent)
+            assertEquals(1, recordingDetector.callCount)
+            assertNotSame(event, recordingDetector.lastEvent)
+            assertTrue(args.logger.errorMessages.isEmpty())
+        } finally {
+            event.recycle()
+        }
+    }
+}

--- a/embrace-android-instrumentation-compose-tap/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/fakes/FakeScreenViewFactory.kt
+++ b/embrace-android-instrumentation-compose-tap/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/fakes/FakeScreenViewFactory.kt
@@ -1,0 +1,88 @@
+package io.embrace.android.embracesdk.internal.instrumentation.compose.tap.fakes
+
+import android.content.Context
+import android.view.View
+import androidx.compose.ui.platform.ComposeView
+
+/**
+ * Builds a stock 1080×2400 phone-screen view hierarchy for use in unit tests:
+ *
+ * - DecorView (1080×2400)
+ *   - StatusBar (1080×88, at y=0)
+ *   - ContentArea (1080×2192, at y=88)
+ *     - Toolbar (1080×200, at y=88)
+ *     - Body (1080×1992, at y=288) — optional [ComposeView] is attached here
+ *   - NavBar (1080×120, at y=2280)
+ */
+internal object FakeScreenViewFactory {
+
+    private const val SCREEN_WIDTH = 1080
+    private const val SCREEN_HEIGHT = 2400
+    private const val STATUS_BAR_HEIGHT = 88
+    private const val TOOLBAR_HEIGHT = 200
+    private const val NAV_BAR_HEIGHT = 120
+
+    fun createScreen(context: Context, composeView: ComposeView? = null): View {
+        val contentTop = STATUS_BAR_HEIGHT
+        val contentBottom = SCREEN_HEIGHT - NAV_BAR_HEIGHT
+        val contentHeight = contentBottom - contentTop
+        val bodyTop = contentTop + TOOLBAR_HEIGHT
+        val bodyHeight = contentHeight - TOOLBAR_HEIGHT
+
+        val statusBar = PositionedView(
+            context = context,
+            winX = 0,
+            winY = 0,
+            width = SCREEN_WIDTH,
+            height = STATUS_BAR_HEIGHT,
+        )
+        val toolbar = PositionedView(
+            context = context,
+            winX = 0,
+            winY = contentTop,
+            width = SCREEN_WIDTH,
+            height = TOOLBAR_HEIGHT,
+        )
+        val body = PositionedFrameLayout(
+            context = context,
+            winX = 0,
+            winY = bodyTop,
+            width = SCREEN_WIDTH,
+            height = bodyHeight,
+        )
+        val navBar = PositionedView(
+            context = context,
+            winX = 0,
+            winY = contentBottom,
+            width = SCREEN_WIDTH,
+            height = NAV_BAR_HEIGHT,
+        )
+
+        if (composeView != null) {
+            body.addView(composeView)
+        }
+
+        val content = PositionedFrameLayout(
+            context = context,
+            winX = 0,
+            winY = contentTop,
+            width = SCREEN_WIDTH,
+            height = contentHeight,
+        )
+        content.addView(toolbar)
+        content.addView(body)
+
+        val decor = PositionedFrameLayout(
+            context = context,
+            winX = 0,
+            winY = 0,
+            width = SCREEN_WIDTH,
+            height = SCREEN_HEIGHT,
+        )
+        decor.addView(statusBar)
+        decor.addView(content)
+        decor.addView(navBar)
+
+        return decor
+    }
+}

--- a/embrace-android-instrumentation-compose-tap/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/fakes/PositionedFrameLayout.kt
+++ b/embrace-android-instrumentation-compose-tap/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/fakes/PositionedFrameLayout.kt
@@ -1,0 +1,26 @@
+package io.embrace.android.embracesdk.internal.instrumentation.compose.tap.fakes
+
+import android.content.Context
+import android.widget.FrameLayout
+
+internal class PositionedFrameLayout(
+    context: Context,
+    private val winX: Int,
+    private val winY: Int,
+    width: Int,
+    height: Int,
+) : FrameLayout(context) {
+
+    init {
+        layout(0, 0, width, height)
+    }
+
+    override fun getLocationInWindow(outLocation: IntArray) {
+        outLocation[0] = winX
+        outLocation[1] = winY
+    }
+
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        // no-op so children keep the bounds they were created with
+    }
+}

--- a/embrace-android-instrumentation-compose-tap/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/fakes/PositionedView.kt
+++ b/embrace-android-instrumentation-compose-tap/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/fakes/PositionedView.kt
@@ -1,0 +1,32 @@
+package io.embrace.android.embracesdk.internal.instrumentation.compose.tap.fakes
+
+import android.content.Context
+import android.view.View
+
+/**
+ * A [View] that reports a fixed window position and counts how many times the iterator queried it.
+ *
+ * The counter lets tests place this view inside a parent and use the count as a sentinel for
+ * whether the iterator descended into that parent.
+ */
+internal class PositionedView(
+    context: Context,
+    private val winX: Int,
+    private val winY: Int,
+    width: Int,
+    height: Int,
+) : View(context) {
+
+    var locationCheckCount: Int = 0
+        private set
+
+    init {
+        layout(0, 0, width, height)
+    }
+
+    override fun getLocationInWindow(outLocation: IntArray) {
+        locationCheckCount++
+        outLocation[0] = winX
+        outLocation[1] = winY
+    }
+}


### PR DESCRIPTION
## Goal
Reduce the overhead of the Compose tap instrumentation by only walking `View` and `SemanticNode`s that have bounds enclosing the `[x, y]` location of the `MotionEvent`. This avoids walking `ViewGroup`s and composables that are off-screen, invisible or otherwise cannot be the tapped element.

This PR also adds `Text` semantics as a fallback label, which will pick up the text labels of elements (such as buttons) that don't have a `SemanticNode` with a content description or `OnClick` label.