### PR TITLE
build(deps): bump protobuf from 4.34.1 to 4.35.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ otelKotlin = "0.3.0"
 # Pinned to 1.10.x: 1.11.0+ requires kotlin-stdlib 2.2.20, which breaks our minimum supported Kotlin (2.0.21).
 kotlinxCoroutines = "1.10.2"
 kotlinxSerialization = "1.8.1"
-protobuf = "4.34.1"
+protobuf = "4.35.0"
 profileinstaller = "1.3.1" # version pinned to 1.3.1 because of AGP bug
 okhttp = "4.12.0"
 firebase = "25.0.2"


### PR DESCRIPTION
Bumps `protobuf` from 4.34.1 to 4.35.0.

Updates `com.google.protobuf:protobuf-java` from 4.34.1 to 4.35.0
- [Release notes](https://github.com/protocolbuffers/protobuf/releases)
- [Commits](https://github.com/protocolbuffers/protobuf/commits)

Updates `com.google.protobuf:protobuf-java-util` from 4.34.1 to 4.35.0

---
updated-dependencies:
- dependency-name: com.google.protobuf:protobuf-java dependency-version: 4.35.0 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: com.google.protobuf:protobuf-java-util dependency-version: 4.35.0 dependency-type: direct:production update-type: version-update:semver-minor ...

## Goal

<!-- Describe what this change seeks to address -->

## Testing

<!-- Describe how this change has been tested -->
