### PR TITLE
Add a binary format fast-path for the RemoteConfig on startup

### DIFF
--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/InstrumentationApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/InstrumentationApi.kt
@@ -99,22 +99,27 @@ public interface InstrumentationApi {
     )
 
     /**
-     * Observe navigation within the given [Activity] that is controlled by the given [navigationController].
-     *
+     * Register the given [navigationController] so that navigation it performs within the given [Activity] is observed.
      * [navigationController] is intentionally typeless so the SDK can introspect about its capabilities and do the required
-     * wiring in order to observe and track navigation
+     * wiring in order to observe and track navigation. Currently, only instance of `androidx.navigation.NavController` is supported.
+     *
+     * This method should be called during the host [Activity]'s `onResume()` callback after the starting destination is loaded.
      */
     public fun observeNavigation(activity: Activity, navigationController: Any)
 
     /**
-     * Record the given [screen] has been loaded. Calling this does not affect automatic navigation tracking instrumentation.
+     * Record that the given [screen] has been loaded.
+     *
+     * This is independent of the other forms of navigation instrumentation. Calling it neither affects nor is affected by other navigation
+     * instrumentation.
      */
     public fun screenLoaded(screen: String): Unit = screenLoaded(screen, emptyMap())
 
     /**
-     * Record the given [screen] has been loaded. Calling this does not affect automatic navigation tracking instrumentation.
+     * Record that the given [screen] has been loaded with the given attributes [eventAttributes].
      *
-     * Optionally pass in [eventAttributes] to be recorded with the screen loading event.
+     * This is independent of the other forms of navigation instrumentation. Calling it neither affects nor is affected by other navigation
+     * instrumentation.
      */
     public fun screenLoaded(screen: String, eventAttributes: Map<String, String>)
 }

--- a/embrace-android-config/build.gradle.kts
+++ b/embrace-android-config/build.gradle.kts
@@ -11,4 +11,5 @@ dependencies {
     testImplementation(project(":embrace-test-common"))
     testImplementation(project(":embrace-android-config-fakes"))
     testImplementation(libs.mockwebserver)
+    testImplementation(libs.kotlin.reflect)
 }

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
@@ -57,6 +57,7 @@ class ConfigServiceImpl(
         RemoteConfigStoreImpl(
             serializer = serializer,
             storageDir = File(filesDir, "embrace_remote_config"),
+            deviceIdProvider = ::deviceId,
         )
     }
 
@@ -74,6 +75,10 @@ class ConfigServiceImpl(
     }
 
     override val deviceId: String = run {
+        // fast path: the deviceId cached in the binary config avoids the SharedPreferences load
+        remoteConfigStore.loadDeviceId()?.let { return@run it }
+
+        // canonical source: SharedPreferences, generating and persisting a new id on first launch
         val deviceId = store.getString(DEVICE_IDENTIFIER_KEY)
         if (deviceId != null) {
             return@run deviceId

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/store/BinaryRemoteConfigDecoder.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/store/BinaryRemoteConfigDecoder.kt
@@ -1,0 +1,210 @@
+package io.embrace.android.embracesdk.internal.config.store
+
+import io.embrace.android.embracesdk.internal.config.remote.AppExitInfoConfig
+import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.DataRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.KillSwitchRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.LogRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.NetworkRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.NetworkSpanForwardingRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.OtelKotlinSdkConfig
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.SessionRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.ThreadBlockageRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.UiRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.UserSessionRemoteConfig
+import java.io.DataInput
+
+internal class BinaryRemoteConfigDecoder {
+
+    /**
+     * Reads a [RemoteConfig] previously written by [BinaryRemoteConfigEncoder]. The format version
+     * is validated first; a mismatch returns null, which the store treats as a cache miss and falls
+     * back to the JSON file.
+     *
+     * After the version, the header (cached deviceId + threshold) is read and handed to [onHeader].
+     * If [onHeader] returns `true` the SDK is disabled for this device, so decoding stops and a
+     * minimal [RemoteConfig] carrying only the threshold is returned — enough for the authoritative
+     * downstream `SdkModeBehavior` gate to fire, without paying to decode the rest of the payload.
+     * [onHeader] must not throw: this read also runs on the background config-refresh poll, where an
+     * uncaught exception would suppress all future poll executions.
+     *
+     * When [onHeader] returns `false` the remaining fields are read in declaration order, mirroring
+     * the encoder. Each type is built via its complete primary constructor with positional arguments
+     * (no named args, no reliance on defaults): adding, removing, retyping, or reordering a property
+     * fails to compile, forcing the codec to be updated in lockstep. Kotlin evaluates call arguments
+     * left-to-right, so the inline reads below execute in the exact order the encoder wrote them.
+     */
+    fun DataInput.readRemoteConfig(onHeader: (Header) -> Boolean): RemoteConfig? {
+        val version = readInt()
+        if (version != BinaryRemoteConfigFormat.VERSION) {
+            return null
+        }
+        val deviceId = readUTF()
+        val threshold = readNullableInt()
+        if (onHeader(Header(version, threshold, deviceId))) {
+            return RemoteConfig(threshold = threshold)
+        }
+        return readConfig(threshold)
+    }
+
+    /**
+     * Reads only the cached deviceId from the header (version + deviceId), stopping before the rest
+     * of the payload. Returns null on a version mismatch or any non-binary content, mirroring
+     * [readRemoteConfig]'s miss semantics, so the caller falls back to its canonical deviceId source.
+     */
+    fun DataInput.readDeviceId(): String? {
+        val version = readInt()
+        if (version != BinaryRemoteConfigFormat.VERSION) {
+            return null
+        }
+        return readUTF()
+    }
+
+    private fun DataInput.readConfig(threshold: Int?): RemoteConfig = RemoteConfig(
+        threshold, // threshold (already read as part of the header)
+        readStringSet(), // disabledEventAndLogPatterns
+        readStringSet(), // disabledUrlPatterns
+        readCollection(::LinkedHashSet) { readNetworkCaptureRule() }, // networkCaptureRules
+        readNullable { readUiConfig() }, // uiConfig
+        readNullable { readNetworkConfig() }, // networkConfig
+        readNullable { readSessionConfig() }, // sessionConfig
+        readNullable { readLogConfig() }, // logConfig
+        readNullable { readThreadBlockageConfig() }, // threadBlockageRemoteConfig
+        readNullable { readDataConfig() }, // dataConfig
+        readNullable { readKillSwitchConfig() }, // killSwitchConfig
+        readNullableBoolean(), // internalExceptionCaptureEnabled
+        readNullable { readAppExitInfoConfig() }, // appExitInfoConfig
+        readNullable { readBackgroundActivityConfig() }, // backgroundActivityConfig
+        readNullableInt(), // maxUserSessionProperties
+        readNullable { readNetworkSpanForwardingConfig() }, // networkSpanForwardingRemoteConfig
+        readNullableBoolean(), // uiLoadInstrumentationEnabled
+        readNullable { readOtelKotlinSdkConfig() }, // otelKotlinSdkConfig
+        readNullableFloat(), // pctStateCaptureEnabledV2
+        readNullableFloat(), // pctNetworkCallbackConnectivityServiceEnabled
+        readNullableFloat(), // pctNavigationStateCaptureEnabled
+        readNullable { readUserSessionConfig() }, // userSession
+    )
+
+    private fun DataInput.readNetworkCaptureRule() = NetworkCaptureRuleRemoteConfig(
+        readUTF(), // id
+        readNullableLong(), // duration
+        readUTF(), // method
+        readUTF(), // urlRegex
+        readLong(), // expiresIn
+        readLong(), // maxSize
+        readInt(), // maxCount
+        readCollection(::LinkedHashSet) { readInt() }.orEmpty(), // statusCodes
+    )
+
+    private fun DataInput.readUiConfig() = UiRemoteConfig(
+        readNullableInt(), // breadcrumbs
+        readNullableInt(), // taps
+        readNullableInt(), // webViews
+        readNullableInt(), // fragments
+    )
+
+    private fun DataInput.readNetworkConfig() = NetworkRemoteConfig(
+        readNullableInt(), // defaultCaptureLimit
+        readStringIntMap(), // domainLimits
+    )
+
+    private fun DataInput.readSessionConfig() = SessionRemoteConfig(
+        readNullableBoolean(), // isEnabled
+    )
+
+    private fun DataInput.readLogConfig() = LogRemoteConfig(
+        readNullableInt(), // logMessageMaximumAllowedLength
+        readNullableInt(), // logInfoLimit
+        readNullableInt(), // logWarnLimit
+        readNullableInt(), // logErrorLimit
+    )
+
+    private fun DataInput.readThreadBlockageConfig() = ThreadBlockageRemoteConfig(
+        readNullableInt(), // pctEnabled
+        readNullableLong(), // sampleIntervalMs
+        readNullableInt(), // maxStacktracesPerInterval
+        readNullableInt(), // stacktraceFrameLimit
+        readNullableInt(), // intervalsPerSession
+        readNullableInt(), // minDuration
+        readNullableInt(), // monitorThreadPriority
+    )
+
+    private fun DataInput.readDataConfig() = DataRemoteConfig(
+        readNullableFloat(), // pctThermalStatusEnabled
+    )
+
+    private fun DataInput.readKillSwitchConfig() = KillSwitchRemoteConfig(
+        readNullableBoolean(), // sigHandlerDetection
+        readNullableBoolean(), // jetpackCompose
+    )
+
+    private fun DataInput.readAppExitInfoConfig() = AppExitInfoConfig(
+        readNullableInt(), // appExitInfoTracesLimit
+        readNullableFloat(), // pctAeiCaptureEnabled
+        readNullableInt(), // aeiMaxNum
+    )
+
+    private fun DataInput.readBackgroundActivityConfig() = BackgroundActivityRemoteConfig(
+        readNullableFloat(), // threshold
+    )
+
+    private fun DataInput.readNetworkSpanForwardingConfig() = NetworkSpanForwardingRemoteConfig(
+        readNullableFloat(), // pctEnabled
+    )
+
+    private fun DataInput.readOtelKotlinSdkConfig() = OtelKotlinSdkConfig(
+        readNullableFloat(), // pctEnabled
+    )
+
+    private fun DataInput.readUserSessionConfig() = UserSessionRemoteConfig(
+        readNullableInt(), // maxDurationSeconds
+        readNullableInt(), // inactivityTimeoutSeconds
+    )
+
+    fun DataInput.readStringSet(): Set<String>? = readCollection(::LinkedHashSet) { readUTF() }
+
+    inline fun <E, C : MutableCollection<E>> DataInput.readCollection(factory: () -> C, readItem: DataInput.() -> E): C? {
+        val count = readInt()
+        if (count == -1) {
+            return null
+        }
+
+        val collection = factory()
+        repeat(count) {
+            collection.add(readItem())
+        }
+        return collection
+    }
+
+    fun DataInput.readStringIntMap(): Map<String, Int>? {
+        val count = readInt()
+        if (count == -1) {
+            return null
+        }
+
+        val map = LinkedHashMap<String, Int>(count)
+        repeat(count) {
+            map[readUTF()] = readInt()
+        }
+        return map
+    }
+
+    inline fun <T> DataInput.readNullable(reader: DataInput.() -> T): T? =
+        if (readBoolean()) reader() else null
+
+    fun DataInput.readNullableInt(): Int? = readNullable { readInt() }
+
+    fun DataInput.readNullableLong(): Long? = readNullable { readLong() }
+
+    fun DataInput.readNullableFloat(): Float? = readNullable { readFloat() }
+
+    fun DataInput.readNullableBoolean(): Boolean? = readNullable { readBoolean() }
+
+    data class Header(
+        val version: Int,
+        val threshold: Int?,
+        val deviceId: String,
+    )
+}

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/store/BinaryRemoteConfigEncoder.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/store/BinaryRemoteConfigEncoder.kt
@@ -1,0 +1,174 @@
+package io.embrace.android.embracesdk.internal.config.store
+
+import io.embrace.android.embracesdk.internal.config.remote.AppExitInfoConfig
+import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.DataRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.KillSwitchRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.LogRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.NetworkRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.NetworkSpanForwardingRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.OtelKotlinSdkConfig
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.SessionRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.ThreadBlockageRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.UiRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.UserSessionRemoteConfig
+import java.io.DataOutput
+
+internal class BinaryRemoteConfigEncoder {
+
+    /**
+     * Writes [config] to [this] in declaration order. The decoder must read fields back in the
+     * exact same order. A header is written first — the format version, the cached [deviceId], and
+     * the SDK-enablement [RemoteConfig.threshold] — so the decoder can evaluate the startup gate
+     * before decoding the rest. Nullable scalars are prefixed with a boolean presence flag; nullable
+     * collections write a length of -1 when absent.
+     */
+    fun DataOutput.write(deviceId: String, config: RemoteConfig) {
+        writeInt(BinaryRemoteConfigFormat.VERSION)
+        writeUTF(deviceId)
+        writeNullableInt(config.threshold)
+        writeStrings(config.disabledEventAndLogPatterns)
+        writeStrings(config.disabledUrlPatterns)
+        writeCollection(config.networkCaptureRules) { writeNetworkCaptureRule(it) }
+        writeNullable(config.uiConfig) { writeUiConfig(it) }
+        writeNullable(config.networkConfig) { writeNetworkConfig(it) }
+        writeNullable(config.sessionConfig) { writeSessionConfig(it) }
+        writeNullable(config.logConfig) { writeLogConfig(it) }
+        writeNullable(config.threadBlockageRemoteConfig) { writeThreadBlockageConfig(it) }
+        writeNullable(config.dataConfig) { writeDataConfig(it) }
+        writeNullable(config.killSwitchConfig) { writeKillSwitchConfig(it) }
+        writeNullableBoolean(config.internalExceptionCaptureEnabled)
+        writeNullable(config.appExitInfoConfig) { writeAppExitInfoConfig(it) }
+        writeNullable(config.backgroundActivityConfig) { writeBackgroundActivityConfig(it) }
+        writeNullableInt(config.maxUserSessionProperties)
+        writeNullable(config.networkSpanForwardingRemoteConfig) { writeNetworkSpanForwardingConfig(it) }
+        writeNullableBoolean(config.uiLoadInstrumentationEnabled)
+        writeNullable(config.otelKotlinSdkConfig) { writeOtelKotlinSdkConfig(it) }
+        writeNullableFloat(config.pctStateCaptureEnabledV2)
+        writeNullableFloat(config.pctNetworkCallbackConnectivityServiceEnabled)
+        writeNullableFloat(config.pctNavigationStateCaptureEnabled)
+        writeNullable(config.userSession) { writeUserSessionConfig(it) }
+    }
+
+    private fun DataOutput.writeNetworkCaptureRule(rule: NetworkCaptureRuleRemoteConfig) {
+        writeUTF(rule.id)
+        writeNullableLong(rule.duration)
+        writeUTF(rule.method)
+        writeUTF(rule.urlRegex)
+        writeLong(rule.expiresIn)
+        writeLong(rule.maxSize)
+        writeInt(rule.maxCount)
+        writeCollection(rule.statusCodes) { writeInt(it) }
+    }
+
+    private fun DataOutput.writeUiConfig(config: UiRemoteConfig) {
+        writeNullableInt(config.breadcrumbs)
+        writeNullableInt(config.taps)
+        writeNullableInt(config.webViews)
+        writeNullableInt(config.fragments)
+    }
+
+    private fun DataOutput.writeNetworkConfig(config: NetworkRemoteConfig) {
+        writeNullableInt(config.defaultCaptureLimit)
+        writeStringIntMap(config.domainLimits)
+    }
+
+    private fun DataOutput.writeSessionConfig(config: SessionRemoteConfig) {
+        writeNullableBoolean(config.isEnabled)
+    }
+
+    private fun DataOutput.writeLogConfig(config: LogRemoteConfig) {
+        writeNullableInt(config.logMessageMaximumAllowedLength)
+        writeNullableInt(config.logInfoLimit)
+        writeNullableInt(config.logWarnLimit)
+        writeNullableInt(config.logErrorLimit)
+    }
+
+    private fun DataOutput.writeThreadBlockageConfig(config: ThreadBlockageRemoteConfig) {
+        writeNullableInt(config.pctEnabled)
+        writeNullableLong(config.sampleIntervalMs)
+        writeNullableInt(config.maxStacktracesPerInterval)
+        writeNullableInt(config.stacktraceFrameLimit)
+        writeNullableInt(config.intervalsPerSession)
+        writeNullableInt(config.minDuration)
+        writeNullableInt(config.monitorThreadPriority)
+    }
+
+    private fun DataOutput.writeDataConfig(config: DataRemoteConfig) {
+        writeNullableFloat(config.pctThermalStatusEnabled)
+    }
+
+    private fun DataOutput.writeKillSwitchConfig(config: KillSwitchRemoteConfig) {
+        writeNullableBoolean(config.sigHandlerDetection)
+        writeNullableBoolean(config.jetpackCompose)
+    }
+
+    private fun DataOutput.writeAppExitInfoConfig(config: AppExitInfoConfig) {
+        writeNullableInt(config.appExitInfoTracesLimit)
+        writeNullableFloat(config.pctAeiCaptureEnabled)
+        writeNullableInt(config.aeiMaxNum)
+    }
+
+    private fun DataOutput.writeBackgroundActivityConfig(config: BackgroundActivityRemoteConfig) {
+        writeNullableFloat(config.threshold)
+    }
+
+    private fun DataOutput.writeNetworkSpanForwardingConfig(config: NetworkSpanForwardingRemoteConfig) {
+        writeNullableFloat(config.pctEnabled)
+    }
+
+    private fun DataOutput.writeOtelKotlinSdkConfig(config: OtelKotlinSdkConfig) {
+        writeNullableFloat(config.pctEnabled)
+    }
+
+    private fun DataOutput.writeUserSessionConfig(config: UserSessionRemoteConfig) {
+        writeNullableInt(config.maxDurationSeconds)
+        writeNullableInt(config.inactivityTimeoutSeconds)
+    }
+
+    fun DataOutput.writeStrings(strings: Collection<String>?) {
+        writeCollection(strings) { writeUTF(it) }
+    }
+
+    inline fun <T> DataOutput.writeCollection(collection: Collection<T>?, encoder: DataOutput.(T) -> Unit) {
+        if (collection == null) {
+            writeInt(-1)
+            return
+        }
+
+        val count = collection.size
+        writeInt(count)
+
+        // we break out the iteration to ensure the number of elements written exactly matches the count provided
+        val iterator = collection.iterator()
+        repeat(count) {
+            encoder(iterator.next())
+        }
+    }
+
+    fun DataOutput.writeStringIntMap(map: Map<String, Int>?) {
+        writeCollection(map?.entries) { (key, value) ->
+            writeUTF(key)
+            writeInt(value)
+        }
+    }
+
+    inline fun <T> DataOutput.writeNullable(value: T?, encoder: DataOutput.(T) -> Unit) {
+        if (value != null) {
+            writeBoolean(true)
+            encoder(value)
+        } else {
+            writeBoolean(false)
+        }
+    }
+
+    fun DataOutput.writeNullableInt(value: Int?) = writeNullable(value) { writeInt(it) }
+
+    fun DataOutput.writeNullableLong(value: Long?) = writeNullable(value) { writeLong(it) }
+
+    fun DataOutput.writeNullableFloat(value: Float?) = writeNullable(value) { writeFloat(it) }
+
+    fun DataOutput.writeNullableBoolean(value: Boolean?) = writeNullable(value) { writeBoolean(it) }
+}

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/store/BinaryRemoteConfigFormat.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/store/BinaryRemoteConfigFormat.kt
@@ -1,0 +1,20 @@
+package io.embrace.android.embracesdk.internal.config.store
+
+/**
+ * Constants describing the on-disk binary format written by [BinaryRemoteConfigEncoder] and read by
+ * [BinaryRemoteConfigDecoder].
+ */
+internal object BinaryRemoteConfigFormat {
+
+    /**
+     * Version of the binary layout, written as the first value of every encoded payload.
+     *
+     * Increment this whenever the binary layout changes in any way — a new/removed/reordered/retyped
+     * field on [io.embrace.android.embracesdk.internal.config.remote.RemoteConfig] or any nested
+     * config type, or a change to how a value is written. The decoder rejects any payload whose
+     * version does not match, which causes the store to fall back to reading the JSON cache.
+     *
+     * `BinaryRemoteConfigSchemaTest` fails whenever the layout changes without this being bumped.
+     */
+    const val VERSION: Int = 1
+}

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/store/RemoteConfigStore.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/store/RemoteConfigStore.kt
@@ -16,4 +16,11 @@ internal interface RemoteConfigStore {
      * Saves a new remote configuration, overwriting whatever was stored before.
      */
     fun saveResponse(response: ConfigHttpResponse)
+
+    /**
+     * Loads the deviceId cached alongside the most recent binary config, if present. Returns null
+     * when there is no binary cache yet (a fresh install, or a legacy JSON-only cache), in which case
+     * the caller should fall back to its canonical deviceId source.
+     */
+    fun loadDeviceId(): String?
 }

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/store/RemoteConfigStoreImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/store/RemoteConfigStoreImpl.kt
@@ -1,47 +1,59 @@
 package io.embrace.android.embracesdk.internal.config.store
 
+import io.embrace.android.embracesdk.internal.config.behavior.BehaviorThresholdCheck
+import io.embrace.android.embracesdk.internal.config.behavior.SdkModeBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.config.source.ConfigHttpResponse
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
+import java.io.DataInputStream
+import java.io.DataOutputStream
 import java.io.File
 
 internal class RemoteConfigStoreImpl(
     private val serializer: PlatformSerializer,
     storageDir: File,
+    private val deviceIdProvider: () -> String,
 ) : RemoteConfigStore {
+
+    private val encoder = BinaryRemoteConfigEncoder()
+    private val decoder = BinaryRemoteConfigDecoder()
 
     init {
         storageDir.mkdirs()
     }
 
-    private val configFile = File(storageDir, "most_recent_response").apply {
+    private val jsonFile = File(storageDir, "most_recent_response").apply {
         createNewFile()
     }
+
+    private val binaryCacheFile = File(storageDir, "config_cache.bin")
 
     private val etagFile = File(storageDir, "etag").apply {
         createNewFile()
     }
 
     override fun loadResponse(): ConfigHttpResponse? {
-        try {
-            val cfg = configFile.inputStream().buffered().use {
-                serializer.fromJson(it, RemoteConfig::class.java)
+        val cfg = readBinaryCache() ?: readJsonPrimary() ?: return null
+        return ConfigHttpResponse(
+            cfg,
+            etagFile.readText().ifEmpty {
+                null
             }
-            return ConfigHttpResponse(
-                cfg,
-                etagFile.readText().ifEmpty {
-                    null
-                }
-            )
-        } catch (exc: Exception) {
-            return null
-        }
+        )
     }
 
     override fun saveResponse(response: ConfigHttpResponse) {
+        val cfg = response.cfg ?: return
+
+        // invalidate the derived cache up-front so it can never be staler than the primary we're
+        // about to write: a crash mid-save leaves the cache absent (→ JSON fallback) rather than
+        // pointing at an older config. It is regenerated below once the primary is durable.
+        binaryCacheFile.delete()
+
         try {
-            configFile.outputStream().buffered().use { stream ->
-                serializer.toJson(response.cfg, RemoteConfig::class.java, stream)
+            // the JSON primary (and its etag) is the source of truth and must be persisted first
+            jsonFile.outputStream().buffered().use { stream ->
+                serializer.toJson(cfg, RemoteConfig::class.java, stream)
             }
             response.etag?.let(etagFile::writeText)
         } catch (exc: Exception) {
@@ -50,12 +62,54 @@ internal class RemoteConfigStoreImpl(
             // where the SDK is disabled & persistence fails. In that scenario we prefer
             // the default SDK behavior which will fetch the correct config eventually
             purgeCache()
+            return
+        }
+
+        // the binary cache is a best-effort accelerator derived from the primary; if it can't be
+        // written, drop it so the next load falls back to the JSON primary
+        try {
+            DataOutputStream(binaryCacheFile.outputStream().buffered()).use { stream ->
+                with(encoder) { stream.write(deviceIdProvider(), cfg) }
+            }
+        } catch (exc: Exception) {
+            binaryCacheFile.delete()
         }
     }
 
+    override fun loadDeviceId(): String? = try {
+        DataInputStream(binaryCacheFile.inputStream().buffered()).use { input ->
+            with(decoder) { input.readDeviceId() }
+        }
+    } catch (exc: Exception) {
+        null
+    }
+
+    private fun readBinaryCache(): RemoteConfig? = try {
+        DataInputStream(binaryCacheFile.inputStream().buffered()).use { input ->
+            with(decoder) { input.readRemoteConfig(::isSdkDisabled) }
+        }
+    } catch (exc: Exception) {
+        null
+    }
+
+    private fun readJsonPrimary(): RemoteConfig? = try {
+        jsonFile.inputStream().buffered().use {
+            serializer.fromJson(it, RemoteConfig::class.java)
+        }
+    } catch (exc: Exception) {
+        null
+    }
+
+    private fun isSdkDisabled(header: BinaryRemoteConfigDecoder.Header): Boolean =
+        SdkModeBehaviorImpl(
+            BehaviorThresholdCheck { header.deviceId },
+            RemoteConfig(threshold = header.threshold),
+        ).isSdkDisabled()
+
     private fun purgeCache() {
         try {
-            configFile.delete()
+            jsonFile.delete()
+            binaryCacheFile.delete()
             etagFile.delete()
         } catch (ignored: Exception) {
         }

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeRemoteConfigStore.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeRemoteConfigStore.kt
@@ -9,10 +9,14 @@ class FakeRemoteConfigStore(
 
     var saveCount: Int = 0
 
+    var deviceId: String? = null
+
     override fun loadResponse(): ConfigHttpResponse? = impl
 
     override fun saveResponse(response: ConfigHttpResponse) {
         saveCount++
         impl = response
     }
+
+    override fun loadDeviceId(): String? = deviceId
 }

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/store/BinaryRemoteConfigCodecTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/store/BinaryRemoteConfigCodecTest.kt
@@ -1,0 +1,142 @@
+package io.embrace.android.embracesdk.internal.config.store
+
+import io.embrace.android.embracesdk.internal.config.remote.AppExitInfoConfig
+import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.DataRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.KillSwitchRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.LogRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.NetworkRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.NetworkSpanForwardingRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.OtelKotlinSdkConfig
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.SessionRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.ThreadBlockageRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.UiRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.UserSessionRemoteConfig
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+
+internal class BinaryRemoteConfigCodecTest {
+
+    private val encoder = BinaryRemoteConfigEncoder()
+    private val decoder = BinaryRemoteConfigDecoder()
+
+    private fun encode(config: RemoteConfig, deviceId: String = TEST_DEVICE_ID): ByteArray {
+        val baos = ByteArrayOutputStream()
+        DataOutputStream(baos).use { out -> with(encoder) { out.write(deviceId, config) } }
+        return baos.toByteArray()
+    }
+
+    private fun decode(
+        bytes: ByteArray,
+        onHeader: (BinaryRemoteConfigDecoder.Header) -> Boolean = { false },
+    ): RemoteConfig? =
+        DataInputStream(ByteArrayInputStream(bytes)).use { input ->
+            with(decoder) { input.readRemoteConfig(onHeader) }
+        }
+
+    @Test
+    fun `empty config round-trips`() {
+        val config = RemoteConfig()
+        assertEquals(config, decode(encode(config)))
+    }
+
+    @Test
+    fun `decoding rejects an unsupported version`() {
+        val baos = ByteArrayOutputStream()
+        DataOutputStream(baos).use { it.writeInt(BinaryRemoteConfigFormat.VERSION + 1) }
+        assertNull("decoding should reject unsupported version", decode(baos.toByteArray()))
+    }
+
+    @Test
+    fun `fully populated config round-trips`() {
+        val config = RemoteConfig(
+            threshold = 50,
+            disabledEventAndLogPatterns = setOf("event-a", "event-b"),
+            disabledUrlPatterns = setOf("https://example.com"),
+            networkCaptureRules = setOf(
+                NetworkCaptureRuleRemoteConfig(
+                    id = "rule-1",
+                    duration = 1000L,
+                    method = "GET",
+                    urlRegex = ".*",
+                    expiresIn = 5L,
+                    maxSize = 200L,
+                    maxCount = 3,
+                    statusCodes = setOf(200, -1),
+                )
+            ),
+            uiConfig = UiRemoteConfig(breadcrumbs = 1, taps = 2, webViews = 3, fragments = 4),
+            networkConfig = NetworkRemoteConfig(defaultCaptureLimit = 10, domainLimits = mapOf("x" to 1, "y" to 2)),
+            sessionConfig = SessionRemoteConfig(isEnabled = true),
+            logConfig = LogRemoteConfig(100, 1, 2, 3),
+            threadBlockageRemoteConfig = ThreadBlockageRemoteConfig(1, 2L, 3, 4, 5, 6, 7),
+            dataConfig = DataRemoteConfig(pctThermalStatusEnabled = 0.5f),
+            killSwitchConfig = KillSwitchRemoteConfig(sigHandlerDetection = true, jetpackCompose = false),
+            internalExceptionCaptureEnabled = true,
+            appExitInfoConfig = AppExitInfoConfig(appExitInfoTracesLimit = 100, pctAeiCaptureEnabled = 0.25f, aeiMaxNum = 5),
+            backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 0.75f),
+            maxUserSessionProperties = 42,
+            networkSpanForwardingRemoteConfig = NetworkSpanForwardingRemoteConfig(pctEnabled = 0.1f),
+            uiLoadInstrumentationEnabled = false,
+            otelKotlinSdkConfig = OtelKotlinSdkConfig(pctEnabled = 0.9f),
+            pctStateCaptureEnabledV2 = 0.2f,
+            pctNetworkCallbackConnectivityServiceEnabled = 0.3f,
+            pctNavigationStateCaptureEnabled = 0.4f,
+            userSession = UserSessionRemoteConfig(maxDurationSeconds = 3600, inactivityTimeoutSeconds = 30),
+        )
+
+        val decoded = decode(encode(config))
+        requireNotNull(decoded) { "BinaryRemoteConfigDecoder.decode returned null - is the version number correct?" }
+
+        // AppExitInfoConfig is a plain class with no structural equals; compare the rest via copy
+        // and its fields individually.
+        assertEquals(config.copy(appExitInfoConfig = null), decoded.copy(appExitInfoConfig = null))
+        assertEquals(config.appExitInfoConfig?.appExitInfoTracesLimit, decoded.appExitInfoConfig?.appExitInfoTracesLimit)
+        assertEquals(config.appExitInfoConfig?.pctAeiCaptureEnabled, decoded.appExitInfoConfig?.pctAeiCaptureEnabled)
+        assertEquals(config.appExitInfoConfig?.aeiMaxNum, decoded.appExitInfoConfig?.aeiMaxNum)
+
+        // re-encoding the decoded config must produce identical bytes (stable round-trip)
+        assertArrayEquals(encode(config), encode(decoded))
+    }
+
+    @Test
+    fun `header exposes version, threshold and deviceId`() {
+        var captured: BinaryRemoteConfigDecoder.Header? = null
+        decode(encode(RemoteConfig(threshold = 42), deviceId = "device-abc")) {
+            captured = it
+            false
+        }
+        assertEquals(BinaryRemoteConfigFormat.VERSION, captured?.version)
+        assertEquals(42, captured?.threshold)
+        assertEquals("device-abc", captured?.deviceId)
+    }
+
+    @Test
+    fun `gate stop short-circuits and returns a minimal config carrying only the threshold`() {
+        val config = RemoteConfig(
+            threshold = 10,
+            maxUserSessionProperties = 99,
+            disabledUrlPatterns = setOf("https://example.com"),
+        )
+        val decoded = decode(encode(config)) { true }
+        assertEquals(RemoteConfig(threshold = 10), decoded)
+    }
+
+    @Test
+    fun `gate continue decodes the full config`() {
+        val config = RemoteConfig(threshold = 10, maxUserSessionProperties = 99)
+        assertEquals(config, decode(encode(config)) { false })
+    }
+
+    private companion object {
+        const val TEST_DEVICE_ID = "device-1234567890"
+    }
+}

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/store/BinaryRemoteConfigSchemaTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/store/BinaryRemoteConfigSchemaTest.kt
@@ -1,0 +1,172 @@
+package io.embrace.android.embracesdk.internal.config.store
+
+import io.embrace.android.embracesdk.internal.config.remote.AppExitInfoConfig
+import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.DataRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.KillSwitchRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.LogRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.NetworkRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.NetworkSpanForwardingRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.OtelKotlinSdkConfig
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.SessionRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.ThreadBlockageRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.UiRemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.UserSessionRemoteConfig
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.full.primaryConstructor
+
+/**
+ * Guards the binary codec against silent drift. The binary format is positional, so any change to
+ * the fields of [RemoteConfig] or any nested type it encodes alters the wire layout. This test
+ * fingerprints those types via reflection and compares against [GOLDEN_SCHEMA].
+ *
+ * When it fails because the layout legitimately changed:
+ *  1. update [BinaryRemoteConfigEncoder] and [BinaryRemoteConfigDecoder] to match,
+ *  2. bump [BinaryRemoteConfigFormat.VERSION] (old caches then fall back to JSON), and
+ *  3. replace [GOLDEN_SCHEMA] below with the printed actual schema.
+ *
+ * The schema embeds the version, so a `VERSION` bump and a schema update land in the same diff.
+ * Reflection lives only in this test — the production load path stays reflection-free.
+ */
+internal class BinaryRemoteConfigSchemaTest {
+
+    @Test
+    fun `binary schema matches the golden schema`() {
+        assertEquals(
+            "RemoteConfig's binary layout changed. Update the encoder + decoder, bump " +
+                "BinaryRemoteConfigFormat.VERSION (old caches fall back to JSON), and replace " +
+                "GOLDEN_SCHEMA with the actual schema shown here.",
+            GOLDEN_SCHEMA.trim(),
+            actualSchema().trim(),
+        )
+    }
+
+    private fun actualSchema(): String = buildString {
+        append("version: ").append(BinaryRemoteConfigFormat.VERSION)
+        CODEC_TYPES.forEach { type ->
+            append('\n').append(type.simpleName).append(':')
+            type.primaryConstructor!!.parameters.forEach { param ->
+                append("\n  ").append(param.name).append(": ").append(render(param.type))
+            }
+        }
+    }
+
+    private fun render(type: KType): String {
+        val name = (type.classifier as? KClass<*>)?.simpleName ?: type.toString()
+        val args =
+            if (type.arguments.isEmpty()) {
+                ""
+            } else {
+                type.arguments.joinToString(separator = ", ", prefix = "<", postfix = ">") {
+                    it.type?.let(::render) ?: "*"
+                }
+            }
+        return name + args + if (type.isMarkedNullable) "?" else ""
+    }
+
+    private companion object {
+
+        /**
+         * Every type the binary codec touches, in encoding order. A nested type added to the codec
+         * must be added here too, or its fields won't be guarded.
+         */
+        val CODEC_TYPES: List<KClass<*>> = listOf(
+            RemoteConfig::class,
+            NetworkCaptureRuleRemoteConfig::class,
+            UiRemoteConfig::class,
+            NetworkRemoteConfig::class,
+            SessionRemoteConfig::class,
+            LogRemoteConfig::class,
+            ThreadBlockageRemoteConfig::class,
+            DataRemoteConfig::class,
+            KillSwitchRemoteConfig::class,
+            AppExitInfoConfig::class,
+            BackgroundActivityRemoteConfig::class,
+            NetworkSpanForwardingRemoteConfig::class,
+            OtelKotlinSdkConfig::class,
+            UserSessionRemoteConfig::class,
+        )
+
+        val GOLDEN_SCHEMA = """
+            version: 1
+            RemoteConfig:
+              threshold: Int?
+              disabledEventAndLogPatterns: Set<String>?
+              disabledUrlPatterns: Set<String>?
+              networkCaptureRules: Set<NetworkCaptureRuleRemoteConfig>?
+              uiConfig: UiRemoteConfig?
+              networkConfig: NetworkRemoteConfig?
+              sessionConfig: SessionRemoteConfig?
+              logConfig: LogRemoteConfig?
+              threadBlockageRemoteConfig: ThreadBlockageRemoteConfig?
+              dataConfig: DataRemoteConfig?
+              killSwitchConfig: KillSwitchRemoteConfig?
+              internalExceptionCaptureEnabled: Boolean?
+              appExitInfoConfig: AppExitInfoConfig?
+              backgroundActivityConfig: BackgroundActivityRemoteConfig?
+              maxUserSessionProperties: Int?
+              networkSpanForwardingRemoteConfig: NetworkSpanForwardingRemoteConfig?
+              uiLoadInstrumentationEnabled: Boolean?
+              otelKotlinSdkConfig: OtelKotlinSdkConfig?
+              pctStateCaptureEnabledV2: Float?
+              pctNetworkCallbackConnectivityServiceEnabled: Float?
+              pctNavigationStateCaptureEnabled: Float?
+              userSession: UserSessionRemoteConfig?
+            NetworkCaptureRuleRemoteConfig:
+              id: String
+              duration: Long?
+              method: String
+              urlRegex: String
+              expiresIn: Long
+              maxSize: Long
+              maxCount: Int
+              statusCodes: Set<Int>
+            UiRemoteConfig:
+              breadcrumbs: Int?
+              taps: Int?
+              webViews: Int?
+              fragments: Int?
+            NetworkRemoteConfig:
+              defaultCaptureLimit: Int?
+              domainLimits: Map<String, Int>?
+            SessionRemoteConfig:
+              isEnabled: Boolean?
+            LogRemoteConfig:
+              logMessageMaximumAllowedLength: Int?
+              logInfoLimit: Int?
+              logWarnLimit: Int?
+              logErrorLimit: Int?
+            ThreadBlockageRemoteConfig:
+              pctEnabled: Int?
+              sampleIntervalMs: Long?
+              maxStacktracesPerInterval: Int?
+              stacktraceFrameLimit: Int?
+              intervalsPerSession: Int?
+              minDuration: Int?
+              monitorThreadPriority: Int?
+            DataRemoteConfig:
+              pctThermalStatusEnabled: Float?
+            KillSwitchRemoteConfig:
+              sigHandlerDetection: Boolean?
+              jetpackCompose: Boolean?
+            AppExitInfoConfig:
+              appExitInfoTracesLimit: Int?
+              pctAeiCaptureEnabled: Float?
+              aeiMaxNum: Int?
+            BackgroundActivityRemoteConfig:
+              threshold: Float?
+            NetworkSpanForwardingRemoteConfig:
+              pctEnabled: Float?
+            OtelKotlinSdkConfig:
+              pctEnabled: Float?
+            UserSessionRemoteConfig:
+              maxDurationSeconds: Int?
+              inactivityTimeoutSeconds: Int?
+        """.trimIndent()
+    }
+}

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/store/RemoteConfigStoreImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/store/RemoteConfigStoreImplTest.kt
@@ -14,35 +14,94 @@ internal class RemoteConfigStoreImplTest {
 
     private lateinit var store: RemoteConfigStoreImpl
     private lateinit var dir: File
+    private val serializer = TestPlatformSerializer()
 
     @Before
     fun setUp() {
         dir = Files.createTempDirectory("test").toFile()
-        store = RemoteConfigStoreImpl(TestPlatformSerializer(), dir)
+        store = RemoteConfigStoreImpl(serializer, dir, deviceIdProvider = { ENABLED_DEVICE_ID })
     }
 
     @Test
-    fun `test config store`() {
+    fun `config round-trips through the store`() {
         assertNull(store.loadResponse())
 
-        // store a config
-        val config = RemoteConfig(50)
+        val config = RemoteConfig(threshold = 100, maxUserSessionProperties = 7)
         store.saveResponse(ConfigHttpResponse(config, "etag"))
 
-        // load the config
         val loaded = checkNotNull(store.loadResponse())
         assertEquals(config, loaded.cfg)
         assertEquals("etag", loaded.etag)
 
-        val newConfig = RemoteConfig(100)
+        val newConfig = RemoteConfig(threshold = 100, maxUserSessionProperties = 9)
         store.saveResponse(ConfigHttpResponse(newConfig, "another"))
 
         val newLoaded = checkNotNull(store.loadResponse())
         assertEquals(newConfig, newLoaded.cfg)
         assertEquals("another", newLoaded.etag)
+    }
 
-        store.saveResponse(ConfigHttpResponse(newConfig, "another"))
-        assertEquals(newConfig, newLoaded.cfg)
-        assertEquals("another", newLoaded.etag)
+    @Test
+    fun `null etag loads as null`() {
+        store.saveResponse(ConfigHttpResponse(RemoteConfig(threshold = 100), null))
+        assertNull(checkNotNull(store.loadResponse()).etag)
+    }
+
+    @Test
+    fun `saving always writes a complete JSON primary`() {
+        val config = RemoteConfig(threshold = 100, maxUserSessionProperties = 5)
+        store.saveResponse(ConfigHttpResponse(config, "etag"))
+        assertEquals(config, readJsonPrimary())
+    }
+
+    @Test
+    fun `disabled threshold short-circuits the binary read to a minimal config`() {
+        // threshold 0 disables the SDK for every device, so the gate fires regardless of deviceId
+        val config = RemoteConfig(threshold = 0, maxUserSessionProperties = 99)
+        store.saveResponse(ConfigHttpResponse(config, "etag"))
+
+        val loaded = checkNotNull(store.loadResponse())
+        assertEquals(RemoteConfig(threshold = 0), loaded.cfg)
+    }
+
+    @Test
+    fun `falls back to the JSON primary when the binary cache is absent`() {
+        // an install with only the JSON primary (e.g. before the first binary write, or after an upgrade)
+        writeJsonPrimary(RemoteConfig(threshold = 100, maxUserSessionProperties = 3))
+        File(dir, "etag").writeText("primary-etag")
+
+        val loaded = checkNotNull(store.loadResponse())
+        assertEquals(RemoteConfig(threshold = 100, maxUserSessionProperties = 3), loaded.cfg)
+        assertEquals("primary-etag", loaded.etag)
+    }
+
+    @Test
+    fun `loadDeviceId returns the deviceId cached in the binary config`() {
+        assertNull(store.loadDeviceId())
+
+        store.saveResponse(ConfigHttpResponse(RemoteConfig(threshold = 100), "etag"))
+        assertEquals(ENABLED_DEVICE_ID, store.loadDeviceId())
+    }
+
+    @Test
+    fun `loadDeviceId returns null when only a JSON primary exists`() {
+        writeJsonPrimary(RemoteConfig(threshold = 100))
+        assertNull(store.loadDeviceId())
+    }
+
+    private fun readJsonPrimary(): RemoteConfig =
+        File(dir, "most_recent_response").inputStream().buffered().use {
+            serializer.fromJson(it, RemoteConfig::class.java)
+        }
+
+    private fun writeJsonPrimary(config: RemoteConfig) {
+        File(dir, "most_recent_response").outputStream().buffered().use {
+            serializer.toJson(config, RemoteConfig::class.java, it)
+        }
+    }
+
+    private companion object {
+        // deviceId whose normalized value is 0, so any positive threshold leaves the SDK enabled
+        const val ENABLED_DEVICE_ID = "00000000000000000000000000000000"
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/TelemetryDestinationImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/TelemetryDestinationImpl.kt
@@ -130,7 +130,7 @@ class TelemetryDestinationImpl(
         val spanToken = startSpanCapture(
             schemaType = state,
             startTimeMs = clock.now(),
-            private = true
+            private = false
         )
 
         return SessionPartStateTokenImpl(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/ClockDrift.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/ClockDrift.kt
@@ -4,12 +4,37 @@ package io.embrace.android.embracesdk.internal.capture.metadata
  * Reported difference / drift between our internal clock and the system auxiliary clocks (GNSS and Network Time). Positive values
  * indicate that the specified clock is behind our clock, negative values indicate it is ahead.
  */
-data class ClockDrift(
+class ClockDrift private constructor(
     val networkDriftMillis: Long?,
     val gnssDriftMillis: Long?,
 ) {
-    constructor(wallTimeMillis: Long, networkTimeMillis: Long?, gnssTimeMillis: Long?) : this(
-        networkDriftMillis = networkTimeMillis?.let { wallTimeMillis - it },
-        gnssDriftMillis = gnssTimeMillis?.let { wallTimeMillis - it },
-    )
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ClockDrift
+
+        if (networkDriftMillis != other.networkDriftMillis) return false
+        if (gnssDriftMillis != other.gnssDriftMillis) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = networkDriftMillis?.hashCode() ?: 0
+        result = 31 * result + (gnssDriftMillis?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String {
+        return "ClockDrift(networkDriftMillis=$networkDriftMillis, gnssDriftMillis=$gnssDriftMillis)"
+    }
+
+    companion object {
+        fun fromWallDrift(wallTimeMillis: Long, networkTimeMillis: Long?, gnssTimeMillis: Long?) =
+            ClockDrift(
+                networkDriftMillis = networkTimeMillis?.let { wallTimeMillis - it },
+                gnssDriftMillis = gnssTimeMillis?.let { wallTimeMillis - it },
+            )
+    }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/ClockDrift.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/ClockDrift.kt
@@ -4,37 +4,16 @@ package io.embrace.android.embracesdk.internal.capture.metadata
  * Reported difference / drift between our internal clock and the system auxiliary clocks (GNSS and Network Time). Positive values
  * indicate that the specified clock is behind our clock, negative values indicate it is ahead.
  */
-class ClockDrift private constructor(
+data class ClockDrift(
     val networkDriftMillis: Long?,
     val gnssDriftMillis: Long?,
 ) {
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as ClockDrift
-
-        if (networkDriftMillis != other.networkDriftMillis) return false
-        if (gnssDriftMillis != other.gnssDriftMillis) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = networkDriftMillis?.hashCode() ?: 0
-        result = 31 * result + (gnssDriftMillis?.hashCode() ?: 0)
-        return result
-    }
-
-    override fun toString(): String {
-        return "ClockDrift(networkDriftMillis=$networkDriftMillis, gnssDriftMillis=$gnssDriftMillis)"
-    }
-
     companion object {
-        fun fromWallDrift(wallTimeMillis: Long, networkTimeMillis: Long?, gnssTimeMillis: Long?) =
-            ClockDrift(
-                networkDriftMillis = networkTimeMillis?.let { wallTimeMillis - it },
-                gnssDriftMillis = gnssTimeMillis?.let { wallTimeMillis - it },
-            )
+        /**
+         * Computes the drift between the wall clock and an auxiliary clock, both expressed in milliseconds since the epoch.
+         * Positive return values indicate the auxiliary clock is behind the wall clock; negative values indicate it is ahead.
+         */
+        @JvmStatic
+        fun calculateDrift(wallTimeMillis: Long, auxTimeMillis: Long): Long = wallTimeMillis - auxTimeMillis
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/ClockDrift.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/ClockDrift.kt
@@ -13,7 +13,6 @@ data class ClockDrift(
          * Computes the drift between the wall clock and an auxiliary clock, both expressed in milliseconds since the epoch.
          * Positive return values indicate the auxiliary clock is behind the wall clock; negative values indicate it is ahead.
          */
-        @JvmStatic
         fun calculateDrift(wallTimeMillis: Long, auxTimeMillis: Long): Long = wallTimeMillis - auxTimeMillis
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/ClockDrift.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/ClockDrift.kt
@@ -1,0 +1,15 @@
+package io.embrace.android.embracesdk.internal.capture.metadata
+
+/**
+ * Reported difference / drift between our internal clock and the system auxiliary clocks (GNSS and Network Time). Positive values
+ * indicate that the specified clock is behind our clock, negative values indicate it is ahead.
+ */
+data class ClockDrift(
+    val networkDriftMillis: Long?,
+    val gnssDriftMillis: Long?,
+) {
+    constructor(wallTimeMillis: Long, networkTimeMillis: Long?, gnssTimeMillis: Long?) : this(
+        networkDriftMillis = networkTimeMillis?.let { wallTimeMillis - it },
+        gnssDriftMillis = gnssTimeMillis?.let { wallTimeMillis - it },
+    )
+}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
@@ -7,8 +7,10 @@ import android.os.Build
 import android.os.Environment
 import android.os.Process
 import android.os.StatFs
+import android.os.SystemClock
 import android.os.storage.StorageManager
 import androidx.annotation.RequiresApi
+import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.envelope.resource.EnvelopeResourceSource
 import io.embrace.android.embracesdk.internal.store.KeyValueStore
@@ -24,6 +26,7 @@ internal class EmbraceMetadataService(
     private val storageStatsManager: Lazy<StorageStatsManager?>,
     private val configService: ConfigService,
     private val store: KeyValueStore,
+    private val clock: Clock,
     private val metadataBackgroundWorker: BackgroundWorker,
 ) : MetadataService {
 
@@ -89,6 +92,32 @@ internal class EmbraceMetadataService(
     }
 
     override fun getDiskUsage(): DiskUsage? = diskUsage
+
+    override fun getClockDrift(): ClockDrift? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            return null
+        }
+
+        val wallTime = clock.now()
+
+        val gnssTime = runCatching { SystemClock.currentGnssTimeClock().millis() }.getOrNull()
+        val networkTime =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                runCatching { SystemClock.currentNetworkTimeClock().millis() }.getOrNull()
+            } else {
+                null
+            }
+
+        if (gnssTime == null && networkTime == null) {
+            return null
+        }
+
+        return ClockDrift(
+            wallTimeMillis = wallTime,
+            networkTimeMillis = networkTime,
+            gnssTimeMillis = gnssTime,
+        )
+    }
 
     private companion object {
         const val PREVIOUS_APP_VERSION_KEY = "io.embrace.lastappversion"

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
@@ -112,7 +112,7 @@ internal class EmbraceMetadataService(
             return null
         }
 
-        return ClockDrift(
+        return ClockDrift.fromWallDrift(
             wallTimeMillis = wallTime,
             networkTimeMillis = networkTime,
             gnssTimeMillis = gnssTime,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
@@ -37,6 +37,9 @@ internal class EmbraceMetadataService(
     @Volatile
     private var diskUsage: DiskUsage? = null
 
+    @Volatile
+    private var clockDrift: ClockDrift? = null
+
     private var appVersion: String?
         get() = store.getString(PREVIOUS_APP_VERSION_KEY)
         set(value) = store.edit { putString(PREVIOUS_APP_VERSION_KEY, value) }
@@ -66,6 +69,7 @@ internal class EmbraceMetadataService(
             if (diskUsage == null) {
                 diskUsage = DiskUsage(null, free)
             }
+            clockDrift = computeClockDrift()
         }
     }
 
@@ -93,7 +97,9 @@ internal class EmbraceMetadataService(
 
     override fun getDiskUsage(): DiskUsage? = diskUsage
 
-    override fun getClockDrift(): ClockDrift? {
+    override fun getClockDrift(): ClockDrift? = clockDrift
+
+    private fun computeClockDrift(): ClockDrift? {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
             return null
         }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
@@ -98,25 +98,26 @@ internal class EmbraceMetadataService(
             return null
         }
 
-        val wallTime = clock.now()
+        val gnssDrift = runCatching {
+            val gnss = SystemClock.currentGnssTimeClock().millis()
+            ClockDrift.calculateDrift(wallTimeMillis = clock.now(), auxTimeMillis = gnss)
+        }.getOrNull()
 
-        val gnssTime = runCatching { SystemClock.currentGnssTimeClock().millis() }.getOrNull()
-        val networkTime =
+        val networkDrift =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                runCatching { SystemClock.currentNetworkTimeClock().millis() }.getOrNull()
+                runCatching {
+                    val network = SystemClock.currentNetworkTimeClock().millis()
+                    ClockDrift.calculateDrift(wallTimeMillis = clock.now(), auxTimeMillis = network)
+                }.getOrNull()
             } else {
                 null
             }
 
-        if (gnssTime == null && networkTime == null) {
+        if (gnssDrift == null && networkDrift == null) {
             return null
         }
 
-        return ClockDrift.fromWallDrift(
-            wallTimeMillis = wallTime,
-            networkTimeMillis = networkTime,
-            gnssTimeMillis = gnssTime,
-        )
+        return ClockDrift(networkDriftMillis = networkDrift, gnssDriftMillis = gnssDrift)
     }
 
     private companion object {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/MetadataService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/MetadataService.kt
@@ -9,6 +9,14 @@ interface MetadataService {
     fun getDiskUsage(): DiskUsage?
 
     /**
+     * Gets the current device's time drift relative to its auxiliary clocks if available. This value is read live and does not
+     * depend on [precomputeValues].
+     *
+     * @return the device's time drift relative to its auxiliary clocks
+     */
+    fun getClockDrift(): ClockDrift?
+
+    /**
      * Queues in a single thread executor callables to retrieve values in background
      */
     fun precomputeValues()

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/MetadataService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/MetadataService.kt
@@ -9,8 +9,9 @@ interface MetadataService {
     fun getDiskUsage(): DiskUsage?
 
     /**
-     * Gets the current device's time drift relative to its auxiliary clocks if available. This value is read live and does not
-     * depend on [precomputeValues].
+     * Gets the device's time drift relative to its auxiliary clocks if available. The value is sampled during [precomputeValues] so
+     * that the underlying IPC stays off any consumer's critical path; this method returns `null` until that work completes, and
+     * `null` thereafter if neither auxiliary clock could be read.
      *
      * @return the device's time drift relative to its auxiliary clocks
      */

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CoreModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CoreModuleImpl.kt
@@ -30,8 +30,7 @@ class CoreModuleImpl(
         SharedPrefsStore(
             PreferenceManager.getDefaultSharedPreferences(
                 context
-            ),
-            initModule.jsonSerializer
+            )
         )
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
@@ -145,6 +145,7 @@ class PayloadSourceModuleImpl(
                 lazy { storageManager },
                 configService,
                 coreModule.store,
+                initModule.clock,
                 workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker)
             )
         }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/SharedPrefsStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/SharedPrefsStore.kt
@@ -1,13 +1,14 @@
 package io.embrace.android.embracesdk.internal.prefs
 
 import android.content.SharedPreferences
-import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
+import android.util.JsonReader
+import android.util.JsonToken
 import io.embrace.android.embracesdk.internal.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.store.KeyValueStoreEditor
+import java.io.StringReader
 
 internal class SharedPrefsStore(
     private val impl: SharedPreferences,
-    private val serializer: PlatformSerializer,
 ) : KeyValueStore {
 
     override fun getString(key: String): String? {
@@ -38,14 +39,30 @@ internal class SharedPrefsStore(
         return impl.getStringSet(key, null)
     }
 
-    @Suppress("UNCHECKED_CAST")
     override fun getStringMap(key: String): Map<String, String>? {
         val mapString = impl.getString(key, null) ?: return null
-        return serializer.fromJson(mapString, Map::class.java) as Map<String, String>
+        return try {
+            JsonReader(StringReader(mapString)).use { reader ->
+                val map = LinkedHashMap<String, String>()
+                reader.beginObject()
+                while (reader.hasNext()) {
+                    val name = reader.nextName()
+                    if (reader.peek() == JsonToken.NULL) {
+                        reader.nextNull()
+                    } else {
+                        map[name] = reader.nextString()
+                    }
+                }
+                reader.endObject()
+                map
+            }
+        } catch (exc: Exception) {
+            null
+        }
     }
 
     override fun edit(action: KeyValueStoreEditor.() -> Unit) {
-        SharedPrefsStoreEditor(impl.edit(), serializer).use {
+        SharedPrefsStoreEditor(impl.edit()).use {
             it.action()
         }
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/SharedPrefsStoreEditor.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/SharedPrefsStoreEditor.kt
@@ -1,12 +1,12 @@
 package io.embrace.android.embracesdk.internal.prefs
 
 import android.content.SharedPreferences
-import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
+import android.util.JsonWriter
 import io.embrace.android.embracesdk.internal.store.KeyValueStoreEditor
+import java.io.StringWriter
 
 internal class SharedPrefsStoreEditor(
     private val editor: SharedPreferences.Editor,
-    private val serializer: PlatformSerializer,
 ) : KeyValueStoreEditor, AutoCloseable {
 
     override fun putString(key: String, value: String?) {
@@ -33,9 +33,14 @@ internal class SharedPrefsStoreEditor(
         key: String,
         value: Map<String, String>?,
     ) {
-        val mapString = when {
-            value != null -> serializer.toJson(value, Map::class.java)
-            else -> null
+        val mapString = value?.let { map ->
+            StringWriter().apply {
+                JsonWriter(this).use { writer ->
+                    writer.beginObject()
+                    map.forEach { (k, v) -> writer.name(k).value(v) }
+                    writer.endObject()
+                }
+            }.toString()
         }
         editor.putString(key, mapString)
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImpl.kt
@@ -55,10 +55,10 @@ internal class SessionPartSpanAttrPopulatorImpl(
 
             metadataService.getClockDrift()?.let { drift ->
                 drift.networkDriftMillis?.let {
-                    addSessionPartAttribute(EmbSessionAttributes.EMB_CLOCK_NETWORK_DRIFT_MILLIS, it.toString())
+                    addSessionPartAttribute(EmbSessionAttributes.EMB_CLOCK_NETWORK_DRIFT, it.toString())
                 }
                 drift.gnssDriftMillis?.let {
-                    addSessionPartAttribute(EmbSessionAttributes.EMB_CLOCK_GNSS_DRIFT_MILLIS, it.toString())
+                    addSessionPartAttribute(EmbSessionAttributes.EMB_CLOCK_GNSS_DRIFT, it.toString())
                 }
             }
         }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImpl.kt
@@ -52,6 +52,15 @@ internal class SessionPartSpanAttrPopulatorImpl(
             metadataService.getDiskUsage()?.deviceDiskFree?.let { free ->
                 addSessionPartAttribute(EmbSessionAttributes.EMB_DISK_FREE_BYTES, free.toString())
             }
+
+            metadataService.getClockDrift()?.let { drift ->
+                drift.networkDriftMillis?.let {
+                    addSessionPartAttribute(EmbSessionAttributes.EMB_CLOCK_NETWORK_DRIFT_MILLIS, it.toString())
+                }
+                drift.gnssDriftMillis?.let {
+                    addSessionPartAttribute(EmbSessionAttributes.EMB_CLOCK_GNSS_DRIFT_MILLIS, it.toString())
+                }
+            }
         }
     }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistryTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistryTest.kt
@@ -7,13 +7,19 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeDataSource
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationProvider
+import io.embrace.android.embracesdk.internal.arch.datasource.DataSource
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
+import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
 import io.embrace.android.embracesdk.internal.logging.InternalLoggerImpl
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RuntimeEnvironment
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
 internal class InstrumentationRegistryTest {
@@ -68,5 +74,58 @@ internal class InstrumentationRegistryTest {
         registry.onPostSessionChange()
         assertEquals(1, dataSource.sessionEnds)
         assertEquals(1, dataSource.sessionChanges)
+    }
+
+    @Test
+    fun `datasource iteration is threadsafe`() {
+        val iterationStarted = CountDownLatch(1)
+        val continueIteration = CountDownLatch(1)
+        val newDataSource = FakeDataSource(RuntimeEnvironment.getApplication())
+
+        registry.add(
+            DataSourceState(
+                factory = {
+                    BlockingTestDataSource(iterationStarted, continueIteration)
+                }
+            )
+        )
+
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            val iterationDone = executor.submit {
+                registry.onPostSessionChange()
+            }
+            assertTrue(iterationStarted.await(1, TimeUnit.SECONDS))
+            registry.add(DataSourceState({ newDataSource }))
+            continueIteration.countDown()
+            iterationDone.get(1, TimeUnit.SECONDS)
+        } finally {
+            executor.shutdownNow()
+        }
+
+        assertEquals("Datasource added during registry iteration should not be touched", 0, newDataSource.sessionChanges)
+        registry.onPostSessionChange()
+        assertEquals(1, newDataSource.sessionChanges)
+    }
+
+    private class BlockingTestDataSource(
+        private val iterationStarted: CountDownLatch,
+        private val mayContinue: CountDownLatch,
+    ) : DataSource, SessionPartChangeListener {
+        override val instrumentationName: String = "blocking_test_data_source"
+
+        override fun onDataCaptureEnabled() {}
+        override fun onDataCaptureDisabled() {}
+        override fun resetDataCaptureLimits() {}
+        override fun <T> captureTelemetry(
+            inputValidation: () -> Boolean,
+            invalidInputCallback: () -> Unit,
+            action: TelemetryDestination.() -> T?,
+        ): T? = null
+
+        override fun onPostSessionChange() {
+            iterationStarted.countDown()
+            mayContinue.await(1, TimeUnit.SECONDS)
+        }
     }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/store/KeyValueStoreTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/store/KeyValueStoreTest.kt
@@ -26,7 +26,7 @@ internal class KeyValueStoreTest {
     @Before
     fun setUp() {
         val prefs: SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
-        store = SharedPrefsStore(prefs, TestPlatformSerializer())
+        store = SharedPrefsStore(prefs)
     }
 
     @Test
@@ -72,5 +72,21 @@ internal class KeyValueStoreTest {
         assertEquals(boolValue, store.getBoolean("bool", false))
         assertEquals(setValue, store.getStringSet("set"))
         assertEquals(mapValue, store.getStringMap("map"))
+    }
+
+    @Test
+    fun testStringMapJsonCompatibilityWithMoshi() {
+        val serializer = TestPlatformSerializer()
+        val map = mapOf("a" to "b", "c" to "d")
+
+        // the new reader parses a map serialized the old (Moshi) way
+        store.edit { putString("legacy", serializer.toJson(map, Map::class.java)) }
+        assertEquals(map, store.getStringMap("legacy"))
+
+        // the new writer produces output the old (Moshi) deserializer can read
+        store.edit { putStringMap("new", map) }
+        @Suppress("UNCHECKED_CAST")
+        val viaMoshi = serializer.fromJson(checkNotNull(store.getString("new")), Map::class.java) as Map<String, String>
+        assertEquals(map, viaMoshi)
     }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/ClockDriftTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/ClockDriftTest.kt
@@ -1,80 +1,22 @@
 package io.embrace.android.embracesdk.internal.capture.metadata
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class ClockDriftTest {
 
     @Test
-    fun `both drifts are null when network and gnss times are null`() {
-        val drift = ClockDrift.fromWallDrift(
-            wallTimeMillis = 1_000L,
-            networkTimeMillis = null,
-            gnssTimeMillis = null,
-        )
-
-        assertNull(drift.networkDriftMillis)
-        assertNull(drift.gnssDriftMillis)
+    fun `calculateDrift returns a positive value when the aux clock is behind the wall clock`() {
+        assertEquals(100L, ClockDrift.calculateDrift(wallTimeMillis = 1_000L, auxTimeMillis = 900L))
     }
 
     @Test
-    fun `positive drift when aux clock is behind wall clock`() {
-        val drift = ClockDrift.fromWallDrift(
-            wallTimeMillis = 1_000L,
-            networkTimeMillis = 900L,
-            gnssTimeMillis = 800L,
-        )
-
-        assertEquals(100L, drift.networkDriftMillis)
-        assertEquals(200L, drift.gnssDriftMillis)
+    fun `calculateDrift returns a negative value when the aux clock is ahead of the wall clock`() {
+        assertEquals(-250L, ClockDrift.calculateDrift(wallTimeMillis = 1_000L, auxTimeMillis = 1_250L))
     }
 
     @Test
-    fun `negative drift when aux clock is ahead of wall clock`() {
-        val drift = ClockDrift.fromWallDrift(
-            wallTimeMillis = 1_000L,
-            networkTimeMillis = 1_100L,
-            gnssTimeMillis = 1_300L,
-        )
-
-        assertEquals(-100L, drift.networkDriftMillis)
-        assertEquals(-300L, drift.gnssDriftMillis)
-    }
-
-    @Test
-    fun `zero drift when aux clock matches wall clock`() {
-        val drift = ClockDrift.fromWallDrift(
-            wallTimeMillis = 1_000L,
-            networkTimeMillis = 1_000L,
-            gnssTimeMillis = 1_000L,
-        )
-
-        assertEquals(0L, drift.networkDriftMillis)
-        assertEquals(0L, drift.gnssDriftMillis)
-    }
-
-    @Test
-    fun `network drift is computed when gnss is null`() {
-        val drift = ClockDrift.fromWallDrift(
-            wallTimeMillis = 1_000L,
-            networkTimeMillis = 950L,
-            gnssTimeMillis = null,
-        )
-
-        assertEquals(50L, drift.networkDriftMillis)
-        assertNull(drift.gnssDriftMillis)
-    }
-
-    @Test
-    fun `gnss drift is computed when network is null`() {
-        val drift = ClockDrift.fromWallDrift(
-            wallTimeMillis = 1_000L,
-            networkTimeMillis = null,
-            gnssTimeMillis = 1_050L,
-        )
-
-        assertNull(drift.networkDriftMillis)
-        assertEquals(-50L, drift.gnssDriftMillis)
+    fun `calculateDrift returns zero when the aux clock matches the wall clock`() {
+        assertEquals(0L, ClockDrift.calculateDrift(wallTimeMillis = 1_000L, auxTimeMillis = 1_000L))
     }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/ClockDriftTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/ClockDriftTest.kt
@@ -1,0 +1,80 @@
+package io.embrace.android.embracesdk.internal.capture.metadata
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+internal class ClockDriftTest {
+
+    @Test
+    fun `both drifts are null when network and gnss times are null`() {
+        val drift = ClockDrift.fromWallDrift(
+            wallTimeMillis = 1_000L,
+            networkTimeMillis = null,
+            gnssTimeMillis = null,
+        )
+
+        assertNull(drift.networkDriftMillis)
+        assertNull(drift.gnssDriftMillis)
+    }
+
+    @Test
+    fun `positive drift when aux clock is behind wall clock`() {
+        val drift = ClockDrift.fromWallDrift(
+            wallTimeMillis = 1_000L,
+            networkTimeMillis = 900L,
+            gnssTimeMillis = 800L,
+        )
+
+        assertEquals(100L, drift.networkDriftMillis)
+        assertEquals(200L, drift.gnssDriftMillis)
+    }
+
+    @Test
+    fun `negative drift when aux clock is ahead of wall clock`() {
+        val drift = ClockDrift.fromWallDrift(
+            wallTimeMillis = 1_000L,
+            networkTimeMillis = 1_100L,
+            gnssTimeMillis = 1_300L,
+        )
+
+        assertEquals(-100L, drift.networkDriftMillis)
+        assertEquals(-300L, drift.gnssDriftMillis)
+    }
+
+    @Test
+    fun `zero drift when aux clock matches wall clock`() {
+        val drift = ClockDrift.fromWallDrift(
+            wallTimeMillis = 1_000L,
+            networkTimeMillis = 1_000L,
+            gnssTimeMillis = 1_000L,
+        )
+
+        assertEquals(0L, drift.networkDriftMillis)
+        assertEquals(0L, drift.gnssDriftMillis)
+    }
+
+    @Test
+    fun `network drift is computed when gnss is null`() {
+        val drift = ClockDrift.fromWallDrift(
+            wallTimeMillis = 1_000L,
+            networkTimeMillis = 950L,
+            gnssTimeMillis = null,
+        )
+
+        assertEquals(50L, drift.networkDriftMillis)
+        assertNull(drift.gnssDriftMillis)
+    }
+
+    @Test
+    fun `gnss drift is computed when network is null`() {
+        val drift = ClockDrift.fromWallDrift(
+            wallTimeMillis = 1_000L,
+            networkTimeMillis = null,
+            gnssTimeMillis = 1_050L,
+        )
+
+        assertNull(drift.networkDriftMillis)
+        assertEquals(-50L, drift.gnssDriftMillis)
+    }
+}

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataServiceClockDriftTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataServiceClockDriftTest.kt
@@ -1,0 +1,132 @@
+package io.embrace.android.embracesdk.internal.capture.metadata
+
+import android.app.Application
+import android.app.usage.StorageStatsManager
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
+import io.embrace.android.embracesdk.fakes.FakeKeyValueStore
+import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
+import io.embrace.android.embracesdk.internal.capture.metadata.shadows.EmbraceShadowSystemClock
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+@RunWith(AndroidJUnit4::class)
+@Config(shadows = [EmbraceShadowSystemClock::class])
+internal class EmbraceMetadataServiceClockDriftTest {
+
+    private val wallTimeMillis = FakeClock.DEFAULT_FAKE_CURRENT_TIME
+    private lateinit var service: EmbraceMetadataService
+
+    @Before
+    fun setUp() {
+        EmbraceShadowSystemClock.reset()
+        service = EmbraceMetadataService(
+            resourceSource = lazy { FakeEnvelopeResourceSource() },
+            context = ApplicationProvider.getApplicationContext<Application>(),
+            storageStatsManager = lazy<StorageStatsManager?> { null },
+            configService = FakeConfigService(),
+            store = FakeKeyValueStore(),
+            clock = FakeClock(currentTime = wallTimeMillis),
+            metadataBackgroundWorker = fakeBackgroundWorker(),
+        )
+    }
+
+    @After
+    fun tearDown() {
+        EmbraceShadowSystemClock.reset()
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.P])
+    @Test
+    fun `getClockDrift returns null below Q regardless of clock availability`() {
+        EmbraceShadowSystemClock.gnssClock = fixedClock(wallTimeMillis - 50)
+        EmbraceShadowSystemClock.networkClock = fixedClock(wallTimeMillis - 100)
+
+        assertNull(service.getClockDrift())
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.Q])
+    @Test
+    fun `getClockDrift on Q returns GNSS drift and null network drift`() {
+        EmbraceShadowSystemClock.gnssClock = fixedClock(wallTimeMillis - 50)
+        EmbraceShadowSystemClock.networkClock = fixedClock(wallTimeMillis - 100)
+
+        val drift = service.getClockDrift()
+
+        assertEquals(50L, drift?.gnssDriftMillis)
+        assertNull(drift?.networkDriftMillis)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.Q])
+    @Test
+    fun `getClockDrift on Q returns null when GNSS clock is unavailable`() {
+        assertNull(service.getClockDrift())
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.S])
+    @Test
+    fun `getClockDrift between Q and TIRAMISU does not query network clock`() {
+        EmbraceShadowSystemClock.gnssClock = fixedClock(wallTimeMillis - 25)
+        EmbraceShadowSystemClock.networkClock = fixedClock(wallTimeMillis - 100)
+
+        val drift = service.getClockDrift()
+
+        assertEquals(25L, drift?.gnssDriftMillis)
+        assertNull(drift?.networkDriftMillis)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @Test
+    fun `getClockDrift on TIRAMISU returns both drifts when both clocks are available`() {
+        EmbraceShadowSystemClock.gnssClock = fixedClock(wallTimeMillis - 50)
+        EmbraceShadowSystemClock.networkClock = fixedClock(wallTimeMillis - 100)
+
+        val drift = service.getClockDrift()
+
+        assertEquals(50L, drift?.gnssDriftMillis)
+        assertEquals(100L, drift?.networkDriftMillis)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @Test
+    fun `getClockDrift on TIRAMISU returns only network drift when GNSS is unavailable`() {
+        EmbraceShadowSystemClock.networkClock = fixedClock(wallTimeMillis - 100)
+
+        val drift = service.getClockDrift()
+
+        assertNull(drift?.gnssDriftMillis)
+        assertEquals(100L, drift?.networkDriftMillis)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @Test
+    fun `getClockDrift on TIRAMISU returns only GNSS drift when network is unavailable`() {
+        EmbraceShadowSystemClock.gnssClock = fixedClock(wallTimeMillis - 50)
+
+        val drift = service.getClockDrift()
+
+        assertEquals(50L, drift?.gnssDriftMillis)
+        assertNull(drift?.networkDriftMillis)
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    @Test
+    fun `getClockDrift on TIRAMISU returns null when both clocks are unavailable`() {
+        assertNull(service.getClockDrift())
+    }
+
+    private fun fixedClock(epochMillis: Long): Clock =
+        Clock.fixed(Instant.ofEpochMilli(epochMillis), ZoneOffset.UTC)
+}

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataServiceClockDriftTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataServiceClockDriftTest.kt
@@ -54,6 +54,7 @@ internal class EmbraceMetadataServiceClockDriftTest {
         EmbraceShadowSystemClock.gnssClock = fixedClock(wallTimeMillis - 50)
         EmbraceShadowSystemClock.networkClock = fixedClock(wallTimeMillis - 100)
 
+        service.precomputeValues()
         assertNull(service.getClockDrift())
     }
 
@@ -63,6 +64,7 @@ internal class EmbraceMetadataServiceClockDriftTest {
         EmbraceShadowSystemClock.gnssClock = fixedClock(wallTimeMillis - 50)
         EmbraceShadowSystemClock.networkClock = fixedClock(wallTimeMillis - 100)
 
+        service.precomputeValues()
         val drift = service.getClockDrift()
 
         assertEquals(50L, drift?.gnssDriftMillis)
@@ -72,6 +74,7 @@ internal class EmbraceMetadataServiceClockDriftTest {
     @Config(sdk = [Build.VERSION_CODES.Q])
     @Test
     fun `getClockDrift on Q returns null when GNSS clock is unavailable`() {
+        service.precomputeValues()
         assertNull(service.getClockDrift())
     }
 
@@ -81,6 +84,7 @@ internal class EmbraceMetadataServiceClockDriftTest {
         EmbraceShadowSystemClock.gnssClock = fixedClock(wallTimeMillis - 25)
         EmbraceShadowSystemClock.networkClock = fixedClock(wallTimeMillis - 100)
 
+        service.precomputeValues()
         val drift = service.getClockDrift()
 
         assertEquals(25L, drift?.gnssDriftMillis)
@@ -93,6 +97,7 @@ internal class EmbraceMetadataServiceClockDriftTest {
         EmbraceShadowSystemClock.gnssClock = fixedClock(wallTimeMillis - 50)
         EmbraceShadowSystemClock.networkClock = fixedClock(wallTimeMillis - 100)
 
+        service.precomputeValues()
         val drift = service.getClockDrift()
 
         assertEquals(50L, drift?.gnssDriftMillis)
@@ -104,6 +109,7 @@ internal class EmbraceMetadataServiceClockDriftTest {
     fun `getClockDrift on TIRAMISU returns only network drift when GNSS is unavailable`() {
         EmbraceShadowSystemClock.networkClock = fixedClock(wallTimeMillis - 100)
 
+        service.precomputeValues()
         val drift = service.getClockDrift()
 
         assertNull(drift?.gnssDriftMillis)
@@ -115,6 +121,7 @@ internal class EmbraceMetadataServiceClockDriftTest {
     fun `getClockDrift on TIRAMISU returns only GNSS drift when network is unavailable`() {
         EmbraceShadowSystemClock.gnssClock = fixedClock(wallTimeMillis - 50)
 
+        service.precomputeValues()
         val drift = service.getClockDrift()
 
         assertEquals(50L, drift?.gnssDriftMillis)
@@ -124,6 +131,7 @@ internal class EmbraceMetadataServiceClockDriftTest {
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
     @Test
     fun `getClockDrift on TIRAMISU returns null when both clocks are unavailable`() {
+        service.precomputeValues()
         assertNull(service.getClockDrift())
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/shadows/EmbraceShadowSystemClock.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/shadows/EmbraceShadowSystemClock.kt
@@ -1,0 +1,41 @@
+package io.embrace.android.embracesdk.internal.capture.metadata.shadows
+
+import android.os.SystemClock
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+import java.time.Clock
+import java.time.DateTimeException
+
+/**
+ * Robolectric shadow that allows tests to control the values returned by
+ * [SystemClock.currentGnssTimeClock] and [SystemClock.currentNetworkTimeClock].
+ *
+ * Setting [gnssClock] or [networkClock] to `null` causes the corresponding shadowed method to throw
+ * [DateTimeException], matching the real Android behaviour when no fix / network time is available.
+ */
+@Implements(SystemClock::class)
+@Suppress("UtilityClassWithPublicConstructor")
+class EmbraceShadowSystemClock {
+    companion object {
+        @JvmStatic
+        var gnssClock: Clock? = null
+
+        @JvmStatic
+        var networkClock: Clock? = null
+
+        @Implementation
+        @JvmStatic
+        fun currentGnssTimeClock(): Clock =
+            gnssClock ?: throw DateTimeException("GNSS based time is not available")
+
+        @Implementation
+        @JvmStatic
+        fun currentNetworkTimeClock(): Clock =
+            networkClock ?: throw DateTimeException("Network based time is not available")
+
+        fun reset() {
+            gnssClock = null
+            networkClock = null
+        }
+    }
+}

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
@@ -87,8 +87,8 @@ internal class SessionPartSpanAttrPopulatorImplTest {
             EmbSessionAttributes.EMB_SESSION_END_TYPE to "state",
             EmbSessionAttributes.EMB_ERROR_LOG_COUNT to "0",
             EmbSessionAttributes.EMB_DISK_FREE_BYTES to "500000000",
-            EmbSessionAttributes.EMB_CLOCK_NETWORK_DRIFT_MILLIS to "50",
-            EmbSessionAttributes.EMB_CLOCK_GNSS_DRIFT_MILLIS to "10",
+            EmbSessionAttributes.EMB_CLOCK_NETWORK_DRIFT to "50",
+            EmbSessionAttributes.EMB_CLOCK_GNSS_DRIFT to "10",
         )
         assertEquals(expected, attrs)
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.session.orchestrator
 
+import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeLogLimitingService
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakeTelemetryDestination
@@ -59,6 +60,35 @@ internal class SessionPartSpanAttrPopulatorImplTest {
             EmbSessionAttributes.EMB_SESSION_END_TYPE to "state",
             EmbSessionAttributes.EMB_ERROR_LOG_COUNT to "0",
             EmbSessionAttributes.EMB_DISK_FREE_BYTES to "500000000"
+        )
+        assertEquals(expected, attrs)
+    }
+
+    @Test
+    fun `clock drift attributes populated when aux clocks available`() {
+        populator = SessionPartSpanAttrPopulatorImpl(
+            destination,
+            { 0 },
+            FakeLogLimitingService(),
+            FakeMetadataService(
+                wallClock = FakeClock(1000L),
+                networkClock = FakeClock(950L),
+                gnssClock = FakeClock(990L),
+            ),
+        )
+
+        populator.populateSessionSpanEndAttrs(LifeEventType.STATE, "crashId", false)
+
+        val attrs = destination.attributes
+        val expected = mapOf(
+            EmbSessionAttributes.EMB_CLEAN_EXIT to "true",
+            EmbSessionAttributes.EMB_TERMINATED to "false",
+            EmbSessionAttributes.EMB_CRASH_ID to "crashId",
+            EmbSessionAttributes.EMB_SESSION_END_TYPE to "state",
+            EmbSessionAttributes.EMB_ERROR_LOG_COUNT to "0",
+            EmbSessionAttributes.EMB_DISK_FREE_BYTES to "500000000",
+            EmbSessionAttributes.EMB_CLOCK_NETWORK_DRIFT_MILLIS to "50",
+            EmbSessionAttributes.EMB_CLOCK_GNSS_DRIFT_MILLIS to "10",
         )
         assertEquals(expected, attrs)
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
@@ -66,15 +66,17 @@ internal class SessionPartSpanAttrPopulatorImplTest {
 
     @Test
     fun `clock drift attributes populated when aux clocks available`() {
+        val metadataService = FakeMetadataService(
+            wallClock = FakeClock(1000L),
+            networkClock = FakeClock(950L),
+            gnssClock = FakeClock(990L),
+        ).apply { precomputeValues() }
+
         populator = SessionPartSpanAttrPopulatorImpl(
             destination,
             { 0 },
             FakeLogLimitingService(),
-            FakeMetadataService(
-                wallClock = FakeClock(1000L),
-                networkClock = FakeClock(950L),
-                gnssClock = FakeClock(990L),
-            ),
+            metadataService,
         )
 
         populator.populateSessionSpanEndAttrs(LifeEventType.STATE, "crashId", false)

--- a/embrace-android-instrumentation-androidx-navigation/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/androidx/navigation/NavigationTrackers.kt
+++ b/embrace-android-instrumentation-androidx-navigation/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/androidx/navigation/NavigationTrackers.kt
@@ -17,9 +17,11 @@ import io.embrace.android.embracesdk.instrumentation.androidx.navigation.interna
 import io.embrace.android.embracesdk.internal.arch.navigation.findActivity
 
 /**
- * Wrapper for [rememberNavController] that registers the returned [NavHostController] with the Embrace SDK so navigations are observed.
+ * Composable that wraps [rememberNavController] and registers the created [NavHostController] with the Embrace SDK so its destination
+ * changes are tracked as instances of app navigation.
  *
- * Replace uses of [rememberNavController] with this Composable to enable the functionality.
+ * The SDK will use attributes of the loaded `NavDestination` to identify the event: `route` if non-empty, and otherwise `label` if
+ * non-empty. If both are empty, the name of the `Navigator` will be used as fallback.
  */
 @Composable
 public fun rememberObservedNavController(
@@ -37,8 +39,10 @@ public fun rememberObservedNavController(
 }
 
 /**
- * Composable that creates a Nav3 back stack whose mutations are tracked as navigation state changes. The new navigation state value
- * will be what the [toString] method on the object returns.
+ * Composable that creates a Nav3 back stack whose mutations are tracked as instances of app navigation.
+ *
+ * The SDK will use the value of the [toString] method of the top element of the back stack to identify which destination was navigated to.
+ * Ensure that value is stable and consistently what's expected.
  */
 @Composable
 public fun <T : Any> rememberObservedBackStack(vararg keys: T): SnapshotStateList<T> {

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistryImpl.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistryImpl.kt
@@ -19,7 +19,7 @@ class InstrumentationRegistryImpl(
     private val dataSourceStates = CopyOnWriteArrayList<DataSourceState<*>>()
 
     override fun onPreSessionEnd() {
-        dataSourceStates.toList()
+        dataSourceStates
             .filter { it.dataSource is SessionPartEndListener }
             .map { it.dataSource as SessionPartEndListener }
             .forEach {
@@ -28,7 +28,7 @@ class InstrumentationRegistryImpl(
     }
 
     override fun onPostSessionChange() {
-        dataSourceStates.toList().forEach {
+        dataSourceStates.forEach {
             it.dataSource?.run {
                 resetDataCaptureLimits()
                 if (this is SessionPartChangeListener) {
@@ -75,11 +75,11 @@ class InstrumentationRegistryImpl(
         val stateAttributes = mutableMapOf<String, Any>()
 
         dataSourceStates
-            .toList()
-            .filter { it.dataSource is StateDataSource<*> }
-            .forEach {
-                (it.dataSource as StateDataSource<*>).apply {
-                    stateAttributes[stateAttributeKey] = getCurrentStateValue()
+            .mapTo(ArrayList(dataSourceStates.size)) { it.dataSource }
+            .filterIsInstance<StateDataSource<*>>()
+            .forEach { stateDataSource ->
+                if (stateDataSource.isActive()) {
+                    stateAttributes[stateDataSource.stateAttributeKey] = stateDataSource.getCurrentStateValue()
                 }
             }
 

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/StateDataSource.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/StateDataSource.kt
@@ -94,6 +94,11 @@ abstract class StateDataSource<T : Any>(
      */
     fun getCurrentStateValue(): T = currentState.get()
 
+    /**
+     * Returns true if the data source is currently active
+     */
+    fun isActive(): Boolean = stateCaptureActive.get()
+
     @CallSuper
     override fun onDataCaptureEnabled() {
         if (captureStateOnCreation) {

--- a/embrace-android-instrumentation-navigation/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/ScreenDataSourceTest.kt
+++ b/embrace-android-instrumentation-navigation/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/ScreenDataSourceTest.kt
@@ -4,6 +4,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -27,6 +28,7 @@ internal class ScreenDataSourceTest {
     fun `data source not initialized by default`() {
         assertTrue(args.destination.createdStateTokens.isEmpty())
         assertEquals("Uninitialized", dataSource.getCurrentStateValue())
+        assertFalse(dataSource.isActive())
     }
 
     @Test
@@ -35,6 +37,7 @@ internal class ScreenDataSourceTest {
         dataSource.onScreenLoaded("home")
         assertEquals("home", dataSource.getCurrentStateValue())
         assertTrue(args.destination.createdStateTokens.isNotEmpty())
+        assertTrue(dataSource.isActive())
 
         val secondTime = args.clock.tick()
         dataSource.onScreenLoaded("settings")

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionApiTest.kt
@@ -105,8 +105,8 @@ internal class UserSessionApiTest {
             EmbTelemetryAttributes.EMB_IS_EMULATOR,
             EmbTelemetryAttributes.EMB_OKHTTP3_ON_CLASSPATH,
             EmbSessionAttributes.EMB_HEARTBEAT_TIME_UNIX_NANO,
-            EmbSessionAttributes.EMB_CLOCK_GNSS_DRIFT_MILLIS,
-            EmbSessionAttributes.EMB_CLOCK_NETWORK_DRIFT_MILLIS,
+            EmbSessionAttributes.EMB_CLOCK_GNSS_DRIFT,
+            EmbSessionAttributes.EMB_CLOCK_NETWORK_DRIFT,
         )
 
         // Attributes that are unstable that we should not try to verify

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionApiTest.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -65,7 +66,7 @@ internal class UserSessionApiTest {
                 val attrs = checkNotNull(sessionSpan.attributes)
                 val attributeKeys = attrs.map { it.key }
                 validateExistenceOnly.forEach { key ->
-                    attributeKeys.contains(key)
+                    assertTrue("'$key' not found in attrs", attributeKeys.contains(key))
                 }
 
                 val attributesToCheck = attrs.filterNot {
@@ -104,6 +105,8 @@ internal class UserSessionApiTest {
             EmbTelemetryAttributes.EMB_IS_EMULATOR,
             EmbTelemetryAttributes.EMB_OKHTTP3_ON_CLASSPATH,
             EmbSessionAttributes.EMB_HEARTBEAT_TIME_UNIX_NANO,
+            EmbSessionAttributes.EMB_CLOCK_GNSS_DRIFT_MILLIS,
+            EmbSessionAttributes.EMB_CLOCK_NETWORK_DRIFT_MILLIS,
         )
 
         // Attributes that are unstable that we should not try to verify

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/StateFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/StateFeatureTest.kt
@@ -12,7 +12,6 @@ import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.LinkType
-import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
@@ -31,6 +30,7 @@ import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterfac
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -64,6 +64,9 @@ internal class StateFeatureTest {
             assertAction = {
                 assertTrue(testDataSourceActive)
                 assertTrue(getSingleSessionEnvelope().findSpansOfType(EmbType.State).isNotEmpty())
+            },
+            otelExportAssertion = {
+                assertNotNull(awaitSpansWithType(3, EmbType.State).single { it.name == "emb-state-test" })
             }
         )
     }
@@ -116,7 +119,6 @@ internal class StateFeatureTest {
                 val sessions = listOf(background.first(), foreground.first(), background.last())
                 repeat(sessions.size) { i ->
                     val stateSpan = checkNotNull(sessions[i].getStateSpan("emb-state-test"))
-                    assertTrue(checkNotNull(stateSpan.attributes).hasEmbraceAttribute(PrivateSpan))
                     with(checkNotNull(stateSpan.events)) {
                         repeat(size) { j ->
                             val event = transitions[i][j]

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/StateFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/StateFeatureTest.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.assertions.assertStateTransition
 import io.embrace.android.embracesdk.assertions.findSpansOfType
 import io.embrace.android.embracesdk.assertions.getLogs
 import io.embrace.android.embracesdk.assertions.hasLinkToEmbraceSpan
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.LazyInitStateDataSource
 import io.embrace.android.embracesdk.fakes.TestStateDataSource
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
@@ -22,11 +23,14 @@ import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttributeValue
 import io.embrace.android.embracesdk.internal.otel.spans.hasEmbraceAttributeValue
 import io.embrace.android.embracesdk.internal.session.getSessionSpan
 import io.embrace.android.embracesdk.internal.session.getStateSpan
+import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.semconv.EmbStateTransitionAttributes
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface.Companion.LIFECYCLE_EVENT_GAP
+import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -38,18 +42,27 @@ internal class StateFeatureTest {
 
     @Rule
     @JvmField
-    val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule()
+    val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
+        EmbraceSetupInterface(
+            workerToFake = Worker.Background.LogMessageWorker,
+        ).apply {
+            getFakedWorkerExecutor().blockingMode = false
+        }
+    }
 
     val stateEnabledRemoteConfig = RemoteConfig(pctStateCaptureEnabledV2 = 100.0f)
     val stateDisabledRemoteConfig = RemoteConfig(pctStateCaptureEnabledV2 = 0.0f)
 
     @Test
     fun `state feature on by default`() {
+        var testDataSourceActive = false
         testRule.runTest(
             testCaseAction = {
+                testDataSourceActive = findDataSource<TestStateDataSource>().isActive()
                 recordSession()
             },
             assertAction = {
+                assertTrue(testDataSourceActive)
                 assertTrue(getSingleSessionEnvelope().findSpansOfType(EmbType.State).isNotEmpty())
             }
         )
@@ -449,16 +462,20 @@ internal class StateFeatureTest {
     @Test
     fun `lazy init state data sources generate state span at time of first use`() {
         var initTime = 0L
+        var lazyInitDataSourceActivePreInit = false
         testRule.runTest(
             testCaseAction = {
                 recordSession()
                 recordSession {
                     clock.tick()
                     initTime = clock.now()
-                    findDataSource<LazyInitStateDataSource>().onStateChange("initialized", initTime)
+                    val lazyDataSource = findDataSource<LazyInitStateDataSource>()
+                    lazyInitDataSourceActivePreInit = lazyDataSource.isActive()
+                    lazyDataSource.onStateChange("initialized", initTime)
                 }
             },
             assertAction = {
+                assertFalse(lazyInitDataSourceActivePreInit)
                 val sessionParts = getSessionEnvelopes(2)
                 assertNull(sessionParts[0].getStateSpan("emb-state-lazy-init"))
 
@@ -467,6 +484,34 @@ internal class StateFeatureTest {
                     val firstTransition = checkNotNull(events).first()
                     firstTransition.assertStateTransition(initTime, "initialized")
                 }
+            }
+        )
+    }
+
+    @Test
+    fun `lazy init state data source only add attribute to logs after initialization`() {
+        lateinit var logWorkerExecutor: BlockingScheduledExecutorService
+        testRule.runTest(
+            setupAction = {
+                logWorkerExecutor = getFakedWorkerExecutor().apply {
+                    blockingMode = true
+                }
+            },
+            testCaseAction = {
+                recordSession {
+                    embrace.logInfo("before")
+                    clock.tick()
+                    findDataSource<LazyInitStateDataSource>().onStateChange("initialized", clock.now())
+                    embrace.logInfo("after")
+                    clock.tick(2000L)
+                    logWorkerExecutor.runCurrentlyBlocked()
+                }
+            },
+            assertAction = {
+                val logs = getSingleLogEnvelope().getLogs { checkNotNull(it.attributes).hasEmbraceAttribute(EmbType.System.Log) }
+                assertEquals(2, logs.size)
+                assertFalse(checkNotNull(logs[0].attributes).hasEmbraceAttributeKey("emb.state.lazy-init"))
+                assertTrue(checkNotNull(logs[1].attributes).hasEmbraceAttributeValue("emb.state.lazy-init", "initialized"))
             }
         )
     }

--- a/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSessionAttributes.kt
+++ b/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSessionAttributes.kt
@@ -17,16 +17,16 @@ object EmbSessionAttributes {
     const val EMB_CLEAN_EXIT: String = "emb.clean_exit"
 
     /**
-     * The time delta between wall-time and the GNSS reported time in milliseconds (Wall Time - GNSS Time)
+     * Drift in milliseconds. Positive = GNSS clock behind wall clock. (Wall Time - GNSS Time)
      */
     @ExperimentalSemconv
-    const val EMB_CLOCK_GNSS_DRIFT_MILLIS: String = "emb.clock_gnss_drift_millis"
+    const val EMB_CLOCK_GNSS_DRIFT: String = "emb.clock_gnss_drift"
 
     /**
-     * The time delta between wall-time and the network reported time in milliseconds (Wall Time - Network Time)
+     * Drift in milliseconds. Positive = network clock behind wall clock. (Wall Time - Network Time)
      */
     @ExperimentalSemconv
-    const val EMB_CLOCK_NETWORK_DRIFT_MILLIS: String = "emb.clock_network_drift_millis"
+    const val EMB_CLOCK_NETWORK_DRIFT: String = "emb.clock_network_drift"
 
     /**
      * Whether the session is a cold start.

--- a/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSessionAttributes.kt
+++ b/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSessionAttributes.kt
@@ -17,6 +17,18 @@ object EmbSessionAttributes {
     const val EMB_CLEAN_EXIT: String = "emb.clean_exit"
 
     /**
+     * The time delta between wall-time and the GNSS reported time in milliseconds (Wall Time - GNSS Time)
+     */
+    @ExperimentalSemconv
+    const val EMB_CLOCK_GNSS_DRIFT_MILLIS: String = "emb.clock_gnss_drift_millis"
+
+    /**
+     * The time delta between wall-time and the network reported time in milliseconds (Wall Time - Network Time)
+     */
+    @ExperimentalSemconv
+    const val EMB_CLOCK_NETWORK_DRIFT_MILLIS: String = "emb.clock_network_drift_millis"
+
+    /**
      * Whether the session is a cold start.
      */
     @ExperimentalSemconv

--- a/embrace-android-semconv/src/main/semconv/embrace_android.yaml
+++ b/embrace-android-semconv/src/main/semconv/embrace_android.yaml
@@ -506,6 +506,16 @@ groups:
         brief: "The inactivity timeout (in seconds) that the SDK was configured to use."
         stability: development
         examples: ["300", "1800"]
+      - id: emb.clock_network_drift_millis
+        type: string
+        brief: "The time delta between wall-time and the network reported time in milliseconds (Wall Time - Network Time)"
+        stability: development
+        examples: ["123", "-321"]
+      - id: emb.clock_gnss_drift_millis
+        type: string
+        brief: "The time delta between wall-time and the GNSS reported time in milliseconds (Wall Time - GNSS Time)"
+        stability: development
+        examples: ["987", "-789"]
 
   - id: emb.android
     type: attribute_group

--- a/embrace-android-semconv/src/main/semconv/embrace_android.yaml
+++ b/embrace-android-semconv/src/main/semconv/embrace_android.yaml
@@ -506,14 +506,14 @@ groups:
         brief: "The inactivity timeout (in seconds) that the SDK was configured to use."
         stability: development
         examples: ["300", "1800"]
-      - id: emb.clock_network_drift_millis
+      - id: emb.clock_network_drift
         type: string
-        brief: "The time delta between wall-time and the network reported time in milliseconds (Wall Time - Network Time)"
+        brief: "Drift in milliseconds. Positive = network clock behind wall clock. (Wall Time - Network Time)"
         stability: development
         examples: ["123", "-321"]
-      - id: emb.clock_gnss_drift_millis
+      - id: emb.clock_gnss_drift
         type: string
-        brief: "The time delta between wall-time and the GNSS reported time in milliseconds (Wall Time - GNSS Time)"
+        brief: "Drift in milliseconds. Positive = GNSS clock behind wall clock. (Wall Time - GNSS Time)"
         stability: development
         examples: ["987", "-789"]
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
@@ -1,13 +1,20 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.internal.capture.metadata.ClockDrift
 import io.embrace.android.embracesdk.internal.capture.metadata.DiskUsage
 import io.embrace.android.embracesdk.internal.capture.metadata.MetadataService
+import io.embrace.android.embracesdk.internal.clock.Clock
 
 /**
  * Fake implementation of [MetadataService] that represents an Android device. A [UnsupportedOperationException] will be thrown
  * if you attempt set info about Flutter/Unity/ReactNative on this fake, which is decided for an Android device.
  */
-class FakeMetadataService(sessionId: String? = null) : MetadataService {
+class FakeMetadataService(
+    sessionId: String? = null,
+    private val wallClock: Clock = FakeClock(),
+    private val networkClock: Clock? = null,
+    private val gnssClock: Clock? = null,
+) : MetadataService {
     private companion object {
         private val diskUsage = DiskUsage(
             appDiskUsage = 10000000L,
@@ -22,6 +29,18 @@ class FakeMetadataService(sessionId: String? = null) : MetadataService {
     }
 
     override fun getDiskUsage(): DiskUsage = diskUsage
+
+    override fun getClockDrift(): ClockDrift? {
+        if (networkClock == null && gnssClock == null) {
+            return null
+        }
+
+        return ClockDrift(
+            wallTimeMillis = wallClock.now(),
+            networkTimeMillis = networkClock?.now(),
+            gnssTimeMillis = gnssClock?.now(),
+        )
+    }
 
     override fun precomputeValues() {}
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
@@ -24,21 +24,25 @@ class FakeMetadataService(
 
     private var appSessionId: String? = null
 
+    @Volatile
+    private var clockDrift: ClockDrift? = null
+
     init {
         appSessionId = sessionId
     }
 
     override fun getDiskUsage(): DiskUsage = diskUsage
 
-    override fun getClockDrift(): ClockDrift? {
+    override fun getClockDrift(): ClockDrift? = clockDrift
+
+    override fun precomputeValues() {
         val wall = wallClock.now()
         val gnssDrift = gnssClock?.let { ClockDrift.calculateDrift(wall, it.now()) }
         val networkDrift = networkClock?.let { ClockDrift.calculateDrift(wall, it.now()) }
-        if (gnssDrift == null && networkDrift == null) {
-            return null
+        clockDrift = if (gnssDrift == null && networkDrift == null) {
+            null
+        } else {
+            ClockDrift(networkDriftMillis = networkDrift, gnssDriftMillis = gnssDrift)
         }
-        return ClockDrift(networkDriftMillis = networkDrift, gnssDriftMillis = gnssDrift)
     }
-
-    override fun precomputeValues() {}
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
@@ -35,7 +35,7 @@ class FakeMetadataService(
             return null
         }
 
-        return ClockDrift(
+        return ClockDrift.fromWallDrift(
             wallTimeMillis = wallClock.now(),
             networkTimeMillis = networkClock?.now(),
             gnssTimeMillis = gnssClock?.now(),

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
@@ -31,15 +31,13 @@ class FakeMetadataService(
     override fun getDiskUsage(): DiskUsage = diskUsage
 
     override fun getClockDrift(): ClockDrift? {
-        if (networkClock == null && gnssClock == null) {
+        val wall = wallClock.now()
+        val gnssDrift = gnssClock?.let { ClockDrift.calculateDrift(wall, it.now()) }
+        val networkDrift = networkClock?.let { ClockDrift.calculateDrift(wall, it.now()) }
+        if (gnssDrift == null && networkDrift == null) {
             return null
         }
-
-        return ClockDrift.fromWallDrift(
-            wallTimeMillis = wallClock.now(),
-            networkTimeMillis = networkClock?.now(),
-            gnssTimeMillis = gnssClock?.now(),
-        )
+        return ClockDrift(networkDriftMillis = networkDrift, gnssDriftMillis = gnssDrift)
     }
 
     override fun precomputeValues() {}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,6 +56,7 @@ vanniktech-maven-publish = { module = "com.vanniktech.maven.publish:com.vannikte
 kover = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version.ref = "koverGradlePlugin" }
 agp = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinGradlePlugin" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlinGradlePlugin" }
 kotlin-serialization-compiler-plugin = { module = "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin-embeddable", version.ref = "kotlinGradlePlugin" }
 kotlin-compose-compiler-plugin = { module = "org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable", version.ref = "kotlinGradlePlugin" }
 lifecycle-runtime = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }


### PR DESCRIPTION
# Goal
Reduce the startup overhead of Moshi and the JSON deserialization of `RemoteConfig`.

## Design

The `BinaryRemoteConfigEncoder` and `BinaryRemoteConfigDecoder` classes store and retrieve an ordered binary cache of the `RemoteConfig` along with the `deviceId`. These files are strictly a cache and are invalidated ahead of the JSON file, and will fail to load on any `VERSION` change (which is guarded by a golden schema unit test).

This PR also changes the `SharedPrefsStore.getStringMap` and `SharedPrefsStoreEditor.putStringMap` to use `JsonWriter` and `JsonReader` instead of Moshi to avoid the initialisation overheads when loading persisted sessions and users.

## Testing
New unit tests and a golden schema test which reflects against the `RemoteConfig` graph and ensures binary incompatibilities will be flagged.
