### PR TITLE
Avoid NPEs from GZIPInputStream construction

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
@@ -30,6 +30,7 @@ import io.embrace.android.embracesdk.internal.session.getUserSessionProperties
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.opentelemetry.kotlin.semconv.SessionAttributes
+import java.io.InputStream
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
@@ -107,16 +108,19 @@ internal class PayloadResurrectionServiceImpl(
             if (sessionlessNativeCrashes.isNotEmpty()) {
                 val cachedCrashEnvelopeMetadata = undeliveredPayloads.firstOrNull { it.isCrashEnvelope() }
                 val cachedCrashEnvelope = if (cachedCrashEnvelopeMetadata != null) {
-                    runCatching {
-                        serializer.fromJson<Envelope<LogPayload>>(
-                            inputStream = GZIPInputStream(
-                                cacheStorageService.loadPayloadAsStream(cachedCrashEnvelopeMetadata)
-                            ),
-                            type = checkNotNull(SupportedEnvelopeType.CRASH.serializedType)
-                        ).also {
-                            cacheStorageService.delete(cachedCrashEnvelopeMetadata)
-                        }
-                    }.getOrNull()
+                    try {
+                        cacheStorageService.loadPayloadAsStream(cachedCrashEnvelopeMetadata)
+                            ?.let { rawPayloadAsStream ->
+                                serializer.fromJson<Envelope<LogPayload>>(
+                                    inputStream = GZIPInputStream(rawPayloadAsStream),
+                                    type = checkNotNull(SupportedEnvelopeType.CRASH.serializedType)
+                                )
+                            }
+                    } catch (_: Exception) {
+                        null
+                    } finally {
+                        runCatching { cacheStorageService.delete(cachedCrashEnvelopeMetadata) }
+                    }
                 } else {
                     null
                 }
@@ -170,49 +174,15 @@ internal class PayloadResurrectionServiceImpl(
     ) {
         val resurrectedPayload = when (envelopeType) {
             SupportedEnvelopeType.SESSION -> {
-                val deadPart = serializer.fromJson<Envelope<SessionPartPayload>>(
-                    inputStream = GZIPInputStream(cacheStorageService.loadPayloadAsStream(this)),
-                    type = checkNotNull(envelopeType.serializedType)
-                )
-
-                val sessionId = deadPart.getSessionId()
-                val appState = deadPart.getSessionSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_STATE)
-                val nativeCrash = if (nativeCrashService != null && sessionId != null) {
-                    nativeCrashProvider(sessionId)?.apply {
-                        val nativeCrashEnvelopeMetadata = createNativeCrashEnvelopeMetadata(
-                            sessionId = sessionId,
-                            processIdentifier = processIdentifier
+                cacheStorageService.loadPayloadAsStream(this)
+                    ?.let { rawPayloadAsStream ->
+                        processUndeliveredPayloadImpl(
+                            rawPayloadAsStream,
+                            nativeCrashService,
+                            nativeCrashProvider,
+                            postNativeCrashProcessingCallback,
                         )
-
-                        cachedLogEnvelopeStore.create(
-                            storedTelemetryMetadata = nativeCrashEnvelopeMetadata,
-                            resource = deadPart.resource ?: EnvelopeResource(),
-                            metadata = deadPart.metadata ?: EnvelopeMetadata()
-                        )
-
-                        nativeCrashService.sendNativeCrash(
-                            nativeCrash = this,
-                            userSessionProperties = deadPart.getUserSessionProperties(),
-                            metadata = if (appState != null) {
-                                mapOf(
-                                    EmbSessionAttributes.EMB_STATE to appState,
-                                    EmbSessionAttributes.EMB_PROCESS_IDENTIFIER to processIdentifier
-                                )
-                            } else {
-                                emptyMap()
-                            },
-                        )
-
-                        postNativeCrashProcessingCallback(this)
                     }
-                } else {
-                    null
-                }
-
-                deadPart.resurrectSession(nativeCrash)
-                    ?: throw IllegalArgumentException(
-                        "Session resurrection failed. Payload does not contain exactly one session span."
-                    )
             }
 
             else -> null
@@ -231,6 +201,57 @@ internal class PayloadResurrectionServiceImpl(
                 logger.trackInternalError(InternalErrorType.IntakeFail, e)
             }
         }
+    }
+
+    private fun StoredTelemetryMetadata.processUndeliveredPayloadImpl(
+        rawPayloadAsStream: InputStream,
+        nativeCrashService: NativeCrashService?,
+        nativeCrashProvider: (String) -> NativeCrashData?,
+        postNativeCrashProcessingCallback: (NativeCrashData) -> Unit,
+    ): Envelope<SessionPartPayload> {
+        val deadPart = serializer.fromJson<Envelope<SessionPartPayload>>(
+            inputStream = GZIPInputStream(rawPayloadAsStream),
+            type = checkNotNull(envelopeType.serializedType)
+        )
+
+        val sessionId = deadPart.getSessionId()
+        val appState = deadPart.getSessionSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_STATE)
+        val nativeCrash = if (nativeCrashService != null && sessionId != null) {
+            nativeCrashProvider(sessionId)?.apply {
+                val nativeCrashEnvelopeMetadata = createNativeCrashEnvelopeMetadata(
+                    sessionId = sessionId,
+                    processIdentifier = processIdentifier
+                )
+
+                cachedLogEnvelopeStore.create(
+                    storedTelemetryMetadata = nativeCrashEnvelopeMetadata,
+                    resource = deadPart.resource ?: EnvelopeResource(),
+                    metadata = deadPart.metadata ?: EnvelopeMetadata()
+                )
+
+                nativeCrashService.sendNativeCrash(
+                    nativeCrash = this,
+                    userSessionProperties = deadPart.getUserSessionProperties(),
+                    metadata = if (appState != null) {
+                        mapOf(
+                            EmbSessionAttributes.EMB_STATE to appState,
+                            EmbSessionAttributes.EMB_PROCESS_IDENTIFIER to processIdentifier
+                        )
+                    } else {
+                        emptyMap()
+                    },
+                )
+
+                postNativeCrashProcessingCallback(this)
+            }
+        } else {
+            null
+        }
+
+        return deadPart.resurrectSession(nativeCrash)
+            ?: throw IllegalArgumentException(
+                "Session resurrection failed. Payload does not contain exactly one session span."
+            )
     }
 
     /**

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
@@ -33,6 +33,7 @@ import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.CRASH
 import io.embrace.android.embracesdk.internal.delivery.intake.IntakeService
 import io.embrace.android.embracesdk.internal.delivery.intake.IntakeServiceImpl
+import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageService
 import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.NativeCrashService
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.otel.payload.toEmbracePayload
@@ -53,6 +54,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.io.ByteArrayInputStream
+import java.io.InputStream
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
@@ -238,6 +240,49 @@ class PayloadResurrectionServiceImplTest {
         serializer.errorOnNextOperation()
         resurrectInBackground()
         assertResurrectionFailure()
+    }
+
+    @Test
+    fun `session payload skipped without error when cache returns null stream`() {
+        cacheStorageService.addFakePayload(sessionMetadata)
+        val service = serviceWithNullStreamCache()
+
+        service.resurrectOldPayloads { nativeCrashService }
+
+        assertEquals(0, payloadStorageService.storedPayloadCount())
+        assertEquals(0, cacheStorageService.storedPayloadCount())
+        assertTrue(logger.internalErrorMessages.isEmpty())
+    }
+
+    @Test
+    fun `sessionless native crash sent without envelope data when crash envelope stream returns null`() {
+        val deadSessionCrashData = createNativeCrashData(
+            nativeCrashId = "native-crash-1",
+            sessionId = "no-session-id"
+        )
+        cacheStorageService.addPayload(
+            metadata = fakeCachedCrashEnvelopeMetadata,
+            data = fakeEmptyLogEnvelope()
+        )
+        nativeCrashService.addNativeCrashData(deadSessionCrashData)
+
+        val service = serviceWithNullStreamCache()
+        service.resurrectOldPayloads { nativeCrashService }
+
+        assertEquals(0, payloadStorageService.storedPayloadCount())
+        assertEquals(0, cacheStorageService.storedPayloadCount())
+        assertTrue(cachedLogEnvelopeStore.createdEnvelopes.isEmpty())
+
+        assertEquals(1, nativeCrashService.nativeCrashesSent.size)
+        with(nativeCrashService.nativeCrashesSent.first()) {
+            assertEquals(deadSessionCrashData, first)
+        }
+
+        assertEquals(1, logger.internalErrorMessages.size)
+        assertEquals(
+            InternalErrorType.NativeCrashResurrectionError.toString(),
+            logger.internalErrorMessages.single().msg
+        )
     }
 
     @Test
@@ -475,7 +520,6 @@ class PayloadResurrectionServiceImplTest {
         thread.start()
         thread.join(5000)
     }
-
     private fun Envelope<SessionPartPayload>.resurrectPayload() {
         cacheStorageService.addPayload(
             metadata = sessionMetadata,
@@ -491,6 +535,26 @@ class PayloadResurrectionServiceImplTest {
                 Envelope.sessionEnvelopeType
             )
         }
+    }
+
+    private fun serviceWithNullStreamCache(): PayloadResurrectionServiceImpl {
+        val nullStreamCacheStorage = object : PayloadStorageService by cacheStorageService {
+            override fun loadPayloadAsStream(metadata: StoredTelemetryMetadata): InputStream? = null
+        }
+        return PayloadResurrectionServiceImpl(
+            intakeService = IntakeServiceImpl(
+                schedulingService,
+                payloadStorageService,
+                nullStreamCacheStorage,
+                logger,
+                serializer,
+                PriorityWorker(intakeExecutor),
+            ),
+            cacheStorageService = nullStreamCacheStorage,
+            cachedLogEnvelopeStore = cachedLogEnvelopeStore,
+            logger = logger,
+            serializer = serializer,
+        )
     }
 
     private fun createNativeCrashData(


### PR DESCRIPTION
## Goal
Check that the `InputStream`s returned from `cacheStorageService.loadPayloadAsStream` is non-null before passing them to `GZIPInputStream` (which would result in a `NullPointerException` from the `GZIPInputStream` constructor).

These can happen due to thread races, cache clears, or I/O errors (which are already reported by the `FileStorageServiceImpl`).

## Testing
Added new unit tests to `PayloadResurrectionServiceImplTest` where the payload is returned as `null` and the test can ensure that no errors are raised or logged in these cases.