### PR TITLE
Make Low Power State lazy init

### DIFF
--- a/embrace-android-instrumentation-power-save/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/powersave/PowerStateDataSource.kt
+++ b/embrace-android-instrumentation-power-save/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/powersave/PowerStateDataSource.kt
@@ -19,6 +19,8 @@ class PowerStateDataSource(
     private val powerManagerProvider: Provider<PowerManager?> = { args.systemService(Context.POWER_SERVICE) }
     private val receiver = PowerSaveModeReceiver(powerManagerProvider, ::onPowerSaveModeChanged)
 
+    override val captureStateOnCreation = false
+
     override fun onDataCaptureEnabled() {
         super.onDataCaptureEnabled()
         args.backgroundWorker(Worker.Background.NonIoRegWorker).run {
@@ -35,11 +37,15 @@ class PowerStateDataSource(
 
     private fun onPowerSaveModeChanged(powerSaveMode: Boolean) {
         val timestamp = clock.now()
-        val newState = if (powerSaveMode) {
-            PowerMode.LOW
-        } else {
-            PowerMode.NORMAL
+        if (getCurrentStateValue() != PowerMode.UNKNOWN || powerSaveMode) {
+            onStateChange(
+                newState = if (powerSaveMode) {
+                    PowerMode.LOW
+                } else {
+                    PowerMode.NORMAL
+                },
+                transitionTimeMs = timestamp
+            )
         }
-        onStateChange(newState, timestamp)
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionApiTest.kt
@@ -85,7 +85,7 @@ internal class UserSessionApiTest {
                     "emb.usage.set_username" to "1",
                     "emb.usage.set_user_email" to "1",
                     "emb.usage.set_user_identifier" to "1",
-                    EmbSessionAttributes.EMB_PRIVATE_SEQUENCE_ID to "9",
+                    EmbSessionAttributes.EMB_PRIVATE_SEQUENCE_ID to "8",
                     EmbSessionAttributes.EMB_STARTUP_DURATION to "0"
                 ).toSortedMap()
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LowPowerFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LowPowerFeatureTest.kt
@@ -19,7 +19,6 @@ import io.embrace.android.embracesdk.internal.instrumentation.powersave.PowerSta
 import io.embrace.android.embracesdk.internal.session.getSessionSpan
 import io.embrace.android.embracesdk.internal.session.getStateSpan
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
-import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface.Companion.LIFECYCLE_EVENT_GAP
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -108,10 +107,7 @@ internal class LowPowerFeatureTest {
                 val message = getSingleSessionEnvelope()
                 val sessionSpan = checkNotNull(message.getSessionSpan())
                 with(checkNotNull(message.getStateSpan("emb-state-power"))) {
-                    assertEquals(
-                        checkNotNull(sessionSpan.startTimeNanos).nanosToMillis() + LIFECYCLE_EVENT_GAP,
-                        checkNotNull(startTimeNanos).nanosToMillis()
-                    )
+                    assertEquals(transitions[0].first, checkNotNull(startTimeNanos).nanosToMillis())
                     assertEquals(sessionSpan.endTimeNanos, endTimeNanos)
                     with(checkNotNull(events)) {
                         assertEquals(2, size)
@@ -119,11 +115,6 @@ internal class LowPowerFeatureTest {
                             this[i].assertStateTransition(
                                 timestampMs = transitions[i].first,
                                 newStateValue = transitions[i].second,
-                                notInSession = if (i == 0) {
-                                    1
-                                } else {
-                                    0
-                                }
                             )
                         }
                     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityDisabledTest.kt
@@ -182,7 +182,7 @@ internal class BackgroundActivityDisabledTest {
                     startMs = session2StartMs,
                     endMs = session2EndMs,
                     sessionNumber = 2,
-                    sequenceId = 14,
+                    sequenceId = 13,
                     coldStart = false,
                 )
 


### PR DESCRIPTION
Make lower power state init lazily the previous implementation (that doesn't use State) only recorded a span when the device is in low power mode, so this will behave closer to that.