### PR TITLE
Alter internal logger so that severity is specified with `InternalErrorType`

### DIFF
--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
@@ -176,7 +176,7 @@ class ConfigServiceImpl(
             val decodedSymbols: String = encodedSymbols.decodeBase64()?.utf8() ?: return null
             return serializer.fromJson(decodedSymbols, NativeSymbols::class.java)
         } catch (ex: Exception) {
-            logger.trackInternalError(InternalErrorType.INVALID_NATIVE_SYMBOLS, ex)
+            logger.trackInternalError(InternalErrorType.InvalidNativeSymbols, ex)
         }
 
         return null

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/EmbraceNetworkConnectivityService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/EmbraceNetworkConnectivityService.kt
@@ -30,7 +30,7 @@ internal class EmbraceNetworkConnectivityService(
                 notifyNetworkConnectivityListeners(connectivityStatus)
             }
         } catch (ex: Exception) {
-            logger.trackInternalError(InternalErrorType.NETWORK_STATUS_CAPTURE_FAIL, ex)
+            logger.trackInternalError(InternalErrorType.NetworkStatusCaptureFail, ex)
         }
     }
 
@@ -50,7 +50,7 @@ internal class EmbraceNetworkConnectivityService(
                 ConnectivityStatus.None
             }
         } catch (e: Exception) {
-            logger.trackInternalError(InternalErrorType.NETWORK_STATUS_CAPTURE_FAIL, e)
+            logger.trackInternalError(InternalErrorType.NetworkStatusCaptureFail, e)
             status = OptimisticUnknown
         }
         return status

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/NetworkCallbackConnectivityService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/NetworkCallbackConnectivityService.kt
@@ -118,6 +118,6 @@ internal class NetworkCallbackConnectivityService(
         runCatching {
             action()
         }.onFailure {
-            logger.trackInternalError(InternalErrorType.CONNECTIVITY_UPDATE_FAILURE, it)
+            logger.trackInternalError(InternalErrorType.ConnectivityUpdateFailure, it)
         }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/telemetry/InternalErrorDataSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/telemetry/InternalErrorDataSourceImpl.kt
@@ -20,6 +20,9 @@ internal class InternalErrorDataSourceImpl(
     ) {
 
     override fun trackInternalError(type: InternalErrorType, throwable: Throwable) {
+        if (!type.shouldCapture()) {
+            return
+        }
         captureTelemetry {
             val schemaType = SchemaType.InternalError(throwable)
             addLog(schemaType, LogSeverity.ERROR, "", true)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/user/EmbraceUserService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/user/EmbraceUserService.kt
@@ -63,7 +63,7 @@ internal class EmbraceUserService(
         return try {
             getStoredUserInfo()
         } catch (ex: Exception) {
-            logger.trackInternalError(InternalErrorType.USER_LOAD_FAIL, ex)
+            logger.trackInternalError(InternalErrorType.UserLoadFail, ex)
             null
         }
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
@@ -54,13 +54,13 @@ internal class PayloadResurrectionServiceImpl(
         runCatching {
             processTombstones(nativeCrashServiceProvider)
         }.onFailure {
-            logger.trackInternalError(InternalErrorType.PAYLOAD_RESURRECTION_FAIL, it)
+            logger.trackInternalError(InternalErrorType.PayloadResurrectionFail, it)
         }
         completionListeners.forEach { listener ->
             runCatching {
                 listener()
             }.onFailure {
-                logger.trackInternalError(InternalErrorType.PAYLOAD_RESURRECTION_FAIL, it)
+                logger.trackInternalError(InternalErrorType.PayloadResurrectionFail, it)
             }
         }
     }
@@ -81,7 +81,7 @@ internal class PayloadResurrectionServiceImpl(
                 )
             }.onFailure {
                 logger.trackInternalError(
-                    type = InternalErrorType.PAYLOAD_RESURRECTION_PAYLOAD_FAIL,
+                    type = InternalErrorType.PayloadResurrectionPayloadFail,
                     throwable = it
                 )
             }
@@ -133,7 +133,7 @@ internal class PayloadResurrectionServiceImpl(
                         )
                     } else {
                         logger.trackInternalError(
-                            type = InternalErrorType.NATIVE_CRASH_RESURRECTION_ERROR,
+                            type = InternalErrorType.NativeCrashResurrectionError,
                             throwable = IllegalStateException("Cached native crash envelope data not found")
                         )
                     }
@@ -147,7 +147,7 @@ internal class PayloadResurrectionServiceImpl(
                 }
                 if (sessionlessNativeCrashes.size > 1) {
                     logger.trackInternalError(
-                        type = InternalErrorType.NATIVE_CRASH_RESURRECTION_ERROR,
+                        type = InternalErrorType.NativeCrashResurrectionError,
                         throwable = IllegalStateException("Multiple sessionless native crashes found.")
                     )
                 }
@@ -228,7 +228,7 @@ internal class PayloadResurrectionServiceImpl(
             try {
                 task.get(5, TimeUnit.SECONDS)
             } catch (e: TimeoutException) {
-                logger.trackInternalError(InternalErrorType.INTAKE_FAIL, e)
+                logger.trackInternalError(InternalErrorType.IntakeFail, e)
             }
         }
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/SafeCaptureExtension.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/SafeCaptureExtension.kt
@@ -13,7 +13,7 @@ internal inline fun <R> captureDataSafely(logger: InternalLogger, result: Provid
     return try {
         result()
     } catch (exc: Throwable) {
-        logger.trackInternalError(InternalErrorType.SAFE_DATA_CAPTURE_FAIL, exc)
+        logger.trackInternalError(InternalErrorType.SafeDataCaptureFail, exc)
         null
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/caching/PeriodicSessionPartCacher.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/caching/PeriodicSessionPartCacher.kt
@@ -42,7 +42,7 @@ class PeriodicSessionPartCacher(
             try {
                 provider()
             } catch (ex: Exception) {
-                logger.trackInternalError(InternalErrorType.FG_SESSION_CACHE_FAIL, ex)
+                logger.trackInternalError(InternalErrorType.PeriodicSessionCacheFail, ex)
             }
         }
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionPartTrackerImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionPartTrackerImpl.kt
@@ -67,7 +67,7 @@ internal class SessionPartTrackerImpl(
                 try {
                     activityManager?.setProcessStateSummary(sessionId.toByteArray())
                 } catch (e: Throwable) {
-                    logger.trackInternalError(InternalErrorType.PROCESS_STATE_SUMMARY_FAIL, e)
+                    logger.trackInternalError(InternalErrorType.ProcessStateSummaryFail, e)
                 }
             }
         }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/AppStateTrackerImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/lifecycle/AppStateTrackerImpl.kt
@@ -103,7 +103,7 @@ internal class AppStateTrackerImpl(
         try {
             action()
         } catch (ex: Exception) {
-            logger.trackInternalError(InternalErrorType.APP_STATE_CALLBACK_FAIL, ex)
+            logger.trackInternalError(InternalErrorType.AppStateCallbackFail, ex)
         }
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -83,7 +83,7 @@ internal class SessionOrchestratorImpl(
                 userSessionState = when {
                     stored != null && clock.now() < stored.startTimeMs -> {
                         logger.trackInternalError(
-                            InternalErrorType.CLOCK_BACKWARDS_SHIFT,
+                            InternalErrorType.ClockBackwardsShift,
                             IllegalStateException(
                                 "Clock shifted backwards from previous user session."
                             )

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/InternalErrorDataSourceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/InternalErrorDataSourceImplTest.kt
@@ -31,7 +31,7 @@ internal class InternalErrorDataSourceImplTest {
 
     @Test
     fun `handle throwable with no message`() {
-        dataSource.trackInternalError(InternalErrorType.DELIVERY_SCHEDULING_FAIL, IllegalStateException())
+        dataSource.trackInternalError(InternalErrorType.DeliverySchedulingFail, IllegalStateException())
         val data = args.destination.logEvents.single()
         val attrs = assertInternalErrorLogged(data)
         assertEquals("java.lang.IllegalStateException", attrs[ExceptionAttributes.EXCEPTION_TYPE])
@@ -41,7 +41,7 @@ internal class InternalErrorDataSourceImplTest {
 
     @Test
     fun `handle throwable with message`() {
-        dataSource.trackInternalError(InternalErrorType.DELIVERY_SCHEDULING_FAIL, IllegalArgumentException("Whoops!"))
+        dataSource.trackInternalError(InternalErrorType.DeliverySchedulingFail, IllegalArgumentException("Whoops!"))
         val data = args.destination.logEvents.single()
         val attrs = assertInternalErrorLogged(data)
         assertEquals("java.lang.IllegalArgumentException", attrs[ExceptionAttributes.EXCEPTION_TYPE])
@@ -52,7 +52,7 @@ internal class InternalErrorDataSourceImplTest {
     @Test
     fun `limit not exceeded`() {
         repeat(15) {
-            dataSource.trackInternalError(InternalErrorType.DELIVERY_SCHEDULING_FAIL, IllegalStateException())
+            dataSource.trackInternalError(InternalErrorType.DeliverySchedulingFail, IllegalStateException())
         }
         assertEquals(10, args.destination.logEvents.size)
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
@@ -509,7 +509,7 @@ class PayloadResurrectionServiceImplTest {
         assertEquals(0, cacheStorageService.storedPayloadCount())
         assertEquals(1, logger.internalErrorMessages.size)
         assertEquals(
-            InternalErrorType.PAYLOAD_RESURRECTION_PAYLOAD_FAIL.toString(),
+            InternalErrorType.PayloadResurrectionPayloadFail.toString(),
             logger.internalErrorMessages.single().msg
         )
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -747,7 +747,7 @@ internal class SessionOrchestratorTest {
 
         val errors = logger.internalErrorMessages
         assertEquals(1, errors.size)
-        assertEquals(InternalErrorType.CLOCK_BACKWARDS_SHIFT.toString(), errors[0].msg)
+        assertEquals(InternalErrorType.ClockBackwardsShift.toString(), errors[0].msg)
     }
 
     @Test

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionService.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionService.kt
@@ -56,7 +56,7 @@ class OkHttpRequestExecutionService(
             // for those. But any unexpected error should be logged.
             if (throwable !is IOException) {
                 logger.trackInternalError(
-                    type = InternalErrorType.PAYLOAD_DELIVERY_FAIL,
+                    type = InternalErrorType.PayloadDeliveryFail,
                     throwable = throwable
                 )
             }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImpl.kt
@@ -135,7 +135,7 @@ class IntakeServiceImpl(
                 }
             } else if (!cacheableEnvelopeTypes.contains(metadata.envelopeType)) {
                 logger.trackInternalError(
-                    InternalErrorType.INTAKE_UNEXPECTED_TYPE,
+                    InternalErrorType.IntakeUnexpectedType,
                     IllegalStateException("Unexpected envelope type cache attempt: ${metadata.envelopeType}"),
                 )
             }
@@ -144,7 +144,7 @@ class IntakeServiceImpl(
                 cacheStorageService.delete(it)
             }
         } catch (exc: Throwable) {
-            logger.trackInternalError(InternalErrorType.INTAKE_FAIL, exc)
+            logger.trackInternalError(InternalErrorType.IntakeFail, exc)
         }
     }
 

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImpl.kt
@@ -133,7 +133,7 @@ class SchedulingServiceImpl(
                 }
             }
         } catch (t: Throwable) {
-            logger.trackInternalError(InternalErrorType.DELIVERY_SCHEDULING_FAIL, t)
+            logger.trackInternalError(InternalErrorType.DeliverySchedulingFail, t)
         }
     }
 
@@ -171,7 +171,7 @@ class SchedulingServiceImpl(
                         )
                     } ?: ExecutionResult.NotAttempted
                 } catch (t: Throwable) {
-                    logger.trackInternalError(InternalErrorType.DELIVERY_SCHEDULING_FAIL, t)
+                    logger.trackInternalError(InternalErrorType.DeliverySchedulingFail, t)
                     ExecutionResult.Incomplete(exception = t, retry = false)
                 }
             }

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImplTest.kt
@@ -441,7 +441,7 @@ class IntakeServiceImplTest {
             }
 
         assertEquals(cache1.filename, cacheStorageService.storedFilenames().single())
-        assertEquals(InternalErrorType.INTAKE_UNEXPECTED_TYPE.toString(), logger.internalErrorMessages.single().msg)
+        assertEquals(InternalErrorType.IntakeUnexpectedType.toString(), logger.internalErrorMessages.single().msg)
     }
 
     @Test

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/DeviceImpl.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/DeviceImpl.kt
@@ -68,7 +68,7 @@ class DeviceImpl(
                 displayMetrics.heightPixels
             )
         } catch (ex: Exception) {
-            logger.trackInternalError(InternalErrorType.SCREEN_RES_CAPTURE_FAIL, ex)
+            logger.trackInternalError(InternalErrorType.ScreenResCaptureFail, ex)
             ""
         }
     }

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/InternalErrorType.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/InternalErrorType.kt
@@ -1,40 +1,47 @@
 package io.embrace.android.embracesdk.internal.logging
 
+import io.embrace.android.embracesdk.internal.logging.InternalLogger.Severity
+import io.embrace.android.embracesdk.internal.logging.InternalLogger.Severity.ERROR
+
 /**
  * Represents a type of internal error that can be recorded for the Embrace SDK's telemetry.
  */
-enum class InternalErrorType {
-    UNCAUGHT_EXC_HANDLER,
-    ENABLE_DATA_CAPTURE,
-    NETWORK_STATUS_CAPTURE_FAIL,
-    SCREEN_RES_CAPTURE_FAIL,
-    FG_SESSION_CACHE_FAIL,
-    APP_STATE_CALLBACK_FAIL,
-    THREAD_BLOCKAGE_HEARTBEAT_CHECK_FAIL,
-    DATA_SOURCE_DATA_CAPTURE_FAIL,
-    USER_LOAD_FAIL,
-    NATIVE_CRASH_LOAD_FAIL,
-    NATIVE_CRASH_RESURRECTION_ERROR,
-    INVALID_NATIVE_SYMBOLS,
-    NATIVE_HANDLER_INSTALL_FAIL,
-    SAFE_DATA_CAPTURE_FAIL,
-    PROCESS_STATE_SUMMARY_FAIL,
-    DELIVERY_SCHEDULING_FAIL,
-    PAYLOAD_DELIVERY_FAIL,
-    PAYLOAD_RESURRECTION_FAIL,
-    PAYLOAD_RESURRECTION_PAYLOAD_FAIL,
-    INTAKE_FAIL,
-    INTAKE_UNEXPECTED_TYPE,
-    PAYLOAD_STORAGE_FAIL,
-    INTERNAL_INTERFACE_FAIL,
-    NATIVE_READ_FAIL,
-    APP_LAUNCH_TRACE_FAIL,
-    UI_CALLBACK_FAIL,
-    INSTRUMENTATION_REG_FAIL,
-    URL_STREAM_HANDLER_FACTORY_INSTALL_FAIL,
-    SESSION_STATE_CREATION_FAIL,
-    CONNECTIVITY_UPDATE_FAILURE,
-    CLOCK_BACKWARDS_SHIFT,
-    USER_SESSION_CALLBACK_FAIL,
-    NAV_CONTROLLER_TRACKING_FAIL,
+sealed class InternalErrorType(private val severity: Severity) {
+
+    fun shouldCapture(): Boolean = severity >= ERROR
+
+    override fun toString(): String = javaClass.simpleName
+
+    object UncaughtExceptionHandler : InternalErrorType(ERROR)
+    object ProcessAeiRecords : InternalErrorType(ERROR)
+    object NetworkStatusCaptureFail : InternalErrorType(ERROR)
+    object ScreenResCaptureFail : InternalErrorType(ERROR)
+    object PeriodicSessionCacheFail : InternalErrorType(ERROR)
+    object AppStateCallbackFail : InternalErrorType(ERROR)
+    object ThreadBlockageHeartbeatCheckFail : InternalErrorType(ERROR)
+    object DataSourceDataCaptureFail : InternalErrorType(ERROR)
+    object UserLoadFail : InternalErrorType(ERROR)
+    object NativeCrashLoadFail : InternalErrorType(ERROR)
+    object NativeCrashResurrectionError : InternalErrorType(ERROR)
+    object InvalidNativeSymbols : InternalErrorType(ERROR)
+    object NativeHandlerInstallFail : InternalErrorType(ERROR)
+    object SafeDataCaptureFail : InternalErrorType(ERROR)
+    object ProcessStateSummaryFail : InternalErrorType(ERROR)
+    object DeliverySchedulingFail : InternalErrorType(ERROR)
+    object PayloadDeliveryFail : InternalErrorType(ERROR)
+    object PayloadResurrectionFail : InternalErrorType(ERROR)
+    object PayloadResurrectionPayloadFail : InternalErrorType(ERROR)
+    object IntakeFail : InternalErrorType(ERROR)
+    object IntakeUnexpectedType : InternalErrorType(ERROR)
+    object PayloadStorageFail : InternalErrorType(ERROR)
+    object InternalInterfaceFail : InternalErrorType(ERROR)
+    object NativeReadFail : InternalErrorType(ERROR)
+    object AppLaunchTraceFail : InternalErrorType(ERROR)
+    object UiCallbackFail : InternalErrorType(ERROR)
+    object InstrumentationRegFail : InternalErrorType(ERROR)
+    object UrlStreamHandlerFactoryInstallFail : InternalErrorType(ERROR)
+    object SessionStateCreationFail : InternalErrorType(ERROR)
+    object ConnectivityUpdateFailure : InternalErrorType(ERROR)
+    object ClockBackwardsShift : InternalErrorType(ERROR)
+    object NavControllerTrackingFail : InternalErrorType(ERROR)
 }

--- a/embrace-android-infra/src/test/kotlin/io/embrace/android/embracesdk/internal/logging/InternalErrorTypeTest.kt
+++ b/embrace-android-infra/src/test/kotlin/io/embrace/android/embracesdk/internal/logging/InternalErrorTypeTest.kt
@@ -1,0 +1,19 @@
+package io.embrace.android.embracesdk.internal.logging
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+internal class InternalErrorTypeTest {
+
+    @Test
+    fun `ERROR severity is captured`() {
+        assertTrue(InternalErrorType.UncaughtExceptionHandler.shouldCapture())
+    }
+
+    @Test
+    fun `toString returns simple class name`() {
+        assertEquals("UncaughtExceptionHandler", InternalErrorType.UncaughtExceptionHandler.toString())
+        assertEquals("DeliverySchedulingFail", InternalErrorType.DeliverySchedulingFail.toString())
+    }
+}

--- a/embrace-android-instrumentation-androidx-navigation/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/androidx/navigation/internal/NavControllerTracker.kt
+++ b/embrace-android-instrumentation-androidx-navigation/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/androidx/navigation/internal/NavControllerTracker.kt
@@ -38,7 +38,7 @@ internal class NavControllerTracker(
                 }
             }
         }.onFailure {
-            logger.trackInternalError(InternalErrorType.NAV_CONTROLLER_TRACKING_FAIL, it)
+            logger.trackInternalError(InternalErrorType.NavControllerTrackingFail, it)
         }
     }
 

--- a/embrace-android-instrumentation-androidx-navigation/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/androidx/navigation/internal/NavControllerTrackerTest.kt
+++ b/embrace-android-instrumentation-androidx-navigation/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/androidx/navigation/internal/NavControllerTrackerTest.kt
@@ -126,7 +126,7 @@ internal class NavControllerTrackerTest {
         assertTrue(fakeTracker.attachedCalls.isEmpty())
         assertTrue(
             errorLogger.internalErrorMessages.any {
-                it.msg == InternalErrorType.NAV_CONTROLLER_TRACKING_FAIL.toString()
+                it.msg == InternalErrorType.NavControllerTrackingFail.toString()
             }
         )
     }

--- a/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/BlockedThreadDetector.kt
+++ b/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/BlockedThreadDetector.kt
@@ -122,7 +122,7 @@ class BlockedThreadDetector(
             }
             onMonitorThreadInterval(now)
         } catch (exc: Exception) {
-            logger.trackInternalError(InternalErrorType.THREAD_BLOCKAGE_HEARTBEAT_CHECK_FAIL, exc)
+            logger.trackInternalError(InternalErrorType.ThreadBlockageHeartbeatCheckFail, exc)
         }
     }
 

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistryImpl.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistryImpl.kt
@@ -66,7 +66,7 @@ class InstrumentationRegistryImpl(
                     add(dataSourceState)
                 }
             } catch (exc: Throwable) {
-                logger.trackInternalError(InternalErrorType.INSTRUMENTATION_REG_FAIL, exc)
+                logger.trackInternalError(InternalErrorType.InstrumentationRegFail, exc)
             }
         }
     }

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/DataSourceImpl.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/DataSourceImpl.kt
@@ -55,7 +55,7 @@ abstract class DataSourceImpl(
                 telemetryService.trackAppliedLimit(instrumentationName, AppliedLimitType.DROP)
             }
         } catch (exc: Throwable) {
-            logger.trackInternalError(InternalErrorType.DATA_SOURCE_DATA_CAPTURE_FAIL, exc)
+            logger.trackInternalError(InternalErrorType.DataSourceDataCaptureFail, exc)
         }
         return null
     }

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/StateDataSource.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/StateDataSource.kt
@@ -105,7 +105,7 @@ abstract class StateDataSource<T : Any>(
                 )
             )
         } catch (t: Throwable) {
-            logger.trackInternalError(InternalErrorType.SESSION_STATE_CREATION_FAIL, t)
+            logger.trackInternalError(InternalErrorType.SessionStateCreationFail, t)
         }
     }
 

--- a/embrace-android-instrumentation-app-exit-info/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/AeiDataSourceImpl.kt
+++ b/embrace-android-instrumentation-app-exit-info/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/AeiDataSourceImpl.kt
@@ -41,7 +41,7 @@ internal class AeiDataSourceImpl(
             try {
                 processAeiRecords()
             } catch (exc: Throwable) {
-                logger.trackInternalError(InternalErrorType.ENABLE_DATA_CAPTURE, exc)
+                logger.trackInternalError(InternalErrorType.ProcessAeiRecords, exc)
             }
         }
     }

--- a/embrace-android-instrumentation-crash-jvm/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/EmbraceUncaughtExceptionHandler.kt
+++ b/embrace-android-instrumentation-crash-jvm/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/EmbraceUncaughtExceptionHandler.kt
@@ -25,7 +25,7 @@ internal class EmbraceUncaughtExceptionHandler(
         try {
             dataSource.logUnhandledJvmThrowable(exception)
         } catch (ex: Exception) {
-            logger.trackInternalError(InternalErrorType.UNCAUGHT_EXC_HANDLER, ex)
+            logger.trackInternalError(InternalErrorType.UncaughtExceptionHandler, ex)
         } finally {
             defaultHandler?.uncaughtException(thread, exception)
         }

--- a/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImpl.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImpl.kt
@@ -63,7 +63,7 @@ internal class NativeCrashHandlerInstallerImpl(
                 }
             }
         } catch (ex: Exception) {
-            logger.trackInternalError(InternalErrorType.NATIVE_HANDLER_INSTALL_FAIL, ex)
+            logger.trackInternalError(InternalErrorType.NativeHandlerInstallFail, ex)
         }
     }
 

--- a/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashProcessorImpl.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashProcessorImpl.kt
@@ -57,7 +57,7 @@ internal class NativeCrashProcessorImpl(
                     }
                 } else {
                     logger.trackInternalError(
-                        type = InternalErrorType.NATIVE_CRASH_LOAD_FAIL,
+                        type = InternalErrorType.NativeCrashLoadFail,
                         throwable = FileNotFoundException("Failed to load crash report at ${crashFile.path}")
                     )
                     null
@@ -65,7 +65,7 @@ internal class NativeCrashProcessorImpl(
             } catch (t: Throwable) {
                 crashFile.delete()
                 logger.trackInternalError(
-                    type = InternalErrorType.NATIVE_CRASH_LOAD_FAIL,
+                    type = InternalErrorType.NativeCrashLoadFail,
                     throwable = RuntimeException(
                         "Failed to read native crash file {crashFilePath=" + crashFile.absolutePath + "}.",
                         t

--- a/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/SharedObjectLoaderImpl.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/SharedObjectLoaderImpl.kt
@@ -28,7 +28,7 @@ internal class SharedObjectLoaderImpl(
                 } catch (exc: UnsatisfiedLinkError) {
                     if (!loggedFailure.getAndSet(true)) {
                         logger.trackInternalError(
-                            type = InternalErrorType.NATIVE_READ_FAIL,
+                            type = InternalErrorType.NativeReadFail,
                             throwable = exc
                         )
                     }

--- a/embrace-android-instrumentation-fcm/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/fcm/PushNotificationDataSource.kt
+++ b/embrace-android-instrumentation-fcm/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/fcm/PushNotificationDataSource.kt
@@ -35,7 +35,7 @@ class PushNotificationDataSource(
                 notificationPriority = notification?.notificationPriority,
             )
         } catch (e: Exception) {
-            logger.trackInternalError(InternalErrorType.DATA_SOURCE_DATA_CAPTURE_FAIL, e)
+            logger.trackInternalError(InternalErrorType.DataSourceDataCaptureFail, e)
         }
     }
 

--- a/embrace-android-instrumentation-huc-lite/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/HucLiteDataSource.kt
+++ b/embrace-android-instrumentation-huc-lite/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/HucLiteDataSource.kt
@@ -118,12 +118,12 @@ class HucLiteDataSource(
 
             factoryInstaller(newFactory ?: instrumentedUrlStreamHandlerFactoryProvider())
         }.onFailure {
-            logger.trackInternalError(InternalErrorType.URL_STREAM_HANDLER_FACTORY_INSTALL_FAIL, it)
+            logger.trackInternalError(InternalErrorType.UrlStreamHandlerFactoryInstallFail, it)
         }
     }
 
     private fun errorHandler(t: Throwable) {
-        logger.trackInternalError(InternalErrorType.DATA_SOURCE_DATA_CAPTURE_FAIL, InstrumentationException(t))
+        logger.trackInternalError(InternalErrorType.DataSourceDataCaptureFail, InstrumentationException(t))
     }
 
     class RequestData(

--- a/embrace-android-instrumentation-huc-lite/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huclite/InstrumentedHttpsURLConnectionTest.kt
+++ b/embrace-android-instrumentation-huc-lite/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huclite/InstrumentedHttpsURLConnectionTest.kt
@@ -425,7 +425,7 @@ internal class InstrumentedHttpsURLConnectionTest {
         every { mockWrappedConnection.url } throws FakeIOException()
         instrumentedConnection.responseCode
         assertNoRequestRecorded()
-        assertEquals(InternalErrorType.DATA_SOURCE_DATA_CAPTURE_FAIL.name, getInternalErrors().single().msg)
+        assertEquals(InternalErrorType.DataSourceDataCaptureFail.toString(), getInternalErrors().single().msg)
     }
 
     @Test

--- a/embrace-android-instrumentation-huc/src/main/java/io/embrace/android/embracesdk/instrumentation/huc/InternalNetworkApiImpl.kt
+++ b/embrace-android-instrumentation-huc/src/main/java/io/embrace/android/embracesdk/instrumentation/huc/InternalNetworkApiImpl.kt
@@ -52,5 +52,5 @@ internal class InternalNetworkApiImpl(
         ) ?: false
     }
 
-    override fun logInternalError(error: Throwable) = args.logger.trackInternalError(InternalErrorType.INTERNAL_INTERFACE_FAIL, error)
+    override fun logInternalError(error: Throwable) = args.logger.trackInternalError(InternalErrorType.InternalInterfaceFail, error)
 }

--- a/embrace-android-instrumentation-okhttp/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpDataSource.kt
+++ b/embrace-android-instrumentation-okhttp/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpDataSource.kt
@@ -321,7 +321,7 @@ internal class OkHttpDataSource(
             dataCaptureErrorMessage =
                 "There were errors in capturing the following part(s) of the network call: %s$errors"
             logger.trackInternalError(
-                InternalErrorType.DATA_SOURCE_DATA_CAPTURE_FAIL,
+                InternalErrorType.DataSourceDataCaptureFail,
                 RuntimeException(
                     "Failure during the building of NetworkCaptureData. $dataCaptureErrorMessage",
                     e
@@ -361,7 +361,7 @@ internal class OkHttpDataSource(
             }
         } catch (e: IOException) {
             logger.trackInternalError(
-                InternalErrorType.DATA_SOURCE_DATA_CAPTURE_FAIL,
+                InternalErrorType.DataSourceDataCaptureFail,
                 e
             )
         }

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/AppStartupTraceEmitter.kt
@@ -213,7 +213,7 @@ internal class AppStartupTraceEmitter(
                 recordStartup(traceEndTimeMs, completed)
                 if (appStartupRootSpan.get()?.isRecording() != false) {
                     logger.trackInternalError(
-                        type = InternalErrorType.APP_LAUNCH_TRACE_FAIL,
+                        type = InternalErrorType.AppLaunchTraceFail,
                         throwable = IllegalStateException("App startup trace recording attempted but did not succeed")
                     )
                 }
@@ -248,7 +248,7 @@ internal class AppStartupTraceEmitter(
             appStartupRootSpan.set(rootSpan)
         } else {
             logger.trackInternalError(
-                type = InternalErrorType.APP_LAUNCH_TRACE_FAIL,
+                type = InternalErrorType.AppLaunchTraceFail,
                 throwable = IllegalStateException("App startup trace could not be started")
             )
         }

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/ui/FirstDrawDetector.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/ui/FirstDrawDetector.kt
@@ -48,7 +48,7 @@ internal class FirstDrawDetector(
                 }
             } else if (!loadingActivities.containsKey(instanceId)) {
                 logger.trackInternalError(
-                    type = InternalErrorType.UI_CALLBACK_FAIL,
+                    type = InternalErrorType.UiCallbackFail,
                     throwable = IllegalStateException(
                         "Fail to attach frame rendering callback because the callback on Window was null"
                     )
@@ -69,7 +69,7 @@ internal class FirstDrawDetector(
                 activity.window.decorView.viewTreeObserver.unregisterFrameCommitCallback(firstDrawCallback)
             }.exceptionOrNull()?.let { exception ->
                 logger.trackInternalError(
-                    type = InternalErrorType.UI_CALLBACK_FAIL,
+                    type = InternalErrorType.UiCallbackFail,
                     throwable = IllegalStateException("Failed to unregister first draw callback", exception)
                 )
             }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/InternalErrorLogTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/InternalErrorLogTest.kt
@@ -31,7 +31,7 @@ internal class InternalErrorLogTest {
             },
             testCaseAction = {
                 recordSession {
-                    logger.trackInternalError(InternalErrorType.INTERNAL_INTERFACE_FAIL, RuntimeException("Some error message"))
+                    logger.trackInternalError(InternalErrorType.InternalInterfaceFail, RuntimeException("Some error message"))
                 }
             },
             assertAction = {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PayloadTypesHeaderTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PayloadTypesHeaderTest.kt
@@ -61,7 +61,7 @@ internal class PayloadTypesHeaderTest {
             },
             testCaseAction = {
                 embrace.logInfo("some message")
-                logger.trackInternalError(InternalErrorType.INTERNAL_INTERFACE_FAIL, RuntimeException("some internal error"))
+                logger.trackInternalError(InternalErrorType.InternalInterfaceFail, RuntimeException("some internal error"))
                 embrace.logWarning("uh oh!")
                 clock.tick(2000L)
             },
@@ -97,7 +97,7 @@ internal class PayloadTypesHeaderTest {
             },
             testCaseAction = {
                 embrace.logInfo("log message")
-                logger.trackInternalError(InternalErrorType.INTERNAL_INTERFACE_FAIL, RuntimeException("some internal error"))
+                logger.trackInternalError(InternalErrorType.InternalInterfaceFail, RuntimeException("some internal error"))
                 embrace.logMessage(
                     "Flutter error occurred",
                     Severity.ERROR,
@@ -146,7 +146,7 @@ internal class PayloadTypesHeaderTest {
             },
             testCaseAction = {
                 embrace.logInfo("log message")
-                logger.trackInternalError(InternalErrorType.INTERNAL_INTERFACE_FAIL, RuntimeException("some internal error"))
+                logger.trackInternalError(InternalErrorType.InternalInterfaceFail, RuntimeException("some internal error"))
                 EmbraceInternalApi.unityInternalInterface.logUnhandledUnityException(
                     "UnityException",
                     "Unity error occurred",

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -157,7 +157,7 @@ internal class EmbraceImpl(
                 )
             }
         } catch (t: Throwable) {
-            logger.trackInternalError(InternalErrorType.INSTRUMENTATION_REG_FAIL, t)
+            logger.trackInternalError(InternalErrorType.InstrumentationRegFail, t)
         }
     }
 

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
@@ -137,7 +137,7 @@ internal fun ModuleGraph.triggerPayloadSend() {
         } else {
             val payloadCount = deliveryModule?.cacheStorageService?.getUndeliveredPayloads()?.size ?: 0
             initModule.logger.trackInternalError(
-                type = InternalErrorType.PAYLOAD_RESURRECTION_FAIL,
+                type = InternalErrorType.PayloadResurrectionFail,
                 throwable = IllegalStateException(
                     "Resurrection service not found. Undelivered payloads not processed: $payloadCount"
                 )

--- a/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImpl.kt
+++ b/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImpl.kt
@@ -44,7 +44,7 @@ class FileStorageServiceImpl(
         try {
             storeImpl(metadata, action)
         } catch (exc: Throwable) {
-            logger.trackInternalError(InternalErrorType.PAYLOAD_STORAGE_FAIL, exc)
+            logger.trackInternalError(InternalErrorType.PayloadStorageFail, exc)
         }
     }
 
@@ -92,7 +92,7 @@ class FileStorageServiceImpl(
             metadata.asFile().delete()
         } catch (exc: Throwable) {
             if (exc !is FileNotFoundException) {
-                logger.trackInternalError(InternalErrorType.PAYLOAD_STORAGE_FAIL, exc)
+                logger.trackInternalError(InternalErrorType.PayloadStorageFail, exc)
             }
         } finally {
             storedFiles.remove(metadata)
@@ -103,7 +103,7 @@ class FileStorageServiceImpl(
         return try {
             metadata.asFile().inputStream().buffered()
         } catch (exc: Throwable) {
-            logger.trackInternalError(InternalErrorType.PAYLOAD_STORAGE_FAIL, exc)
+            logger.trackInternalError(InternalErrorType.PayloadStorageFail, exc)
             null
         }
     }
@@ -142,7 +142,7 @@ class FileStorageServiceImpl(
         )
             .take(removalCount)
         removals.forEach(::processDelete)
-        logger.trackInternalError(InternalErrorType.PAYLOAD_STORAGE_FAIL, RuntimeException("Pruned payload storage"))
+        logger.trackInternalError(InternalErrorType.PayloadStorageFail, RuntimeException("Pruned payload storage"))
 
         // notify the caller whether the new payload should be dropped
         val shouldNotPersist = removals.contains(newPayload)

--- a/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/StorageLocationExt.kt
+++ b/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/StorageLocationExt.kt
@@ -15,7 +15,7 @@ fun StorageLocation.asFile(
     try {
         File(rootDirSupplier(), dir).apply(File::mkdirs)
     } catch (exc: Throwable) {
-        logger?.trackInternalError(InternalErrorType.PAYLOAD_STORAGE_FAIL, exc)
+        logger?.trackInternalError(InternalErrorType.PayloadStorageFail, exc)
         File(fallbackDirSupplier(), dir).apply(File::mkdirs)
     }
 }

--- a/embrace-android-utils/src/main/kotlin/io/embrace/android/embracesdk/internal/clock/NormalizedIntervalClock.kt
+++ b/embrace-android-utils/src/main/kotlin/io/embrace/android/embracesdk/internal/clock/NormalizedIntervalClock.kt
@@ -33,7 +33,7 @@ class NormalizedIntervalClock(
         if (prev > 0L && newTime < prev - driftThresholdMs) {
             if (hasLoggedDrift.compareAndSet(false, true)) {
                 logger?.trackInternalError(
-                    InternalErrorType.INTERNAL_INTERFACE_FAIL,
+                    InternalErrorType.InternalInterfaceFail,
                     IllegalStateException(
                         "NormalizedIntervalClock drifted back in time by more than threshold. Delivery is likely out-of-order."
                     )


### PR DESCRIPTION
## Goal

Alters `InternalErrorType` to a sealed class hierarchy that contains an associated severity. This can be a first step towards triaging existing internal errors so that internal telemetry is less noisy. By default I set every error type as `Severity.ERROR`. A subsequent PR will change these for individual error types and prevent sending them as internal errors. The idea here is that we can route errors below `ERROR` severity to a different location in future.

## Testing

Added unit tests.
