### PR TITLE
Handle cases where payloads are not valid GZIP

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
@@ -35,6 +35,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import java.util.zip.GZIPInputStream
+import java.util.zip.ZipException
 import kotlin.math.max
 
 internal class PayloadResurrectionServiceImpl(
@@ -107,23 +108,17 @@ internal class PayloadResurrectionServiceImpl(
             val sessionlessNativeCrashes = nativeCrashes.values.filterNot { processedCrashes.contains(it) }
             if (sessionlessNativeCrashes.isNotEmpty()) {
                 val cachedCrashEnvelopeMetadata = undeliveredPayloads.firstOrNull { it.isCrashEnvelope() }
-                val cachedCrashEnvelope = if (cachedCrashEnvelopeMetadata != null) {
-                    try {
-                        cacheStorageService.loadPayloadAsStream(cachedCrashEnvelopeMetadata)
-                            ?.let { rawPayloadAsStream ->
-                                serializer.fromJson<Envelope<LogPayload>>(
-                                    inputStream = GZIPInputStream(rawPayloadAsStream),
-                                    type = checkNotNull(SupportedEnvelopeType.CRASH.serializedType)
-                                )
-                            }
-                    } catch (_: Exception) {
-                        null
-                    } finally {
-                        runCatching { cacheStorageService.delete(cachedCrashEnvelopeMetadata) }
+                val cachedCrashEnvelope = cachedCrashEnvelopeMetadata
+                    ?.loadDecompressedPayload()
+                    ?.let { payloadStream ->
+                        runCatching {
+                            serializer.fromJson<Envelope<LogPayload>>(
+                                inputStream = payloadStream,
+                                type = checkNotNull(SupportedEnvelopeType.CRASH.serializedType)
+                            )
+                        }.getOrNull()
                     }
-                } else {
-                    null
-                }
+                    ?.also { runCatching { cacheStorageService.delete(cachedCrashEnvelopeMetadata) } }
                 val resource = cachedCrashEnvelope?.resource
                 val metadata = cachedCrashEnvelope?.metadata
                 sessionlessNativeCrashes.forEach { nativeCrash ->
@@ -174,15 +169,14 @@ internal class PayloadResurrectionServiceImpl(
     ) {
         val resurrectedPayload = when (envelopeType) {
             SupportedEnvelopeType.SESSION -> {
-                cacheStorageService.loadPayloadAsStream(this)
-                    ?.let { rawPayloadAsStream ->
-                        processUndeliveredPayloadImpl(
-                            rawPayloadAsStream,
-                            nativeCrashService,
-                            nativeCrashProvider,
-                            postNativeCrashProcessingCallback,
-                        )
-                    }
+                loadDecompressedPayload()?.let { payloadStream ->
+                    processUndeliveredPayloadImpl(
+                        payloadStream,
+                        nativeCrashService,
+                        nativeCrashProvider,
+                        postNativeCrashProcessingCallback,
+                    )
+                }
             }
 
             else -> null
@@ -204,13 +198,13 @@ internal class PayloadResurrectionServiceImpl(
     }
 
     private fun StoredTelemetryMetadata.processUndeliveredPayloadImpl(
-        rawPayloadAsStream: InputStream,
+        payloadStream: InputStream,
         nativeCrashService: NativeCrashService?,
         nativeCrashProvider: (String) -> NativeCrashData?,
         postNativeCrashProcessingCallback: (NativeCrashData) -> Unit,
     ): Envelope<SessionPartPayload> {
         val deadPart = serializer.fromJson<Envelope<SessionPartPayload>>(
-            inputStream = GZIPInputStream(rawPayloadAsStream),
+            inputStream = payloadStream,
             type = checkNotNull(envelopeType.serializedType)
         )
 
@@ -303,6 +297,15 @@ internal class PayloadResurrectionServiceImpl(
             this
         }
     }
+
+    private fun StoredTelemetryMetadata.loadDecompressedPayload(): InputStream? =
+        cacheStorageService.loadPayloadAsStream(this)?.let {
+            try {
+                GZIPInputStream(it)
+            } catch (_: ZipException) {
+                null
+            }
+        }
 
     /**
      * To approximate the time of any snapshot to be converted into a failed span, we look to the session span of the payload and take

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
@@ -245,12 +245,26 @@ class PayloadResurrectionServiceImplTest {
     @Test
     fun `session payload skipped without error when cache returns null stream`() {
         cacheStorageService.addFakePayload(sessionMetadata)
-        val service = serviceWithNullStreamCache()
+        val service = serviceWithPayloadStream(null)
 
         service.resurrectOldPayloads { nativeCrashService }
 
         assertEquals(0, payloadStorageService.storedPayloadCount())
         assertEquals(0, cacheStorageService.storedPayloadCount())
+        assertEquals(1, cacheStorageService.deleteCount.get())
+        assertTrue(logger.internalErrorMessages.isEmpty())
+    }
+
+    @Test
+    fun `session payload skipped without error when gzip stream is invalid`() {
+        cacheStorageService.addFakePayload(sessionMetadata)
+        val service = serviceWithPayloadStream("hi there".byteInputStream())
+
+        service.resurrectOldPayloads { nativeCrashService }
+
+        assertEquals(0, payloadStorageService.storedPayloadCount())
+        assertEquals(0, cacheStorageService.storedPayloadCount())
+        assertEquals(1, cacheStorageService.deleteCount.get())
         assertTrue(logger.internalErrorMessages.isEmpty())
     }
 
@@ -266,7 +280,7 @@ class PayloadResurrectionServiceImplTest {
         )
         nativeCrashService.addNativeCrashData(deadSessionCrashData)
 
-        val service = serviceWithNullStreamCache()
+        val service = serviceWithPayloadStream(null)
         service.resurrectOldPayloads { nativeCrashService }
 
         assertEquals(0, payloadStorageService.storedPayloadCount())
@@ -537,9 +551,9 @@ class PayloadResurrectionServiceImplTest {
         }
     }
 
-    private fun serviceWithNullStreamCache(): PayloadResurrectionServiceImpl {
+    private fun serviceWithPayloadStream(payloadStream: InputStream?): PayloadResurrectionServiceImpl {
         val nullStreamCacheStorage = object : PayloadStorageService by cacheStorageService {
-            override fun loadPayloadAsStream(metadata: StoredTelemetryMetadata): InputStream? = null
+            override fun loadPayloadAsStream(metadata: StoredTelemetryMetadata): InputStream? = payloadStream
         }
         return PayloadResurrectionServiceImpl(
             intakeService = IntakeServiceImpl(


### PR DESCRIPTION
## Goal
When a payload is not valid GZIP the `GZIPInputStream` constructor throws a `ZIPException`, these should be ignored and the payload be deleted.

This PR only adds the `ZIPException` handling and relies of the existing code path to ignore the `null` `InputStream` and delete the payload.

## Testing
Added another unit test, and assert the `deleteCount`s