### PR TITLE
Dedupe session payloads at resurrection

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogEnvelopeSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogEnvelopeSourceImpl.kt
@@ -40,7 +40,8 @@ internal class LogEnvelopeSourceImpl(
             val envelope = cachedLogEnvelopeStore.get(
                 createNativeCrashEnvelopeMetadata(
                     sessionPartId = nativeCrash?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID),
-                    processIdentifier = nativeCrash?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_PROCESS_IDENTIFIER)
+                    processIdentifier = nativeCrash?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_PROCESS_IDENTIFIER),
+                    userSessionId = nativeCrash?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID),
                 )
             )
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModule.kt
@@ -18,6 +18,7 @@ interface DeliveryModule {
     val payloadStore: PayloadStore
     val intakeService: IntakeService
     val payloadCachingService: PayloadCachingService
+    val payloadStorageService: PayloadStorageService
     val cacheStorageService: PayloadStorageService
     val cachedLogEnvelopeStore: CachedLogEnvelopeStore
     val schedulingService: SchedulingService

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
@@ -84,7 +84,7 @@ class DeliveryModuleImpl(
         )
     }
 
-    private val payloadStorageService: PayloadStorageService by singleton {
+    override val payloadStorageService: PayloadStorageService by singleton {
         payloadStorageServiceProvider?.invoke() ?: run {
             val location = StorageLocation.PAYLOAD.asFile(
                 logger = initModule.logger,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
@@ -42,7 +42,13 @@ class DeliveryModuleImpl(
     private val processIdProvider = { otelModule.otelSdkConfig.processIdentifier }
 
     override val payloadStore: PayloadStore by singleton {
-        PayloadStoreImpl(intakeService, initModule.clock, processIdProvider, initModule.uuidSource)
+        PayloadStoreImpl(
+            intakeService,
+            initModule.clock,
+            processIdProvider,
+            initModule.uuidSource,
+            essentialServiceModule.sessionIdProvider::getActiveSessionIds,
+        )
     }
 
     private val dataPersistenceWorker: PriorityWorker<StoredTelemetryMetadata> by singleton {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
@@ -154,6 +154,7 @@ class PayloadSourceModuleImpl(
         deliveryModule ?: return@singleton null
         PayloadResurrectionServiceImpl(
             intakeService = deliveryModule.intakeService,
+            payloadStorageService = deliveryModule.payloadStorageService,
             cacheStorageService = deliveryModule.cacheStorageService,
             cachedLogEnvelopeStore = deliveryModule.cachedLogEnvelopeStore,
             logger = initModule.logger,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
@@ -126,7 +126,8 @@ internal class PayloadResurrectionServiceImpl(
                     if (resource != null && metadata != null) {
                         cachedLogEnvelopeStore.create(
                             storedTelemetryMetadata = createNativeCrashEnvelopeMetadata(
-                                sessionPartId = nativeCrash.sessionPartId
+                                sessionPartId = nativeCrash.sessionPartId,
+                                userSessionId = nativeCrash.userSessionId,
                             ),
                             resource = resource,
                             metadata = metadata
@@ -181,7 +182,8 @@ internal class PayloadResurrectionServiceImpl(
                     nativeCrashProvider(sessionId)?.apply {
                         val nativeCrashEnvelopeMetadata = createNativeCrashEnvelopeMetadata(
                             sessionPartId = sessionId,
-                            processIdentifier = processIdentifier
+                            processIdentifier = processIdentifier,
+                            userSessionId = userSessionId,
                         )
 
                         cachedLogEnvelopeStore.create(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
@@ -38,6 +38,7 @@ import kotlin.math.max
 
 internal class PayloadResurrectionServiceImpl(
     private val intakeService: IntakeService,
+    private val payloadStorageService: PayloadStorageService,
     private val cacheStorageService: PayloadStorageService,
     private val cachedLogEnvelopeStore: CachedLogEnvelopeStore,
     private val logger: InternalLogger,
@@ -68,9 +69,13 @@ internal class PayloadResurrectionServiceImpl(
     private fun processTombstones(nativeCrashServiceProvider: Provider<NativeCrashService?>) {
         val nativeCrashService = nativeCrashServiceProvider()
         val undeliveredPayloads = cacheStorageService.getUndeliveredPayloads()
-        val payloadsToResurrect = undeliveredPayloads.filterNot { it.isCrashEnvelope() }
+        val nonCrashPayloads = undeliveredPayloads.filterNot { it.isCrashEnvelope() }
+        val (payloadsToResurrect, redundantPayloads) = dedupeSessionPayloads(nonCrashPayloads)
         val nativeCrashes = nativeCrashService?.getNativeCrashes()?.associateBy { it.sessionPartId } ?: emptyMap()
         val processedCrashes = mutableSetOf<NativeCrashData>()
+
+        // delete duplicate cached payloads as the surviving copy has already been stored in payloadStorageService
+        redundantPayloads.forEach { cacheStorageService.delete(it) }
 
         payloadsToResurrect.forEach { payload ->
             runCatching {
@@ -163,6 +168,63 @@ internal class PayloadResurrectionServiceImpl(
     }
 
     private fun StoredTelemetryMetadata.isCrashEnvelope() = envelopeType == SupportedEnvelopeType.CRASH
+
+    /**
+     * Splits payloads into two collections: one that should be resurrected, and another that should be
+     * discarded.
+     *
+     * Cached session payloads can be redundant either when another cached payload has the same session
+     * ID, or when the session ID is matched by a complete payload in [payloadStorageService].
+     *
+     * Non-SESSION payloads and SESSION payloads with no encoded session IDs (legacy v1 filenames)
+     * bypass the dedupe checks.
+     */
+    private fun dedupeSessionPayloads(
+        candidates: List<StoredTelemetryMetadata>,
+    ): Pair<List<StoredTelemetryMetadata>, List<StoredTelemetryMetadata>> {
+        val alreadyDeliverable: Set<SessionKey> = payloadStorageService.getPayloadsByPriority()
+            .mapNotNullTo(mutableSetOf()) { it.sessionKey() }
+
+        // For each session key in the cache, find the latest timestamp — that's the winner.
+        val latestTimestampPerKey = mutableMapOf<SessionKey, Long>()
+        candidates.forEach { meta ->
+            val key = meta.sessionKey() ?: return@forEach
+            val current = latestTimestampPerKey[key]
+            if (current == null || meta.timestamp > current) {
+                latestTimestampPerKey[key] = meta.timestamp
+            }
+        }
+
+        val deliverables = mutableListOf<StoredTelemetryMetadata>()
+        val redundant = mutableListOf<StoredTelemetryMetadata>()
+        val emittedKeys = mutableSetOf<SessionKey>()
+
+        candidates.forEach { meta ->
+            val key = meta.sessionKey()
+            when {
+                key == null -> deliverables += meta
+                key in alreadyDeliverable -> redundant += meta
+                key !in emittedKeys && meta.timestamp == latestTimestampPerKey[key] -> {
+                    deliverables += meta
+                    emittedKeys += key
+                }
+                else -> redundant += meta
+            }
+        }
+        return deliverables to redundant
+    }
+
+    private fun StoredTelemetryMetadata.sessionKey(): SessionKey? {
+        return if (envelopeType == SupportedEnvelopeType.SESSION &&
+            (userSessionId.isNotEmpty() || sessionPartId.isNotEmpty())
+        ) {
+            SessionKey(userSessionId, sessionPartId)
+        } else {
+            null
+        }
+    }
+
+    private data class SessionKey(val userSessionId: String, val sessionPartId: String)
 
     private fun StoredTelemetryMetadata.processUndeliveredPayload(
         nativeCrashService: NativeCrashService?,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/PayloadStoreImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/PayloadStoreImpl.kt
@@ -15,6 +15,7 @@ import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsSnapshot
 import io.embrace.android.embracesdk.internal.utils.UuidSource
 
 internal class PayloadStoreImpl(
@@ -22,6 +23,7 @@ internal class PayloadStoreImpl(
     private val clock: Clock,
     private val processIdProvider: () -> String,
     private val uuidSource: UuidSource,
+    private val sessionIdsProvider: () -> SessionIdsSnapshot,
 ) : PayloadStore {
 
     override fun storeSessionPartPayload(
@@ -109,14 +111,17 @@ internal class PayloadStoreImpl(
         payloadType: PayloadType,
         payloadTypesHeader: String = payloadType.value,
     ): StoredTelemetryMetadata {
+        val sessionIds = sessionIdsProvider()
         return StoredTelemetryMetadata(
-            clock.now(),
-            uuidSource.createUuid(),
-            processIdProvider(),
-            type,
-            complete,
+            timestamp = clock.now(),
+            uuid = uuidSource.createUuid(),
+            processIdentifier = processIdProvider(),
+            envelopeType = type,
+            complete = complete,
             payloadType = payloadType,
-            payloadTypesHeader = payloadTypesHeader
+            payloadTypesHeader = payloadTypesHeader,
+            userSessionId = sessionIds.userSessionId,
+            sessionPartId = sessionIds.sessionPartId,
         )
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeDeliveryModule.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeDeliveryModule.kt
@@ -13,6 +13,7 @@ class FakeDeliveryModule(
     override val payloadStore: PayloadStore = FakePayloadStore(),
     override val intakeService: IntakeService = FakeIntakeService(),
     override val payloadCachingService: PayloadCachingService = FakePayloadCachingService(),
+    override val payloadStorageService: PayloadStorageService = FakePayloadStorageService(),
     override val cacheStorageService: PayloadStorageService = FakePayloadStorageService(),
     override val cachedLogEnvelopeStore: CachedLogEnvelopeStore = FakeCachedLogEnvelopeStore(),
     override val schedulingService: SchedulingService = FakeSchedulingService(),

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
@@ -21,7 +21,13 @@ import io.embrace.android.embracesdk.fakes.fakeEnvelopeResource
 import io.embrace.android.embracesdk.fakes.fakeIncompleteSessionEnvelope
 import io.embrace.android.embracesdk.fakes.fakeLaterEnvelopeMetadata
 import io.embrace.android.embracesdk.fakes.fakeLaterEnvelopeResource
+import io.embrace.android.embracesdk.fixtures.FAKE_SESSION_PART_ID
+import io.embrace.android.embracesdk.fixtures.FAKE_SESSION_PART_ID_2
+import io.embrace.android.embracesdk.fixtures.FAKE_USER_SESSION_ID
+import io.embrace.android.embracesdk.fixtures.FAKE_USER_SESSION_ID_2
 import io.embrace.android.embracesdk.fixtures.fakeCachedSessionStoredTelemetryMetadata
+import io.embrace.android.embracesdk.fixtures.fakeSessionStoredTelemetryMetadata
+import io.embrace.android.embracesdk.fixtures.fakeSessionStoredTelemetryMetadata2
 import io.embrace.android.embracesdk.internal.arch.attrs.asPair
 import io.embrace.android.embracesdk.internal.arch.attrs.isEmbraceAttributeName
 import io.embrace.android.embracesdk.internal.arch.schema.AppTerminationCause
@@ -90,6 +96,7 @@ class PayloadResurrectionServiceImplTest {
                 serializer,
                 PriorityWorker(intakeExecutor),
             ),
+            payloadStorageService = payloadStorageService,
             cacheStorageService = cacheStorageService,
             cachedLogEnvelopeStore = cachedLogEnvelopeStore,
             logger = logger,
@@ -160,6 +167,96 @@ class PayloadResurrectionServiceImplTest {
     }
 
     @Test
+    fun `cached session is skipped if payloadStorageService has payload with same session id`() {
+        // simulate a race where a complete session payload _and_ cached session payload are both on disk
+        payloadStorageService.addPayload(
+            metadata = fakeSessionStoredTelemetryMetadata,
+            data = deadSessionEnvelope
+        )
+        cacheStorageService.addPayload(
+            metadata = sessionMetadata,
+            data = deadSessionEnvelope
+        )
+        assertEquals(1, payloadStorageService.storedPayloadCount())
+        assertEquals(1, cacheStorageService.storedPayloadCount())
+
+        resurrectInBackground()
+
+        val stored = payloadStorageService.storedPayloadMetadata().single()
+        assertEquals(fakeSessionStoredTelemetryMetadata, stored)
+        assertEquals(0, cacheStorageService.storedPayloadCount())
+    }
+
+    @Test
+    fun `duplicate session snapshots only send the most recent one`() {
+        val earlierMeta = sessionMetadata.copy(
+            timestamp = sessionMetadata.timestamp - 5_000L,
+            uuid = "earlier-uuid"
+        )
+        val earlierEnvelope = fakeIncompleteSessionEnvelope(
+            startMs = earlierMeta.timestamp,
+            lastHeartbeatTimeMs = earlierMeta.timestamp + 100L
+        )
+        cacheStorageService.addPayload(metadata = earlierMeta, data = earlierEnvelope)
+        cacheStorageService.addPayload(metadata = sessionMetadata, data = deadSessionEnvelope)
+
+        resurrectInBackground()
+
+        val stored = payloadStorageService.storedPayloadMetadata().single()
+        assertEquals(sessionMetadata.copy(complete = true), stored)
+        assertEquals(0, cacheStorageService.storedPayloadCount())
+    }
+
+    @Test
+    fun `legacy session snapshot with empty session IDs bypasses dedup and is resurrected`() {
+        // simulate a payload that uses v1 filename encoding
+        val legacyMeta = sessionMetadata.copy(userSessionId = "", sessionPartId = "")
+        cacheStorageService.addPayload(metadata = legacyMeta, data = deadSessionEnvelope)
+
+        resurrectInBackground()
+
+        val stored = payloadStorageService.storedPayloadMetadata().single()
+        assertEquals(legacyMeta.copy(complete = true), stored)
+        assertEquals(0, cacheStorageService.storedPayloadCount())
+    }
+
+    @Test
+    fun `dedupe does not affect unrelated sessions`() {
+        payloadStorageService.addPayload(
+            metadata = fakeSessionStoredTelemetryMetadata,
+            data = deadSessionEnvelope
+        )
+        cacheStorageService.addPayload(
+            metadata = sessionMetadata,
+            data = deadSessionEnvelope
+        )
+
+        // Session B is only in the cache — should be resurrected normally.
+        val sessionBMeta = fakeSessionStoredTelemetryMetadata2.copy(complete = false)
+        val sessionBEnvelope = fakeIncompleteSessionEnvelope(
+            sessionId = "session-b",
+            startMs = sessionBMeta.timestamp,
+            lastHeartbeatTimeMs = sessionBMeta.timestamp + 1000L
+        )
+        cacheStorageService.addPayload(metadata = sessionBMeta, data = sessionBEnvelope)
+
+        resurrectInBackground()
+
+        val storedKeys = payloadStorageService.storedPayloadMetadata()
+            .map { it.userSessionId to it.sessionPartId }
+            .toSet()
+        assertEquals(
+            setOf(
+                FAKE_USER_SESSION_ID to FAKE_SESSION_PART_ID,
+                FAKE_USER_SESSION_ID_2 to FAKE_SESSION_PART_ID_2,
+            ),
+            storedKeys
+        )
+        assertEquals(2, payloadStorageService.storedPayloadCount())
+        assertEquals(0, cacheStorageService.storedPayloadCount())
+    }
+
+    @Test
     fun `snapshot will be delivered as failed span once resurrected`() {
         deadSessionEnvelope.resurrectPayload()
 
@@ -210,6 +307,8 @@ class PayloadResurrectionServiceImplTest {
         val sessionSpan = getStoredParts().single().getSessionSpan()
         assertEquals("dead-session-native-crash", sessionSpan?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID))
 
+        // clear snapshots before running second scenario
+        payloadStorageService.clearStorage()
         nativeCrashService.addNativeCrashData(
             createNativeCrashData(
                 nativeCrashId = "dead-session-native-crash",
@@ -447,6 +546,7 @@ class PayloadResurrectionServiceImplTest {
         }
         val service = PayloadResurrectionServiceImpl(
             intakeService = hangingIntakeService,
+            payloadStorageService = payloadStorageService,
             cacheStorageService = cacheStorageService,
             cachedLogEnvelopeStore = cachedLogEnvelopeStore,
             logger = logger,

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStoreTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStoreTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.session.orchestrator
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeIntakeService
 import io.embrace.android.embracesdk.fakes.FakePayloadIntake
+import io.embrace.android.embracesdk.fakes.FakeSessionIdProvider
 import io.embrace.android.embracesdk.fakes.FakeUuidSource
 import io.embrace.android.embracesdk.fakes.fakeSessionEnvelope
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
@@ -21,13 +22,26 @@ import org.junit.Test
 
 class V2PayloadStoreTest {
 
+    private companion object {
+        const val USER_SESSION_ID = "fakeUserSessionId"
+        const val SESSION_PART_ID = "fakeSessionPartId"
+    }
+
     private lateinit var store: PayloadStoreImpl
     private lateinit var intakeService: FakeIntakeService
+    private lateinit var sessionIdProvider: FakeSessionIdProvider
 
     @Before
     fun setUp() {
         intakeService = FakeIntakeService()
-        store = PayloadStoreImpl(intakeService, FakeClock(), { "fakeProcessId" }, FakeUuidSource())
+        sessionIdProvider = FakeSessionIdProvider(userSessionId = USER_SESSION_ID, sessionPartId = SESSION_PART_ID)
+        store = PayloadStoreImpl(
+            intakeService,
+            FakeClock(),
+            { "fakeProcessId" },
+            FakeUuidSource(),
+            sessionIdProvider::getActiveSessionIds,
+        )
     }
 
     @Test
@@ -37,7 +51,7 @@ class V2PayloadStoreTest {
         verifySessionIntake(
             envelope,
             intakeService.getIntakes(),
-            "p3_1692201601000_fakeuuid_fakeProcessId_true_session_v1.json"
+            "p3_1692201601000_fakeuuid_fakeProcessId_true_session_${USER_SESSION_ID}_${SESSION_PART_ID}_v2.json"
         )
     }
 
@@ -48,7 +62,7 @@ class V2PayloadStoreTest {
         verifySessionIntake(
             envelope,
             intakeService.getIntakes(),
-            "p3_1692201601000_fakeuuid_fakeProcessId_true_session_v1.json"
+            "p3_1692201601000_fakeuuid_fakeProcessId_true_session_${USER_SESSION_ID}_${SESSION_PART_ID}_v2.json"
         )
     }
 
@@ -59,7 +73,10 @@ class V2PayloadStoreTest {
 
         val intake = intakeService.getIntakes<LogPayload>().single()
         assertSame(envelope, intake.envelope)
-        assertEquals("p5_1692201601000_fakeuuid_fakeProcessId_true_unknown_v1.json", intake.metadata.filename)
+        assertEquals(
+            "p5_1692201601000_fakeuuid_fakeProcessId_true_unknown_${USER_SESSION_ID}_${SESSION_PART_ID}_v2.json",
+            intake.metadata.filename
+        )
         assertEquals(0, intakeService.shutdownCount)
     }
 
@@ -76,7 +93,7 @@ class V2PayloadStoreTest {
         verifySessionIntake(
             envelope,
             intakeService.getIntakes(false),
-            "p3_1692201601000_fakeuuid_fakeProcessId_false_session_v1.json"
+            "p3_1692201601000_fakeuuid_fakeProcessId_false_session_${USER_SESSION_ID}_${SESSION_PART_ID}_v2.json"
         )
     }
 
@@ -117,7 +134,10 @@ class V2PayloadStoreTest {
 
         val intake = intakeService.getIntakes<Pair<String, ByteArray>>().single()
         assertSame(envelope, intake.envelope)
-        assertEquals("p4_1692201601000_fakeuuid_fakeProcessId_true_attachment_v1.json", intake.metadata.filename)
+        assertEquals(
+            "p4_1692201601000_fakeuuid_fakeProcessId_true_attachment_${USER_SESSION_ID}_${SESSION_PART_ID}_v2.json",
+            intake.metadata.filename
+        )
         assertEquals(0, intakeService.shutdownCount)
     }
 

--- a/embrace-android-delivery-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/DeliveryFixtures.kt
+++ b/embrace-android-delivery-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/DeliveryFixtures.kt
@@ -5,6 +5,11 @@ import io.embrace.android.embracesdk.internal.delivery.PayloadType
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
 
+const val FAKE_USER_SESSION_ID = "fa1a3ec1d50f4c0fa9f0b6c3e2f1a8d5"
+const val FAKE_SESSION_PART_ID = "f1e2d3c4b5a69788776655443322110f"
+const val FAKE_USER_SESSION_ID_2 = "deadbeefcafef00d1234567890abcdef"
+const val FAKE_SESSION_PART_ID_2 = "0123456789abcdef0123456789abcdef"
+
 val fakeCachedSessionStoredTelemetryMetadata = StoredTelemetryMetadata(
     timestamp = DEFAULT_FAKE_CURRENT_TIME + 1000L,
     uuid = "30690ad1-6b87-4e08-b72c-7deca14451d8",
@@ -12,6 +17,8 @@ val fakeCachedSessionStoredTelemetryMetadata = StoredTelemetryMetadata(
     envelopeType = SupportedEnvelopeType.SESSION,
     complete = false,
     payloadType = PayloadType.SESSION,
+    userSessionId = FAKE_USER_SESSION_ID,
+    sessionPartId = FAKE_SESSION_PART_ID,
 )
 
 val fakeSessionStoredTelemetryMetadata = StoredTelemetryMetadata(
@@ -19,8 +26,10 @@ val fakeSessionStoredTelemetryMetadata = StoredTelemetryMetadata(
     uuid = "30690ad1-6b87-4e08-b72c-7deca14451d8",
     processIdentifier = "8115ec91-3e5e-4d8a-816d-cc40306f9822",
     envelopeType = SupportedEnvelopeType.SESSION,
-    true,
+    complete = true,
     payloadType = PayloadType.SESSION,
+    userSessionId = FAKE_USER_SESSION_ID,
+    sessionPartId = FAKE_SESSION_PART_ID,
 )
 
 val fakeSessionStoredTelemetryMetadata2 = StoredTelemetryMetadata(
@@ -29,6 +38,8 @@ val fakeSessionStoredTelemetryMetadata2 = StoredTelemetryMetadata(
     processIdentifier = "8115ec91-3e5e-4d8a-816d-cc40306f9822",
     envelopeType = SupportedEnvelopeType.SESSION,
     payloadType = PayloadType.SESSION,
+    userSessionId = FAKE_USER_SESSION_ID_2,
+    sessionPartId = FAKE_SESSION_PART_ID_2,
 )
 
 val fakeLogStoredTelemetryMetadata = StoredTelemetryMetadata(
@@ -55,4 +66,6 @@ val fakeNativeCrashStoredTelemetryMetadata = StoredTelemetryMetadata(
     envelopeType = SupportedEnvelopeType.CRASH,
     complete = false,
     payloadType = PayloadType.NATIVE_CRASH,
+    userSessionId = FAKE_USER_SESSION_ID,
+    sessionPartId = "bb6b5b1ea2ff48928382fe81d7991ced",
 )

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/CachedLogEnvelopeStore.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/CachedLogEnvelopeStore.kt
@@ -39,12 +39,15 @@ interface CachedLogEnvelopeStore {
         fun createNativeCrashEnvelopeMetadata(
             sessionPartId: String? = null,
             processIdentifier: String? = null,
+            userSessionId: String? = null,
         ) = StoredTelemetryMetadata(
             timestamp = 0L,
             uuid = sessionPartId ?: "none",
             processIdentifier = processIdentifier ?: "none",
             envelopeType = SupportedEnvelopeType.CRASH,
             payloadType = PayloadType.NATIVE_CRASH,
+            userSessionId = userSessionId.orEmpty(),
+            sessionPartId = sessionPartId.orEmpty(),
         )
     }
 }

--- a/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImpl.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImpl.kt
@@ -64,10 +64,11 @@ internal class NativeCrashHandlerInstallerImpl(
     private fun updateSessionIds() {
         val ids = args.activeSessionIds()
         val sessionPartId = sanitizeSessionId(ids.sessionPartId)
+        val userSessionId = sanitizeSessionId(ids.userSessionId)
         delegate.onSessionChange(
             sessionPartId,
-            sanitizeSessionId(ids.userSessionId),
-            createNativeReportPath(sessionPartId)
+            userSessionId,
+            createNativeReportPath(sessionPartId, userSessionId)
         )
     }
 
@@ -112,13 +113,15 @@ internal class NativeCrashHandlerInstallerImpl(
         }
     }
 
-    private fun createNativeReportPath(sanitizedSessionPartId: String): String {
+    private fun createNativeReportPath(sanitizedSessionPartId: String, sanitizedUserSessionId: String): String {
         val metadata = StoredTelemetryMetadata(
             timestamp = clock.now(),
             uuid = sanitizedSessionPartId,
             processIdentifier = processIdentifier,
             envelopeType = SupportedEnvelopeType.CRASH,
             payloadType = PayloadType.NATIVE_CRASH,
+            userSessionId = sanitizedUserSessionId,
+            sessionPartId = sanitizedSessionPartId,
         )
         return File(outputDir.value, metadata.filename).absolutePath
     }

--- a/embrace-android-instrumentation-crash-ndk/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImplTest.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImplTest.kt
@@ -80,16 +80,17 @@ class NativeCrashHandlerInstallerImplTest {
         nativeCrashHandlerInstaller.install()
 
         assertTrue(fakeDelegate.signalHandlerInstalled)
-        assertEquals("p1_1692201601000_null_pid_true_native_v1.json", getFilename())
+        assertEquals("p1_1692201601000_null_pid_true_native_null_null_v2.json", getFilename())
     }
 
     @Test
     fun `report path containing session ID`() {
         sessionId = "sid"
+        userSessionId = "usid"
         nativeCrashHandlerInstaller.install()
 
         assertTrue(fakeDelegate.signalHandlerInstalled)
-        assertEquals("p1_1692201601000_sid_pid_true_native_v1.json", getFilename())
+        assertEquals("p1_1692201601000_sid_pid_true_native_usid_sid_v2.json", getFilename())
     }
 
     @Test
@@ -120,14 +121,15 @@ class NativeCrashHandlerInstallerImplTest {
     fun `report path updated on new session`() {
         nativeCrashHandlerInstaller.install()
         executorService.runCurrentlyBlocked()
-        assertEquals("p1_1692201601000_null_pid_true_native_v1.json", getFilename())
+        assertEquals("p1_1692201601000_null_pid_true_native_null_null_v2.json", getFilename())
 
         // trigger new session and update report path
         args.clock.tick(9000)
         sessionId = "sid"
+        userSessionId = "usid"
         args.sessionChangeListeners.forEach { it.onPostSessionChange() }
         assertTrue(fakeDelegate.signalHandlerInstalled)
-        assertEquals("p1_1692201610000_sid_pid_true_native_v1.json", getFilename())
+        assertEquals("p1_1692201610000_sid_pid_true_native_usid_sid_v2.json", getFilename())
     }
 
     @Test

--- a/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadata.kt
+++ b/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadata.kt
@@ -16,21 +16,43 @@ data class StoredTelemetryMetadata(
     val complete: Boolean = true,
     val payloadType: PayloadType = PayloadType.UNKNOWN,
     val payloadTypesHeader: String = payloadType.value,
+    val userSessionId: String = "",
+    val sessionPartId: String = "",
 ) {
     val filename: String = "${envelopeType.priority}_${timestamp}_${uuid}_${processIdentifier}_${complete}_${
         payloadType.filenameComponent
-    }_v1.json"
+    }_${encodeId(userSessionId)}_${encodeId(sessionPartId)}_$V2_TOKEN"
 
     companion object {
+        private const val V1_TOKEN = "v1.json"
+        private const val V2_TOKEN = "v2.json"
+        private const val EMPTY_ID_TOKEN = "none"
+
+        private fun encodeId(id: String): String = id.ifEmpty { EMPTY_ID_TOKEN }
+
+        private fun decodeId(token: String): String = when (token) {
+            EMPTY_ID_TOKEN -> ""
+            else -> token
+        }
+
         /**
          * Parses a filename and constructs a [StoredTelemetryMetadata] object. This returns a
          * [Result] because the filename may be invalid.
+         *
+         * Supports both v1 (no session IDs) and v2 (with userSessionId & sessionPartId) formats.
+         * v1 filenames will default v2 fields to empty strings.
          */
         fun fromFilename(filename: String): Result<StoredTelemetryMetadata> {
             val parts = filename.split("_")
-            if (parts.size != 7) {
-                return failure(IllegalArgumentException("Invalid filename: $filename"))
+            val version = parts.lastOrNull()
+            return when {
+                version == V1_TOKEN && parts.size == 7 -> parseV1(filename, parts)
+                version == V2_TOKEN && parts.size == 9 -> parseV2(filename, parts)
+                else -> failure(IllegalArgumentException("Invalid filename: $filename"))
             }
+        }
+
+        private fun parseV1(filename: String, parts: List<String>): Result<StoredTelemetryMetadata> {
             val envelopeType = SupportedEnvelopeType.fromPriority(parts[0]) ?: return failure(
                 IllegalArgumentException("Invalid priority: $filename")
             )
@@ -45,12 +67,41 @@ data class StoredTelemetryMetadata(
             val payloadType = PayloadType.fromFilenameComponent(parts[5])
             return success(
                 StoredTelemetryMetadata(
-                    timestamp,
-                    uuid,
-                    processId,
-                    envelopeType,
-                    complete,
-                    payloadType,
+                    timestamp = timestamp,
+                    uuid = uuid,
+                    processIdentifier = processId,
+                    envelopeType = envelopeType,
+                    complete = complete,
+                    payloadType = payloadType,
+                )
+            )
+        }
+
+        private fun parseV2(filename: String, parts: List<String>): Result<StoredTelemetryMetadata> {
+            val envelopeType = SupportedEnvelopeType.fromPriority(parts[0]) ?: return failure(
+                IllegalArgumentException("Invalid priority: $filename")
+            )
+            val timestamp = parts[1].toLongOrNull() ?: return failure(
+                IllegalArgumentException("Invalid timestamp: $filename")
+            )
+            val uuid = parts[2]
+            val processId = parts[3]
+            val complete = parts[4].toBooleanStrictOrNull() ?: return failure(
+                IllegalArgumentException("Invalid completeness state: $filename")
+            )
+            val payloadType = PayloadType.fromFilenameComponent(parts[5])
+            val userSessionId = decodeId(parts[6])
+            val sessionPartId = decodeId(parts[7])
+            return success(
+                StoredTelemetryMetadata(
+                    timestamp = timestamp,
+                    uuid = uuid,
+                    processIdentifier = processId,
+                    envelopeType = envelopeType,
+                    complete = complete,
+                    payloadType = payloadType,
+                    userSessionId = userSessionId,
+                    sessionPartId = sessionPartId,
                 )
             )
         }

--- a/embrace-android-telemetry-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadataTest.kt
+++ b/embrace-android-telemetry-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadataTest.kt
@@ -10,6 +10,8 @@ class StoredTelemetryMetadataTest {
         private const val TIMESTAMP = 1726739283136
         private const val UUID = "c2610cd1-389f-422a-bfbc-25312c7a599a"
         private const val PROCESS_ID = "fakeProcessId"
+        private const val USER_SESSION_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        private const val SESSION_PART_ID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     }
 
     private val typeNameMap = mapOf(
@@ -20,22 +22,60 @@ class StoredTelemetryMetadataTest {
     )
 
     @Test
-    fun `construct objects`() {
+    fun `construct objects with session ids`() {
         typeNameMap.entries.forEach { (type, priority) ->
             listOf(true, false).forEach { payloadComplete ->
                 assertEquals(
-                    "${priority}_${TIMESTAMP}_${UUID}_${PROCESS_ID}_${payloadComplete}_aei_v1.json",
+                    "${priority}_${TIMESTAMP}_${UUID}_${PROCESS_ID}_${payloadComplete}_aei_${USER_SESSION_ID}_${SESSION_PART_ID}_v2.json",
                     StoredTelemetryMetadata(
-                        TIMESTAMP,
-                        UUID,
-                        PROCESS_ID,
-                        type,
-                        payloadComplete,
-                        payloadType = PayloadType.AEI
+                        timestamp = TIMESTAMP,
+                        uuid = UUID,
+                        processIdentifier = PROCESS_ID,
+                        envelopeType = type,
+                        complete = payloadComplete,
+                        payloadType = PayloadType.AEI,
+                        userSessionId = USER_SESSION_ID,
+                        sessionPartId = SESSION_PART_ID,
                     ).filename
                 )
             }
         }
+    }
+
+    @Test
+    fun `construct objects with empty session ids encodes none`() {
+        typeNameMap.entries.forEach { (type, priority) ->
+            listOf(true, false).forEach { payloadComplete ->
+                assertEquals(
+                    "${priority}_${TIMESTAMP}_${UUID}_${PROCESS_ID}_${payloadComplete}_aei_none_none_v2.json",
+                    StoredTelemetryMetadata(
+                        timestamp = TIMESTAMP,
+                        uuid = UUID,
+                        processIdentifier = PROCESS_ID,
+                        envelopeType = type,
+                        complete = payloadComplete,
+                        payloadType = PayloadType.AEI,
+                    ).filename
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `construct objects with only one empty session id`() {
+        val filename = StoredTelemetryMetadata(
+            timestamp = TIMESTAMP,
+            uuid = UUID,
+            processIdentifier = PROCESS_ID,
+            envelopeType = SupportedEnvelopeType.SESSION,
+            payloadType = PayloadType.SESSION,
+            userSessionId = USER_SESSION_ID,
+            sessionPartId = "",
+        ).filename
+        assertEquals(
+            "p3_${TIMESTAMP}_${UUID}_${PROCESS_ID}_true_session_${USER_SESSION_ID}_none_v2.json",
+            filename
+        )
     }
 
     @Test
@@ -48,28 +88,106 @@ class StoredTelemetryMetadataTest {
             "p4_${TIMESTAMP}_b_c_true_v1.json",
             "p1_b_c_false_v1.json",
             "p3_${TIMESTAMP}_b_c_d_v1.json",
-            "p3_${TIMESTAMP}_c_d_v1.json"
+            "p3_${TIMESTAMP}_c_d_v1.json",
+            "p3_${TIMESTAMP}_${UUID}_${PROCESS_ID}_true_session_$USER_SESSION_ID" + "_v3.json",
+            "p3_${TIMESTAMP}_${UUID}_${PROCESS_ID}_true_session_${USER_SESSION_ID}_v2.json",
+            "p9_${TIMESTAMP}_${UUID}_${PROCESS_ID}_true_session_${USER_SESSION_ID}_${SESSION_PART_ID}_v2.json",
+            "p3_notATimestamp_${UUID}_${PROCESS_ID}_true_session_${USER_SESSION_ID}_${SESSION_PART_ID}_v2.json",
+            "p3_${TIMESTAMP}_${UUID}_${PROCESS_ID}_notABool_session_${USER_SESSION_ID}_${SESSION_PART_ID}_v2.json",
         )
         badFilenames.forEach { filename ->
             val result = StoredTelemetryMetadata.fromFilename(filename)
-            assertTrue("Filename failed: $filename", result.isFailure)
+            assertTrue("Filename should fail: $filename", result.isFailure)
         }
     }
 
     @Test
-    fun `from valid filename`() {
+    fun `from valid v1 filename decodes with empty session ids`() {
         typeNameMap.entries.forEach { (type, priority) ->
             listOf(true, false).forEach { payloadComplete ->
                 val input = "${priority}_${TIMESTAMP}_${UUID}_${PROCESS_ID}_${payloadComplete}_native_v1.json"
                 with(StoredTelemetryMetadata.fromFilename(input).getOrThrow()) {
-                    assertEquals(input, filename)
                     assertEquals(TIMESTAMP, timestamp)
                     assertEquals(UUID, uuid)
+                    assertEquals(PROCESS_ID, processIdentifier)
                     assertEquals(type, envelopeType)
                     assertEquals(payloadComplete, complete)
                     assertEquals(PayloadType.NATIVE_CRASH, payloadType)
+                    assertEquals("", userSessionId)
+                    assertEquals("", sessionPartId)
                 }
             }
         }
+    }
+
+    @Test
+    fun `from valid v2 filename`() {
+        typeNameMap.entries.forEach { (type, priority) ->
+            listOf(true, false).forEach { payloadComplete ->
+                val input =
+                    "${priority}_${TIMESTAMP}_${UUID}_${PROCESS_ID}_${payloadComplete}_native_${USER_SESSION_ID}_${SESSION_PART_ID}_v2.json"
+                with(StoredTelemetryMetadata.fromFilename(input).getOrThrow()) {
+                    assertEquals(input, filename)
+                    assertEquals(TIMESTAMP, timestamp)
+                    assertEquals(UUID, uuid)
+                    assertEquals(PROCESS_ID, processIdentifier)
+                    assertEquals(type, envelopeType)
+                    assertEquals(payloadComplete, complete)
+                    assertEquals(PayloadType.NATIVE_CRASH, payloadType)
+                    assertEquals(USER_SESSION_ID, userSessionId)
+                    assertEquals(SESSION_PART_ID, sessionPartId)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `from valid v2 filename with none decodes to empty session ids`() {
+        val input = "p3_${TIMESTAMP}_${UUID}_${PROCESS_ID}_true_session_none_none_v2.json"
+        with(StoredTelemetryMetadata.fromFilename(input).getOrThrow()) {
+            assertEquals("", userSessionId)
+            assertEquals("", sessionPartId)
+            assertEquals(SupportedEnvelopeType.SESSION, envelopeType)
+            assertEquals(PayloadType.SESSION, payloadType)
+        }
+    }
+
+    @Test
+    fun `v2 round trip preserves all fields`() {
+        val original = StoredTelemetryMetadata(
+            timestamp = TIMESTAMP,
+            uuid = UUID,
+            processIdentifier = PROCESS_ID,
+            envelopeType = SupportedEnvelopeType.SESSION,
+            complete = false,
+            payloadType = PayloadType.SESSION,
+            userSessionId = USER_SESSION_ID,
+            sessionPartId = SESSION_PART_ID,
+        )
+        val decoded = StoredTelemetryMetadata.fromFilename(original.filename).getOrThrow()
+        assertEquals(original.timestamp, decoded.timestamp)
+        assertEquals(original.uuid, decoded.uuid)
+        assertEquals(original.processIdentifier, decoded.processIdentifier)
+        assertEquals(original.envelopeType, decoded.envelopeType)
+        assertEquals(original.complete, decoded.complete)
+        assertEquals(original.payloadType, decoded.payloadType)
+        assertEquals(original.userSessionId, decoded.userSessionId)
+        assertEquals(original.sessionPartId, decoded.sessionPartId)
+        assertEquals(original.filename, decoded.filename)
+    }
+
+    @Test
+    fun `v2 round trip with empty ids preserves empty after decode`() {
+        val original = StoredTelemetryMetadata(
+            timestamp = TIMESTAMP,
+            uuid = UUID,
+            processIdentifier = PROCESS_ID,
+            envelopeType = SupportedEnvelopeType.CRASH,
+            payloadType = PayloadType.NATIVE_CRASH,
+        )
+        val decoded = StoredTelemetryMetadata.fromFilename(original.filename).getOrThrow()
+        assertEquals("", decoded.userSessionId)
+        assertEquals("", decoded.sessionPartId)
+        assertEquals(original.filename, decoded.filename)
     }
 }


### PR DESCRIPTION
## Goal

Alters the payload resurrection logic so that session payloads are deduped if a payload with a similar session ID exists in `payloadStorageService`, or if multiple payloads exist in `cacheStorageService` with the same ID.

This should help mitigate the frequency at which session payload HTTP requests have duplicates, although some baseline level will always be expected as it's impossible to atomically make a HTTP request and delete the file in the context of the environment we run in.

## Testing

Added unit tests.
