### PR TITLE
Improve NDK load time

### DIFF
--- a/embrace-android-instrumentation-crash-ndk/src/main/cpp/CMakeLists.txt
+++ b/embrace-android-instrumentation-crash-ndk/src/main/cpp/CMakeLists.txt
@@ -7,6 +7,8 @@ cmake_minimum_required(VERSION 3.4.1)
 
 set (CMAKE_CXX_STANDARD 17)
 
+add_compile_options(-ffunction-sections -fdata-sections)
+
 # Creates and names a library, sets it as either STATIC
 # or SHARED, and provides the relative paths to its source code.
 # You can define multiple libraries, and CMake builds them for you.
@@ -73,4 +75,13 @@ set_target_properties(embrace-native
 
 add_subdirectory(3rdparty/libunwindstack-ndk/cmake)
 target_link_libraries(embrace-native unwindstack)
+target_link_options(embrace-native PRIVATE "-Wl,--gc-sections")
 target_link_options(embrace-native PRIVATE "-Wl,-z,max-page-size=16384")
+
+# Only export symbols for entry points that must be resolvable by name. In debug builds we export the emb_* symbols for the tests to use.
+if(CMAKE_BUILD_TYPE STREQUAL Debug)
+    set(EMB_VERSION_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/embrace-native-debug.map")
+else()
+    set(EMB_VERSION_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/embrace-native.map")
+endif()
+target_link_options(embrace-native PRIVATE "-Wl,--version-script=${EMB_VERSION_SCRIPT}")

--- a/embrace-android-instrumentation-crash-ndk/src/main/cpp/embrace-native-debug.map
+++ b/embrace-android-instrumentation-crash-ndk/src/main/cpp/embrace-native-debug.map
@@ -1,0 +1,7 @@
+{
+    global:
+        JNI_OnLoad;
+        emb_*;
+    local:
+        *;
+};

--- a/embrace-android-instrumentation-crash-ndk/src/main/cpp/embrace-native.map
+++ b/embrace-android-instrumentation-crash-ndk/src/main/cpp/embrace-native.map
@@ -1,0 +1,7 @@
+{
+    global:
+        JNI_OnLoad;
+        emb_jniIsAttached; # resolved by Embrace Unity (see jni_util.c)
+    local:
+        *;
+};

--- a/embrace-android-instrumentation-crash-ndk/src/main/cpp/jnibridge/emb_ndk_manager.c
+++ b/embrace-android-instrumentation-crash-ndk/src/main/cpp/jnibridge/emb_ndk_manager.c
@@ -29,12 +29,11 @@ static JNIEnv *__emb_jni_env = NULL;
 static emb_env __impl_emb_env = {0};
 static emb_env *__emb_env = &__impl_emb_env;
 
-JNIEXPORT void JNICALL
-Java_io_embrace_android_embracesdk_internal_instrumentation_crash_ndk_jni_JniDelegateImpl_installSignalHandlers(JNIEnv *env,
-                                                                                                                jobject thiz,
-                                                                                                                jstring _crash_marker_path,
-                                                                                                                jstring _report_id,
-                                                                                                                jboolean dev_logging) {
+static void JniDelegateImpl_installSignalHandlers(JNIEnv *env,
+                                                  jobject thiz,
+                                                  jstring _crash_marker_path,
+                                                  jstring _report_id,
+                                                  jboolean dev_logging) {
     if (dev_logging) {
         emb_enable_dev_logging();
     }
@@ -74,19 +73,17 @@ Java_io_embrace_android_embracesdk_internal_instrumentation_crash_ndk_jni_JniDel
     EMB_LOGDEV("Completed signal handler install.");
 }
 
-JNIEXPORT void JNICALL
-Java_io_embrace_android_embracesdk_internal_instrumentation_crash_ndk_jni_JniDelegateImpl_onSessionChange(JNIEnv *env,
-                                                                                                          jobject thiz,
-                                                                                                          jstring _session_id,
-                                                                                                          jstring _report_path) {
+static void JniDelegateImpl_onSessionChange(JNIEnv *env,
+                                            jobject thiz,
+                                            jstring _session_id,
+                                            jstring _report_path) {
     const char *session_id = (*env)->GetStringUTFChars(env, _session_id, 0);
     snprintf(__emb_env->crash.session_id, EMB_SESSION_ID_SIZE, "%s", session_id);
     const char *report_path = (*env)->GetStringUTFChars(env, _report_path, 0);
     snprintf(__emb_env->report_path, EMB_PATH_SIZE, "%s", report_path);
 }
 
-JNIEXPORT jstring JNICALL
-Java_io_embrace_android_embracesdk_internal_instrumentation_crash_ndk_jni_JniDelegateImpl_getCrashReport(
+static jstring JniDelegateImpl_getCrashReport(
         JNIEnv *env, jobject _this, jstring _report_path) {
     EMB_LOGDEV("Called getCrashReport().");
     static pthread_mutex_t crash_reader_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -139,9 +136,7 @@ Java_io_embrace_android_embracesdk_internal_instrumentation_crash_ndk_jni_JniDel
     return payload_str;
 }
 
-JNIEXPORT jstring JNICALL
-Java_io_embrace_android_embracesdk_internal_instrumentation_crash_ndk_jni_JniDelegateImpl_checkForOverwrittenHandlers(JNIEnv *env,
-                                                                                                                      jobject thiz) {
+static jstring JniDelegateImpl_checkForOverwrittenHandlers(JNIEnv *env, jobject thiz) {
     char buffer[WARNING_LOG_BUFFER_SIZE];
     EMB_LOGINFO("Checking for Overwritten handlers");
     if (emb_check_for_overwritten_handlers(buffer, WARNING_LOG_BUFFER_SIZE)) {
@@ -151,9 +146,7 @@ Java_io_embrace_android_embracesdk_internal_instrumentation_crash_ndk_jni_JniDel
     }
 }
 
-JNIEXPORT jboolean JNICALL
-Java_io_embrace_android_embracesdk_internal_instrumentation_crash_ndk_jni_JniDelegateImpl_reinstallSignalHandlers(JNIEnv *env,
-                                                                                                                  jobject thiz) {
+static jboolean JniDelegateImpl_reinstallSignalHandlers(JNIEnv *env, jobject thiz) {
     EMB_LOGINFO("About to reinstall 3rd party handlers");
 
     // install signal handlers
@@ -169,6 +162,25 @@ Java_io_embrace_android_embracesdk_internal_instrumentation_crash_ndk_jni_JniDel
     }
     EMB_LOGDEV("Completed signal handler reinstall.");
     return false;
+}
+
+static const int NATIVE_BRIDGE_METHOD_COUNT = 5;
+
+static const JNINativeMethod JniDelegateImpl_Methods[] = {
+        {"installSignalHandlers", "(Ljava/lang/String;Ljava/lang/String;Z)V", &JniDelegateImpl_installSignalHandlers},
+        {"getCrashReport", "(Ljava/lang/String;)Ljava/lang/String;", &JniDelegateImpl_getCrashReport},
+        {"onSessionChange", "(Ljava/lang/String;Ljava/lang/String;)V", &JniDelegateImpl_onSessionChange},
+        {"checkForOverwrittenHandlers", "()Ljava/lang/String;", &JniDelegateImpl_checkForOverwrittenHandlers},
+        {"reinstallSignalHandlers", "()Z", &JniDelegateImpl_reinstallSignalHandlers},
+};
+
+void EMB_RegisterJniDelegateImpl(JNIEnv *env) {
+    jclass JniDelegateImpl_Class = (*env)->FindClass(env, "io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/jni/JniDelegateImpl");
+    if (!JniDelegateImpl_Class) {
+        return;
+    }
+
+    (*env)->RegisterNatives(env, JniDelegateImpl_Class, JniDelegateImpl_Methods, NATIVE_BRIDGE_METHOD_COUNT);
 }
 
 #pragma clang diagnostic pop

--- a/embrace-android-instrumentation-crash-ndk/src/main/cpp/jnibridge/emb_ndk_manager.h
+++ b/embrace-android-instrumentation-crash-ndk/src/main/cpp/jnibridge/emb_ndk_manager.h
@@ -6,6 +6,7 @@
 #define EMBRACE_NATIVE_CRASHES_EMB_NDK_MANAGER_H
 
 #include "../schema/stack_frames.h"
+#include <jni.h>
 #include <stdbool.h>
 
 #ifdef CLANG_ANALYZE_ASYNCSAFE
@@ -24,5 +25,7 @@ typedef struct {
     bool already_handled_crash;
     emb_crash crash;
 } emb_env;
+
+void EMB_RegisterJniDelegateImpl(JNIEnv *env);
 
 #endif //EMBRACE_NATIVE_CRASHES_EMB_NDK_MANAGER_H

--- a/embrace-android-instrumentation-crash-ndk/src/main/cpp/safejni/jni_util.c
+++ b/embrace-android-instrumentation-crash-ndk/src/main/cpp/safejni/jni_util.c
@@ -1,10 +1,18 @@
 #include "jni_util.h"
+#include "../jnibridge/emb_ndk_manager.h"
 #include <stdbool.h>
 
 JavaVM *emb_JVM;
 
 jint JNI_OnLoad(JavaVM *vm, void *reserved) {
     emb_JVM = vm;
+
+    JNIEnv *env;
+    if ((*vm)->GetEnv(vm, (void **) &env, JNI_VERSION_1_6) != JNI_OK) {
+        return JNI_ERR;
+    }
+    EMB_RegisterJniDelegateImpl(env);
+
     return JNI_VERSION_1_6;
 }
 


### PR DESCRIPTION
## Goal
Reduce the size and loading time of the `embrace-android-instrumentation-crash-ndk` native library.

## Results

- arm64 `libembrace-native.so` reduced to 206.7kb (down from )
- symbol count reduced to 6075 (down from 15223)
- `System.loadLibrary` time reduced, macro-benchmark average of ~14.89 (down from ~26.47ms)
  - Samsung A7 Lite Tablet running Android 14
  - Improvement % is reasonably consistent on flagship devices

These are example histograms of the `install-native-crash-signal-handlers` span captured in a macro-benchmark:

<img width="640" height="480" alt="old_hist" src="https://github.com/user-attachments/assets/ed4221ac-e6e7-4d92-96f9-e0fa1cf6a74f" />
<img width="640" height="480" alt="new_hist" src="https://github.com/user-attachments/assets/fd23d139-b273-4426-80ad-7885fd9afdeb" />

## Testing
Relied largely on existing tests (there is a debug linker version script to retain exported symbols that the connected tests rely on), and macro-benchmarking.