### PR TITLE
Set metadata provider earlier

### DIFF
--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -41,7 +41,6 @@ import io.embrace.android.embracesdk.internal.injection.markSdkInitComplete
 import io.embrace.android.embracesdk.internal.injection.postInit
 import io.embrace.android.embracesdk.internal.injection.postLoadInstrumentation
 import io.embrace.android.embracesdk.internal.injection.registerListeners
-import io.embrace.android.embracesdk.internal.injection.setupMetadataProvider
 import io.embrace.android.embracesdk.internal.injection.triggerPayloadSend
 import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkCaptureDataSource
 import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkRequestDataSource
@@ -127,7 +126,6 @@ internal class EmbraceImpl(
             bootstrapper.postLoadInstrumentation()
             bootstrapper.triggerPayloadSend()
             bootstrapper.markSdkInitComplete()
-            bootstrapper.setupMetadataProvider()
             end()
         } catch (ignored: Throwable) {
             Log.w("Embrace", "Failed to initialize Embrace SDK", ignored)

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
@@ -23,6 +23,8 @@ import java.util.ServiceLoader
  * between modules.
  */
 internal fun ModuleGraph.postInit() {
+    openTelemetryModule.eventService.setMetadataProvider(eventMetadataSupplierProvider())
+
     openTelemetryModule.applyConfiguration(
         sensitiveKeysBehavior = configService.sensitiveKeysBehavior,
         bypassValidation = configService.isOnlyUsingOtelExporters(),
@@ -173,13 +175,6 @@ internal fun ModuleGraph.markSdkInitComplete() {
     val startMsg = "Embrace SDK version ${BuildConfig.VERSION_NAME} started" +
         (appId?.let { " for appId = $it" } ?: " without an app ID")
     initModule.logger.logInfo(startMsg)
-}
-
-/**
- * Set the provider of metadata for the event service
- */
-internal fun ModuleGraph.setupMetadataProvider() {
-    openTelemetryModule.eventService.setMetadataProvider(eventMetadataSupplierProvider())
 }
 
 private fun ModuleGraph.eventMetadataSupplierProvider(): Provider<Map<String, String>> {

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationModule
 import io.embrace.android.embracesdk.fakes.FakeInternalLogger
+import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryLogger
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.internal.arch.InstrumentationRegistry
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
@@ -14,7 +15,9 @@ import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.injection.EssentialServiceModuleImpl
 import io.embrace.android.embracesdk.internal.injection.InitModuleImpl
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
+import io.embrace.android.embracesdk.internal.injection.postInit
 import io.embrace.android.embracesdk.internal.injection.postLoadInstrumentation
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -94,6 +97,48 @@ internal class ModuleInitBootstrapperTest {
             moduleInitBootstrapper.init(
                 context = context,
             )
+        )
+    }
+
+    @Test
+    fun `postInit installs metadata provider before instrumentation loads`() {
+        assertTrue(moduleInitBootstrapper.init(context))
+        val eventService = moduleInitBootstrapper.openTelemetryModule.eventService
+
+        val preLogger = FakeOpenTelemetryLogger()
+        eventService.log(
+            impl = preLogger,
+            eventName = null,
+            body = "before-post-init",
+            timestamp = null,
+            observedTimestamp = null,
+            context = null,
+            severityNumber = null,
+            severityText = null,
+            addCurrentMetadata = true,
+            eventAttributes = null,
+        )
+        assertFalse(
+            preLogger.logs.single().attributes.containsKey(EmbSessionAttributes.EMB_STATE)
+        )
+
+        moduleInitBootstrapper.postInit()
+
+        val postLogger = FakeOpenTelemetryLogger()
+        eventService.log(
+            impl = postLogger,
+            eventName = null,
+            body = "after-post-init",
+            timestamp = null,
+            observedTimestamp = null,
+            context = null,
+            severityNumber = null,
+            severityText = null,
+            addCurrentMetadata = true,
+            eventAttributes = null,
+        )
+        assertTrue(
+            postLogger.logs.single().attributes.containsKey(EmbSessionAttributes.EMB_STATE)
         )
     }
 


### PR DESCRIPTION
## Goal

Configures the metadata provider before instrumentation is loaded so that the collected attributes always contain session information such as `emb.user_session_id`.

## Testing

Added a unit test.
