### PR TITLE
Remove max metaspace JVM arg

### DIFF
--- a/embrace-gradle-plugin-integration-tests/fixtures/react-native-android/android/gradle.properties
+++ b/embrace-gradle-plugin-integration-tests/fixtures/react-native-android/android/gradle.properties
@@ -1,5 +1,5 @@
 # Project-wide Gradle settings.
-org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g
+org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC
 org.gradle.parallel=true
 org.gradle.caching=true
 

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/framework/PluginIntegrationTestRule.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/framework/PluginIntegrationTestRule.kt
@@ -228,7 +228,7 @@ class PluginIntegrationTestRule : ExternalResource() {
                 "-Dorg.gradle.daemon=false",
                 "-Dorg.gradle.parallel=true",
                 "-Dorg.gradle.caching=true",
-                "-Dorg.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g",
+                "-Dorg.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC",
                 "-Dorg.gradle.java.home=${testMatrix.jdk.path}",
                 "-Pembrace.baseUrl=$baseUrl",
                 "-Pagp_version=${testMatrix.agp}",

--- a/examples/ExampleApp/gradle.properties
+++ b/examples/ExampleApp/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g
+org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 description="Embrace Android SDK"
-org.gradle.jvmargs=-Xmx4096M -XX:+UseParallelGC -XX:MaxMetaspaceSize=2g -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx4096M"
+org.gradle.jvmargs=-Xmx4096M -XX:+UseParallelGC -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx4096M"
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true


### PR DESCRIPTION
We are having issues in some CI builds where tasks fail because we are running out of metaspace. To solve this, remove the max metaspace command line arg now that we are using JDK 17 (and that being are minimum) as it seems the right thing to do per this [article](https://www.jasonpearson.dev/metaspace-in-jvm-builds/).