### PR TITLE
Stamp state attribute on logs only if active

### DIFF
--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistryTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistryTest.kt
@@ -7,13 +7,19 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeDataSource
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationProvider
+import io.embrace.android.embracesdk.internal.arch.datasource.DataSource
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
+import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
 import io.embrace.android.embracesdk.internal.logging.InternalLoggerImpl
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RuntimeEnvironment
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
 internal class InstrumentationRegistryTest {
@@ -68,5 +74,58 @@ internal class InstrumentationRegistryTest {
         registry.onPostSessionChange()
         assertEquals(1, dataSource.sessionEnds)
         assertEquals(1, dataSource.sessionChanges)
+    }
+
+    @Test
+    fun `datasource iteration is threadsafe`() {
+        val iterationStarted = CountDownLatch(1)
+        val continueIteration = CountDownLatch(1)
+        val newDataSource = FakeDataSource(RuntimeEnvironment.getApplication())
+
+        registry.add(
+            DataSourceState(
+                factory = {
+                    BlockingTestDataSource(iterationStarted, continueIteration)
+                }
+            )
+        )
+
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            val iterationDone = executor.submit {
+                registry.onPostSessionChange()
+            }
+            assertTrue(iterationStarted.await(1, TimeUnit.SECONDS))
+            registry.add(DataSourceState({ newDataSource }))
+            continueIteration.countDown()
+            iterationDone.get(1, TimeUnit.SECONDS)
+        } finally {
+            executor.shutdownNow()
+        }
+
+        assertEquals("Datasource added during registry iteration should not be touched", 0, newDataSource.sessionChanges)
+        registry.onPostSessionChange()
+        assertEquals(1, newDataSource.sessionChanges)
+    }
+
+    private class BlockingTestDataSource(
+        private val iterationStarted: CountDownLatch,
+        private val mayContinue: CountDownLatch,
+    ) : DataSource, SessionPartChangeListener {
+        override val instrumentationName: String = "blocking_test_data_source"
+
+        override fun onDataCaptureEnabled() {}
+        override fun onDataCaptureDisabled() {}
+        override fun resetDataCaptureLimits() {}
+        override fun <T> captureTelemetry(
+            inputValidation: () -> Boolean,
+            invalidInputCallback: () -> Unit,
+            action: TelemetryDestination.() -> T?,
+        ): T? = null
+
+        override fun onPostSessionChange() {
+            iterationStarted.countDown()
+            mayContinue.await(1, TimeUnit.SECONDS)
+        }
     }
 }

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistryImpl.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistryImpl.kt
@@ -19,7 +19,7 @@ class InstrumentationRegistryImpl(
     private val dataSourceStates = CopyOnWriteArrayList<DataSourceState<*>>()
 
     override fun onPreSessionEnd() {
-        dataSourceStates.toList()
+        dataSourceStates
             .filter { it.dataSource is SessionPartEndListener }
             .map { it.dataSource as SessionPartEndListener }
             .forEach {
@@ -28,7 +28,7 @@ class InstrumentationRegistryImpl(
     }
 
     override fun onPostSessionChange() {
-        dataSourceStates.toList().forEach {
+        dataSourceStates.forEach {
             it.dataSource?.run {
                 resetDataCaptureLimits()
                 if (this is SessionPartChangeListener) {
@@ -75,10 +75,9 @@ class InstrumentationRegistryImpl(
         val stateAttributes = mutableMapOf<String, Any>()
 
         dataSourceStates
-            .toList()
-            .filter { it.dataSource is StateDataSource<*> }
-            .forEach {
-                val stateDataSource = it.dataSource as StateDataSource<*>
+            .mapTo(ArrayList(dataSourceStates.size)) { it.dataSource }
+            .filterIsInstance<StateDataSource<*>>()
+            .forEach { stateDataSource ->
                 if (stateDataSource.isActive()) {
                     stateAttributes[stateDataSource.stateAttributeKey] = stateDataSource.getCurrentStateValue()
                 }

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistryImpl.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistryImpl.kt
@@ -78,8 +78,9 @@ class InstrumentationRegistryImpl(
             .toList()
             .filter { it.dataSource is StateDataSource<*> }
             .forEach {
-                (it.dataSource as StateDataSource<*>).apply {
-                    stateAttributes[stateAttributeKey] = getCurrentStateValue()
+                val stateDataSource = it.dataSource as StateDataSource<*>
+                if (stateDataSource.isActive()) {
+                    stateAttributes[stateDataSource.stateAttributeKey] = stateDataSource.getCurrentStateValue()
                 }
             }
 

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/StateDataSource.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/StateDataSource.kt
@@ -94,6 +94,11 @@ abstract class StateDataSource<T : Any>(
      */
     fun getCurrentStateValue(): T = currentState.get()
 
+    /**
+     * Returns true if the data source is currently active
+     */
+    fun isActive(): Boolean = stateCaptureActive.get()
+
     @CallSuper
     override fun onDataCaptureEnabled() {
         if (captureStateOnCreation) {

--- a/embrace-android-instrumentation-navigation/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/ScreenDataSourceTest.kt
+++ b/embrace-android-instrumentation-navigation/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/ScreenDataSourceTest.kt
@@ -4,6 +4,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -27,6 +28,7 @@ internal class ScreenDataSourceTest {
     fun `data source not initialized by default`() {
         assertTrue(args.destination.createdStateTokens.isEmpty())
         assertEquals("Uninitialized", dataSource.getCurrentStateValue())
+        assertFalse(dataSource.isActive())
     }
 
     @Test
@@ -35,6 +37,7 @@ internal class ScreenDataSourceTest {
         dataSource.onScreenLoaded("home")
         assertEquals("home", dataSource.getCurrentStateValue())
         assertTrue(args.destination.createdStateTokens.isNotEmpty())
+        assertTrue(dataSource.isActive())
 
         val secondTime = args.clock.tick()
         dataSource.onScreenLoaded("settings")

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/StateFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/StateFeatureTest.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.assertions.assertStateTransition
 import io.embrace.android.embracesdk.assertions.findSpansOfType
 import io.embrace.android.embracesdk.assertions.getLogs
 import io.embrace.android.embracesdk.assertions.hasLinkToEmbraceSpan
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.LazyInitStateDataSource
 import io.embrace.android.embracesdk.fakes.TestStateDataSource
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
@@ -22,11 +23,14 @@ import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttributeValue
 import io.embrace.android.embracesdk.internal.otel.spans.hasEmbraceAttributeValue
 import io.embrace.android.embracesdk.internal.session.getSessionSpan
 import io.embrace.android.embracesdk.internal.session.getStateSpan
+import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.semconv.EmbStateTransitionAttributes
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface.Companion.LIFECYCLE_EVENT_GAP
+import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -38,18 +42,27 @@ internal class StateFeatureTest {
 
     @Rule
     @JvmField
-    val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule()
+    val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
+        EmbraceSetupInterface(
+            workerToFake = Worker.Background.LogMessageWorker,
+        ).apply {
+            getFakedWorkerExecutor().blockingMode = false
+        }
+    }
 
     val stateEnabledRemoteConfig = RemoteConfig(pctStateCaptureEnabledV2 = 100.0f)
     val stateDisabledRemoteConfig = RemoteConfig(pctStateCaptureEnabledV2 = 0.0f)
 
     @Test
     fun `state feature on by default`() {
+        var testDataSourceActive = false
         testRule.runTest(
             testCaseAction = {
+                testDataSourceActive = findDataSource<TestStateDataSource>().isActive()
                 recordSession()
             },
             assertAction = {
+                assertTrue(testDataSourceActive)
                 assertTrue(getSingleSessionEnvelope().findSpansOfType(EmbType.State).isNotEmpty())
             }
         )
@@ -449,16 +462,20 @@ internal class StateFeatureTest {
     @Test
     fun `lazy init state data sources generate state span at time of first use`() {
         var initTime = 0L
+        var lazyInitDataSourceActivePreInit = false
         testRule.runTest(
             testCaseAction = {
                 recordSession()
                 recordSession {
                     clock.tick()
                     initTime = clock.now()
-                    findDataSource<LazyInitStateDataSource>().onStateChange("initialized", initTime)
+                    val lazyDataSource = findDataSource<LazyInitStateDataSource>()
+                    lazyInitDataSourceActivePreInit = lazyDataSource.isActive()
+                    lazyDataSource.onStateChange("initialized", initTime)
                 }
             },
             assertAction = {
+                assertFalse(lazyInitDataSourceActivePreInit)
                 val sessionParts = getSessionEnvelopes(2)
                 assertNull(sessionParts[0].getStateSpan("emb-state-lazy-init"))
 
@@ -467,6 +484,34 @@ internal class StateFeatureTest {
                     val firstTransition = checkNotNull(events).first()
                     firstTransition.assertStateTransition(initTime, "initialized")
                 }
+            }
+        )
+    }
+
+    @Test
+    fun `lazy init state data source only add attribute to logs after initialization`() {
+        lateinit var logWorkerExecutor: BlockingScheduledExecutorService
+        testRule.runTest(
+            setupAction = {
+                logWorkerExecutor = getFakedWorkerExecutor().apply {
+                    blockingMode = true
+                }
+            },
+            testCaseAction = {
+                recordSession {
+                    embrace.logInfo("before")
+                    clock.tick()
+                    findDataSource<LazyInitStateDataSource>().onStateChange("initialized", clock.now())
+                    embrace.logInfo("after")
+                    clock.tick(2000L)
+                    logWorkerExecutor.runCurrentlyBlocked()
+                }
+            },
+            assertAction = {
+                val logs = getSingleLogEnvelope().getLogs { checkNotNull(it.attributes).hasEmbraceAttribute(EmbType.System.Log) }
+                assertEquals(2, logs.size)
+                assertFalse(checkNotNull(logs[0].attributes).hasEmbraceAttributeKey("emb.state.lazy-init"))
+                assertTrue(checkNotNull(logs[1].attributes).hasEmbraceAttributeValue("emb.state.lazy-init", "initialized"))
             }
         )
     }


### PR DESCRIPTION
For data sources that are not enabled on creation, only add its current value to a log as an attribute if it's active, i.e. a state has been updated once.