### PR TITLE
Move startup classifier out of startup instrumentation

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitModule.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.internal.SystemInfo
+import io.embrace.android.embracesdk.internal.arch.startup.StartupClassifier
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.InstrumentedConfig
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
@@ -44,4 +45,6 @@ interface InitModule {
     val okHttpClient: OkHttpClient
 
     val uuidSource: UuidSource
+
+    val startupClassifier: StartupClassifier
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitModuleImpl.kt
@@ -1,6 +1,8 @@
 package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.internal.SystemInfo
+import io.embrace.android.embracesdk.internal.arch.startup.StartupClassifier
+import io.embrace.android.embracesdk.internal.arch.startup.StartupClassifierImpl
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.clock.NormalizedIntervalClock
 import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfigImpl
@@ -23,6 +25,7 @@ class InitModuleImpl(
     override val clock: Clock = NormalizedIntervalClock(logger = logger),
     override val systemInfo: SystemInfo = SystemInfo(),
     override val uuidSource: UuidSource = UuidSourceImpl(),
+    override val startupClassifier: StartupClassifier = StartupClassifierImpl(),
 ) : InitModule {
 
     override val telemetryService: TelemetryService by singleton {

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/startup/StartupClassifier.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/startup/StartupClassifier.kt
@@ -1,0 +1,37 @@
+package io.embrace.android.embracesdk.internal.arch.startup
+
+/**
+ * Determines the [StartupType] for the current app instance based on heuristics
+ */
+interface StartupClassifier {
+
+    /**
+     * The type of startup for this app instance. Returns null if it has not collected enough signals to determine it.
+     */
+    fun startupType(): StartupType?
+
+    /**
+     * Determine the startup type once there is indication that the app process is being created to back an app instance that will be used
+     * by a user, rather than do work on the background like processing a notification. The signals it takes in include [sdkInitEndMs]
+     * (when the Embrace SDK was started), [appInitEndMs] (when the Application object creation was completed), and [postAppInitTimeMs]
+     * (the first indication that the process was created to power an app instance for a user).
+     */
+    fun evaluateStartup(
+        sdkInitEndMs: Long?,
+        appInitEndMs: Long?,
+        postAppInitTimeMs: Long,
+    )
+
+    /**
+     * Signals to the classifier that the process launch is assumed to be for some background task that isn't explicitly triggered by
+     * a user.
+     */
+    fun assumeBackgroundStartup()
+}
+
+/**
+ * The maximum time between the end of app init to when additional init activity was detected that we consider the startup
+ * to be cold. Otherwise, we assume the process was created in the background prior to a user app launch, so we classify the
+ * startup as being a warm one.
+ */
+const val MAX_COLD_STARTUP_INIT_GAP_MS: Long = 2000L

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/startup/StartupClassifierImpl.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/startup/StartupClassifierImpl.kt
@@ -1,0 +1,30 @@
+package io.embrace.android.embracesdk.internal.arch.startup
+
+import java.util.concurrent.atomic.AtomicReference
+
+class StartupClassifierImpl : StartupClassifier {
+
+    private val startupType: AtomicReference<StartupType?> = AtomicReference(null)
+
+    override fun startupType(): StartupType? = startupType.get()
+
+    override fun evaluateStartup(
+        sdkInitEndMs: Long?,
+        appInitEndMs: Long?,
+        postAppInitTimeMs: Long,
+    ) {
+        val initEndMs = appInitEndMs ?: sdkInitEndMs ?: return
+        startupType.compareAndSet(
+            null,
+            if (postAppInitTimeMs - initEndMs <= MAX_COLD_STARTUP_INIT_GAP_MS) {
+                StartupType.COLD
+            } else {
+                StartupType.WARM
+            }
+        )
+    }
+
+    override fun assumeBackgroundStartup() {
+        startupType.compareAndSet(null, StartupType.BACKGROUND)
+    }
+}

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/startup/StartupType.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/startup/StartupType.kt
@@ -1,0 +1,23 @@
+package io.embrace.android.embracesdk.internal.arch.startup
+
+/**
+ * Classification of the type of app launch that created the current app process and instance
+ */
+enum class StartupType {
+
+    /**
+     * The app was launched and a new process was created as a result.
+     */
+    COLD,
+
+    /**
+     * The app was launched with an existing app process already in the background.
+     */
+    WARM,
+
+    /**
+     * The app process was created to serve a background job without any indication that it will be used by a user (e.g. an Activity
+     * being created)
+     */
+    BACKGROUND,
+}

--- a/embrace-android-instrumentation-api/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/startup/StartupClassifierImplTest.kt
+++ b/embrace-android-instrumentation-api/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/startup/StartupClassifierImplTest.kt
@@ -1,0 +1,113 @@
+package io.embrace.android.embracesdk.internal.arch.startup
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+internal class StartupClassifierImplTest {
+
+    private lateinit var classifier: StartupClassifierImpl
+
+    @Before
+    fun setUp() {
+        classifier = StartupClassifierImpl()
+    }
+
+    @Test
+    fun `unresolved before any signal`() {
+        assertNull(classifier.startupType())
+    }
+
+    @Test
+    fun `cold when activity init gap is at the threshold`() {
+        classifier.evaluateStartup(
+            sdkInitEndMs = null,
+            appInitEndMs = INIT_END_MS,
+            postAppInitTimeMs = INIT_END_MS + MAX_COLD_STARTUP_INIT_GAP_MS,
+        )
+        assertEquals(StartupType.COLD, classifier.startupType())
+    }
+
+    @Test
+    fun `warm when activity init gap exceeds the threshold`() {
+        classifier.evaluateStartup(
+            sdkInitEndMs = null,
+            appInitEndMs = INIT_END_MS,
+            postAppInitTimeMs = INIT_END_MS + MAX_COLD_STARTUP_INIT_GAP_MS + 1,
+        )
+        assertEquals(StartupType.WARM, classifier.startupType())
+    }
+
+    @Test
+    fun `gap is measured from the sdk init end when the application init end is unknown`() {
+        classifier.evaluateStartup(
+            sdkInitEndMs = INIT_END_MS,
+            appInitEndMs = null,
+            postAppInitTimeMs = INIT_END_MS + MAX_COLD_STARTUP_INIT_GAP_MS,
+        )
+        assertEquals(StartupType.COLD, classifier.startupType())
+    }
+
+    @Test
+    fun `gap is measured from the application init end when both init ends are known`() {
+        classifier.evaluateStartup(
+            sdkInitEndMs = INIT_END_MS,
+            appInitEndMs = INIT_END_MS + MAX_COLD_STARTUP_INIT_GAP_MS,
+            postAppInitTimeMs = INIT_END_MS + MAX_COLD_STARTUP_INIT_GAP_MS + 1,
+        )
+        assertEquals(StartupType.COLD, classifier.startupType())
+    }
+
+    @Test
+    fun `unresolved when no app or SDK init end time is known`() {
+        classifier.evaluateStartup(
+            sdkInitEndMs = null,
+            appInitEndMs = null,
+            postAppInitTimeMs = INIT_END_MS,
+        )
+        assertNull(classifier.startupType())
+    }
+
+    @Test
+    fun `startup type is immutable once resolved`() {
+        classifier.evaluateStartup(
+            sdkInitEndMs = null,
+            appInitEndMs = INIT_END_MS,
+            postAppInitTimeMs = INIT_END_MS + MAX_COLD_STARTUP_INIT_GAP_MS,
+        )
+        classifier.evaluateStartup(
+            sdkInitEndMs = null,
+            appInitEndMs = INIT_END_MS,
+            postAppInitTimeMs = INIT_END_MS + MAX_COLD_STARTUP_INIT_GAP_MS + 1,
+        )
+        assertEquals(StartupType.COLD, classifier.startupType())
+    }
+
+    @Test
+    fun `assumption of background startup is immutable once set`() {
+        classifier.assumeBackgroundStartup()
+        assertEquals(StartupType.BACKGROUND, classifier.startupType())
+        classifier.evaluateStartup(
+            sdkInitEndMs = null,
+            appInitEndMs = INIT_END_MS,
+            postAppInitTimeMs = INIT_END_MS + 1,
+        )
+        assertEquals(StartupType.BACKGROUND, classifier.startupType())
+    }
+
+    @Test
+    fun `cannot set startup to background if already set`() {
+        classifier.evaluateStartup(
+            sdkInitEndMs = null,
+            appInitEndMs = INIT_END_MS,
+            postAppInitTimeMs = INIT_END_MS + 1,
+        )
+        classifier.assumeBackgroundStartup()
+        assertEquals(StartupType.COLD, classifier.startupType())
+    }
+
+    private companion object {
+        const val INIT_END_MS = 100_000L
+    }
+}

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/AppStartupTraceEmitter.kt
@@ -5,6 +5,8 @@ import io.embrace.android.embracesdk.internal.arch.datasource.SpanEvent
 import io.embrace.android.embracesdk.internal.arch.datasource.SpanToken
 import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
 import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
+import io.embrace.android.embracesdk.internal.arch.startup.StartupClassifier
+import io.embrace.android.embracesdk.internal.arch.startup.StartupType
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.instrumentation.startup.ui.hasRenderEvent
 import io.embrace.android.embracesdk.internal.instrumentation.startup.ui.supportFrameCommitCallback
@@ -45,6 +47,7 @@ internal class AppStartupTraceEmitter(
     private val destination: TelemetryDestination,
     private val versionChecker: VersionChecker,
     private val logger: InternalLogger,
+    private val startupClassifier: StartupClassifier,
     manualEnd: Boolean,
     processInfo: ProcessInfo,
 ) : AppStartupDataCollector {
@@ -97,8 +100,8 @@ internal class AppStartupTraceEmitter(
     @Volatile
     private var appStartupCompleteCallback: (() -> Unit)? = null
 
-    @Volatile
-    private var recordColdStart = true
+    private val recordColdStart: Boolean
+        get() = startupClassifier.startupType() == StartupType.COLD
 
     override fun applicationInitStart(timestampMs: Long?) {
         applicationInitStartMs = timestampMs ?: nowMs()
@@ -116,8 +119,12 @@ internal class AppStartupTraceEmitter(
         val sdkInitStartMs = startupServiceProvider()?.getSdkInitStartMs()
         val sdkInitEndMs = startupServiceProvider()?.getSdkInitEndMs()
         if (sdkInitStartMs != null && sdkInitEndMs != null) {
-            applicationActivityCreationGap(sdkInitEndMs)?.let { gap ->
-                recordColdStart = gap <= SDK_AND_ACTIVITY_INIT_GAP
+            startupClassifier.evaluateStartup(
+                sdkInitEndMs = sdkInitEndMs,
+                appInitEndMs = applicationInitEndMs,
+                postAppInitTimeMs = activityInitTimeMs,
+            )
+            if (startupClassifier.startupType() != null) {
                 startTrace(
                     isColdStart = recordColdStart,
                     sdkInitStartMs = sdkInitStartMs,
@@ -400,9 +407,6 @@ internal class AppStartupTraceEmitter(
         }
     }
 
-    private fun applicationActivityCreationGap(sdkInitEndMs: Long): Long? =
-        duration(applicationInitEndMs ?: sdkInitEndMs, firstActivityInitStartMs)
-
     private fun nowMs(): Long = clock.now()
 
     private fun SpanToken.addTraceMetadata() {
@@ -435,12 +439,6 @@ internal class AppStartupTraceEmitter(
     }
 
     companion object {
-        /**
-         * The gap between the end of the Embrace SDK initialization to when the first activity loaded after startup happens.
-         * If this gap is greater than 2 seconds, it is assumed that the app process was not created because the user tapped on the app,
-         * so we track this app launch as a warm start.
-         */
-        const val SDK_AND_ACTIVITY_INIT_GAP: Long = 2000L
         const val COLD_APP_STARTUP_ROOT_SPAN = "app-startup-cold"
         const val WARM_APP_STARTUP_ROOT_SPAN = "app-startup-warm"
         const val PROCESS_INIT_SPAN = "process-init"
@@ -451,11 +449,5 @@ internal class AppStartupTraceEmitter(
         const val ACTIVITY_FIRST_DRAW_SPAN = "activity-first-draw"
         const val ACTIVITY_LOAD_SPAN = "activity-load"
         const val APP_READY_SPAN = "app-ready"
-
-        fun duration(start: Long?, end: Long?): Long? = if (start != null && end != null) {
-            end - start
-        } else {
-            null
-        }
     }
 }

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleImpl.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleImpl.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.instrumentation.startup
 import android.app.Application
 import android.os.SystemClock
 import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
+import io.embrace.android.embracesdk.internal.arch.startup.StartupClassifier
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.instrumentation.startup.activity.UiLoadDataListener
@@ -18,6 +19,7 @@ class DataCaptureServiceModuleImpl(
     logger: InternalLogger,
     destination: TelemetryDestination,
     configService: ConfigService,
+    private val startupClassifier: StartupClassifier,
     versionChecker: VersionChecker = BuildVersionChecker,
 ) : DataCaptureServiceModule {
 
@@ -34,11 +36,12 @@ class DataCaptureServiceModuleImpl(
             destination = destination,
             versionChecker = versionChecker,
             logger = logger,
+            startupClassifier = startupClassifier,
             manualEnd = configService.autoDataCaptureBehavior.isEndStartupWithAppReadyEnabled(),
             processInfo = ProcessInfoImpl(
                 deviceStartTimeMs = deviceStartTimeMs,
                 versionChecker = versionChecker,
-            )
+            ),
         )
     }
 

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleSupplier.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleSupplier.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.instrumentation.startup
 
 import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
+import io.embrace.android.embracesdk.internal.arch.startup.StartupClassifier
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
@@ -15,5 +16,6 @@ typealias DataCaptureServiceModuleSupplier = (
     logger: InternalLogger,
     destination: TelemetryDestination,
     configService: ConfigService,
+    startupClassifier: StartupClassifier,
     versionChecker: VersionChecker,
 ) -> DataCaptureServiceModule

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleImplTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleImplTest.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeTelemetryDestination
 import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
+import io.embrace.android.embracesdk.internal.arch.startup.StartupClassifierImpl
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -14,10 +15,11 @@ internal class DataCaptureServiceModuleImplTest {
     @Test
     fun testDefaultImplementations() {
         val module = DataCaptureServiceModuleImpl(
-            FakeClock(),
-            FakeInternalLogger(),
-            FakeTelemetryDestination(),
-            FakeConfigService(),
+            clock = FakeClock(),
+            logger = FakeInternalLogger(),
+            destination = FakeTelemetryDestination(),
+            configService = FakeConfigService(),
+            startupClassifier = StartupClassifierImpl(),
         )
 
         assertNotNull(module.appStartupDataCollector)
@@ -29,12 +31,13 @@ internal class DataCaptureServiceModuleImplTest {
     @Test
     fun `disable ui load performance capture`() {
         val module = DataCaptureServiceModuleImpl(
-            FakeClock(),
-            FakeInternalLogger(),
-            FakeTelemetryDestination(),
-            FakeConfigService(
+            clock = FakeClock(),
+            logger = FakeInternalLogger(),
+            destination = FakeTelemetryDestination(),
+            configService = FakeConfigService(
                 autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(uiLoadTracingEnabled = false)
             ),
+            startupClassifier = StartupClassifierImpl(),
         )
 
         assertNull(module.uiLoadDataListener)
@@ -44,12 +47,13 @@ internal class DataCaptureServiceModuleImplTest {
     @Test
     fun `enable only selected ui load performance capture`() {
         val module = DataCaptureServiceModuleImpl(
-            FakeClock(),
-            FakeInternalLogger(),
-            FakeTelemetryDestination(),
-            FakeConfigService(
+            clock = FakeClock(),
+            logger = FakeInternalLogger(),
+            destination = FakeTelemetryDestination(),
+            configService = FakeConfigService(
                 autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(uiLoadTracingTraceAll = false)
             ),
+            startupClassifier = StartupClassifierImpl(),
         )
 
         assertNotNull(module.uiLoadDataListener)

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/AppStartupTraceEmitterTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/AppStartupTraceEmitterTest.kt
@@ -10,6 +10,8 @@ import io.embrace.android.embracesdk.fakes.FakeSpanToken
 import io.embrace.android.embracesdk.fakes.FakeTelemetryDestination
 import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
+import io.embrace.android.embracesdk.internal.arch.startup.MAX_COLD_STARTUP_INIT_GAP_MS
+import io.embrace.android.embracesdk.internal.arch.startup.StartupClassifierImpl
 import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.instrumentation.startup.AppStartupTraceEmitter
 import io.embrace.android.embracesdk.internal.instrumentation.startup.AppStartupTraceEmitter.Companion.ACTIVITY_FIRST_DRAW_SPAN
@@ -600,6 +602,7 @@ internal class AppStartupTraceEmitterTest {
             destination = destination,
             versionChecker = BuildVersionChecker,
             logger = logger,
+            startupClassifier = StartupClassifierImpl(),
             manualEnd = manualEnd,
             processInfo = FakeProcessInfo(
                 if (BuildVersionChecker.isAtLeast(VERSION_CODES.N)) {
@@ -607,7 +610,7 @@ internal class AppStartupTraceEmitterTest {
                 } else {
                     null
                 }
-            )
+            ),
         )
 
     private fun AppStartupTraceEmitter.simulateAppStartup(
@@ -760,7 +763,7 @@ internal class AppStartupTraceEmitterTest {
             clock.tick(50L)
             start to end
         } else {
-            clock.tick(AppStartupTraceEmitter.SDK_AND_ACTIVITY_INIT_GAP + 1)
+            clock.tick(MAX_COLD_STARTUP_INIT_GAP_MS + 1)
             null to null
         }
 

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/EmbraceAttributeExtensions.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/EmbraceAttributeExtensions.kt
@@ -68,12 +68,16 @@ fun Span.assertIsPrivateSpan(): Unit = assertHasEmbraceAttribute(PrivateSpan)
 fun Span.assertNotPrivateSpan(): Unit = assertDoesNotHaveEmbraceAttribute(PrivateSpan)
 
 /**
- * Return as a [Attribute] representation, to be used used for Embrace payloads
+ * Return as a [Attribute] representation, to be used for Embrace payloads
  */
 fun EmbraceAttribute.toPayload(): Attribute = Attribute(key, value)
 
 fun Span.assertHasEmbraceAttribute(embraceAttribute: EmbraceAttribute) {
-    assertTrue(checkNotNull(attributes).contains(embraceAttribute.toPayload()))
+    with(checkNotNull(attributes)) {
+        val attrPayload = embraceAttribute.toPayload()
+        assertTrue("Span with name $name does not contain attribute '${attrPayload.key}'", any { it.key == attrPayload.key })
+        assertEquals(attrPayload.data, single { it.key == attrPayload.key }.data)
+    }
 }
 
 fun Span.assertDoesNotHaveEmbraceAttribute(embraceAttribute: EmbraceAttribute) {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
+import io.embrace.android.embracesdk.internal.arch.startup.MAX_COLD_STARTUP_INIT_GAP_MS
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.delivery.PayloadType
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
@@ -160,7 +161,7 @@ internal class AppStartupTraceTest {
                 )
             ),
             testCaseAction = {
-                val initGap = 10000L
+                val initGap = MAX_COLD_STARTUP_INIT_GAP_MS + 1
                 clock.tick(initGap)
                 startupActivityInitMs = clock.now()
                 simulateOpeningActivities(
@@ -232,7 +233,7 @@ internal class AppStartupTraceTest {
                 )
             ),
             testCaseAction = {
-                val initGap = 10000L
+                val initGap = MAX_COLD_STARTUP_INIT_GAP_MS + 1
                 val splashScreenDwellTime = 5000L
                 firstActivityInitMs = clock.tick(initGap)
                 startupActivityInitMs = clock.now() + (3 * LIFECYCLE_EVENT_GAP) + POST_ACTIVITY_ACTION_DWELL +
@@ -430,7 +431,7 @@ internal class AppStartupTraceTest {
                 )
             ),
             testCaseAction = {
-                clock.tick(10000L)
+                clock.tick(MAX_COLD_STARTUP_INIT_GAP_MS + 1)
                 startupActivityInitMs = clock.now()
                 simulateOpeningActivities(
                     addStartupActivity = false,
@@ -464,7 +465,7 @@ internal class AppStartupTraceTest {
                 )
             ),
             testCaseAction = {
-                clock.tick(10000L)
+                clock.tick(MAX_COLD_STARTUP_INIT_GAP_MS + 1)
                 startupActivityInitMs = clock.now()
                 simulateOpeningActivities(
                     addStartupActivity = false,

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
@@ -113,6 +113,7 @@ internal class InitializedModuleGraph(
             initModule.logger,
             instrumentationModule.instrumentationArgs.destination,
             configService,
+            initModule.startupClassifier,
             versionChecker,
         )
     }

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.LifecycleOwner
 import io.embrace.android.embracesdk.core.BuildConfig
 import io.embrace.android.embracesdk.internal.arch.InstrumentationArgs
 import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
+import io.embrace.android.embracesdk.internal.arch.startup.StartupClassifier
 import io.embrace.android.embracesdk.internal.capture.connectivity.NetworkConnectivityService
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.ConfigService
@@ -147,6 +148,7 @@ internal class ModuleInitBootstrapper(
             logger: InternalLogger,
             destination: TelemetryDestination,
             configService: ConfigService,
+            startupClassifier: StartupClassifier,
             versionChecker: VersionChecker,
         ->
         DataCaptureServiceModuleImpl(
@@ -154,7 +156,8 @@ internal class ModuleInitBootstrapper(
             logger,
             destination,
             configService,
-            versionChecker
+            startupClassifier,
+            versionChecker,
         )
     },
     private val deliveryModuleSupplier: DeliveryModuleSupplier = {

--- a/embrace-microbenchmark/src/androidTest/kotlin/io/embrace/android/embracesdk/benchmark/TelemetryDestinationHarness.kt
+++ b/embrace-microbenchmark/src/androidTest/kotlin/io/embrace/android/embracesdk/benchmark/TelemetryDestinationHarness.kt
@@ -3,6 +3,8 @@ package io.embrace.android.embracesdk.benchmark
 import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
 import io.embrace.android.embracesdk.internal.arch.destination.TelemetryDestinationImpl
+import io.embrace.android.embracesdk.internal.arch.startup.StartupClassifier
+import io.embrace.android.embracesdk.internal.arch.startup.StartupClassifierImpl
 import io.embrace.android.embracesdk.internal.clock.NormalizedIntervalClock
 import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfigImpl
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.InstrumentedConfig
@@ -45,6 +47,7 @@ internal class TelemetryDestinationHarness {
         override val logger: InternalLogger = InternalLoggerImpl()
         override val systemInfo: SystemInfo = SystemInfo()
         override val uuidSource: UuidSource = UuidSourceImpl()
+        override val startupClassifier: StartupClassifier = StartupClassifierImpl()
         override val jsonSerializer: PlatformSerializer = EmbraceSerializer()
         override val instrumentedConfig: InstrumentedConfig = InstrumentedConfigImpl
         override val okHttpClient: OkHttpClient = OkHttpClient()


### PR DESCRIPTION
Move startup classification code into a common module so it can be use to determine how user session should transition (coming in future PR)