### PR TITLE
Support opentelemetry-kotlin 0.4.0

### DIFF
--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
@@ -162,7 +162,7 @@ class FakeEmbraceSdkSpan(
     }
 
     override fun asNewContext(): Context? = sdkSpan?.let {
-        openTelemetry.context.storeSpan(parentContext, it)
+        parentContext.storeSpan(it)
     }
 
     override fun asW3cTraceParent(): String? = sdkSpan?.spanContext?.run { "00-${traceId}-${spanId}-01" }

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMutableAttributeContainer.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMutableAttributeContainer.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.opentelemetry.kotlin.attributes.AnyValue
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 
 class FakeAttributesMutator(
@@ -35,6 +36,14 @@ class FakeAttributesMutator(
     }
 
     override fun setStringListAttribute(key: String, value: List<String>) {
+        attributes[key] = value
+    }
+
+    override fun setByteArrayAttribute(key: String, value: ByteArray) {
+        attributes[key] = value
+    }
+
+    override fun setAnyValueAttribute(key: String, value: AnyValue) {
         attributes[key] = value
     }
 }

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpan.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpan.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.opentelemetry.kotlin.attributes.AnyValue
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.tracing.StatusData
 import io.opentelemetry.kotlin.tracing.model.SpanLink
@@ -73,5 +74,11 @@ class FakeSpan(
     }
 
     override fun setStringListAttribute(key: String, value: List<String>) {
+    }
+
+    override fun setByteArrayAttribute(key: String, value: ByteArray) {
+    }
+
+    override fun setAnyValueAttribute(key: String, value: AnyValue) {
     }
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbAttributesMutator.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbAttributesMutator.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.otel.impl
 
+import io.opentelemetry.kotlin.attributes.AnyValue
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 import java.util.concurrent.ConcurrentHashMap
 
@@ -39,6 +40,14 @@ internal class EmbAttributesMutator(
     }
 
     override fun setStringListAttribute(key: String, value: List<String>) {
+        map[key] = value
+    }
+
+    override fun setByteArrayAttribute(key: String, value: ByteArray) {
+        map[key] = value
+    }
+
+    override fun setAnyValueAttribute(key: String, value: AnyValue) {
         map[key] = value
     }
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbInvalidSpan.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbInvalidSpan.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.otel.impl
 
 import io.opentelemetry.kotlin.OpenTelemetry
+import io.opentelemetry.kotlin.attributes.AnyValue
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.tracing.Span
 import io.opentelemetry.kotlin.tracing.SpanContext
@@ -55,5 +56,11 @@ internal class EmbInvalidSpan(openTelemetry: OpenTelemetry) : Span, SpanCreation
     }
 
     override fun setStringListAttribute(key: String, value: List<String>) {
+    }
+
+    override fun setByteArrayAttribute(key: String, value: ByteArray) {
+    }
+
+    override fun setAnyValueAttribute(key: String, value: AnyValue) {
     }
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpan.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpan.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.OpenTelemetry
+import io.opentelemetry.kotlin.attributes.AnyValue
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.tracing.Span
 import io.opentelemetry.kotlin.tracing.SpanContext
@@ -49,6 +50,14 @@ class EmbSpan(
     }
 
     override fun setBooleanAttribute(key: String, value: Boolean) {
+        setStringAttribute(key, value.toString())
+    }
+
+    override fun setByteArrayAttribute(key: String, value: ByteArray) {
+        setStringAttribute(key, value.contentToString())
+    }
+
+    override fun setAnyValueAttribute(key: String, value: AnyValue) {
         setStringAttribute(key, value.toString())
     }
 

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImpl.kt
@@ -322,7 +322,7 @@ private class EmbraceSpanImpl(
         }
 
     override fun asNewContext(): Context? = startedSpan.get()?.run {
-        return otelSpanStartArgs.openTelemetry.context.storeSpan(parentContext, this)
+        return parentContext.storeSpan(this)
     }
 
     override fun asW3cTraceParent(): String? = startedSpan.get()?.spanContext?.run { "00-$traceId-$spanId-01" }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/OtelSpanStartArgsTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/OtelSpanStartArgsTest.kt
@@ -52,7 +52,7 @@ internal class OtelSpanStartArgsTest {
             assertTrue(contains(EmbType.Performance.Default))
         }
         assertEquals("emb-test", args.initialSpanName)
-        val spanContext = fakeOpenTelemetry(false).span.fromContext(args.parentContext).spanContext
+        val spanContext = args.parentContext.extractSpan().spanContext
         assertFalse(spanContext.isValid)
 
         args.startSpan(startTime).assertSpan(
@@ -66,7 +66,7 @@ internal class OtelSpanStartArgsTest {
     fun `add parent after initial creation`() {
         val parent = tracer.startSpan("parent")
         val otel = fakeOpenTelemetry(true)
-        val ctx = otel.context.storeSpan(otel.context.root(), parent)
+        val ctx = otel.context.root().storeSpan(parent)
         val args = OtelSpanStartArgs(
             name = "test",
             type = EmbType.Performance.Default,
@@ -76,7 +76,7 @@ internal class OtelSpanStartArgsTest {
             parentCtx = ctx,
             openTelemetry = otel
         )
-        val spanContext = otel.span.fromContext(args.parentContext).spanContext
+        val spanContext = args.parentContext.extractSpan().spanContext
         assertEquals(parent.spanContext.traceId, spanContext.traceId)
 
         val startTime = otelClock.now()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalLoggerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalLoggerTest.kt
@@ -160,7 +160,7 @@ internal class ExternalLoggerTest {
                     eventName = "my.event",
                     timestamp = logTime,
                     observedTimestamp = observedTime,
-                    context = embOpenTelemetry.context.storeSpan(embOpenTelemetry.context.root(), span),
+                    context = embOpenTelemetry.context.root().storeSpan(span),
                     severityNumber = SeverityNumber.INFO,
                     severityText = "",
                 ) {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
@@ -88,7 +88,7 @@ internal class ExternalTracerTest {
                 recordSession {
                     val span = embTracer.startSpan("external-span")
                     startTimeMs = clock.now()
-                    val parentContext = embOpenTelemetry.context.storeSpan(embOpenTelemetry.context.root(), span)
+                    val parentContext = embOpenTelemetry.context.root().storeSpan(span)
                     val childSpan = embTracer.startSpan("child-span", parentContext)
                     childSpan.setStatus(StatusData.Error("oh no"))
                     val exception = RuntimeException("bah")
@@ -178,7 +178,7 @@ internal class ExternalTracerTest {
                 embOpenTelemetry = embrace.getOpenTelemetryKotlin()
                 recordSession {
                     val parentSpan = embTracer.startSpan("external-span")
-                    val parentContext = embOpenTelemetry.context.storeSpan(embOpenTelemetry.context.root(), parentSpan)
+                    val parentContext = embOpenTelemetry.context.root().storeSpan(parentSpan)
                     embTracer.startSpan("set-parent-explicitly", parentContext).end()
                     parentSpan.end()
                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ openTelemetryCore = "1.62.0"
 moshi = "1.15.2"
 lifecycle = "2.7.0" # version pinned to 2.7.0 because of AGP bug
 annotation = "1.10.0"
-otelKotlin = "0.3.0"
+otelKotlin = "0.4.0"
 # Pinned to 1.10.x: 1.11.0+ requires kotlin-stdlib 2.2.20, which breaks our minimum supported Kotlin (2.0.21).
 kotlinxCoroutines = "1.10.2"
 kotlinxSerialization = "1.8.1"


### PR DESCRIPTION
## Goal

Alters our use of opentelemetry-kotlin so that it follows API changes made in 0.4.0.