### PR TITLE
Add in concept of a background-only user session at the SDK level

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadata.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadata.kt
@@ -15,6 +15,7 @@ data class UserSessionMetadata(
     val inactivityTimeoutSecs: Long,
     val partIndex: Int,
     val lastActivityMs: Long,
+    val isBackgroundOnly: Boolean = false,
 ) {
     fun isOverMaxDuration(clock: Clock): Boolean =
         clock.now() - startTimeMs > maxDurationSecs * 1_000L
@@ -22,12 +23,23 @@ data class UserSessionMetadata(
     fun isInactive(clock: Clock): Boolean =
         clock.now() - lastActivityMs > inactivityTimeoutSecs * 1_000L
 
-    val attributes: Map<String, Any> = mapOf(
-        EmbSessionAttributes.EMB_USER_SESSION_START_TS to startTimeMs,
-        EmbSessionAttributes.EMB_USER_SESSION_ID to userSessionId,
-        EmbSessionAttributes.EMB_USER_SESSION_NUMBER to userSessionNumber,
-        EmbSessionAttributes.EMB_USER_SESSION_MAX_DURATION_SECONDS to maxDurationSecs,
-        EmbSessionAttributes.EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS to inactivityTimeoutSecs,
-        SessionAttributes.SESSION_ID to userSessionId,
-    )
+    val attributes: Map<String, Any> = buildMap {
+        put(EmbSessionAttributes.EMB_USER_SESSION_START_TS, startTimeMs)
+        put(EmbSessionAttributes.EMB_USER_SESSION_ID, userSessionId)
+        put(EmbSessionAttributes.EMB_USER_SESSION_NUMBER, userSessionNumber)
+        put(EmbSessionAttributes.EMB_USER_SESSION_MAX_DURATION_SECONDS, maxDurationSecs)
+        put(EmbSessionAttributes.EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS, inactivityTimeoutSecs)
+        put(SessionAttributes.SESSION_ID, userSessionId)
+        if (isBackgroundOnly) {
+            put(EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART, BACKGROUND_ONLY_MARKER)
+        }
+    }
+
+    companion object {
+        /**
+         * The value of the [EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART] attribute when
+         * the user session is background-only. The attribute is omitted otherwise.
+         */
+        internal const val BACKGROUND_ONLY_MARKER = "1"
+    }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStore.kt
@@ -47,6 +47,8 @@ internal class UserSessionMetadataStore(private val store: KeyValueStore) {
         val inactivityTimeoutSecs = attrs[EmbSessionAttributes.EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS]?.toLongOrNull() ?: return null
         val partIndex = attrs[EmbSessionAttributes.EMB_USER_SESSION_PART_INDEX]?.toIntOrNull() ?: return null
         val lastActivityMs = attrs[KEY_LAST_ACTIVITY_TS]?.toLongOrNull() ?: return null
+        val isBackgroundOnly =
+            attrs[EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART] == UserSessionMetadata.BACKGROUND_ONLY_MARKER
         return UserSessionMetadata(
             startTimeMs = startMs,
             userSessionId = id,
@@ -55,6 +57,7 @@ internal class UserSessionMetadataStore(private val store: KeyValueStore) {
             inactivityTimeoutSecs = inactivityTimeoutSecs,
             partIndex = partIndex,
             lastActivityMs = lastActivityMs,
+            isBackgroundOnly = isBackgroundOnly,
         )
     }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStoreTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStoreTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.session
 import io.embrace.android.embracesdk.fakes.FakeKeyValueStore
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
@@ -30,6 +31,16 @@ internal class UserSessionMetadataStoreTest {
         partIndex = 2,
         lastActivityMs = 9000L,
     )
+    private val metadataBackgroundOnly = UserSessionMetadata(
+        startTimeMs = 3000L,
+        userSessionId = "test-uuid-3",
+        userSessionNumber = 7L,
+        maxDurationSecs = 3600L,
+        inactivityTimeoutSecs = 1800L,
+        partIndex = 4,
+        lastActivityMs = 3000L,
+        isBackgroundOnly = true,
+    )
 
     @Before
     fun setUp() {
@@ -45,30 +56,30 @@ internal class UserSessionMetadataStoreTest {
     @Test
     fun `save and load round-trips all fields`() {
         metadataStore.save(metadata)
-        val loaded = checkNotNull(metadataStore.load())
+        metadata.assertMetadataEquals(metadataStore.load())
+    }
 
-        assertEquals(metadata.startTimeMs, loaded.startTimeMs)
-        assertEquals(metadata.userSessionId, loaded.userSessionId)
-        assertEquals(metadata.userSessionNumber, loaded.userSessionNumber)
-        assertEquals(metadata.maxDurationSecs, loaded.maxDurationSecs)
-        assertEquals(metadata.inactivityTimeoutSecs, loaded.inactivityTimeoutSecs)
-        assertEquals(metadata.partIndex, loaded.partIndex)
-        assertEquals(metadata.lastActivityMs, loaded.lastActivityMs)
+    @Test
+    fun `save and load background only metadata`() {
+        metadataStore.save(metadataBackgroundOnly)
+        val loaded = metadataStore.load()
+        metadataBackgroundOnly.assertMetadataEquals(loaded)
+        assertEquals(true, loaded?.isBackgroundOnly)
+    }
+
+    @Test
+    fun `session persisted without the background marker loads as a regular session`() {
+        metadataStore.save(metadata)
+        val loaded = checkNotNull(saveAndRemoveFromRawMap(metadata, EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART))
+        metadata.assertMetadataEquals(loaded)
+        assertFalse(loaded.isBackgroundOnly)
     }
 
     @Test
     fun `values can be overwritten`() {
         metadataStore.save(metadata)
         metadataStore.save(metadata2)
-        val loaded = checkNotNull(metadataStore.load())
-
-        assertEquals(metadata2.startTimeMs, loaded.startTimeMs)
-        assertEquals(metadata2.userSessionId, loaded.userSessionId)
-        assertEquals(metadata2.userSessionNumber, loaded.userSessionNumber)
-        assertEquals(metadata2.maxDurationSecs, loaded.maxDurationSecs)
-        assertEquals(metadata2.inactivityTimeoutSecs, loaded.inactivityTimeoutSecs)
-        assertEquals(metadata2.partIndex, loaded.partIndex)
-        assertEquals(metadata2.lastActivityMs, loaded.lastActivityMs)
+        metadata2.assertMetadataEquals(metadataStore.load())
     }
 
     @Test
@@ -80,61 +91,61 @@ internal class UserSessionMetadataStoreTest {
 
     @Test
     fun `load returns null when session id is missing`() {
-        metadataStore.save(metadata)
-        val stored = checkNotNull(kvStore.getStringMap("embrace.user_session")).toMutableMap()
-        stored.remove(EmbSessionAttributes.EMB_USER_SESSION_ID)
-        kvStore.edit { putStringMap("embrace.user_session", stored) }
-
-        assertNull(metadataStore.load())
+        assertNull(saveAndRemoveFromRawMap(metadata, EmbSessionAttributes.EMB_USER_SESSION_ID))
     }
 
     @Test
     fun `load returns null when start timestamp is missing`() {
-        metadataStore.save(metadata)
-        val stored = checkNotNull(kvStore.getStringMap("embrace.user_session")).toMutableMap()
-        stored.remove(EmbSessionAttributes.EMB_USER_SESSION_START_TS)
-        kvStore.edit { putStringMap("embrace.user_session", stored) }
-
-        assertNull(metadataStore.load())
+        assertNull(saveAndRemoveFromRawMap(metadata, EmbSessionAttributes.EMB_USER_SESSION_START_TS))
     }
 
     @Test
     fun `load returns null when session number is missing`() {
-        metadataStore.save(metadata)
-        val stored = checkNotNull(kvStore.getStringMap("embrace.user_session")).toMutableMap()
-        stored.remove(EmbSessionAttributes.EMB_USER_SESSION_NUMBER)
-        kvStore.edit { putStringMap("embrace.user_session", stored) }
-
-        assertNull(metadataStore.load())
+        assertNull(saveAndRemoveFromRawMap(metadata, EmbSessionAttributes.EMB_USER_SESSION_NUMBER))
     }
 
     @Test
     fun `load returns null when max duration is missing`() {
-        metadataStore.save(metadata)
-        val stored = checkNotNull(kvStore.getStringMap("embrace.user_session")).toMutableMap()
-        stored.remove(EmbSessionAttributes.EMB_USER_SESSION_MAX_DURATION_SECONDS)
-        kvStore.edit { putStringMap("embrace.user_session", stored) }
-
-        assertNull(metadataStore.load())
+        assertNull(saveAndRemoveFromRawMap(metadata, EmbSessionAttributes.EMB_USER_SESSION_MAX_DURATION_SECONDS))
     }
 
     @Test
     fun `load returns null when inactivity timeout is missing`() {
-        metadataStore.save(metadata)
-        val stored = checkNotNull(kvStore.getStringMap("embrace.user_session")).toMutableMap()
-        stored.remove(EmbSessionAttributes.EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS)
-        kvStore.edit { putStringMap("embrace.user_session", stored) }
-
-        assertNull(metadataStore.load())
+        assertNull(saveAndRemoveFromRawMap(metadata, EmbSessionAttributes.EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS))
     }
 
     @Test
     fun `load returns null when part index is missing`() {
-        metadataStore.save(metadata)
-        val stored = checkNotNull(kvStore.getStringMap("embrace.user_session")).toMutableMap()
-        stored.remove(EmbSessionAttributes.EMB_USER_SESSION_PART_INDEX)
-        kvStore.edit { putStringMap("embrace.user_session", stored) }
+        assertNull(saveAndRemoveFromRawMap(metadata, EmbSessionAttributes.EMB_USER_SESSION_PART_INDEX))
+    }
 
-        assertNull(metadataStore.load())
+    private fun getRawMap(): MutableMap<String, String> = checkNotNull(kvStore.getStringMap("embrace.user_session")).toMutableMap()
+
+    private fun saveAndRemoveFromRawMap(
+        sessionMetadata: UserSessionMetadata,
+        attribute: String,
+    ): UserSessionMetadata? {
+        metadataStore.save(sessionMetadata)
+        kvStore.edit {
+            putStringMap(
+                "embrace.user_session",
+                getRawMap().apply {
+                    remove(attribute)
+                }
+            )
+        }
+        return metadataStore.load()
+    }
+
+    private fun UserSessionMetadata.assertMetadataEquals(other: UserSessionMetadata?) {
+        checkNotNull(other)
+        assertEquals(startTimeMs, other.startTimeMs)
+        assertEquals(userSessionId, other.userSessionId)
+        assertEquals(userSessionNumber, other.userSessionNumber)
+        assertEquals(maxDurationSecs, other.maxDurationSecs)
+        assertEquals(inactivityTimeoutSecs, other.inactivityTimeoutSecs)
+        assertEquals(partIndex, other.partIndex)
+        assertEquals(lastActivityMs, other.lastActivityMs)
+        assertEquals(isBackgroundOnly, other.isBackgroundOnly)
     }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
@@ -70,6 +70,17 @@ internal class SessionPartSpanAttrPopulatorImplTest {
         assertEquals("1800", attrs[EmbSessionAttributes.EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS])
         assertEquals("user-session-uuid", attrs[SessionAttributes.SESSION_ID])
         assertEquals("id", attrs[EmbSessionAttributes.EMB_SESSION_PART_ID])
+        assertFalse(attrs.containsKey(EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART))
+    }
+
+    @Test
+    fun `background-only marker stamped on session part span`() {
+        populator.populateSessionSpanStartAttrs(zygote, userSession.copy(isBackgroundOnly = true))
+
+        val attrs = destination.attributes
+        assertEquals("1", attrs[EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART])
+        assertEquals("user-session-uuid", attrs[EmbSessionAttributes.EMB_USER_SESSION_ID])
+        assertEquals("user-session-uuid", attrs[SessionAttributes.SESSION_ID])
     }
 
     @Test

--- a/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSessionAttributes.kt
+++ b/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSessionAttributes.kt
@@ -59,6 +59,12 @@ object EmbSessionAttributes {
     const val EMB_HEARTBEAT_TIME_UNIX_NANO: String = "emb.heartbeat_time_unix_nano"
 
     /**
+     * Set to 1 when the session part belongs to a background user session, i.e. a user session covering a period when the app process is alive but the user is not active. Omitted for regular user sessions.
+     */
+    @ExperimentalSemconv
+    const val EMB_IS_BACKGROUND_ONLY_PART: String = "emb.is_background_only_part"
+
+    /**
      * Set to 1 when the SDK knows for certain this is the final part of a session (max duration reached, inactivity timeout, or manual termination). Omitted when the value would be 0.
      */
     @ExperimentalSemconv

--- a/embrace-android-semconv/src/main/semconv/embrace_android.yaml
+++ b/embrace-android-semconv/src/main/semconv/embrace_android.yaml
@@ -477,6 +477,11 @@ groups:
         brief: "Set to 1 when the SDK knows for certain this is the final part of a session (max duration reached, inactivity timeout, or manual termination). Omitted when the value would be 0."
         stability: development
         examples: ["1"]
+      - id: emb.is_background_only_part
+        type: string
+        brief: "Set to 1 when the session part belongs to a background user session, i.e. a user session covering a period when the app process is alive but the user is not active. Omitted for regular user sessions."
+        stability: development
+        examples: ["1"]
       - id: emb.user_session_termination_reason
         type:
           allow_custom_values: false


### PR DESCRIPTION
Add a new dimension to classifying user sessions - that they are only in the background, used when the app is not considered "active".