### PR TITLE
Move OkHttpClient init off the main thread

### DIFF
--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
@@ -44,7 +44,7 @@ class ConfigServiceImpl(
     worker: BackgroundWorker,
     private val serializer: PlatformSerializer,
     store: KeyValueStore,
-    okHttpClient: OkHttpClient,
+    okHttpClient: Lazy<OkHttpClient>,
     abis: Array<String>,
     private val sdkVersion: String,
     private val apiLevel: Int,

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/source/OkHttpRemoteConfigSource.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/source/OkHttpRemoteConfigSource.kt
@@ -11,7 +11,7 @@ import okio.buffer
 import java.io.IOException
 
 internal class OkHttpRemoteConfigSource(
-    private val okhttpClient: OkHttpClient,
+    private val okhttpClient: Lazy<OkHttpClient>,
     private val serializer: PlatformSerializer,
     private val configEndpoint: ConfigEndpoint,
 ) : RemoteConfigSource {
@@ -30,7 +30,7 @@ internal class OkHttpRemoteConfigSource(
 
     private fun fetchConfigImpl(): ConfigHttpResponse? {
         val request = prepareRequest()
-        val call = okhttpClient.newCall(request)
+        val call = okhttpClient.value.newCall(request)
         val response = call.execute()
         return processResponse(response)
     }

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImplTest.kt
@@ -115,7 +115,7 @@ internal class ConfigServiceImplTest {
         worker = fakeBackgroundWorker(),
         serializer = serializer,
         store = FakeKeyValueStore(),
-        okHttpClient = okHttpClient,
+        okHttpClient = lazyOf(okHttpClient),
         abis = arrayOf("arm64-v8a"),
         sdkVersion = "1.2.3",
         apiLevel = 36,

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/NativeSymbolTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/NativeSymbolTest.kt
@@ -79,7 +79,7 @@ class NativeSymbolTest {
             worker = fakeBackgroundWorker(),
             serializer = serializer,
             store = FakeKeyValueStore(),
-            okHttpClient = okHttpClient,
+            okHttpClient = lazyOf(okHttpClient),
             abis = arrayOf(arch),
             sdkVersion = "1.2.3",
             apiLevel = 36,

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/OkHttpRemoteConfigSourceTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/OkHttpRemoteConfigSourceTest.kt
@@ -47,7 +47,7 @@ class OkHttpRemoteConfigSourceTest {
         val gzipSink = GzipSink(configResponseBuffer).buffer()
         TestPlatformSerializer().toJson(remoteConfig, gzipSink.outputStream())
         source = OkHttpRemoteConfigSource(
-            client,
+            lazyOf(client),
             TestPlatformSerializer(),
             ConfigEndpoint(
                 "deviceId",

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitModule.kt
@@ -42,7 +42,7 @@ interface InitModule {
 
     val instrumentedConfig: InstrumentedConfig
 
-    val okHttpClient: OkHttpClient
+    val okHttpClient: Lazy<OkHttpClient>
 
     val uuidSource: UuidSource
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitModuleImpl.kt
@@ -40,7 +40,7 @@ class InitModuleImpl(
 
     override val instrumentedConfig: InstrumentedConfig = InstrumentedConfigImpl
 
-    override val okHttpClient by singleton {
+    override val okHttpClient: Lazy<OkHttpClient> = lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
         EmbTrace.trace("okhttp-client-init") {
             OkHttpClient()
                 .newBuilder()

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionService.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionService.kt
@@ -23,7 +23,7 @@ import java.io.InputStream
 import java.util.zip.GZIPInputStream
 
 class OkHttpRequestExecutionService(
-    private val okHttpClient: OkHttpClient,
+    private val okHttpClient: Lazy<OkHttpClient>,
     private val coreBaseUrl: String,
     private val lazyDeviceId: Lazy<String>,
     private val appId: String,
@@ -50,7 +50,7 @@ class OkHttpRequestExecutionService(
 
         var executionError: Throwable? = null
         val httpCallResponse = try {
-            okHttpClient.newCall(request).execute()
+            okHttpClient.value.newCall(request).execute()
         } catch (throwable: Throwable) {
             // IOExceptions are expected during the execution of a network request is expected, so don't log errors
             // for those. But any unexpected error should be logged.

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionServiceTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionServiceTest.kt
@@ -59,7 +59,7 @@ class OkHttpRequestExecutionServiceTest {
             .readTimeout(1, TimeUnit.SECONDS)
             .build()
         requestExecutionService = OkHttpRequestExecutionService(
-            okHttpClient = client,
+            okHttpClient = lazyOf(client),
             coreBaseUrl = testServerUrl,
             lazyDeviceId = lazy { testDeviceId },
             appId = testAppId,
@@ -77,7 +77,7 @@ class OkHttpRequestExecutionServiceTest {
     fun `return incomplete if the server does not exist`() {
         // given a request execution service with a non existent url
         requestExecutionService = OkHttpRequestExecutionService(
-            okHttpClient = client,
+            okHttpClient = lazyOf(client),
             coreBaseUrl = "https://nonexistenturl:1565/",
             lazyDeviceId = lazy { testDeviceId },
             appId = testAppId,

--- a/embrace-microbenchmark/src/androidTest/kotlin/io/embrace/android/embracesdk/benchmark/TelemetryDestinationHarness.kt
+++ b/embrace-microbenchmark/src/androidTest/kotlin/io/embrace/android/embracesdk/benchmark/TelemetryDestinationHarness.kt
@@ -50,7 +50,7 @@ internal class TelemetryDestinationHarness {
         override val startupClassifier: StartupClassifier = StartupClassifierImpl()
         override val jsonSerializer: PlatformSerializer = EmbraceSerializer()
         override val instrumentedConfig: InstrumentedConfig = InstrumentedConfigImpl
-        override val okHttpClient: OkHttpClient = OkHttpClient()
+        override val okHttpClient: Lazy<OkHttpClient> = lazyOf(OkHttpClient())
     }
 
     private object NoopTelemetryService : TelemetryService {


### PR DESCRIPTION
## Goal
Move the initialisation of the `OkHttpClient` off the main thread. We never actually use of the `OkHttpClient` on the main thread, but we have been forcing its initialization on the main thread by directly passing it to its use sites.

This PR makes the `OkHttpClient` references `Lazy<OkHttpClient>` and also changes the `LazyThreadSafetyMode` to `SYNCHRONIZED` for this one instance (where `singleton` is `PUBLISHED`). This defers the initialization to the first use and as a side-effect moves the init to an IO worker thread.

## Testing
Measured in macrobenchmarks and updated the related unit tests.
