### PR TITLE
Reduce internal error noise

### DIFF
--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
@@ -80,7 +80,7 @@ class PayloadStorageServiceImplTest {
     @Test
     fun `load non existent file`() {
         assertNull(service.loadPayloadAsStream(metadata))
-        assertNotNull(logger.internalErrorMessages.single().throwable)
+        assertTrue(logger.internalErrorMessages.isEmpty())
     }
 
     @Test

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
@@ -125,8 +125,6 @@ class PayloadStorageServiceImplTest {
             Pair(1000L, SESSION)
         )
         assertEquals(expected, outputs)
-        val msg = logger.internalErrorMessages.last().throwable?.message
-        assertEquals("Pruned payload storage", msg)
     }
 
     @Test

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/AppStartupTraceEmitter.kt
@@ -211,12 +211,6 @@ internal class AppStartupTraceEmitter(
         if (!dataCollectionComplete.getAndSet(true)) {
             EmbTrace.trace("record-startup") {
                 recordStartup(traceEndTimeMs, completed)
-                if (appStartupRootSpan.get()?.isRecording() != false) {
-                    logger.trackInternalError(
-                        type = InternalErrorType.AppLaunchTraceFail,
-                        throwable = IllegalStateException("App startup trace recording attempted but did not succeed")
-                    )
-                }
             }
             appStartupCompleteCallback?.invoke()
         }

--- a/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImpl.kt
+++ b/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImpl.kt
@@ -103,6 +103,8 @@ class FileStorageServiceImpl(
     override fun loadPayloadAsStream(metadata: StoredTelemetryMetadata): InputStream? {
         return try {
             metadata.asFile().inputStream().buffered()
+        } catch (_: FileNotFoundException) {
+            null
         } catch (exc: Throwable) {
             logger.trackInternalError(InternalErrorType.PayloadStorageFail, exc)
             null

--- a/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImpl.kt
+++ b/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImpl.kt
@@ -143,7 +143,6 @@ class FileStorageServiceImpl(
         )
             .take(removalCount)
         removals.forEach(::processDelete)
-        logger.trackInternalError(InternalErrorType.PayloadStorageFail, RuntimeException("Pruned payload storage"))
 
         // notify the caller whether the new payload should be dropped
         val shouldNotPersist = removals.contains(newPayload)

--- a/embrace-android-telemetry-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImplTest.kt
+++ b/embrace-android-telemetry-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImplTest.kt
@@ -63,9 +63,9 @@ class FileStorageServiceImplTest {
     }
 
     @Test
-    fun `load payload stream error`() {
+    fun `load payload stream no file`() {
         assertNull(service.loadPayloadAsStream(fakeSessionStoredTelemetryMetadata))
-        checkNotNull(logger.internalErrorMessages.single())
+        assertTrue(logger.internalErrorMessages.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
## Goal
Reduce the amount of noise produced by `trackInternalError`s for errors that are expected:

 - App startup may not be recording due to user interactions, leading to errors that cannot be actioned
 - `pruneStorage` should not try to report internal errors when the disk is full to avoid making the situation worse
 - `loadPayloadAsStream` should not report `FileNotFoundException`s as these are expected

## Testing
Updated test to not expect internal errors that have been removed