### PR TITLE
Added clock drift attributes for GNSS and Network time to the session

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/ClockDrift.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/ClockDrift.kt
@@ -4,12 +4,37 @@ package io.embrace.android.embracesdk.internal.capture.metadata
  * Reported difference / drift between our internal clock and the system auxiliary clocks (GNSS and Network Time). Positive values
  * indicate that the specified clock is behind our clock, negative values indicate it is ahead.
  */
-data class ClockDrift(
+class ClockDrift private constructor(
     val networkDriftMillis: Long?,
     val gnssDriftMillis: Long?,
 ) {
-    constructor(wallTimeMillis: Long, networkTimeMillis: Long?, gnssTimeMillis: Long?) : this(
-        networkDriftMillis = networkTimeMillis?.let { wallTimeMillis - it },
-        gnssDriftMillis = gnssTimeMillis?.let { wallTimeMillis - it },
-    )
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ClockDrift
+
+        if (networkDriftMillis != other.networkDriftMillis) return false
+        if (gnssDriftMillis != other.gnssDriftMillis) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = networkDriftMillis?.hashCode() ?: 0
+        result = 31 * result + (gnssDriftMillis?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String {
+        return "ClockDrift(networkDriftMillis=$networkDriftMillis, gnssDriftMillis=$gnssDriftMillis)"
+    }
+
+    companion object {
+        fun fromWallDrift(wallTimeMillis: Long, networkTimeMillis: Long?, gnssTimeMillis: Long?) =
+            ClockDrift(
+                networkDriftMillis = networkTimeMillis?.let { wallTimeMillis - it },
+                gnssDriftMillis = gnssTimeMillis?.let { wallTimeMillis - it },
+            )
+    }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/ClockDrift.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/ClockDrift.kt
@@ -4,37 +4,16 @@ package io.embrace.android.embracesdk.internal.capture.metadata
  * Reported difference / drift between our internal clock and the system auxiliary clocks (GNSS and Network Time). Positive values
  * indicate that the specified clock is behind our clock, negative values indicate it is ahead.
  */
-class ClockDrift private constructor(
+data class ClockDrift(
     val networkDriftMillis: Long?,
     val gnssDriftMillis: Long?,
 ) {
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as ClockDrift
-
-        if (networkDriftMillis != other.networkDriftMillis) return false
-        if (gnssDriftMillis != other.gnssDriftMillis) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = networkDriftMillis?.hashCode() ?: 0
-        result = 31 * result + (gnssDriftMillis?.hashCode() ?: 0)
-        return result
-    }
-
-    override fun toString(): String {
-        return "ClockDrift(networkDriftMillis=$networkDriftMillis, gnssDriftMillis=$gnssDriftMillis)"
-    }
-
     companion object {
-        fun fromWallDrift(wallTimeMillis: Long, networkTimeMillis: Long?, gnssTimeMillis: Long?) =
-            ClockDrift(
-                networkDriftMillis = networkTimeMillis?.let { wallTimeMillis - it },
-                gnssDriftMillis = gnssTimeMillis?.let { wallTimeMillis - it },
-            )
+        /**
+         * Computes the drift between the wall clock and an auxiliary clock, both expressed in milliseconds since the epoch.
+         * Positive return values indicate the auxiliary clock is behind the wall clock; negative values indicate it is ahead.
+         */
+        @JvmStatic
+        fun calculateDrift(wallTimeMillis: Long, auxTimeMillis: Long): Long = wallTimeMillis - auxTimeMillis
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/ClockDrift.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/ClockDrift.kt
@@ -13,7 +13,6 @@ data class ClockDrift(
          * Computes the drift between the wall clock and an auxiliary clock, both expressed in milliseconds since the epoch.
          * Positive return values indicate the auxiliary clock is behind the wall clock; negative values indicate it is ahead.
          */
-        @JvmStatic
         fun calculateDrift(wallTimeMillis: Long, auxTimeMillis: Long): Long = wallTimeMillis - auxTimeMillis
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/ClockDrift.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/ClockDrift.kt
@@ -1,0 +1,15 @@
+package io.embrace.android.embracesdk.internal.capture.metadata
+
+/**
+ * Reported difference / drift between our internal clock and the system auxiliary clocks (GNSS and Network Time). Positive values
+ * indicate that the specified clock is behind our clock, negative values indicate it is ahead.
+ */
+data class ClockDrift(
+    val networkDriftMillis: Long?,
+    val gnssDriftMillis: Long?,
+) {
+    constructor(wallTimeMillis: Long, networkTimeMillis: Long?, gnssTimeMillis: Long?) : this(
+        networkDriftMillis = networkTimeMillis?.let { wallTimeMillis - it },
+        gnssDriftMillis = gnssTimeMillis?.let { wallTimeMillis - it },
+    )
+}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
@@ -7,8 +7,10 @@ import android.os.Build
 import android.os.Environment
 import android.os.Process
 import android.os.StatFs
+import android.os.SystemClock
 import android.os.storage.StorageManager
 import androidx.annotation.RequiresApi
+import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.envelope.resource.EnvelopeResourceSource
 import io.embrace.android.embracesdk.internal.store.KeyValueStore
@@ -24,6 +26,7 @@ internal class EmbraceMetadataService(
     private val storageStatsManager: Lazy<StorageStatsManager?>,
     private val configService: ConfigService,
     private val store: KeyValueStore,
+    private val clock: Clock,
     private val metadataBackgroundWorker: BackgroundWorker,
 ) : MetadataService {
 
@@ -89,6 +92,32 @@ internal class EmbraceMetadataService(
     }
 
     override fun getDiskUsage(): DiskUsage? = diskUsage
+
+    override fun getClockDrift(): ClockDrift? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            return null
+        }
+
+        val wallTime = clock.now()
+
+        val gnssTime = runCatching { SystemClock.currentGnssTimeClock().millis() }.getOrNull()
+        val networkTime =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                runCatching { SystemClock.currentNetworkTimeClock().millis() }.getOrNull()
+            } else {
+                null
+            }
+
+        if (gnssTime == null && networkTime == null) {
+            return null
+        }
+
+        return ClockDrift(
+            wallTimeMillis = wallTime,
+            networkTimeMillis = networkTime,
+            gnssTimeMillis = gnssTime,
+        )
+    }
 
     private companion object {
         const val PREVIOUS_APP_VERSION_KEY = "io.embrace.lastappversion"

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
@@ -112,7 +112,7 @@ internal class EmbraceMetadataService(
             return null
         }
 
-        return ClockDrift(
+        return ClockDrift.fromWallDrift(
             wallTimeMillis = wallTime,
             networkTimeMillis = networkTime,
             gnssTimeMillis = gnssTime,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
@@ -37,6 +37,9 @@ internal class EmbraceMetadataService(
     @Volatile
     private var diskUsage: DiskUsage? = null
 
+    @Volatile
+    private var clockDrift: ClockDrift? = null
+
     private var appVersion: String?
         get() = store.getString(PREVIOUS_APP_VERSION_KEY)
         set(value) = store.edit { putString(PREVIOUS_APP_VERSION_KEY, value) }
@@ -66,6 +69,7 @@ internal class EmbraceMetadataService(
             if (diskUsage == null) {
                 diskUsage = DiskUsage(null, free)
             }
+            clockDrift = computeClockDrift()
         }
     }
 
@@ -93,7 +97,9 @@ internal class EmbraceMetadataService(
 
     override fun getDiskUsage(): DiskUsage? = diskUsage
 
-    override fun getClockDrift(): ClockDrift? {
+    override fun getClockDrift(): ClockDrift? = clockDrift
+
+    private fun computeClockDrift(): ClockDrift? {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
             return null
         }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
@@ -98,25 +98,26 @@ internal class EmbraceMetadataService(
             return null
         }
 
-        val wallTime = clock.now()
+        val gnssDrift = runCatching {
+            val gnss = SystemClock.currentGnssTimeClock().millis()
+            ClockDrift.calculateDrift(wallTimeMillis = clock.now(), auxTimeMillis = gnss)
+        }.getOrNull()
 
-        val gnssTime = runCatching { SystemClock.currentGnssTimeClock().millis() }.getOrNull()
-        val networkTime =
+        val networkDrift =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                runCatching { SystemClock.currentNetworkTimeClock().millis() }.getOrNull()
+                runCatching {
+                    val network = SystemClock.currentNetworkTimeClock().millis()
+                    ClockDrift.calculateDrift(wallTimeMillis = clock.now(), auxTimeMillis = network)
+                }.getOrNull()
             } else {
                 null
             }
 
-        if (gnssTime == null && networkTime == null) {
+        if (gnssDrift == null && networkDrift == null) {
             return null
         }
 
-        return ClockDrift.fromWallDrift(
-            wallTimeMillis = wallTime,
-            networkTimeMillis = networkTime,
-            gnssTimeMillis = gnssTime,
-        )
+        return ClockDrift(networkDriftMillis = networkDrift, gnssDriftMillis = gnssDrift)
     }
 
     private companion object {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/MetadataService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/MetadataService.kt
@@ -9,6 +9,14 @@ interface MetadataService {
     fun getDiskUsage(): DiskUsage?
 
     /**
+     * Gets the current device's time drift relative to its auxiliary clocks if available. This value is read live and does not
+     * depend on [precomputeValues].
+     *
+     * @return the device's time drift relative to its auxiliary clocks
+     */
+    fun getClockDrift(): ClockDrift?
+
+    /**
      * Queues in a single thread executor callables to retrieve values in background
      */
     fun precomputeValues()

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/MetadataService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/MetadataService.kt
@@ -9,8 +9,9 @@ interface MetadataService {
     fun getDiskUsage(): DiskUsage?
 
     /**
-     * Gets the current device's time drift relative to its auxiliary clocks if available. This value is read live and does not
-     * depend on [precomputeValues].
+     * Gets the device's time drift relative to its auxiliary clocks if available. The value is sampled during [precomputeValues] so
+     * that the underlying IPC stays off any consumer's critical path; this method returns `null` until that work completes, and
+     * `null` thereafter if neither auxiliary clock could be read.
      *
      * @return the device's time drift relative to its auxiliary clocks
      */

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
@@ -145,6 +145,7 @@ class PayloadSourceModuleImpl(
                 lazy { storageManager },
                 configService,
                 coreModule.store,
+                initModule.clock,
                 workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker)
             )
         }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImpl.kt
@@ -55,10 +55,10 @@ internal class SessionPartSpanAttrPopulatorImpl(
 
             metadataService.getClockDrift()?.let { drift ->
                 drift.networkDriftMillis?.let {
-                    addSessionPartAttribute(EmbSessionAttributes.EMB_CLOCK_NETWORK_DRIFT_MILLIS, it.toString())
+                    addSessionPartAttribute(EmbSessionAttributes.EMB_CLOCK_NETWORK_DRIFT, it.toString())
                 }
                 drift.gnssDriftMillis?.let {
-                    addSessionPartAttribute(EmbSessionAttributes.EMB_CLOCK_GNSS_DRIFT_MILLIS, it.toString())
+                    addSessionPartAttribute(EmbSessionAttributes.EMB_CLOCK_GNSS_DRIFT, it.toString())
                 }
             }
         }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImpl.kt
@@ -52,6 +52,15 @@ internal class SessionPartSpanAttrPopulatorImpl(
             metadataService.getDiskUsage()?.deviceDiskFree?.let { free ->
                 addSessionPartAttribute(EmbSessionAttributes.EMB_DISK_FREE_BYTES, free.toString())
             }
+
+            metadataService.getClockDrift()?.let { drift ->
+                drift.networkDriftMillis?.let {
+                    addSessionPartAttribute(EmbSessionAttributes.EMB_CLOCK_NETWORK_DRIFT_MILLIS, it.toString())
+                }
+                drift.gnssDriftMillis?.let {
+                    addSessionPartAttribute(EmbSessionAttributes.EMB_CLOCK_GNSS_DRIFT_MILLIS, it.toString())
+                }
+            }
         }
     }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/ClockDriftTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/ClockDriftTest.kt
@@ -1,80 +1,22 @@
 package io.embrace.android.embracesdk.internal.capture.metadata
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class ClockDriftTest {
 
     @Test
-    fun `both drifts are null when network and gnss times are null`() {
-        val drift = ClockDrift.fromWallDrift(
-            wallTimeMillis = 1_000L,
-            networkTimeMillis = null,
-            gnssTimeMillis = null,
-        )
-
-        assertNull(drift.networkDriftMillis)
-        assertNull(drift.gnssDriftMillis)
+    fun `calculateDrift returns a positive value when the aux clock is behind the wall clock`() {
+        assertEquals(100L, ClockDrift.calculateDrift(wallTimeMillis = 1_000L, auxTimeMillis = 900L))
     }
 
     @Test
-    fun `positive drift when aux clock is behind wall clock`() {
-        val drift = ClockDrift.fromWallDrift(
-            wallTimeMillis = 1_000L,
-            networkTimeMillis = 900L,
-            gnssTimeMillis = 800L,
-        )
-
-        assertEquals(100L, drift.networkDriftMillis)
-        assertEquals(200L, drift.gnssDriftMillis)
+    fun `calculateDrift returns a negative value when the aux clock is ahead of the wall clock`() {
+        assertEquals(-250L, ClockDrift.calculateDrift(wallTimeMillis = 1_000L, auxTimeMillis = 1_250L))
     }
 
     @Test
-    fun `negative drift when aux clock is ahead of wall clock`() {
-        val drift = ClockDrift.fromWallDrift(
-            wallTimeMillis = 1_000L,
-            networkTimeMillis = 1_100L,
-            gnssTimeMillis = 1_300L,
-        )
-
-        assertEquals(-100L, drift.networkDriftMillis)
-        assertEquals(-300L, drift.gnssDriftMillis)
-    }
-
-    @Test
-    fun `zero drift when aux clock matches wall clock`() {
-        val drift = ClockDrift.fromWallDrift(
-            wallTimeMillis = 1_000L,
-            networkTimeMillis = 1_000L,
-            gnssTimeMillis = 1_000L,
-        )
-
-        assertEquals(0L, drift.networkDriftMillis)
-        assertEquals(0L, drift.gnssDriftMillis)
-    }
-
-    @Test
-    fun `network drift is computed when gnss is null`() {
-        val drift = ClockDrift.fromWallDrift(
-            wallTimeMillis = 1_000L,
-            networkTimeMillis = 950L,
-            gnssTimeMillis = null,
-        )
-
-        assertEquals(50L, drift.networkDriftMillis)
-        assertNull(drift.gnssDriftMillis)
-    }
-
-    @Test
-    fun `gnss drift is computed when network is null`() {
-        val drift = ClockDrift.fromWallDrift(
-            wallTimeMillis = 1_000L,
-            networkTimeMillis = null,
-            gnssTimeMillis = 1_050L,
-        )
-
-        assertNull(drift.networkDriftMillis)
-        assertEquals(-50L, drift.gnssDriftMillis)
+    fun `calculateDrift returns zero when the aux clock matches the wall clock`() {
+        assertEquals(0L, ClockDrift.calculateDrift(wallTimeMillis = 1_000L, auxTimeMillis = 1_000L))
     }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/ClockDriftTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/ClockDriftTest.kt
@@ -1,0 +1,80 @@
+package io.embrace.android.embracesdk.internal.capture.metadata
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+internal class ClockDriftTest {
+
+    @Test
+    fun `both drifts are null when network and gnss times are null`() {
+        val drift = ClockDrift.fromWallDrift(
+            wallTimeMillis = 1_000L,
+            networkTimeMillis = null,
+            gnssTimeMillis = null,
+        )
+
+        assertNull(drift.networkDriftMillis)
+        assertNull(drift.gnssDriftMillis)
+    }
+
+    @Test
+    fun `positive drift when aux clock is behind wall clock`() {
+        val drift = ClockDrift.fromWallDrift(
+            wallTimeMillis = 1_000L,
+            networkTimeMillis = 900L,
+            gnssTimeMillis = 800L,
+        )
+
+        assertEquals(100L, drift.networkDriftMillis)
+        assertEquals(200L, drift.gnssDriftMillis)
+    }
+
+    @Test
+    fun `negative drift when aux clock is ahead of wall clock`() {
+        val drift = ClockDrift.fromWallDrift(
+            wallTimeMillis = 1_000L,
+            networkTimeMillis = 1_100L,
+            gnssTimeMillis = 1_300L,
+        )
+
+        assertEquals(-100L, drift.networkDriftMillis)
+        assertEquals(-300L, drift.gnssDriftMillis)
+    }
+
+    @Test
+    fun `zero drift when aux clock matches wall clock`() {
+        val drift = ClockDrift.fromWallDrift(
+            wallTimeMillis = 1_000L,
+            networkTimeMillis = 1_000L,
+            gnssTimeMillis = 1_000L,
+        )
+
+        assertEquals(0L, drift.networkDriftMillis)
+        assertEquals(0L, drift.gnssDriftMillis)
+    }
+
+    @Test
+    fun `network drift is computed when gnss is null`() {
+        val drift = ClockDrift.fromWallDrift(
+            wallTimeMillis = 1_000L,
+            networkTimeMillis = 950L,
+            gnssTimeMillis = null,
+        )
+
+        assertEquals(50L, drift.networkDriftMillis)
+        assertNull(drift.gnssDriftMillis)
+    }
+
+    @Test
+    fun `gnss drift is computed when network is null`() {
+        val drift = ClockDrift.fromWallDrift(
+            wallTimeMillis = 1_000L,
+            networkTimeMillis = null,
+            gnssTimeMillis = 1_050L,
+        )
+
+        assertNull(drift.networkDriftMillis)
+        assertEquals(-50L, drift.gnssDriftMillis)
+    }
+}

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataServiceClockDriftTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataServiceClockDriftTest.kt
@@ -1,0 +1,132 @@
+package io.embrace.android.embracesdk.internal.capture.metadata
+
+import android.app.Application
+import android.app.usage.StorageStatsManager
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
+import io.embrace.android.embracesdk.fakes.FakeKeyValueStore
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
+import io.embrace.android.embracesdk.internal.capture.metadata.shadows.EmbraceShadowSystemClock
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+@RunWith(AndroidJUnit4::class)
+@Config(shadows = [EmbraceShadowSystemClock::class])
+internal class EmbraceMetadataServiceClockDriftTest {
+
+    private val wallTimeMillis = FakeClock.DEFAULT_FAKE_CURRENT_TIME
+    private lateinit var service: EmbraceMetadataService
+
+    @Before
+    fun setUp() {
+        EmbraceShadowSystemClock.reset()
+        service = EmbraceMetadataService(
+            resourceSource = lazy { FakeEnvelopeResourceSource() },
+            context = ApplicationProvider.getApplicationContext<Application>(),
+            storageStatsManager = lazy<StorageStatsManager?> { null },
+            configService = FakeConfigService(),
+            store = FakeKeyValueStore(),
+            clock = FakeClock(currentTime = wallTimeMillis),
+            metadataBackgroundWorker = fakeBackgroundWorker(),
+        )
+    }
+
+    @After
+    fun tearDown() {
+        EmbraceShadowSystemClock.reset()
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.P])
+    @Test
+    fun `getClockDrift returns null below Q regardless of clock availability`() {
+        EmbraceShadowSystemClock.gnssClock = fixedClock(wallTimeMillis - 50)
+        EmbraceShadowSystemClock.networkClock = fixedClock(wallTimeMillis - 100)
+
+        assertNull(service.getClockDrift())
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.Q])
+    @Test
+    fun `getClockDrift on Q returns GNSS drift and null network drift`() {
+        EmbraceShadowSystemClock.gnssClock = fixedClock(wallTimeMillis - 50)
+        EmbraceShadowSystemClock.networkClock = fixedClock(wallTimeMillis - 100)
+
+        val drift = service.getClockDrift()
+
+        assertEquals(50L, drift?.gnssDriftMillis)
+        assertNull(drift?.networkDriftMillis)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.Q])
+    @Test
+    fun `getClockDrift on Q returns null when GNSS clock is unavailable`() {
+        assertNull(service.getClockDrift())
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.S])
+    @Test
+    fun `getClockDrift between Q and TIRAMISU does not query network clock`() {
+        EmbraceShadowSystemClock.gnssClock = fixedClock(wallTimeMillis - 25)
+        EmbraceShadowSystemClock.networkClock = fixedClock(wallTimeMillis - 100)
+
+        val drift = service.getClockDrift()
+
+        assertEquals(25L, drift?.gnssDriftMillis)
+        assertNull(drift?.networkDriftMillis)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @Test
+    fun `getClockDrift on TIRAMISU returns both drifts when both clocks are available`() {
+        EmbraceShadowSystemClock.gnssClock = fixedClock(wallTimeMillis - 50)
+        EmbraceShadowSystemClock.networkClock = fixedClock(wallTimeMillis - 100)
+
+        val drift = service.getClockDrift()
+
+        assertEquals(50L, drift?.gnssDriftMillis)
+        assertEquals(100L, drift?.networkDriftMillis)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @Test
+    fun `getClockDrift on TIRAMISU returns only network drift when GNSS is unavailable`() {
+        EmbraceShadowSystemClock.networkClock = fixedClock(wallTimeMillis - 100)
+
+        val drift = service.getClockDrift()
+
+        assertNull(drift?.gnssDriftMillis)
+        assertEquals(100L, drift?.networkDriftMillis)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @Test
+    fun `getClockDrift on TIRAMISU returns only GNSS drift when network is unavailable`() {
+        EmbraceShadowSystemClock.gnssClock = fixedClock(wallTimeMillis - 50)
+
+        val drift = service.getClockDrift()
+
+        assertEquals(50L, drift?.gnssDriftMillis)
+        assertNull(drift?.networkDriftMillis)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @Test
+    fun `getClockDrift on TIRAMISU returns null when both clocks are unavailable`() {
+        assertNull(service.getClockDrift())
+    }
+
+    private fun fixedClock(epochMillis: Long): Clock =
+        Clock.fixed(Instant.ofEpochMilli(epochMillis), ZoneOffset.UTC)
+}

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataServiceClockDriftTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataServiceClockDriftTest.kt
@@ -54,6 +54,7 @@ internal class EmbraceMetadataServiceClockDriftTest {
         EmbraceShadowSystemClock.gnssClock = fixedClock(wallTimeMillis - 50)
         EmbraceShadowSystemClock.networkClock = fixedClock(wallTimeMillis - 100)
 
+        service.precomputeValues()
         assertNull(service.getClockDrift())
     }
 
@@ -63,6 +64,7 @@ internal class EmbraceMetadataServiceClockDriftTest {
         EmbraceShadowSystemClock.gnssClock = fixedClock(wallTimeMillis - 50)
         EmbraceShadowSystemClock.networkClock = fixedClock(wallTimeMillis - 100)
 
+        service.precomputeValues()
         val drift = service.getClockDrift()
 
         assertEquals(50L, drift?.gnssDriftMillis)
@@ -72,6 +74,7 @@ internal class EmbraceMetadataServiceClockDriftTest {
     @Config(sdk = [Build.VERSION_CODES.Q])
     @Test
     fun `getClockDrift on Q returns null when GNSS clock is unavailable`() {
+        service.precomputeValues()
         assertNull(service.getClockDrift())
     }
 
@@ -81,6 +84,7 @@ internal class EmbraceMetadataServiceClockDriftTest {
         EmbraceShadowSystemClock.gnssClock = fixedClock(wallTimeMillis - 25)
         EmbraceShadowSystemClock.networkClock = fixedClock(wallTimeMillis - 100)
 
+        service.precomputeValues()
         val drift = service.getClockDrift()
 
         assertEquals(25L, drift?.gnssDriftMillis)
@@ -93,6 +97,7 @@ internal class EmbraceMetadataServiceClockDriftTest {
         EmbraceShadowSystemClock.gnssClock = fixedClock(wallTimeMillis - 50)
         EmbraceShadowSystemClock.networkClock = fixedClock(wallTimeMillis - 100)
 
+        service.precomputeValues()
         val drift = service.getClockDrift()
 
         assertEquals(50L, drift?.gnssDriftMillis)
@@ -104,6 +109,7 @@ internal class EmbraceMetadataServiceClockDriftTest {
     fun `getClockDrift on TIRAMISU returns only network drift when GNSS is unavailable`() {
         EmbraceShadowSystemClock.networkClock = fixedClock(wallTimeMillis - 100)
 
+        service.precomputeValues()
         val drift = service.getClockDrift()
 
         assertNull(drift?.gnssDriftMillis)
@@ -115,6 +121,7 @@ internal class EmbraceMetadataServiceClockDriftTest {
     fun `getClockDrift on TIRAMISU returns only GNSS drift when network is unavailable`() {
         EmbraceShadowSystemClock.gnssClock = fixedClock(wallTimeMillis - 50)
 
+        service.precomputeValues()
         val drift = service.getClockDrift()
 
         assertEquals(50L, drift?.gnssDriftMillis)
@@ -124,6 +131,7 @@ internal class EmbraceMetadataServiceClockDriftTest {
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     @Test
     fun `getClockDrift on TIRAMISU returns null when both clocks are unavailable`() {
+        service.precomputeValues()
         assertNull(service.getClockDrift())
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/shadows/EmbraceShadowSystemClock.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/shadows/EmbraceShadowSystemClock.kt
@@ -1,0 +1,41 @@
+package io.embrace.android.embracesdk.internal.capture.metadata.shadows
+
+import android.os.SystemClock
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+import java.time.Clock
+import java.time.DateTimeException
+
+/**
+ * Robolectric shadow that allows tests to control the values returned by
+ * [SystemClock.currentGnssTimeClock] and [SystemClock.currentNetworkTimeClock].
+ *
+ * Setting [gnssClock] or [networkClock] to `null` causes the corresponding shadowed method to throw
+ * [DateTimeException], matching the real Android behaviour when no fix / network time is available.
+ */
+@Implements(SystemClock::class)
+@Suppress("UtilityClassWithPublicConstructor")
+class EmbraceShadowSystemClock {
+    companion object {
+        @JvmStatic
+        var gnssClock: Clock? = null
+
+        @JvmStatic
+        var networkClock: Clock? = null
+
+        @Implementation
+        @JvmStatic
+        fun currentGnssTimeClock(): Clock =
+            gnssClock ?: throw DateTimeException("GNSS based time is not available")
+
+        @Implementation
+        @JvmStatic
+        fun currentNetworkTimeClock(): Clock =
+            networkClock ?: throw DateTimeException("Network based time is not available")
+
+        fun reset() {
+            gnssClock = null
+            networkClock = null
+        }
+    }
+}

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
@@ -87,8 +87,8 @@ internal class SessionPartSpanAttrPopulatorImplTest {
             EmbSessionAttributes.EMB_SESSION_END_TYPE to "state",
             EmbSessionAttributes.EMB_ERROR_LOG_COUNT to "0",
             EmbSessionAttributes.EMB_DISK_FREE_BYTES to "500000000",
-            EmbSessionAttributes.EMB_CLOCK_NETWORK_DRIFT_MILLIS to "50",
-            EmbSessionAttributes.EMB_CLOCK_GNSS_DRIFT_MILLIS to "10",
+            EmbSessionAttributes.EMB_CLOCK_NETWORK_DRIFT to "50",
+            EmbSessionAttributes.EMB_CLOCK_GNSS_DRIFT to "10",
         )
         assertEquals(expected, attrs)
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.session.orchestrator
 
+import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeLogLimitingService
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakeTelemetryDestination
@@ -59,6 +60,35 @@ internal class SessionPartSpanAttrPopulatorImplTest {
             EmbSessionAttributes.EMB_SESSION_END_TYPE to "state",
             EmbSessionAttributes.EMB_ERROR_LOG_COUNT to "0",
             EmbSessionAttributes.EMB_DISK_FREE_BYTES to "500000000"
+        )
+        assertEquals(expected, attrs)
+    }
+
+    @Test
+    fun `clock drift attributes populated when aux clocks available`() {
+        populator = SessionPartSpanAttrPopulatorImpl(
+            destination,
+            { 0 },
+            FakeLogLimitingService(),
+            FakeMetadataService(
+                wallClock = FakeClock(1000L),
+                networkClock = FakeClock(950L),
+                gnssClock = FakeClock(990L),
+            ),
+        )
+
+        populator.populateSessionSpanEndAttrs(LifeEventType.STATE, "crashId", false)
+
+        val attrs = destination.attributes
+        val expected = mapOf(
+            EmbSessionAttributes.EMB_CLEAN_EXIT to "true",
+            EmbSessionAttributes.EMB_TERMINATED to "false",
+            EmbSessionAttributes.EMB_CRASH_ID to "crashId",
+            EmbSessionAttributes.EMB_SESSION_END_TYPE to "state",
+            EmbSessionAttributes.EMB_ERROR_LOG_COUNT to "0",
+            EmbSessionAttributes.EMB_DISK_FREE_BYTES to "500000000",
+            EmbSessionAttributes.EMB_CLOCK_NETWORK_DRIFT_MILLIS to "50",
+            EmbSessionAttributes.EMB_CLOCK_GNSS_DRIFT_MILLIS to "10",
         )
         assertEquals(expected, attrs)
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
@@ -66,15 +66,17 @@ internal class SessionPartSpanAttrPopulatorImplTest {
 
     @Test
     fun `clock drift attributes populated when aux clocks available`() {
+        val metadataService = FakeMetadataService(
+            wallClock = FakeClock(1000L),
+            networkClock = FakeClock(950L),
+            gnssClock = FakeClock(990L),
+        ).apply { precomputeValues() }
+
         populator = SessionPartSpanAttrPopulatorImpl(
             destination,
             { 0 },
             FakeLogLimitingService(),
-            FakeMetadataService(
-                wallClock = FakeClock(1000L),
-                networkClock = FakeClock(950L),
-                gnssClock = FakeClock(990L),
-            ),
+            metadataService,
         )
 
         populator.populateSessionSpanEndAttrs(LifeEventType.STATE, "crashId", false)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionApiTest.kt
@@ -105,8 +105,8 @@ internal class UserSessionApiTest {
             EmbTelemetryAttributes.EMB_IS_EMULATOR,
             EmbTelemetryAttributes.EMB_OKHTTP3_ON_CLASSPATH,
             EmbSessionAttributes.EMB_HEARTBEAT_TIME_UNIX_NANO,
-            EmbSessionAttributes.EMB_CLOCK_GNSS_DRIFT_MILLIS,
-            EmbSessionAttributes.EMB_CLOCK_NETWORK_DRIFT_MILLIS,
+            EmbSessionAttributes.EMB_CLOCK_GNSS_DRIFT,
+            EmbSessionAttributes.EMB_CLOCK_NETWORK_DRIFT,
         )
 
         // Attributes that are unstable that we should not try to verify

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionApiTest.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -65,7 +66,7 @@ internal class UserSessionApiTest {
                 val attrs = checkNotNull(sessionSpan.attributes)
                 val attributeKeys = attrs.map { it.key }
                 validateExistenceOnly.forEach { key ->
-                    attributeKeys.contains(key)
+                    assertTrue("'$key' not found in attrs", attributeKeys.contains(key))
                 }
 
                 val attributesToCheck = attrs.filterNot {
@@ -104,6 +105,8 @@ internal class UserSessionApiTest {
             EmbTelemetryAttributes.EMB_IS_EMULATOR,
             EmbTelemetryAttributes.EMB_OKHTTP3_ON_CLASSPATH,
             EmbSessionAttributes.EMB_HEARTBEAT_TIME_UNIX_NANO,
+            EmbSessionAttributes.EMB_CLOCK_GNSS_DRIFT_MILLIS,
+            EmbSessionAttributes.EMB_CLOCK_NETWORK_DRIFT_MILLIS,
         )
 
         // Attributes that are unstable that we should not try to verify

--- a/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSessionAttributes.kt
+++ b/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSessionAttributes.kt
@@ -17,16 +17,16 @@ object EmbSessionAttributes {
     const val EMB_CLEAN_EXIT: String = "emb.clean_exit"
 
     /**
-     * The time delta between wall-time and the GNSS reported time in milliseconds (Wall Time - GNSS Time)
+     * Drift in milliseconds. Positive = GNSS clock behind wall clock. (Wall Time - GNSS Time)
      */
     @ExperimentalSemconv
-    const val EMB_CLOCK_GNSS_DRIFT_MILLIS: String = "emb.clock_gnss_drift_millis"
+    const val EMB_CLOCK_GNSS_DRIFT: String = "emb.clock_gnss_drift"
 
     /**
-     * The time delta between wall-time and the network reported time in milliseconds (Wall Time - Network Time)
+     * Drift in milliseconds. Positive = network clock behind wall clock. (Wall Time - Network Time)
      */
     @ExperimentalSemconv
-    const val EMB_CLOCK_NETWORK_DRIFT_MILLIS: String = "emb.clock_network_drift_millis"
+    const val EMB_CLOCK_NETWORK_DRIFT: String = "emb.clock_network_drift"
 
     /**
      * Whether the session is a cold start.

--- a/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSessionAttributes.kt
+++ b/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSessionAttributes.kt
@@ -17,6 +17,18 @@ object EmbSessionAttributes {
     const val EMB_CLEAN_EXIT: String = "emb.clean_exit"
 
     /**
+     * The time delta between wall-time and the GNSS reported time in milliseconds (Wall Time - GNSS Time)
+     */
+    @ExperimentalSemconv
+    const val EMB_CLOCK_GNSS_DRIFT_MILLIS: String = "emb.clock_gnss_drift_millis"
+
+    /**
+     * The time delta between wall-time and the network reported time in milliseconds (Wall Time - Network Time)
+     */
+    @ExperimentalSemconv
+    const val EMB_CLOCK_NETWORK_DRIFT_MILLIS: String = "emb.clock_network_drift_millis"
+
+    /**
      * Whether the session is a cold start.
      */
     @ExperimentalSemconv

--- a/embrace-android-semconv/src/main/semconv/embrace_android.yaml
+++ b/embrace-android-semconv/src/main/semconv/embrace_android.yaml
@@ -506,6 +506,16 @@ groups:
         brief: "The inactivity timeout (in seconds) that the SDK was configured to use."
         stability: development
         examples: ["300", "1800"]
+      - id: emb.clock_network_drift_millis
+        type: string
+        brief: "The time delta between wall-time and the network reported time in milliseconds (Wall Time - Network Time)"
+        stability: development
+        examples: ["123", "-321"]
+      - id: emb.clock_gnss_drift_millis
+        type: string
+        brief: "The time delta between wall-time and the GNSS reported time in milliseconds (Wall Time - GNSS Time)"
+        stability: development
+        examples: ["987", "-789"]
 
   - id: emb.android
     type: attribute_group

--- a/embrace-android-semconv/src/main/semconv/embrace_android.yaml
+++ b/embrace-android-semconv/src/main/semconv/embrace_android.yaml
@@ -506,14 +506,14 @@ groups:
         brief: "The inactivity timeout (in seconds) that the SDK was configured to use."
         stability: development
         examples: ["300", "1800"]
-      - id: emb.clock_network_drift_millis
+      - id: emb.clock_network_drift
         type: string
-        brief: "The time delta between wall-time and the network reported time in milliseconds (Wall Time - Network Time)"
+        brief: "Drift in milliseconds. Positive = network clock behind wall clock. (Wall Time - Network Time)"
         stability: development
         examples: ["123", "-321"]
-      - id: emb.clock_gnss_drift_millis
+      - id: emb.clock_gnss_drift
         type: string
-        brief: "The time delta between wall-time and the GNSS reported time in milliseconds (Wall Time - GNSS Time)"
+        brief: "Drift in milliseconds. Positive = GNSS clock behind wall clock. (Wall Time - GNSS Time)"
         stability: development
         examples: ["987", "-789"]
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
@@ -1,13 +1,20 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.internal.capture.metadata.ClockDrift
 import io.embrace.android.embracesdk.internal.capture.metadata.DiskUsage
 import io.embrace.android.embracesdk.internal.capture.metadata.MetadataService
+import io.embrace.android.embracesdk.internal.clock.Clock
 
 /**
  * Fake implementation of [MetadataService] that represents an Android device. A [UnsupportedOperationException] will be thrown
  * if you attempt set info about Flutter/Unity/ReactNative on this fake, which is decided for an Android device.
  */
-class FakeMetadataService(sessionId: String? = null) : MetadataService {
+class FakeMetadataService(
+    sessionId: String? = null,
+    private val wallClock: Clock = FakeClock(),
+    private val networkClock: Clock? = null,
+    private val gnssClock: Clock? = null,
+) : MetadataService {
     private companion object {
         private val diskUsage = DiskUsage(
             appDiskUsage = 10000000L,
@@ -22,6 +29,18 @@ class FakeMetadataService(sessionId: String? = null) : MetadataService {
     }
 
     override fun getDiskUsage(): DiskUsage = diskUsage
+
+    override fun getClockDrift(): ClockDrift? {
+        if (networkClock == null && gnssClock == null) {
+            return null
+        }
+
+        return ClockDrift(
+            wallTimeMillis = wallClock.now(),
+            networkTimeMillis = networkClock?.now(),
+            gnssTimeMillis = gnssClock?.now(),
+        )
+    }
 
     override fun precomputeValues() {}
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
@@ -24,21 +24,25 @@ class FakeMetadataService(
 
     private var appSessionId: String? = null
 
+    @Volatile
+    private var clockDrift: ClockDrift? = null
+
     init {
         appSessionId = sessionId
     }
 
     override fun getDiskUsage(): DiskUsage = diskUsage
 
-    override fun getClockDrift(): ClockDrift? {
+    override fun getClockDrift(): ClockDrift? = clockDrift
+
+    override fun precomputeValues() {
         val wall = wallClock.now()
         val gnssDrift = gnssClock?.let { ClockDrift.calculateDrift(wall, it.now()) }
         val networkDrift = networkClock?.let { ClockDrift.calculateDrift(wall, it.now()) }
-        if (gnssDrift == null && networkDrift == null) {
-            return null
+        clockDrift = if (gnssDrift == null && networkDrift == null) {
+            null
+        } else {
+            ClockDrift(networkDriftMillis = networkDrift, gnssDriftMillis = gnssDrift)
         }
-        return ClockDrift(networkDriftMillis = networkDrift, gnssDriftMillis = gnssDrift)
     }
-
-    override fun precomputeValues() {}
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
@@ -35,7 +35,7 @@ class FakeMetadataService(
             return null
         }
 
-        return ClockDrift(
+        return ClockDrift.fromWallDrift(
             wallTimeMillis = wallClock.now(),
             networkTimeMillis = networkClock?.now(),
             gnssTimeMillis = gnssClock?.now(),

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
@@ -31,15 +31,13 @@ class FakeMetadataService(
     override fun getDiskUsage(): DiskUsage = diskUsage
 
     override fun getClockDrift(): ClockDrift? {
-        if (networkClock == null && gnssClock == null) {
+        val wall = wallClock.now()
+        val gnssDrift = gnssClock?.let { ClockDrift.calculateDrift(wall, it.now()) }
+        val networkDrift = networkClock?.let { ClockDrift.calculateDrift(wall, it.now()) }
+        if (gnssDrift == null && networkDrift == null) {
             return null
         }
-
-        return ClockDrift.fromWallDrift(
-            wallTimeMillis = wallClock.now(),
-            networkTimeMillis = networkClock?.now(),
-            gnssTimeMillis = gnssClock?.now(),
-        )
+        return ClockDrift(networkDriftMillis = networkDrift, gnssDriftMillis = gnssDrift)
     }
 
     override fun precomputeValues() {}


### PR DESCRIPTION
## Goal
Calculate and report the differences between the anchored wall time and GNSS time && Network time (when available). These time deltas are added as attributes to the session span on-end.

## Testing
Added new test cases to cover the new attributes.