### PR TITLE
Resolve internal NoSuchElementExceptions

### DIFF
--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/CollectionExtensions.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/CollectionExtensions.kt
@@ -72,3 +72,11 @@ fun <T> Collection<T>.threadSafeTake(n: Int): List<T> {
         }
     }
 }
+
+/**
+ * A stable and thread-safe implementation of [toList]. [toList] has a race between a `size` check and an unprotected `get(0)` or
+ * `iterator().next()` call which can fail if the last item it removed from the collection after the `size == 1` check.
+ */
+fun <T> Collection<T>.threadSafeToList(): List<T> {
+    return ArrayList(this)
+}

--- a/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImpl.kt
+++ b/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImpl.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
+import io.embrace.android.embracesdk.internal.utils.threadSafeToList
 import io.embrace.android.embracesdk.internal.worker.PriorityWorker
 import java.io.File
 import java.io.FileNotFoundException
@@ -109,7 +110,7 @@ class FileStorageServiceImpl(
     }
 
     override fun getStoredPayloads(): List<StoredTelemetryMetadata> {
-        return storedFiles.toList()
+        return storedFiles.threadSafeToList()
     }
 
     /**


### PR DESCRIPTION
## Goal
Replace the use of `CopyOnWriteArraySet.toList()` with a new `threadSafeToList()` extension function that avoids the race between the `size` check and unconditional `iterator().next()` in the stdlib `toList()` implementation.

The `threadSafeToList()` extension function was added to our existing `CollectionExtensions.kt`.