### PR TITLE
Fix flakey AEI test

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AeiFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AeiFeatureTest.kt
@@ -15,13 +15,13 @@ import io.embrace.android.embracesdk.fakes.TestAeiData
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.setupFakeAeiData
-import io.embrace.android.embracesdk.semconv.EmbAndroidAttributes
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.config.remote.AppExitInfoConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.semconv.EmbAeiAttributes
+import io.embrace.android.embracesdk.semconv.EmbAndroidAttributes
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -162,7 +162,12 @@ internal class AeiFeatureTest {
                 recordSession()
             },
             assertAction = {
-                val envelopes = getLogEnvelopes(expectedSize)
+                // All AEI logs are created at potentially the same time and the actual timestamps in the log
+                // isn't mapped to the time when the payload is created. As such, opt out of order validation.
+                val envelopes = getLogEnvelopes(
+                    expectedSize = expectedSize,
+                    logsOrderedByTimestamp = false
+                )
                 assertEquals(expectedSize, envelopes.size)
                 val logs = envelopes.mapNotNull { it.data.logs?.singleOrNull() }
                     .filter { it.attributes?.findAttributeValue("emb.type") == "sys.exit" }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePayloadAssertionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePayloadAssertionInterface.kt
@@ -65,19 +65,31 @@ internal class EmbracePayloadAssertionInterface(
      * Returns the list of log payload envelopes that have been sent. If [expectedSize] is specified,
      * it will wait a maximum of 1 second for the number of payloads that exist to equal
      * to that before returning, timing out if it doesn't.
+     *
+     * Set [logsOrderedByTimestamp] to false if the logs in each payload envelope are all after or equal to all the logs
+     * in the previously delivered payload. This is true in most cases, so we can use the log timestamps as a proxy for
+     * the delivery order. But in some instances, where a payload contains log with order timestamps, this proxy
+     * relationship no longer holds
      */
-    internal fun getLogEnvelopes(expectedSize: Int) = retrieveLogEnvelopes(expectedSize)
+    internal fun getLogEnvelopes(
+        expectedSize: Int,
+        logsOrderedByTimestamp: Boolean = true
+    ) = retrieveLogEnvelopes(expectedSize, logsOrderedByTimestamp)
+
     internal fun getSingleLogEnvelope() = getLogEnvelopes(1).single()
 
     private fun retrieveLogEnvelopes(
         expectedSize: Int,
+        logsOrderedByTimestamp: Boolean,
     ): List<Envelope<LogPayload>> {
         val supplier = { checkNotNull(apiServer).getLogEnvelopes() }
         try {
             val envelopes = retrievePayload(expectedSize = expectedSize, supplier = supplier)
-            val envelopesByType = envelopes.groupBy { it.type ?: "" }
-            envelopesByType.forEach {
-                assertLogsDeliveredInOrder(it.value)
+            if (logsOrderedByTimestamp) {
+                val envelopesByType = envelopes.groupBy { it.type ?: "" }
+                envelopesByType.forEach {
+                    assertLogsDeliveredInOrder(it.value)
+                }
             }
             return envelopes
         } catch (exc: TimeoutException) {


### PR DESCRIPTION
So the delivery order validation isn't really validating the right thing - the deilvery order is based on the time a payload is created (i.e. the timestamp on the file name), not the timestamps of the logs inside that payload, which is what we were validating against. Typically, this technically-wrong timestamp is a good enough proxy since the times the payloads are created is in the same order as the times the correponding logs are recorded, assuming there are no network issues changing the order. To truly validate the thing the right sort order is being adherd to in delivery, we can't look at the log timestamp.

But doing that is gonna take some plumbing changes, and I don't think this is the right time to do it. So to solve the flake, which happens in AEI being while the logs recorded with increasing timestamps, they are all written within the same millisecond, so their priorities are the same when it comes to the time. So to break the tie, it uses UUID, which isn't stable (because of TestUuid generator isn't threadsafe), hence we get stuff out of order.  
  
The quickest way to solving the flake is to opt out of this order assertion, which is what I've done :sweat_smile: