### PR TITLE
Transition to background-only user session if app inactive

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
@@ -72,6 +72,7 @@ class UserSessionOrchestrationModuleImpl(
             initModule.logger,
             workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker),
             initModule.uuidSource,
+            initModule.startupClassifier,
         )
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadata.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadata.kt
@@ -5,34 +5,135 @@ import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.opentelemetry.kotlin.semconv.SessionAttributes
 
 /**
- * Holds metadata about the user session.
+ * Holds metadata about the user session. Creating new instances with updated attributes is only permitted to support specific
+ * user session state mutations:
+ *
+ * - Update with a new [partIndex]: [withPartIndex]
+ * - Update last time the user session was active: [Classified.withNewActivity]
+ * - Classify whether this user session is background-only: [Unclassified.classify])
  */
-data class UserSessionMetadata(
-    val startTimeMs: Long,
-    val userSessionId: String,
-    val userSessionNumber: Long,
-    val maxDurationSecs: Long,
-    val inactivityTimeoutSecs: Long,
-    val partIndex: Int,
-    val lastActivityMs: Long,
-    val isBackgroundOnly: Boolean = false,
-) {
+sealed interface UserSessionMetadata {
+    val startTimeMs: Long
+    val userSessionId: String
+    val userSessionNumber: Long
+    val maxDurationSecs: Long
+    val inactivityTimeoutSecs: Long
+    val partIndex: Int
+    val lastActivityMs: Long
+
+    /**
+     * Whether this user session is background-only, or null if that is not yet known because the startup has not been classified.
+     */
+    val isBackgroundOnly: Boolean?
+
+    /**
+     * Create a new metadata instance of this user session with the give index of the last created part
+     */
+    fun withPartIndex(updatedPartIndex: Int): UserSessionMetadata
+
     fun isOverMaxDuration(clock: Clock): Boolean =
         clock.now() - startTimeMs > maxDurationSecs * 1_000L
 
     fun isInactive(clock: Clock): Boolean =
         clock.now() - lastActivityMs > inactivityTimeoutSecs * 1_000L
 
-    val attributes: Map<String, Any> = buildMap {
-        put(EmbSessionAttributes.EMB_USER_SESSION_START_TS, startTimeMs)
-        put(EmbSessionAttributes.EMB_USER_SESSION_ID, userSessionId)
-        put(EmbSessionAttributes.EMB_USER_SESSION_NUMBER, userSessionNumber)
-        put(EmbSessionAttributes.EMB_USER_SESSION_MAX_DURATION_SECONDS, maxDurationSecs)
-        put(EmbSessionAttributes.EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS, inactivityTimeoutSecs)
-        put(SessionAttributes.SESSION_ID, userSessionId)
-        if (isBackgroundOnly) {
-            put(EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART, BACKGROUND_ONLY_MARKER)
+    val attributes: Map<String, Any>
+        get() = buildMap {
+            put(EmbSessionAttributes.EMB_USER_SESSION_START_TS, startTimeMs)
+            put(EmbSessionAttributes.EMB_USER_SESSION_ID, userSessionId)
+            put(EmbSessionAttributes.EMB_USER_SESSION_NUMBER, userSessionNumber)
+            put(EmbSessionAttributes.EMB_USER_SESSION_MAX_DURATION_SECONDS, maxDurationSecs)
+            put(EmbSessionAttributes.EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS, inactivityTimeoutSecs)
+            put(SessionAttributes.SESSION_ID, userSessionId)
+            if (isBackgroundOnly == true) {
+                put(EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART, BACKGROUND_ONLY_MARKER)
+            }
         }
+
+    /**
+     * A user session where whether it is background-only or not is known
+     */
+    class Classified(
+        override val startTimeMs: Long,
+        override val userSessionId: String,
+        override val userSessionNumber: Long,
+        override val maxDurationSecs: Long,
+        override val inactivityTimeoutSecs: Long,
+        override val partIndex: Int,
+        override val lastActivityMs: Long,
+        override val isBackgroundOnly: Boolean,
+    ) : UserSessionMetadata {
+
+        override fun withPartIndex(updatedPartIndex: Int): Classified = Classified(
+            startTimeMs = startTimeMs,
+            userSessionId = userSessionId,
+            userSessionNumber = userSessionNumber,
+            maxDurationSecs = maxDurationSecs,
+            inactivityTimeoutSecs = inactivityTimeoutSecs,
+            partIndex = updatedPartIndex,
+            lastActivityMs = lastActivityMs,
+            isBackgroundOnly = isBackgroundOnly,
+        )
+
+        /**
+         * This user session with its last activity recorded at the given time.
+         */
+        fun withNewActivity(lastActivityTimeMs: Long): Classified = Classified(
+            startTimeMs = startTimeMs,
+            userSessionId = userSessionId,
+            userSessionNumber = userSessionNumber,
+            maxDurationSecs = maxDurationSecs,
+            inactivityTimeoutSecs = inactivityTimeoutSecs,
+            partIndex = partIndex,
+            lastActivityMs = lastActivityTimeMs,
+            isBackgroundOnly = isBackgroundOnly,
+        )
+    }
+
+    /**
+     * A user session created at process start whose startup classification has not resolved. Whether it's background-only or not
+     * is not yet determined.
+     */
+    class Unclassified(
+        override val startTimeMs: Long,
+        override val userSessionId: String,
+        override val userSessionNumber: Long,
+        override val maxDurationSecs: Long,
+        override val inactivityTimeoutSecs: Long,
+        override val partIndex: Int,
+        override val lastActivityMs: Long,
+    ) : UserSessionMetadata {
+
+        override val isBackgroundOnly: Boolean?
+            get() = null
+
+        override fun withPartIndex(updatedPartIndex: Int): Unclassified = Unclassified(
+            startTimeMs = startTimeMs,
+            userSessionId = userSessionId,
+            userSessionNumber = userSessionNumber,
+            maxDurationSecs = maxDurationSecs,
+            inactivityTimeoutSecs = inactivityTimeoutSecs,
+            partIndex = updatedPartIndex,
+            lastActivityMs = lastActivityMs,
+        )
+
+        /**
+         * Create a new [Classified] instance of this user session's metadata when whether it is background-only can be determined.
+         * Optionally update the [lastActivityMs] if the classification implies there is new user activity.
+         */
+        fun classify(
+            isBackgroundOnly: Boolean,
+            updatedLastActivityMs: Long = lastActivityMs
+        ): Classified = Classified(
+            startTimeMs = startTimeMs,
+            userSessionId = userSessionId,
+            userSessionNumber = userSessionNumber,
+            maxDurationSecs = maxDurationSecs,
+            inactivityTimeoutSecs = inactivityTimeoutSecs,
+            partIndex = partIndex,
+            lastActivityMs = updatedLastActivityMs,
+            isBackgroundOnly = isBackgroundOnly,
+        )
     }
 
     companion object {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStore.kt
@@ -14,9 +14,9 @@ internal class UserSessionMetadataStore(private val store: KeyValueStore) {
     }
 
     /**
-     * Persists the given [UserSessionMetadata] to the store.
+     * Persists the given [UserSessionMetadata.Classified] to the store.
      */
-    fun save(metadata: UserSessionMetadata) {
+    fun save(metadata: UserSessionMetadata.Classified) {
         store.edit {
             val map = metadata.attributes.mapValues { it.value.toString() }.toMutableMap()
             map[EmbSessionAttributes.EMB_USER_SESSION_PART_INDEX] = metadata.partIndex.toString()
@@ -35,10 +35,9 @@ internal class UserSessionMetadataStore(private val store: KeyValueStore) {
     }
 
     /**
-     * Loads a [UserSessionMetadata] from the store, or returns null if any required attribute
-     * is absent or cannot be parsed.
+     * Loads a [UserSessionMetadata.Classified] from the store, or returns null if any required attribute is absent or cannot be parsed.
      */
-    fun load(): UserSessionMetadata? {
+    fun load(): UserSessionMetadata.Classified? {
         val attrs = store.getStringMap(KEY_SESSION) ?: return null
         val id = attrs[EmbSessionAttributes.EMB_USER_SESSION_ID] ?: return null
         val startMs = attrs[EmbSessionAttributes.EMB_USER_SESSION_START_TS]?.toLongOrNull() ?: return null
@@ -47,9 +46,8 @@ internal class UserSessionMetadataStore(private val store: KeyValueStore) {
         val inactivityTimeoutSecs = attrs[EmbSessionAttributes.EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS]?.toLongOrNull() ?: return null
         val partIndex = attrs[EmbSessionAttributes.EMB_USER_SESSION_PART_INDEX]?.toIntOrNull() ?: return null
         val lastActivityMs = attrs[KEY_LAST_ACTIVITY_TS]?.toLongOrNull() ?: return null
-        val isBackgroundOnly =
-            attrs[EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART] == UserSessionMetadata.BACKGROUND_ONLY_MARKER
-        return UserSessionMetadata(
+        val isBackgroundOnly = attrs[EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART] == UserSessionMetadata.BACKGROUND_ONLY_MARKER
+        return UserSessionMetadata.Classified(
             startTimeMs = startMs,
             userSessionId = id,
             userSessionNumber = number,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionState.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionState.kt
@@ -3,25 +3,26 @@ package io.embrace.android.embracesdk.internal.session
 /**
  * Describes the possible states of a user session.
  */
-internal sealed class UserSessionState {
+internal sealed interface UserSessionState {
 
     /**
      * The orchestrator is loading initial state from the persistent store.
      */
-    object Initializing : UserSessionState()
+    object Initializing : UserSessionState
 
     /**
      * No user session is active and none has been created previously.
      */
-    object NoActiveSession : UserSessionState()
+    object NoActiveSession : UserSessionState
 
     /**
-     * A user session is active. [metadata] is guaranteed to be present.
+     * A user session is active and can host session parts. Its metadata is [UserSessionMetadata.Unclassified] until the startup
+     * classification resolves and [UserSessionMetadata.Classified] after.
      */
-    data class Active(val metadata: UserSessionMetadata) : UserSessionState()
+    data class Active(val metadata: UserSessionMetadata) : UserSessionState
 
     /**
      * A user session was previously active but has now terminated.
      */
-    object Terminated : UserSessionState()
+    object Terminated : UserSessionState
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestrator.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestrator.kt
@@ -37,3 +37,8 @@ interface SessionOrchestrator : AppStateListener, CrashTeardownHandler {
      */
     fun addUserSessionListener(listener: UserSessionListener)
 }
+
+/**
+ * How long after SDK init do we classify a user session if it has not already been classified by an app launch.
+ */
+internal const val BACKGROUND_STARTUP_WINDOW_MS = 5_000L

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -68,6 +68,7 @@ internal class SessionOrchestratorImpl(
     private val lock = Any()
     private val userSessionListeners = CopyOnWriteArrayList<UserSessionListener>()
 
+    @Volatile
     private var state = appStateTracker.getAppState()
 
     @Volatile
@@ -151,11 +152,13 @@ internal class SessionOrchestratorImpl(
     }
 
     override fun onForeground() {
-        val transitionType = synchronized(lock) {
+        // Hold the as we cancel the inactivity timer and determine the transition type. The lock would be acquired in transitionState()
+        // anyway so we're just handing on for the entire duration instead of dropping it and reacquiring it again.
+        synchronized(lock) {
             inactivityTimerState?.cancel()
             inactivityTimerState = null
             val metadata = currentUserSession()
-            if (metadata?.isBackgroundOnly == true) {
+            val transitionType = if (metadata?.isBackgroundOnly == true) {
                 TransitionType.BACKGROUND_ONLY_SESSION_END
             } else if (metadata?.isInactive(clock) == true) {
                 TransitionType.INACTIVITY_FOREGROUND
@@ -164,30 +167,30 @@ internal class SessionOrchestratorImpl(
             } else {
                 TransitionType.ON_FOREGROUND
             }
+
+            val timestamp = clock.now()
+
+            transitionState(
+                transitionType = transitionType,
+                timestamp = timestamp,
+                oldSessionAction = { initial: SessionPartToken ->
+                    payloadFactory.endPayloadWithState(AppState.BACKGROUND, timestamp, initial)
+                },
+                newSessionAction = {
+                    payloadFactory.startPayloadWithState(
+                        state = AppState.FOREGROUND,
+                        timestamp = timestamp,
+                        coldStart = coldStart,
+                        userSessionPartIndex = ::incrementPartIndex,
+                        sessionPartNumber = ::incrementSessionPartNumber,
+                    )
+                },
+                earlyTerminationCondition = {
+                    return@transitionState shouldRunOnForeground(state)
+                }
+            )
+            coldStart = false
         }
-
-        val timestamp = clock.now()
-
-        transitionState(
-            transitionType = transitionType,
-            timestamp = timestamp,
-            oldSessionAction = { initial: SessionPartToken ->
-                payloadFactory.endPayloadWithState(AppState.BACKGROUND, timestamp, initial)
-            },
-            newSessionAction = {
-                payloadFactory.startPayloadWithState(
-                    state = AppState.FOREGROUND,
-                    timestamp = timestamp,
-                    coldStart = coldStart,
-                    userSessionPartIndex = ::incrementPartIndex,
-                    sessionPartNumber = ::incrementSessionPartNumber,
-                )
-            },
-            earlyTerminationCondition = {
-                return@transitionState shouldRunOnForeground(state)
-            }
-        )
-        coldStart = false
     }
 
     override fun onBackground() {
@@ -263,12 +266,14 @@ internal class SessionOrchestratorImpl(
         (userSessionState as? Active)?.metadata
 
     override fun addUserSessionListener(listener: UserSessionListener) {
-        userSessionListeners.add(listener)
-        currentUserSession()?.let { metadata ->
-            try {
-                listener.onSessionStateEvent(UserSessionActive(metadata.userSessionId))
-            } catch (e: Exception) {
-                logger.trackInternalError(InternalErrorType.UserSessionCallbackFail, e)
+        synchronized(lock) {
+            userSessionListeners.add(listener)
+            currentUserSession()?.let { metadata ->
+                try {
+                    listener.onSessionStateEvent(UserSessionActive(metadata.userSessionId))
+                } catch (e: Exception) {
+                    logger.trackInternalError(InternalErrorType.UserSessionCallbackFail, e)
+                }
             }
         }
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -3,8 +3,12 @@
 package io.embrace.android.embracesdk.internal.session.orchestrator
 
 import io.embrace.android.embracesdk.SessionStateEvent
+import io.embrace.android.embracesdk.SessionStateEvent.UserSessionActive
+import io.embrace.android.embracesdk.SessionStateEvent.UserSessionEnded
 import io.embrace.android.embracesdk.internal.arch.InstrumentationRegistry
 import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
+import io.embrace.android.embracesdk.internal.arch.startup.StartupClassifier
+import io.embrace.android.embracesdk.internal.arch.startup.StartupType
 import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.arch.state.AppStateTracker
 import io.embrace.android.embracesdk.internal.clock.Clock
@@ -20,6 +24,7 @@ import io.embrace.android.embracesdk.internal.session.UserSessionListener
 import io.embrace.android.embracesdk.internal.session.UserSessionMetadata
 import io.embrace.android.embracesdk.internal.session.UserSessionMetadataStore
 import io.embrace.android.embracesdk.internal.session.UserSessionState
+import io.embrace.android.embracesdk.internal.session.UserSessionState.Active
 import io.embrace.android.embracesdk.internal.session.id.SessionPartTracker
 import io.embrace.android.embracesdk.internal.session.message.PayloadFactory
 import io.embrace.android.embracesdk.internal.store.Ordinal
@@ -51,6 +56,7 @@ internal class SessionOrchestratorImpl(
     private val logger: InternalLogger,
     private val backgroundWorker: BackgroundWorker,
     private val uuidSource: UuidSource,
+    private val startupClassifier: StartupClassifier,
 ) : SessionOrchestrator {
 
     /**
@@ -75,6 +81,9 @@ internal class SessionOrchestratorImpl(
 
     @Volatile
     private var maxDurationTimerState: SessionTimerState? = null
+
+    @Volatile
+    private var backgroundStartupWindowTimerState: SessionTimerState? = null
 
     init {
         loadPersistedUserSession()
@@ -107,13 +116,13 @@ internal class SessionOrchestratorImpl(
                     // Continue a background-only user session if it won't extend it beyond its max duration
                     // Don't set any expiry timers those aren't applicable when the user isn't considered active
                     stored != null && stored.isBackgroundOnly && !stored.isOverMaxDuration(clock) -> {
-                        UserSessionState.Active(stored)
+                        Active(stored)
                     }
 
-                    // Continue a user session if it won't extend it beyond its max duration and it's within it inactivity grace period
+                    // Continue a user session if it won't extend it beyond its max duration and is within its inactivity grace period
                     stored != null && !stored.isBackgroundOnly && !stored.isOverMaxDuration(clock) && !stored.isInactive(clock) -> {
                         scheduleMaxDurationTimeout(stored)
-                        UserSessionState.Active(stored)
+                        Active(stored)
                     }
 
                     else -> UserSessionState.NoActiveSession
@@ -251,14 +260,13 @@ internal class SessionOrchestratorImpl(
     }
 
     override fun currentUserSession(): UserSessionMetadata? =
-        (userSessionState as? UserSessionState.Active)?.metadata
+        (userSessionState as? Active)?.metadata
 
     override fun addUserSessionListener(listener: UserSessionListener) {
         userSessionListeners.add(listener)
-        val state = userSessionState
-        if (state is UserSessionState.Active) {
+        currentUserSession()?.let { metadata ->
             try {
-                listener.onSessionStateEvent(SessionStateEvent.UserSessionActive(state.metadata.userSessionId))
+                listener.onSessionStateEvent(UserSessionActive(metadata.userSessionId))
             } catch (e: Exception) {
                 logger.trackInternalError(InternalErrorType.UserSessionCallbackFail, e)
             }
@@ -353,14 +361,12 @@ internal class SessionOrchestratorImpl(
             // update the current state of the SDK
             state = endAppState
 
-            // update newly created session
+            // update newly created session part and user session, if applicable
             val userSession = currentUserSession()
             if (newSessionPart != null) {
                 if (userSession != null) {
                     // persist partIndex to handle user session restoration in new process
-                    val updatedUserSession = userSession.copy(partIndex = newSessionPart.userSessionPartIndex)
-                    metadataStore.save(updatedUserSession)
-                    userSessionState = UserSessionState.Active(updatedUserSession)
+                    setActiveUserSession(userSession.withPartIndex(newSessionPart.userSessionPartIndex))
 
                     if (endAppState == AppState.FOREGROUND) {
                         sessionTracker.setProcessStateSummary(newSessionPart.sessionPartId, userSession.userSessionId)
@@ -390,10 +396,9 @@ internal class SessionOrchestratorImpl(
         }
     }
 
-    private fun scheduleInactivityTimeout() {
+    private fun scheduleInactivityTimeout(metadata: UserSessionMetadata.Classified?) {
         inactivityTimerState?.cancel()
-        val metadata = currentUserSession() ?: return
-        if (!metadata.isBackgroundOnly) {
+        if (metadata != null && !metadata.isBackgroundOnly) {
             inactivityTimerState = SessionTimerState(
                 backgroundWorker.schedule<Unit>(
                     ::onInactivityTimeout,
@@ -404,8 +409,8 @@ internal class SessionOrchestratorImpl(
         }
     }
 
-    private fun scheduleMaxDurationTimeout(metadata: UserSessionMetadata) {
-        if (!metadata.isBackgroundOnly) {
+    private fun scheduleMaxDurationTimeout(metadata: UserSessionMetadata?) {
+        if (metadata is UserSessionMetadata.Classified && !metadata.isBackgroundOnly) {
             maxDurationTimerState?.cancel()
             val remainingSecs = metadata.maxDurationSecs - ((clock.now() - metadata.startTimeMs) / 1_000L)
             val delay = max(remainingSecs, 0)
@@ -419,9 +424,18 @@ internal class SessionOrchestratorImpl(
         }
     }
 
+    /**
+     * Cancels and clears the background-startup window timer once it's no longer needed
+     */
+    private fun clearBackgroundStartupWindowTimer() {
+        backgroundStartupWindowTimerState?.cancel()
+        backgroundStartupWindowTimerState = null
+    }
+
     private fun onMaxDurationTimeout() {
         synchronized(lock) {
-            if (userSessionState !is UserSessionState.Active || currentUserSession()?.isBackgroundOnly == true) {
+            val metadata = currentUserSessionIfClassified()
+            if (metadata == null || metadata.isBackgroundOnly) {
                 return
             }
             val currentAppState = state
@@ -453,7 +467,8 @@ internal class SessionOrchestratorImpl(
 
     private fun onInactivityTimeout() {
         synchronized(lock) {
-            if (currentUserSession()?.isBackgroundOnly == true) {
+            val metadata = currentUserSessionIfClassified()
+            if (metadata == null || metadata.isBackgroundOnly) {
                 return
             }
             val timestamp = clock.now()
@@ -503,96 +518,151 @@ internal class SessionOrchestratorImpl(
 
     /**
      * Decides what to do with the user session at the start of a session-part transition.
-     * Crashes leave the user session untouched. INITIAL with state=BACKGROUND defers user-session
-     * creation to the first foreground entry — the first user session of a process must originate
-     * from a foreground transition.
      */
     private fun transitionUserSession(transitionType: TransitionType, endAppState: AppState, timestamp: Long) {
         when {
+            // User session does not need to be modified when the part transition is happening due to a crash
             transitionType == TransitionType.CRASH -> {}
 
-            transitionType == TransitionType.INITIAL && state == AppState.BACKGROUND -> {}
+            // User session needs to be established when the SDK starts up.
+            // Create an unclassified user session and schedule a task to classify as background-only if it's not classified when it runs.
+            transitionType == TransitionType.INITIAL && state == AppState.BACKGROUND -> {
+                if (userSessionState !is Active) {
+                    val newMetadata = createUnclassifiedUserSession(timestamp)
+                    setActiveUserSession(newMetadata)
+                    notifyListeners(UserSessionActive(newMetadata.userSessionId))
+                    backgroundStartupWindowTimerState = SessionTimerState(
+                        backgroundWorker.schedule<Unit>(
+                            ::makeCurrentUserSessionBackgroundOnly,
+                            BACKGROUND_STARTUP_WINDOW_MS,
+                            TimeUnit.MILLISECONDS,
+                        )
+                    )
+                }
+            }
 
-            transitionType.endsUserSession -> handleUserSessionTransition(timestamp, endAppState)
+            // User session being ended explicitly - end current one and start a new one based on the expected endAppState.
+            transitionType.endsUserSession -> {
+                clearBackgroundStartupWindowTimer()
+                transitionToNewUserSession(timestamp, endAppState)
+                scheduleSessionEndTimers(endAppState)
+            }
 
+            // Transitions where the current user session may continue
             else -> {
-                handleNewSessionPart(timestamp, endAppState)
-                if (endAppState == AppState.FOREGROUND && maxDurationTimerState == null) {
-                    currentUserSession()?.let {
-                        scheduleMaxDurationTimeout(it)
-                    }
-                } else if (endAppState == AppState.BACKGROUND) {
-                    scheduleInactivityTimeout()
+                clearBackgroundStartupWindowTimer()
+
+                // Update the current user session either by modifying the existing one or replacing it with a new one
+                when (val current = currentUserSession()) {
+                    is UserSessionMetadata.Unclassified -> setActiveUserSession(
+                        current.classify(
+                            isBackgroundOnly = endAppState == AppState.BACKGROUND,
+                            updatedLastActivityMs = timestamp
+                        )
+                    )
+
+                    is UserSessionMetadata.Classified ->
+                        if (current.continueUserSession(timestamp, endAppState)) {
+                            setActiveUserSession(current.withNewActivity(timestamp))
+                        } else {
+                            transitionToNewUserSession(timestamp, endAppState)
+                        }
+
+                    null -> transitionToNewUserSession(timestamp, endAppState)
+                }
+
+                scheduleSessionEndTimers(endAppState)
+            }
+        }
+    }
+
+    private fun createUnclassifiedUserSession(startTimeMs: Long): UserSessionMetadata.Unclassified =
+        UserSessionMetadata.Unclassified(
+            startTimeMs = startTimeMs,
+            userSessionId = uuidSource.createUuid(),
+            userSessionNumber = ordinalStore.incrementAndGet(Ordinal.USER_SESSION).toLong(),
+            maxDurationSecs = configService.sessionBehavior.getMaxSessionDurationMs() / 1_000L,
+            inactivityTimeoutSecs = configService.sessionBehavior.getSessionInactivityTimeoutMs() / 1_000L,
+            partIndex = 0,
+            lastActivityMs = startTimeMs,
+        )
+
+    /**
+     * The background-startup window elapsed without the app entering the foreground and classifying the user session as not
+     * background-only, so we assume the process creation was not triggered by an app launch and classify it as background-only.
+     */
+    private fun makeCurrentUserSessionBackgroundOnly() {
+        synchronized(lock) {
+            val userSession = currentUserSession()
+            if (userSession is UserSessionMetadata.Unclassified) {
+                startupClassifier.assumeBackgroundStartup()
+                if (startupClassifier.startupType() == StartupType.BACKGROUND) {
+                    setActiveUserSession(userSession.classify(isBackgroundOnly = true))
+                    destination.addSessionPartAttribute(
+                        EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART,
+                        UserSessionMetadata.BACKGROUND_ONLY_MARKER,
+                    )
                 }
             }
         }
     }
 
     /**
-     * Called whenever a new session part is successfully created for a non-terminating, non-crash
-     * transition. Continues the active user session if it can host the new part; otherwise ends
-     * it (if there is one) and starts a new user session whose flavour follows [endAppState].
+     * Schedule the appropriate user session ending timers given the app state
      */
-    private fun handleNewSessionPart(timestamp: Long, endAppState: AppState) {
-        val current = userSessionState as? UserSessionState.Active
-        if (current != null && current.metadata.continueUserSession(timestamp, endAppState)) {
-            val updatedMetadata = current.metadata.copy(lastActivityMs = timestamp)
-            metadataStore.save(updatedMetadata)
-            userSessionState = UserSessionState.Active(updatedMetadata)
-        } else {
-            handleUserSessionTransition(timestamp, endAppState)
+    private fun scheduleSessionEndTimers(endAppState: AppState) {
+        val userSession = currentUserSessionIfClassified()
+        if (endAppState == AppState.FOREGROUND && maxDurationTimerState == null) {
+            scheduleMaxDurationTimeout(userSession)
+        } else if (endAppState == AppState.BACKGROUND) {
+            scheduleInactivityTimeout(userSession)
         }
     }
 
     /**
-     * Called when the active user session ends for any reason other than a crash. Terminates it, then always starts based on
+     * Called when the active user session ends for any reason other than a crash. Terminates it, then start a new one based on
      * the post transition [AppState]
      */
-    private fun handleUserSessionTransition(timestamp: Long, endAppState: AppState) {
-        val state = userSessionState
-        if (state is UserSessionState.Active) {
-            terminateUserSession(state)
+    private fun transitionToNewUserSession(timestamp: Long, endAppState: AppState) {
+        // End current user session if it exists
+        currentUserSession()?.let {
+            maxDurationTimerState?.cancel()
+            maxDurationTimerState = null
+            inactivityTimerState?.cancel()
+            inactivityTimerState = null
+            metadataStore.clear()
+            userSessionState = UserSessionState.Terminated
+            notifyListeners(UserSessionEnded(it.userSessionId))
         }
-        startNewUserSession(timestamp, endAppState)
+
+        // Start new user session, make it active, and broadcast new user session being active to listeners. The caller is
+        // responsible for scheduling the new session's end timers (see scheduleSessionEndTimers).
+        val newMetadata = createUnclassifiedUserSession(timestamp).classify(isBackgroundOnly = endAppState == AppState.BACKGROUND)
+        setActiveUserSession(newMetadata)
+        notifyListeners(UserSessionActive(newMetadata.userSessionId))
     }
 
-    private fun startNewUserSession(startTimeMs: Long, endAppState: AppState) {
-        val maxDurationMs = configService.sessionBehavior.getMaxSessionDurationMs()
-        val inactivityTimeoutMs = configService.sessionBehavior.getSessionInactivityTimeoutMs()
-        val userSessionNumber = ordinalStore.incrementAndGet(Ordinal.USER_SESSION).toLong()
-        val newMetadata = UserSessionMetadata(
-            startTimeMs = startTimeMs,
-            userSessionId = uuidSource.createUuid(),
-            userSessionNumber = userSessionNumber,
-            maxDurationSecs = maxDurationMs / 1_000L,
-            inactivityTimeoutSecs = inactivityTimeoutMs / 1_000L,
-            partIndex = 0,
-            lastActivityMs = startTimeMs,
-            isBackgroundOnly = endAppState == AppState.BACKGROUND,
-        )
-        metadataStore.save(newMetadata)
-        userSessionState = UserSessionState.Active(newMetadata)
-        notifyListeners(SessionStateEvent.UserSessionActive(newMetadata.userSessionId))
-
-        if (endAppState == AppState.FOREGROUND) {
-            scheduleMaxDurationTimeout(newMetadata)
+    /**
+     * Persists [metadata] and adopts it as the active user session. An unclassified user session is persisted as background-only
+     * so that a process death inside the background-startup window reads as a background start, while remaining unclassified in memory
+     * until the foreground transition or the window resolves it.
+     */
+    private fun setActiveUserSession(metadata: UserSessionMetadata) {
+        val persisted = when (metadata) {
+            is UserSessionMetadata.Classified -> metadata
+            is UserSessionMetadata.Unclassified -> metadata.classify(isBackgroundOnly = true)
         }
+        metadataStore.save(persisted)
+        userSessionState = Active(metadata)
     }
 
-    private fun terminateUserSession(state: UserSessionState.Active) {
-        maxDurationTimerState?.cancel()
-        maxDurationTimerState = null
-        inactivityTimerState?.cancel()
-        inactivityTimerState = null
-        metadataStore.clear()
-        userSessionState = UserSessionState.Terminated
-        notifyListeners(SessionStateEvent.UserSessionEnded(state.metadata.userSessionId))
-    }
+    private fun currentUserSessionIfClassified(): UserSessionMetadata.Classified? =
+        currentUserSession() as? UserSessionMetadata.Classified
 
     /**
      * Returns true if this user session should continue and false if a new one should be started.
      */
-    private fun UserSessionMetadata.continueUserSession(timestamp: Long, endAppState: AppState): Boolean =
+    private fun UserSessionMetadata.Classified.continueUserSession(timestamp: Long, endAppState: AppState): Boolean =
         when {
             // Don't continue session if current time is not congruent with the user session's timestamp
             timestamp < startTimeMs -> {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -62,9 +62,7 @@ internal class SessionOrchestratorImpl(
     /**
      * Tracks whether the foreground phase comes from a cold start or not.
      */
-    @Volatile
     private var coldStart = true
-
     private val lock = Any()
     private val userSessionListeners = CopyOnWriteArrayList<UserSessionListener>()
 
@@ -77,13 +75,8 @@ internal class SessionOrchestratorImpl(
     @Volatile
     private var lastManualEndMs: Long? = null
 
-    @Volatile
     private var inactivityTimerState: SessionTimerState? = null
-
-    @Volatile
     private var maxDurationTimerState: SessionTimerState? = null
-
-    @Volatile
     private var backgroundStartupWindowTimerState: SessionTimerState? = null
 
     init {
@@ -152,8 +145,8 @@ internal class SessionOrchestratorImpl(
     }
 
     override fun onForeground() {
-        // Hold the as we cancel the inactivity timer and determine the transition type. The lock would be acquired in transitionState()
-        // anyway so we're just handing on for the entire duration instead of dropping it and reacquiring it again.
+        // Hold the lock as we cancel the inactivity timer and determine the transition type. The lock would be acquired in
+        // transitionState() anyway so we're just hanging on to it for the entire duration instead of dropping and reacquiring it again.
         synchronized(lock) {
             inactivityTimerState?.cancel()
             inactivityTimerState = null

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/TransitionType.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/TransitionType.kt
@@ -46,7 +46,7 @@ enum class TransitionType(
         userSessionTerminationReason = EmbUserSessionTerminationReasonValues.MAX_DURATION_REACHED,
     ),
     BACKGROUND_ONLY_SESSION_END(
-        userSessionTerminationReason = EmbUserSessionTerminationReasonValues.END_BACKGROUND_ONLY_USER_SESSION,
+        userSessionTerminationReason = EmbUserSessionTerminationReasonValues.BACKGROUND_ONLY_USER_SESSION_FOREGROUNDED,
         nextAppState = AppState.FOREGROUND,
     );
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStoreTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStoreTest.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.internal.session
 import io.embrace.android.embracesdk.fakes.FakeKeyValueStore
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
@@ -13,7 +12,7 @@ internal class UserSessionMetadataStoreTest {
     private lateinit var kvStore: FakeKeyValueStore
     private lateinit var metadataStore: UserSessionMetadataStore
 
-    private val metadata = UserSessionMetadata(
+    private val metadata = UserSessionMetadata.Classified(
         startTimeMs = 1000L,
         userSessionId = "test-uuid",
         userSessionNumber = 3L,
@@ -21,8 +20,9 @@ internal class UserSessionMetadataStoreTest {
         inactivityTimeoutSecs = 1800L,
         partIndex = 1,
         lastActivityMs = 5000L,
+        isBackgroundOnly = false,
     )
-    private val metadata2 = UserSessionMetadata(
+    private val metadata2 = UserSessionMetadata.Classified(
         startTimeMs = 2000L,
         userSessionId = "test-uuid-2",
         userSessionNumber = 5L,
@@ -30,8 +30,9 @@ internal class UserSessionMetadataStoreTest {
         inactivityTimeoutSecs = 3600L,
         partIndex = 2,
         lastActivityMs = 9000L,
+        isBackgroundOnly = false,
     )
-    private val metadataBackgroundOnly = UserSessionMetadata(
+    private val metadataBackgroundOnly = UserSessionMetadata.Classified(
         startTimeMs = 3000L,
         userSessionId = "test-uuid-3",
         userSessionNumber = 7L,
@@ -72,7 +73,7 @@ internal class UserSessionMetadataStoreTest {
         metadataStore.save(metadata)
         val loaded = checkNotNull(saveAndRemoveFromRawMap(metadata, EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART))
         metadata.assertMetadataEquals(loaded)
-        assertFalse(loaded.isBackgroundOnly)
+        assertEquals(false, loaded.isBackgroundOnly)
     }
 
     @Test
@@ -122,7 +123,7 @@ internal class UserSessionMetadataStoreTest {
     private fun getRawMap(): MutableMap<String, String> = checkNotNull(kvStore.getStringMap("embrace.user_session")).toMutableMap()
 
     private fun saveAndRemoveFromRawMap(
-        sessionMetadata: UserSessionMetadata,
+        sessionMetadata: UserSessionMetadata.Classified,
         attribute: String,
     ): UserSessionMetadata? {
         metadataStore.save(sessionMetadata)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionIdProviderImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionIdProviderImplTest.kt
@@ -36,7 +36,7 @@ internal class SessionIdProviderImplTest {
 
     @Test
     fun `getCurrentUserSessionId returns the orchestrator's active user session id`() {
-        sessionOrchestrator.currentSession = UserSessionMetadata(
+        sessionOrchestrator.currentSession = UserSessionMetadata.Classified(
             startTimeMs = 1000L,
             userSessionId = "user-session-uuid",
             userSessionNumber = 1L,
@@ -44,6 +44,7 @@ internal class SessionIdProviderImplTest {
             inactivityTimeoutSecs = 300L,
             partIndex = 1,
             lastActivityMs = 1000L,
+            isBackgroundOnly = false,
         )
         assertEquals("user-session-uuid", provider.getCurrentUserSessionId())
     }
@@ -52,7 +53,7 @@ internal class SessionIdProviderImplTest {
     fun `getActiveSessionIds returns IDs from session parts tracker even if current session per the orchestrator differs`() {
         val token = fakeSessionPartToken()
         sessionPartTracker.currentSession = token
-        sessionOrchestrator.currentSession = UserSessionMetadata(
+        sessionOrchestrator.currentSession = UserSessionMetadata.Classified(
             startTimeMs = token.startTime + 10_000L,
             userSessionId = "new-user-session",
             userSessionNumber = 2,
@@ -60,6 +61,7 @@ internal class SessionIdProviderImplTest {
             inactivityTimeoutSecs = 300L,
             partIndex = token.userSessionPartIndex + 1,
             lastActivityMs = token.startTime + 10_000L,
+            isBackgroundOnly = false,
         )
         assertEquals(SessionIdsSnapshot(token.userSessionId, token.sessionPartId), provider.getActiveSessionIds())
     }
@@ -67,7 +69,7 @@ internal class SessionIdProviderImplTest {
     @Test
     fun `getActiveSessionIds falls back to the orchestrator's user session id when no active session part`() {
         sessionPartTracker.currentSession = null
-        sessionOrchestrator.currentSession = UserSessionMetadata(
+        sessionOrchestrator.currentSession = UserSessionMetadata.Classified(
             startTimeMs = 1000L,
             userSessionId = "user-session-uuid",
             userSessionNumber = 1L,
@@ -75,6 +77,7 @@ internal class SessionIdProviderImplTest {
             inactivityTimeoutSecs = 300L,
             partIndex = 1,
             lastActivityMs = 1000L,
+            isBackgroundOnly = false,
         )
         assertEquals(
             SessionIdsSnapshot(userSessionId = "user-session-uuid", sessionPartId = ""),

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorListenerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorListenerTest.kt
@@ -27,6 +27,7 @@ import io.embrace.android.embracesdk.fakes.injection.FakePayloadSourceModule
 import io.embrace.android.embracesdk.internal.arch.InstrumentationRegistry
 import io.embrace.android.embracesdk.internal.arch.InstrumentationRegistryImpl
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
+import io.embrace.android.embracesdk.internal.arch.startup.StartupClassifierImpl
 import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.capture.session.PropertyScope
 import io.embrace.android.embracesdk.internal.capture.session.UserSessionPropertiesService
@@ -71,6 +72,7 @@ internal class SessionOrchestratorListenerTest {
     private lateinit var instrumentationRegistry: InstrumentationRegistry
     private lateinit var fakeDataSource: FakeDataSource
     private lateinit var logger: FakeInternalLogger
+    private lateinit var startupClassifier: StartupClassifierImpl
     private lateinit var currentSessionPartSpan: FakeCurrentSessionPartSpan
     private lateinit var destination: FakeTelemetryDestination
     private var orchestratorStartTimeMs: Long = 0
@@ -82,6 +84,7 @@ internal class SessionOrchestratorListenerTest {
     fun setUp() {
         clock = FakeClock()
         logger = FakeInternalLogger(throwOnInternalError = false)
+        startupClassifier = StartupClassifierImpl()
         configService = FakeConfigService(
             backgroundActivityBehavior = createBackgroundActivityBehavior(
                 remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 100f))
@@ -220,7 +223,7 @@ internal class SessionOrchestratorListenerTest {
 
     private fun restoredMetadataStore() = UserSessionMetadataStore(FakeKeyValueStore()).also { store ->
         store.save(
-            UserSessionMetadata(
+            UserSessionMetadata.Classified(
                 startTimeMs = clock.now(),
                 userSessionId = "restored-id",
                 userSessionNumber = 7L,
@@ -228,6 +231,7 @@ internal class SessionOrchestratorListenerTest {
                 inactivityTimeoutSecs = TimeUnit.MILLISECONDS.toSeconds(inactivityMs),
                 partIndex = 1,
                 lastActivityMs = clock.now(),
+                isBackgroundOnly = false,
             )
         )
     }
@@ -327,6 +331,7 @@ internal class SessionOrchestratorListenerTest {
             logger,
             fakeBackgroundWorker(),
             TestUuidSource(),
+            startupClassifier,
         ).apply {
             start()
         }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorListenerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorListenerTest.kt
@@ -221,6 +221,26 @@ internal class SessionOrchestratorListenerTest {
         assertTrue(logger.internalErrorMessages.any { it.msg == InternalErrorType.UserSessionCallbackFail.toString() })
     }
 
+    @Test
+    fun `registering a listener from within a listener callback does not deadlock`() {
+        configService = sessionBehaviorConfig()
+        createOrchestrator(AppState.FOREGROUND)
+
+        val innerEvents = mutableListOf<SessionStateEvent>()
+        var innerRegistered = false
+        orchestrator.addUserSessionListener {
+            if (!innerRegistered) {
+                innerRegistered = true
+                orchestrator.addUserSessionListener { event ->
+                    innerEvents.add(event)
+                }
+            }
+        }
+
+        assertTrue(innerRegistered)
+        assertEquals(listOf(SessionStateEvent.UserSessionActive::class), innerEvents.map { it::class })
+    }
+
     private fun restoredMetadataStore() = UserSessionMetadataStore(FakeKeyValueStore()).also { store ->
         store.save(
             UserSessionMetadata.Classified(

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -24,6 +24,8 @@ import io.embrace.android.embracesdk.fakes.injection.FakePayloadSourceModule
 import io.embrace.android.embracesdk.internal.arch.InstrumentationRegistry
 import io.embrace.android.embracesdk.internal.arch.InstrumentationRegistryImpl
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
+import io.embrace.android.embracesdk.internal.arch.startup.StartupClassifierImpl
+import io.embrace.android.embracesdk.internal.arch.startup.StartupType
 import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.capture.session.PropertyScope
 import io.embrace.android.embracesdk.internal.capture.session.UserSessionPropertiesService
@@ -78,6 +80,7 @@ internal class SessionOrchestratorTest {
     private lateinit var instrumentationRegistry: InstrumentationRegistry
     private lateinit var fakeDataSource: FakeDataSource
     private lateinit var logger: FakeInternalLogger
+    private lateinit var startupClassifier: StartupClassifierImpl
     private lateinit var currentSessionPartSpan: FakeCurrentSessionPartSpan
     private lateinit var destination: FakeTelemetryDestination
     private var orchestratorStartTimeMs: Long = 0
@@ -89,6 +92,7 @@ internal class SessionOrchestratorTest {
     fun setUp() {
         clock = FakeClock()
         logger = FakeInternalLogger(throwOnInternalError = false)
+        startupClassifier = StartupClassifierImpl()
     }
 
     @Test
@@ -101,8 +105,11 @@ internal class SessionOrchestratorTest {
         assertTrue(store.storedSessionPartPayloads.isEmpty())
         assertTrue(store.cachedEmptyCrashPayloads.isEmpty())
         assertEquals(1, fakeDataSource.enableDataCaptureCount)
-        // starting in bg produces no user session.
-        assertNull(orchestrator.currentUserSession())
+        with(checkNotNull(activeUserSession())) {
+            assertEquals(1L, userSessionNumber)
+            assertNull(isBackgroundOnly)
+            assertNull(startupClassifier.startupType())
+        }
     }
 
     @Test
@@ -125,7 +132,7 @@ internal class SessionOrchestratorTest {
         clock.tick()
         val foregroundTime = clock.now()
         val sessionSpan = currentSessionPartSpan.sessionSpan
-        assertNull(orchestrator.currentUserSession())
+        val initialUserSession = activeUserSession()
         orchestrator.onForeground()
         assertEquals(1, fakeDataSource.enableDataCaptureCount)
         validateSession(
@@ -134,7 +141,10 @@ internal class SessionOrchestratorTest {
             endType = LifeEventType.BKGND_STATE
         )
         assertTrue(store.cachedEmptyCrashPayloads.isEmpty())
-        assertNotNull(orchestrator.currentUserSession())
+        with(checkNotNull(activeUserSession())) {
+            assertEquals(initialUserSession.userSessionId, userSessionId)
+            assertEquals(false, isBackgroundOnly)
+        }
     }
 
     @Test
@@ -472,14 +482,14 @@ internal class SessionOrchestratorTest {
         val backgroundOnlySession = activeUserSession()
         assertNotEquals(first.userSessionId, backgroundOnlySession.userSessionId)
         assertEquals(2L, backgroundOnlySession.userSessionNumber)
-        assertTrue(backgroundOnlySession.isBackgroundOnly)
+        assertEquals(true, backgroundOnlySession.isBackgroundOnly)
 
         // foregrounding ends the background-only user session and starts a regular one
         orchestrator.onForeground()
         val second = activeUserSession()
         assertNotEquals(backgroundOnlySession.userSessionId, second.userSessionId)
         assertEquals(3L, second.userSessionNumber)
-        assertFalse(second.isBackgroundOnly)
+        assertEquals(false, second.isBackgroundOnly)
         assertEquals(1, second.partIndex)
     }
 
@@ -795,7 +805,7 @@ internal class SessionOrchestratorTest {
         assertNotEquals(first.userSessionId, second.userSessionId)
         assertEquals(2L, second.userSessionNumber)
         assertEquals(1, second.partIndex)
-        assertTrue(second.isBackgroundOnly)
+        assertEquals(true, second.isBackgroundOnly)
 
         val errors = logger.internalErrorMessages
         assertEquals(1, errors.size)
@@ -811,7 +821,7 @@ internal class SessionOrchestratorTest {
 
         val firstSession = activeUserSession()
         assertEquals(1L, firstSession.userSessionNumber)
-        assertFalse(firstSession.isBackgroundOnly)
+        assertEquals(false, firstSession.isBackgroundOnly)
 
         orchestrator.onBackground()
 
@@ -821,7 +831,7 @@ internal class SessionOrchestratorTest {
         val backgroundOnlySession = activeUserSession()
         assertNotEquals(firstSession.userSessionId, backgroundOnlySession.userSessionId)
         assertEquals(2L, backgroundOnlySession.userSessionNumber)
-        assertTrue(backgroundOnlySession.isBackgroundOnly)
+        assertEquals(true, backgroundOnlySession.isBackgroundOnly)
 
         // check that a background-only user session won't time out due to inactivity - it's already considered to be inactive
         runTimerThread(inactivityMs * 10)
@@ -833,7 +843,7 @@ internal class SessionOrchestratorTest {
         val sessionAfterFg = activeUserSession()
         assertNotEquals(backgroundOnlySession.userSessionId, sessionAfterFg.userSessionId)
         assertEquals(3L, sessionAfterFg.userSessionNumber)
-        assertFalse(sessionAfterFg.isBackgroundOnly)
+        assertEquals(false, sessionAfterFg.isBackgroundOnly)
 
         // a regular user session will survive a foregrounding if it's within the inactivity grace period
         orchestrator.onBackground()
@@ -986,6 +996,7 @@ internal class SessionOrchestratorTest {
             logger,
             BackgroundWorker(inactivityWorkerExecutor),
             TestUuidSource(),
+            startupClassifier,
         ).apply {
             start()
         }
@@ -1016,10 +1027,14 @@ internal class SessionOrchestratorTest {
             startingAppState = AppState.BACKGROUND,
             configService = backgroundEnabledConfigService(),
         )
-        assertNull(orchestrator.currentUserSession())
+        val initialUserSession = activeUserSession()
 
-        runTimerThread(maxDurationMs * 2)
-        assertNull(orchestrator.currentUserSession())
+        // The background-startup window elapses, so the task run on the thread should classify it as background-only.
+        // It should still be the active one as there should be no timers that end it.
+        runTimerThread(BACKGROUND_STARTUP_WINDOW_MS + 1)
+        val current = activeUserSession()
+        assertEquals(initialUserSession.userSessionId, current.userSessionId)
+        assertEquals(true, current.isBackgroundOnly)
     }
 
     @Test
@@ -1098,8 +1113,9 @@ internal class SessionOrchestratorTest {
         assertNotEquals(first.userSessionId, second.userSessionId)
         assertEquals(2L, second.userSessionNumber)
         assertEquals(1, second.partIndex)
-        // created while backgrounded, so the replacement is a background user session
-        assertTrue(second.isBackgroundOnly)
+
+        // created while backgrounded, so the new uer session is background-only
+        assertEquals(true, second.isBackgroundOnly)
 
         // The session part created by the BG max-duration rotation must remain BG.
         val activePart = checkNotNull(sessionTracker.getActiveSessionPart())
@@ -1150,7 +1166,7 @@ internal class SessionOrchestratorTest {
         val second = activeUserSession()
         assertNotEquals(first.userSessionId, second.userSessionId)
         assertEquals(2L, second.userSessionNumber)
-        assertTrue(second.isBackgroundOnly)
+        assertEquals(true, second.isBackgroundOnly)
         assertNull(sessionTracker.getActiveSessionPart())
 
         orchestrator.onForeground()
@@ -1281,7 +1297,7 @@ internal class SessionOrchestratorTest {
         runTimerThread(inactivityMs)
 
         val backgroundOnlySession = activeUserSession()
-        assertTrue(backgroundOnlySession.isBackgroundOnly)
+        assertEquals(true, backgroundOnlySession.isBackgroundOnly)
         assertEquals("1", backgroundOnlySession.attributes[EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART])
     }
 
@@ -1301,12 +1317,12 @@ internal class SessionOrchestratorTest {
 
         val backgroundOnlySession = activeUserSession()
         assertNotEquals(first.userSessionId, backgroundOnlySession.userSessionId)
-        assertTrue(backgroundOnlySession.isBackgroundOnly)
+        assertEquals(true, backgroundOnlySession.isBackgroundOnly)
 
         orchestrator.onForeground()
         val regular = activeUserSession()
         assertNotEquals(backgroundOnlySession.userSessionId, regular.userSessionId)
-        assertFalse(regular.isBackgroundOnly)
+        assertEquals(false, regular.isBackgroundOnly)
     }
 
     @Test
@@ -1326,12 +1342,12 @@ internal class SessionOrchestratorTest {
 
         val restored = activeUserSession()
         assertEquals("bg-session-id", restored.userSessionId)
-        assertTrue(restored.isBackgroundOnly)
+        assertEquals(true, restored.isBackgroundOnly)
 
         orchestrator.onForeground()
         val regular = activeUserSession()
         assertNotEquals("bg-session-id", regular.userSessionId)
-        assertFalse(regular.isBackgroundOnly)
+        assertEquals(false, regular.isBackgroundOnly)
     }
 
     @Test
@@ -1348,13 +1364,16 @@ internal class SessionOrchestratorTest {
             metadataStoreOverride = store,
         )
 
-        // user session not restored
-        assertNull(orchestrator.currentUserSession())
+        // the expired session is not restored - a new unclassified one is active instead
+        val initialUserSession = activeUserSession()
+        assertNotEquals("bg-session-id", initialUserSession.userSessionId)
+        assertNull(initialUserSession.isBackgroundOnly)
 
+        // Foregrounding turns that new session into a regular, not background-only one
         orchestrator.onForeground()
         val regular = activeUserSession()
-        assertNotEquals("bg-session-id", regular.userSessionId)
-        assertFalse(regular.isBackgroundOnly)
+        assertEquals(initialUserSession.userSessionId, regular.userSessionId)
+        assertEquals(false, regular.isBackgroundOnly)
     }
 
     @Test
@@ -1373,7 +1392,200 @@ internal class SessionOrchestratorTest {
 
         val session = activeUserSession()
         assertNotEquals("bg-session-id", session.userSessionId)
-        assertFalse(session.isBackgroundOnly)
+        assertEquals(false, session.isBackgroundOnly)
+    }
+
+    @Test
+    fun `background-startup window elapsing resolves unclassified session to background-only`() {
+        createOrchestrator(
+            startingAppState = AppState.BACKGROUND,
+            configService = backgroundEnabledConfigService(),
+        )
+
+        val initialUserSession = activeUserSession()
+        assertNull(initialUserSession.isBackgroundOnly)
+        assertNull(startupClassifier.startupType())
+        assertNull(destination.attributes[EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART])
+
+        runTimerThread(BACKGROUND_STARTUP_WINDOW_MS + 1)
+
+        with(checkNotNull(activeUserSession())) {
+            assertEquals(initialUserSession.userSessionId, userSessionId)
+            assertEquals(true, isBackgroundOnly)
+            assertEquals(StartupType.BACKGROUND, startupClassifier.startupType())
+            assertEquals("1", destination.attributes[EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART])
+        }
+
+        // foregrounding ends the background-only session and starts a regular one
+        orchestrator.onForeground()
+        val regular = activeUserSession()
+        assertNotEquals(initialUserSession.userSessionId, regular.userSessionId)
+        assertEquals(false, regular.isBackgroundOnly)
+    }
+
+    @Test
+    fun `foregrounding within background-startup window does not resolve the startup classification`() {
+        createOrchestrator(
+            startingAppState = AppState.BACKGROUND,
+            configService = backgroundEnabledConfigService(),
+        )
+        val initialUserSession = activeUserSession()
+
+        clock.tick(1000)
+        orchestrator.onForeground()
+
+        with(checkNotNull(activeUserSession())) {
+            assertEquals(initialUserSession.userSessionId, userSessionId)
+            assertEquals(false, isBackgroundOnly)
+            assertNull(startupClassifier.startupType())
+        }
+
+        // the previously scheduled timer should be cancelled and not classify the startup type
+        runTimerThread(BACKGROUND_STARTUP_WINDOW_MS)
+        assertNull(startupClassifier.startupType())
+    }
+
+    @Test
+    fun `unclassified user session is persisted as background-only during the window`() {
+        val store = UserSessionMetadataStore(FakeKeyValueStore())
+        createOrchestrator(
+            startingAppState = AppState.BACKGROUND,
+            configService = backgroundEnabledConfigService(),
+            metadataStoreOverride = store,
+        )
+
+        val initialUserSession = activeUserSession()
+        assertNull(initialUserSession.isBackgroundOnly)
+
+        // persisted user session will presume it's background-only because it will only be read in this state if the process dies with
+        // it being further classified
+        val persisted = checkNotNull(store.load())
+        assertEquals(initialUserSession.userSessionId, persisted.userSessionId)
+        assertEquals(true, persisted.isBackgroundOnly)
+
+        // foregrounding within the window rewrites the persisted copy as a regular session
+        clock.tick(1000)
+        orchestrator.onForeground()
+        assertEquals(false, checkNotNull(store.load()).isBackgroundOnly)
+    }
+
+    @Test
+    fun `manual end during the background-startup window terminates the pending session`() {
+        createOrchestrator(
+            startingAppState = AppState.BACKGROUND,
+            configService = backgroundEnabledConfigService(),
+        )
+        val pending = activeUserSession()
+
+        clock.tick(1000)
+        orchestrator.endSessionWithManual()
+
+        // the replacement is created in the background, so it is committed background-only
+        val replacement = activeUserSession()
+        assertNotEquals(pending.userSessionId, replacement.userSessionId)
+        assertEquals(true, replacement.isBackgroundOnly)
+
+        // the previously scheduled timer should be cancelled and not classify the startup type
+        runTimerThread(BACKGROUND_STARTUP_WINDOW_MS + 1)
+        assertNull(startupClassifier.startupType())
+    }
+
+    @Test
+    fun `crash during the background-startup window leaves the pending session untouched`() {
+        val store = UserSessionMetadataStore(FakeKeyValueStore())
+        createOrchestrator(
+            startingAppState = AppState.BACKGROUND,
+            configService = backgroundEnabledConfigService(),
+            metadataStoreOverride = store,
+        )
+        val initialUserSession = activeUserSession()
+
+        orchestrator.handleCrash("crash-id")
+
+        assertEquals(initialUserSession.userSessionId, activeUserSession().userSessionId)
+        assertEquals(true, checkNotNull(store.load()).isBackgroundOnly)
+    }
+
+    @Test
+    fun `restored regular user session for a new process continues in background as such past the background-startup window`() {
+        val store = storeWithUserSession(userSessionId = "regular-id")
+
+        clock.tick(1000)
+        createOrchestrator(
+            startingAppState = AppState.BACKGROUND,
+            configService = backgroundEnabledConfigService(),
+            metadataStoreOverride = store,
+        )
+
+        with(checkNotNull(activeUserSession())) {
+            assertEquals("regular-id", userSessionId)
+            assertEquals(false, isBackgroundOnly)
+            assertNull(startupClassifier.startupType())
+        }
+
+        runTimerThread(BACKGROUND_STARTUP_WINDOW_MS + 1)
+
+        with(checkNotNull(activeUserSession())) {
+            assertEquals("regular-id", userSessionId)
+            assertEquals(false, isBackgroundOnly)
+            assertNull(startupClassifier.startupType())
+        }
+    }
+
+    @Test
+    fun `cold start foregrounding within the background-startup window is classified regular`() {
+        createOrchestrator(
+            startingAppState = AppState.BACKGROUND,
+            configService = backgroundEnabledConfigService(),
+        )
+        val initialUserSession = activeUserSession()
+
+        // A slow Application.onCreate keeps the app in the background for most of the window before the first activity foregrounds.
+        // As long as that happens within the background-startup window, the session created at process start should still
+        // become regular user session.
+        clock.tick(BACKGROUND_STARTUP_WINDOW_MS - 1)
+        orchestrator.onForeground()
+
+        with(checkNotNull(activeUserSession())) {
+            assertEquals(initialUserSession.userSessionId, userSessionId)
+            assertEquals(false, isBackgroundOnly)
+        }
+
+        // the previously scheduled timer should be cancelled
+        runTimerThread(BACKGROUND_STARTUP_WINDOW_MS + 1)
+        with(checkNotNull(activeUserSession())) {
+            assertEquals(initialUserSession.userSessionId, userSessionId)
+            assertEquals(false, isBackgroundOnly)
+            assertNull(startupClassifier.startupType())
+        }
+    }
+
+    @Test
+    fun `background startup timer doesn't reclassify startup if already classified`() {
+        createOrchestrator(
+            startingAppState = AppState.BACKGROUND,
+            configService = backgroundEnabledConfigService(),
+        )
+        val initialUserSession = activeUserSession()
+
+        startupClassifier.evaluateStartup(
+            sdkInitEndMs = clock.now(),
+            appInitEndMs = clock.now() + 1,
+            postAppInitTimeMs = clock.now() + 2,
+        )
+        assertEquals(StartupType.COLD, startupClassifier.startupType())
+
+        // The timer fires but doesn't reclassify the startup or classify the user session
+        runTimerThread(BACKGROUND_STARTUP_WINDOW_MS + 1)
+        assertNull(activeUserSession().isBackgroundOnly)
+        assertNull(destination.attributes[EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART])
+
+        // the imminent foregrounding that occurs after startup classification will classify the session
+        orchestrator.onForeground()
+        with(checkNotNull(activeUserSession())) {
+            assertEquals(initialUserSession.userSessionId, userSessionId)
+            assertEquals(false, isBackgroundOnly)
+        }
     }
 
     private fun backgroundEnabledConfigService() = FakeConfigService(
@@ -1425,7 +1637,7 @@ internal class SessionOrchestratorTest {
         persistedInactivityTimeoutMs: Long = inactivityMs,
     ): UserSessionMetadataStore = UserSessionMetadataStore(FakeKeyValueStore()).apply {
         save(
-            UserSessionMetadata(
+            UserSessionMetadata.Classified(
                 startTimeMs = startTimeMs,
                 userSessionId = userSessionId,
                 userSessionNumber = userSessionNumber,

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
@@ -28,15 +28,8 @@ internal class SessionPartSpanAttrPopulatorImplTest {
         userSessionPartIndex = 5,
         sessionPartNumber = 12,
     )
-    private val userSession = UserSessionMetadata(
-        startTimeMs = 1000L,
-        userSessionId = "user-session-uuid",
-        userSessionNumber = 3L,
-        maxDurationSecs = 43200L,
-        inactivityTimeoutSecs = 1800L,
-        partIndex = 2,
-        lastActivityMs = 1000L,
-    )
+    private val userSession = testClassifiedUserSession(isBackgroundOnly = false)
+    private val backgroundOnlyUserSession = testClassifiedUserSession(isBackgroundOnly = true)
     private lateinit var populator: SessionPartSpanAttrPopulatorImpl
     private lateinit var destination: FakeTelemetryDestination
 
@@ -75,7 +68,7 @@ internal class SessionPartSpanAttrPopulatorImplTest {
 
     @Test
     fun `background-only marker stamped on session part span`() {
-        populator.populateSessionSpanStartAttrs(zygote, userSession.copy(isBackgroundOnly = true))
+        populator.populateSessionSpanStartAttrs(zygote, backgroundOnlyUserSession)
 
         val attrs = destination.attributes
         assertEquals("1", attrs[EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART])
@@ -176,4 +169,15 @@ internal class SessionPartSpanAttrPopulatorImplTest {
         )
         assertEquals(expected, attrs)
     }
+
+    private fun testClassifiedUserSession(isBackgroundOnly: Boolean) = UserSessionMetadata.Classified(
+        startTimeMs = 1000L,
+        userSessionId = "user-session-uuid",
+        userSessionNumber = 3L,
+        maxDurationSecs = 43200L,
+        inactivityTimeoutSecs = 1800L,
+        partIndex = 2,
+        lastActivityMs = 1000L,
+        isBackgroundOnly = isBackgroundOnly,
+    )
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/TransitionTypeTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/TransitionTypeTest.kt
@@ -52,7 +52,7 @@ internal class TransitionTypeTest {
         val attrs = TransitionType.BACKGROUND_ONLY_SESSION_END.endAttributes
         assertEquals("1", attrs[EmbSessionAttributes.EMB_IS_FINAL_SESSION_PART])
         assertEquals(
-            EmbSessionAttributes.EmbUserSessionTerminationReasonValues.END_BACKGROUND_ONLY_USER_SESSION,
+            EmbSessionAttributes.EmbUserSessionTerminationReasonValues.BACKGROUND_ONLY_USER_SESSION_FOREGROUNDED,
             attrs[EmbSessionAttributes.EMB_USER_SESSION_TERMINATION_REASON],
         )
     }

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/AppStartupTraceEmitterTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/AppStartupTraceEmitterTest.kt
@@ -11,7 +11,9 @@ import io.embrace.android.embracesdk.fakes.FakeTelemetryDestination
 import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.arch.startup.MAX_COLD_STARTUP_INIT_GAP_MS
+import io.embrace.android.embracesdk.internal.arch.startup.StartupClassifier
 import io.embrace.android.embracesdk.internal.arch.startup.StartupClassifierImpl
+import io.embrace.android.embracesdk.internal.arch.startup.StartupType
 import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.instrumentation.startup.AppStartupTraceEmitter
 import io.embrace.android.embracesdk.internal.instrumentation.startup.AppStartupTraceEmitter.Companion.ACTIVITY_FIRST_DRAW_SPAN
@@ -118,6 +120,22 @@ internal class AppStartupTraceEmitterTest {
     @Test
     fun `verify warm start trace without application init start and end triggered in T`() {
         createTraceEmitter().simulateAppStartup(isColdStart = false, hasAppInitEvents = false)
+    }
+
+    @Config(sdk = [VERSION_CODES.TIRAMISU])
+    @Test
+    fun `startup already classified as background records a warm trace even with a cold-sized init gap`() {
+        // The session orchestrator's background-startup window elapsed before any activity was created, so it resolved the
+        // shared classification to BACKGROUND. When an activity is eventually created with a gap that would otherwise be a cold
+        // start, the trace is recorded as warm rather than cold - the accepted consequence of treating a slow process start as a
+        // background launch.
+        val classifier = StartupClassifierImpl().apply { assumeBackgroundStartup() }
+        createTraceEmitter(startupClassifier = classifier).simulateAppStartup(verifyTrace = false)
+
+        val spanMap = destination.completedSpans().associateBy { it.name }
+        assertNotNull(spanMap.warmAppStartupRootSpan())
+        assertNull(spanMap.coldAppStartupRootSpan())
+        assertEquals(StartupType.BACKGROUND, classifier.startupType())
     }
 
     @Config(sdk = [VERSION_CODES.TIRAMISU])
@@ -595,14 +613,17 @@ internal class AppStartupTraceEmitterTest {
             )
     }
 
-    private fun createTraceEmitter(manualEnd: Boolean = false) =
+    private fun createTraceEmitter(
+        manualEnd: Boolean = false,
+        startupClassifier: StartupClassifier = StartupClassifierImpl(),
+    ) =
         AppStartupTraceEmitter(
             clock = clock,
             startupServiceProvider = { startupService },
             destination = destination,
             versionChecker = BuildVersionChecker,
             logger = logger,
-            startupClassifier = StartupClassifierImpl(),
+            startupClassifier = startupClassifier,
             manualEnd = manualEnd,
             processInfo = FakeProcessInfo(
                 if (BuildVersionChecker.isAtLeast(VERSION_CODES.N)) {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionAeiGoldenFileTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionAeiGoldenFileTest.kt
@@ -50,15 +50,21 @@ internal class UserSessionAeiGoldenFileTest {
 
     @Test
     fun `aei log without active session`() {
+        var pendingUserSessionId: String? = null
         testRule.runTest(
             setupAction = { setupFakeAeiData(listOf(anr.toAeiObject())) },
             testCaseAction = {
                 testRule.setup.getFakedWorkerExecutor(Worker.Background.NonIoRegWorker).runCurrentlyBlocked()
+                pendingUserSessionId = checkNotNull(
+                    testRule.bootstrapper.userSessionOrchestrationModule.sessionOrchestrator.currentUserSession()
+                ).userSessionId
             },
             assertAction = {
+                // the process started in the background, so the AEI log belongs to the
+                // flavour-pending user session created at process start, with no session part
                 assertLogPayloadMatchesGoldenFile(
                     envelope = getSingleLogEnvelope(),
-                    expectedUserSessionId = "",
+                    expectedUserSessionId = checkNotNull(pendingUserSessionId),
                     expectedSessionPartId = "",
                     goldenFile = "user_session_aei_log_no_session.json",
                 )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionGoldenFileTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionGoldenFileTest.kt
@@ -70,19 +70,26 @@ internal class UserSessionGoldenFileTest {
     }
 
     /**
-     * Asserts that a log without a user session contains empty attributes for the user session ID and session part ID.
+     * Asserts that a log recorded in the background before the app ever foregrounds carries the
+     * id of the flavour-pending user session created at process start, with an empty session
+     * part ID.
      */
     @Test
     fun `log without user session`() {
+        var pendingUserSessionId: String? = null
         testRule.runTest(
             testCaseAction = {
                 embrace.logMessage("Hi", Severity.INFO, mapOf(EmbSessionAttributes.EMB_PRIVATE_SEND_MODE to "immediate"))
+                pendingUserSessionId = checkNotNull(
+                    testRule.bootstrapper.userSessionOrchestrationModule.sessionOrchestrator.currentUserSession()
+                ).userSessionId
             },
             assertAction = {
-                assertPayloadsMatchGoldenFiles(
-                    logsWithNoUserSession = listOf(
-                        LogDiff(getSingleLogEnvelope(), "log_without_user_session.json"),
-                    ),
+                assertLogPayloadMatchesGoldenFile(
+                    envelope = getSingleLogEnvelope(),
+                    expectedUserSessionId = checkNotNull(pendingUserSessionId),
+                    expectedSessionPartId = "",
+                    goldenFile = "log_without_user_session.json",
                 )
             }
         )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionInactivityTimeoutGoldenFileTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionInactivityTimeoutGoldenFileTest.kt
@@ -68,6 +68,9 @@ internal class UserSessionInactivityTimeoutGoldenFileTest {
 
                 assertPayloadsMatchGoldenFiles(
                     UserSessionDiff(
+                        // the pre-foreground part belongs to the first user session: its
+                        // flavour-pending session resolved to regular when the app foregrounded
+                        SessionPartDiff(bgPartEnvelopes[0], "user_session_bg_timeout_1.json"),
                         SessionPartDiff(sessionPartEnvelopes[0], "user_session_bg_timeout_2.json"),
                         SessionPartDiff(bgPartEnvelopes[1], "user_session_bg_timeout_3.json"),
                     ),
@@ -76,9 +79,6 @@ internal class UserSessionInactivityTimeoutGoldenFileTest {
                     ),
                     UserSessionDiff(
                         SessionPartDiff(sessionPartEnvelopes[1], "user_session_bg_timeout_5.json")
-                    ),
-                    partsWithNoUserSession = listOf(
-                        SessionPartDiff(bgPartEnvelopes[0], "user_session_bg_timeout_1.json")
                     ),
                 )
             }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
@@ -106,7 +106,6 @@ internal class JvmCrashFeatureTest {
                 payloadStorageService.getPersistedCrashLog().getLastLog().assertCrash(
                     crashIdFromSession = ba.getCrashedId(),
                     crashTimeMs = crashTimeMs,
-                    hasSession = false,
                 )
             }
         )
@@ -124,7 +123,6 @@ internal class JvmCrashFeatureTest {
                 payloadStorageService.getPersistedCrashLog().getLastLog().assertCrash(
                     crashIdFromSession = null,
                     crashTimeMs = crashTimeMs,
-                    hasSession = false,
                 )
             }
         )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LogFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LogFeatureTest.kt
@@ -88,7 +88,6 @@ internal class LogFeatureTest {
                     expectedSeverityNumber = SeverityNumber.WARN,
                     expectedSeverityText = Severity.WARNING.name,
                     expectedTimeMs = logTimestamps.remove(),
-                    hasSession = false,
                 )
             }
         )
@@ -112,7 +111,6 @@ internal class LogFeatureTest {
                     expectedSeverityNumber = SeverityNumber.ERROR,
                     expectedSeverityText = Severity.ERROR.name,
                     expectedTimeMs = logTimestamps.remove(),
-                    hasSession = false,
                 )
             }
         )
@@ -141,7 +139,6 @@ internal class LogFeatureTest {
                         expectedSeverityNumber = getOtelSeverity(severity),
                         expectedSeverityText = severity.name,
                         expectedTimeMs = logTimestamps.remove(),
-                        hasSession = false,
                     )
                 }
             }
@@ -172,7 +169,6 @@ internal class LogFeatureTest {
                         expectedSeverityText = severity.name,
                         expectedTimeMs = logTimestamps.remove(),
                         expectedProperties = customProperties,
-                        hasSession = false,
                     )
                 }
             })
@@ -200,7 +196,6 @@ internal class LogFeatureTest {
                     expectedExceptionMessage = checkNotNull(testException.message),
                     expectedStacktrace = testException.getSafeStackTrace()?.toList(),
                     expectedEmbType = "sys.exception",
-                    hasSession = false,
                 )
             }
         )
@@ -228,7 +223,6 @@ internal class LogFeatureTest {
                     expectedExceptionMessage = checkNotNull(testException.message),
                     expectedStacktrace = testException.getSafeStackTrace()?.toList(),
                     expectedEmbType = "sys.exception",
-                    hasSession = false,
                 )
             }
         )
@@ -264,7 +258,6 @@ internal class LogFeatureTest {
                         expectedStacktrace = testException.getSafeStackTrace()?.toList(),
                         expectedProperties = customProperties,
                         expectedEmbType = "sys.exception",
-                        hasSession = false,
                     )
                 }
             }
@@ -300,7 +293,6 @@ internal class LogFeatureTest {
                         expectedStacktrace = testException.getSafeStackTrace()?.toList(),
                         expectedProperties = customProperties,
                         expectedEmbType = "sys.exception",
-                        hasSession = false,
                     )
                 }
             }
@@ -327,7 +319,6 @@ internal class LogFeatureTest {
                     expectedType = LogExceptionType.HANDLED.value,
                     expectedStacktrace = stacktrace.toList(),
                     expectedEmbType = "sys.exception",
-                    hasSession = false,
                 )
             }
         )
@@ -357,7 +348,6 @@ internal class LogFeatureTest {
                         expectedType = LogExceptionType.HANDLED.value,
                         expectedStacktrace = stacktrace.toList(),
                         expectedEmbType = "sys.exception",
-                        hasSession = false,
                     )
                 }
             }
@@ -389,7 +379,6 @@ internal class LogFeatureTest {
                         expectedStacktrace = stacktrace.toList(),
                         expectedProperties = customProperties,
                         expectedEmbType = "sys.exception",
-                        hasSession = false,
                     )
                 }
             }
@@ -428,7 +417,6 @@ internal class LogFeatureTest {
                         expectedStacktrace = stacktrace.toList(),
                         expectedProperties = customProperties,
                         expectedEmbType = "sys.exception",
-                        hasSession = false,
                     )
                 }
             }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionIdPropagationTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionIdPropagationTest.kt
@@ -249,6 +249,7 @@ internal class UserSessionIdPropagationTest {
     fun `AEI log contains session part id and user session id`() {
         val sessionPartId = "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
         val userSessionId = "2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e"
+        var currentUserSessionId: String? = null
         testRule.runTest(
             setupAction = {
                 val ctx = ApplicationProvider.getApplicationContext<Application>()
@@ -270,12 +271,16 @@ internal class UserSessionIdPropagationTest {
             },
             testCaseAction = { recordSession() },
             assertAction = {
+                // the AEI log was emitted before the app foregrounded, so it carries the id of
+                // the flavour-pending user session - which resolved to the recorded session's
+                // user session when the app entered the foreground - and no session part id
+                currentUserSessionId = getSingleSessionEnvelope().getUserSessionId()
                 val logAttrs = checkNotNull(getSingleLogEnvelope().getLogOfType(EmbType.System.Exit).attributes)
                 assertEquals(sessionPartId, logAttrs.findAttributeValue(AEI_SESSION_PART_ID))
                 assertEquals(userSessionId, logAttrs.findAttributeValue(AEI_USER_SESSION_ID))
                 assertEquals("", logAttrs.findAttributeValue(EMB_SESSION_PART_ID))
-                assertEquals("", logAttrs.findAttributeValue(EMB_USER_SESSION_ID))
-                assertEquals("", logAttrs.findAttributeValue(SESSION_ID))
+                assertEquals(currentUserSessionId, logAttrs.findAttributeValue(EMB_USER_SESSION_ID))
+                assertEquals(currentUserSessionId, logAttrs.findAttributeValue(SESSION_ID))
             },
             otelExportAssertion = {
                 val log = awaitLogs(1) { it.attributes.toStringMap().containsKey(EmbType.System.Exit.key) }.single()
@@ -283,8 +288,8 @@ internal class UserSessionIdPropagationTest {
                 assertEquals(sessionPartId, logAttrs[AEI_SESSION_PART_ID])
                 assertEquals(userSessionId, logAttrs[AEI_USER_SESSION_ID])
                 assertEquals("", logAttrs[EMB_SESSION_PART_ID])
-                assertEquals("", logAttrs[EMB_USER_SESSION_ID])
-                assertEquals("", logAttrs[SESSION_ID])
+                assertEquals(currentUserSessionId, logAttrs[EMB_USER_SESSION_ID])
+                assertEquals(currentUserSessionId, logAttrs[SESSION_ID])
             },
         )
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionLifecycleTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionLifecycleTest.kt
@@ -2,10 +2,12 @@ package io.embrace.android.embracesdk.testcases.session
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.findSessionSpan
+import io.embrace.android.embracesdk.assertions.findSpansOfType
 import io.embrace.android.embracesdk.assertions.getSessionId
 import io.embrace.android.embracesdk.assertions.getUserSessionId
 import io.embrace.android.embracesdk.assertions.getUserSessionTerminationReason
 import io.embrace.android.embracesdk.assertions.isFinalSessionPart
+import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
@@ -20,6 +22,8 @@ import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSI
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_NUMBER
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_PART_INDEX
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_START_TS
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbUserSessionTerminationReasonValues.BACKGROUND_ONLY_USER_SESSION_FOREGROUNDED
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbUserSessionTerminationReasonValues.INACTIVITY
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbUserSessionTerminationReasonValues.MANUAL
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
@@ -53,7 +57,7 @@ internal class UserSessionLifecycleTest {
     }
 
     @Test
-    fun `user session created only once the app enters the foreground`() {
+    fun `user session created at process start resolves to the foreground session`() {
         testRule.runTest(
             persistedRemoteConfig = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(100f)),
             testCaseAction = { recordSession() },
@@ -61,21 +65,64 @@ internal class UserSessionLifecycleTest {
                 val bgSession = getSingleSessionEnvelope(AppState.BACKGROUND)
                 val fgSession = getSingleSessionEnvelope(AppState.FOREGROUND)
 
+                // the pre-foreground part belongs to the user session created eagerly at process
+                // start, whose pending flavour resolved to the regular user session of this
+                // launch when the app entered the foreground
                 val bgSessionSpan = bgSession.findSessionSpan()
                 val bgAttrs = bgSessionSpan.attributes
-                assertEquals("", bgAttrs?.findAttributeValue(EMB_USER_SESSION_ID))
-                assertEquals("", bgAttrs?.findAttributeValue(EMB_SESSION_PART_ID))
-                assertNull(bgAttrs?.findAttributeValue(EMB_USER_SESSION_NUMBER))
-                assertNull(bgAttrs?.findAttributeValue(EMB_USER_SESSION_PART_INDEX))
-                assertNull(bgAttrs?.findAttributeValue(EMB_USER_SESSION_START_TS))
+                assertEquals(fgSession.getUserSessionId(), bgAttrs?.findAttributeValue(EMB_USER_SESSION_ID))
+                assertFalse(bgAttrs?.findAttributeValue(EMB_SESSION_PART_ID).isNullOrBlank())
+                assertEquals("1", bgAttrs?.findAttributeValue(EMB_USER_SESSION_NUMBER))
+                assertEquals("1", bgAttrs?.findAttributeValue(EMB_USER_SESSION_PART_INDEX))
+                assertNotNull(bgAttrs?.findAttributeValue(EMB_USER_SESSION_START_TS))
 
-                // entering foreground creates the first user session
                 val fgSessionSpan = fgSession.findSessionSpan()
                 assertNotNull(fgSession.getUserSessionId())
                 assertEquals(fgSession.getUserSessionId(), fgSession.getSessionId())
                 assertEquals("1", fgSessionSpan.attributes?.findAttributeValue(EMB_USER_SESSION_NUMBER))
                 assertFalse(fgSession.isFinalSessionPart())
                 assertNull(fgSession.getUserSessionTerminationReason())
+            }
+        )
+    }
+
+    @Test
+    fun `process foregrounding after the background-startup window splits into background-only then regular session`() {
+        testRule.runTest(
+            persistedRemoteConfig = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(100f)),
+            testCaseAction = {
+                // The process starts in the background and does not foreground within the 5s
+                // background-startup window, so the eagerly-created process-start session is
+                // classified background-only when the window elapses.
+                clock.tick(6_000L)
+                unblockTimerThread()
+                // The app foregrounds only afterwards (e.g. a slow background launch the OS later
+                // surfaced). This ends the background-only session and starts a regular one.
+                recordSession()
+            },
+            assertAction = {
+                val bgSession = getSingleSessionEnvelope(AppState.BACKGROUND)
+                val fgSession = getSingleSessionEnvelope(AppState.FOREGROUND)
+
+                // The pre-foreground part is the background-only session (number 1): it carries the
+                // marker and ends with the background-only termination reason when the app foregrounds.
+                val bgAttrs = bgSession.findSessionSpan().attributes
+                assertEquals("1", bgAttrs?.findAttributeValue(EMB_IS_BACKGROUND_ONLY_PART))
+                assertEquals("1", bgAttrs?.findAttributeValue(EMB_USER_SESSION_NUMBER))
+                assertTrue(bgSession.isFinalSessionPart())
+                assertEquals(BACKGROUND_ONLY_USER_SESSION_FOREGROUNDED, bgSession.getUserSessionTerminationReason())
+
+                // The foreground part is a distinct, regular user session (number 2) - no marker.
+                val fgAttrs = fgSession.findSessionSpan().attributes
+                assertNotEquals(bgSession.getUserSessionId(), fgSession.getUserSessionId())
+                assertNull(fgAttrs?.findAttributeValue(EMB_IS_BACKGROUND_ONLY_PART))
+                assertEquals("2", fgAttrs?.findAttributeValue(EMB_USER_SESSION_NUMBER))
+
+                // The late foreground is recorded as a warm startup, not cold, and lands in the
+                // regular foreground session - the accepted consequence of the fixed window.
+                val perfSpanNames = fgSession.findSpansOfType(EmbType.Performance.Default).map { it.name }
+                assertTrue(perfSpanNames.contains("emb-app-startup-warm"))
+                assertFalse(perfSpanNames.contains("emb-app-startup-cold"))
             }
         )
     }
@@ -296,8 +343,9 @@ internal class UserSessionLifecycleTest {
                 val secondSession = sessions[1].findSessionSpan()
 
                 assertNotEquals(sessions[0].getUserSessionId(), sessions[1].getUserSessionId())
-                // cold-start background session ends before any user session exists
-                assertNull(firstBg.attributes?.findAttributeValue(EMB_USER_SESSION_NUMBER))
+                // the cold-start background part belongs to the first user session, created
+                // eagerly at process start and resolved to regular at the first foreground
+                assertEquals("1", firstBg.attributes?.findAttributeValue(EMB_USER_SESSION_NUMBER))
                 assertEquals("1", firstSession.attributes?.findAttributeValue(EMB_USER_SESSION_NUMBER))
                 assertEquals("1", secondBg.attributes?.findAttributeValue(EMB_USER_SESSION_NUMBER))
                 assertEquals("2", secondSession.attributes?.findAttributeValue(EMB_USER_SESSION_NUMBER))

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionLifecycleTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionLifecycleTest.kt
@@ -17,12 +17,12 @@ import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
 import io.embrace.android.embracesdk.internal.worker.Worker
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_SESSION_PART_ID
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_ID
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_NUMBER
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_PART_INDEX
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSION_START_TS
-import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbUserSessionTerminationReasonValues.BACKGROUND_ONLY_USER_SESSION_FOREGROUNDED
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbUserSessionTerminationReasonValues.INACTIVITY
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbUserSessionTerminationReasonValues.MANUAL
@@ -46,6 +46,8 @@ import kotlin.time.Duration.Companion.seconds
 @RunWith(AndroidJUnit4::class)
 internal class UserSessionLifecycleTest {
 
+    private val backgroundActivityEnabledConfig = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(100f))
+
     @Rule
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
@@ -59,15 +61,16 @@ internal class UserSessionLifecycleTest {
     @Test
     fun `user session created at process start resolves to the foreground session`() {
         testRule.runTest(
-            persistedRemoteConfig = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(100f)),
-            testCaseAction = { recordSession() },
+            persistedRemoteConfig = backgroundActivityEnabledConfig,
+            testCaseAction = {
+                recordSession()
+            },
             assertAction = {
                 val bgSession = getSingleSessionEnvelope(AppState.BACKGROUND)
                 val fgSession = getSingleSessionEnvelope(AppState.FOREGROUND)
 
-                // the pre-foreground part belongs to the user session created eagerly at process
-                // start, whose pending flavour resolved to the regular user session of this
-                // launch when the app entered the foreground
+                // the pre-foreground part belongs to the user session created eagerly at process start and classified as regular
+                // when the app entered the foreground
                 val bgSessionSpan = bgSession.findSessionSpan()
                 val bgAttrs = bgSessionSpan.attributes
                 assertEquals(fgSession.getUserSessionId(), bgAttrs?.findAttributeValue(EMB_USER_SESSION_ID))
@@ -75,6 +78,7 @@ internal class UserSessionLifecycleTest {
                 assertEquals("1", bgAttrs?.findAttributeValue(EMB_USER_SESSION_NUMBER))
                 assertEquals("1", bgAttrs?.findAttributeValue(EMB_USER_SESSION_PART_INDEX))
                 assertNotNull(bgAttrs?.findAttributeValue(EMB_USER_SESSION_START_TS))
+                assertNull(bgAttrs?.findAttributeValue(EMB_IS_BACKGROUND_ONLY_PART))
 
                 val fgSessionSpan = fgSession.findSessionSpan()
                 assertNotNull(fgSession.getUserSessionId())
@@ -82,22 +86,22 @@ internal class UserSessionLifecycleTest {
                 assertEquals("1", fgSessionSpan.attributes?.findAttributeValue(EMB_USER_SESSION_NUMBER))
                 assertFalse(fgSession.isFinalSessionPart())
                 assertNull(fgSession.getUserSessionTerminationReason())
+
+                val perfSpanNames = fgSession.findSpansOfType(EmbType.Performance.Default).map { it.name }
+                assertFalse(perfSpanNames.contains("emb-app-startup-warm"))
+                assertTrue(perfSpanNames.contains("emb-app-startup-cold"))
             }
         )
     }
 
     @Test
     fun `process foregrounding after the background-startup window splits into background-only then regular session`() {
+
         testRule.runTest(
-            persistedRemoteConfig = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(100f)),
+            persistedRemoteConfig = backgroundActivityEnabledConfig,
             testCaseAction = {
-                // The process starts in the background and does not foreground within the 5s
-                // background-startup window, so the eagerly-created process-start session is
-                // classified background-only when the window elapses.
                 clock.tick(6_000L)
                 unblockTimerThread()
-                // The app foregrounds only afterwards (e.g. a slow background launch the OS later
-                // surfaced). This ends the background-only session and starts a regular one.
                 recordSession()
             },
             assertAction = {

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_aei_log_no_session.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_aei_log_no_session.json
@@ -56,7 +56,7 @@
         },
         {
           "key": "emb.user_session_id",
-          "value": ""
+          "value": "__EMBRACE_TEST_USER_SESSION_ID__"
         },
         {
           "key": "exit_status",
@@ -84,7 +84,7 @@
         },
         {
           "key": "session.id",
-          "value": ""
+          "value": "__EMBRACE_TEST_USER_SESSION_ID__"
         },
         {
           "key": "session_id_error",

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_basic_span.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_basic_span.json
@@ -118,7 +118,7 @@
     },
     {
       "key": "emb.user_session_start_ts",
-      "value": "169220160010"
+      "value": "169220160000"
     },
     {
       "key": "session.id",

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_1.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_1.json
@@ -97,6 +97,26 @@
       "value": "__EMBRACE_TEST_USER_SESSION_ID__"
     },
     {
+      "key": "emb.user_session_inactivity_timeout_seconds",
+      "value": "1800"
+    },
+    {
+      "key": "emb.user_session_max_duration_seconds",
+      "value": "43200"
+    },
+    {
+      "key": "emb.user_session_number",
+      "value": "1"
+    },
+    {
+      "key": "emb.user_session_part_index",
+      "value": "1"
+    },
+    {
+      "key": "emb.user_session_start_ts",
+      "value": "169220160000"
+    },
+    {
       "key": "session.id",
       "value": "__EMBRACE_TEST_USER_SESSION_ID__"
     }

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_2.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_2.json
@@ -110,11 +110,11 @@
     },
     {
       "key": "emb.user_session_part_index",
-      "value": "1"
+      "value": "2"
     },
     {
       "key": "emb.user_session_start_ts",
-      "value": "169220160010"
+      "value": "169220160000"
     },
     {
       "key": "session.id",

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_3.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_3.json
@@ -110,11 +110,11 @@
     },
     {
       "key": "emb.user_session_part_index",
-      "value": "2"
+      "value": "3"
     },
     {
       "key": "emb.user_session_start_ts",
-      "value": "169220160010"
+      "value": "169220160000"
     },
     {
       "key": "emb.user_session_termination_reason",

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_4.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_4.json
@@ -122,7 +122,7 @@
     },
     {
       "key": "emb.user_session_termination_reason",
-      "value": "end_background_only_user_session"
+      "value": "background_only_user_session_foregrounded"
     },
     {
       "key": "session.id",

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_custom_timeouts.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_custom_timeouts.json
@@ -114,7 +114,7 @@
     },
     {
       "key": "emb.user_session_start_ts",
-      "value": "169220160010"
+      "value": "169220160000"
     },
     {
       "key": "session.id",

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_jvm_crash_span.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_jvm_crash_span.json
@@ -126,7 +126,7 @@
     },
     {
       "key": "emb.user_session_start_ts",
-      "value": "169220160010"
+      "value": "169220160000"
     },
     {
       "key": "session.id",

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_manual_end_1.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_manual_end_1.json
@@ -122,7 +122,7 @@
     },
     {
       "key": "emb.user_session_start_ts",
-      "value": "169220160010"
+      "value": "169220160000"
     },
     {
       "key": "emb.user_session_termination_reason",

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_max_duration_1.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_max_duration_1.json
@@ -118,7 +118,7 @@
     },
     {
       "key": "emb.user_session_start_ts",
-      "value": "169220160010"
+      "value": "169220160000"
     },
     {
       "key": "emb.user_session_termination_reason",

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_part_1.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_part_1.json
@@ -114,7 +114,7 @@
     },
     {
       "key": "emb.user_session_start_ts",
-      "value": "169220160010"
+      "value": "169220160000"
     },
     {
       "key": "session.id",

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_part_2.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_part_2.json
@@ -110,7 +110,7 @@
     },
     {
       "key": "emb.user_session_start_ts",
-      "value": "169220160010"
+      "value": "169220160000"
     },
     {
       "key": "session.id",

--- a/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSessionAttributes.kt
+++ b/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSessionAttributes.kt
@@ -208,6 +208,6 @@ object EmbSessionAttributes {
          * Background user session ended because the app entered the foreground.
          */
         @ExperimentalSemconv
-        const val END_BACKGROUND_ONLY_USER_SESSION: String = "end_background_only_user_session"
+        const val BACKGROUND_ONLY_USER_SESSION_FOREGROUNDED: String = "background_only_user_session_foregrounded"
     }
 }

--- a/embrace-android-semconv/src/main/semconv/embrace_android.yaml
+++ b/embrace-android-semconv/src/main/semconv/embrace_android.yaml
@@ -498,13 +498,13 @@ groups:
               value: "manual"
               brief: "Session ended by manual termination."
               stability: development
-            - id: end_background_only_user_session
-              value: "end_background_only_user_session"
-              brief: "Background user session ended because the app entered the foreground."
+            - id: background_only_user_session_foregrounded
+              value: "background_only_user_session_foregrounded"
+              brief: "Background-only user session ended because the app entered the foreground."
               stability: development
         brief: "The reason the session part was terminated."
         stability: development
-        examples: ["max_duration_reached", "inactivity", "manual", "end_background_only_user_session"]
+        examples: ["max_duration_reached", "inactivity", "manual", "background_only_user_session_foregrounded"]
       - id: emb.user_session_max_duration_seconds
         type: string
         brief: "The maximum session duration (in seconds) that the SDK was configured to use."


### PR DESCRIPTION
Change `SessionOrchestratorImpl` to support creating background-only user sessions if appropriate. This includes making the initial startup user session one where we haven't classified as background-only yet, and instead do that when we foreground or when a fallback timer fires that expresses we've waited long enough (currently 5 seconds after the SDK has initiailized, since that's the only reliable time we can trigger this). This fallback timer will also classify the startup type.

As a result of this the implementation was refactored so the transitions go through common paths. New tests have been added to cover new edge cases, while existing ones are verified via existing testing.