### PR TITLE
Persist payloads on intake even after a crash log is received

### DIFF
--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImpl.kt
@@ -39,6 +39,13 @@ class IntakeServiceImpl(
     // session lands before the process dies).
     private val state = AtomicReference(State.ACTIVE)
 
+    // Set if the current process has taken in a new log that signifies that it will end soon due to a JVM crash.
+    // This value is checked later when we encounter a session part, which could be one that we are resurrecting and not the one
+    // that is being ended by the JVM crash. In the case of the former, we process it normally. In the case of the latter,
+    // we process it on the current thread (which should be the main thread) because we know it's going to crash anyway, and we
+    // want to ensure that it is successfully persisted.
+    private val crashingProcessingIdentifier = AtomicReference<String?>(null)
+
     override fun shutdown() {
         worker.shutdownAndWait(shutdownTimeoutMs)
     }
@@ -52,6 +59,7 @@ class IntakeServiceImpl(
 
         if (metadata.isCrashTerminatingProcess() && metadata.complete) {
             if (state.compareAndSet(State.ACTIVE, State.CRASH_RECEIVED)) {
+                crashingProcessingIdentifier.set(metadata.processIdentifier)
                 schedulingService.shutdown()
                 // non-blocking shutdown: reject subsequent submissions but defer the drain to
                 // payloadStore.handleCrash's later intakeService.shutdown() call
@@ -62,10 +70,15 @@ class IntakeServiceImpl(
             return immediateFuture()
         }
 
-        if (metadata.envelopeType == SESSION && metadata.complete &&
-            state.compareAndSet(State.CRASH_RECEIVED, State.SEALED)
-        ) {
+        // The worker is shut down once a crash is detected, so anything arriving before the service is sealed must be persisted
+        // synchronously (like resurrected session parts) or be unrecoverably loss.
+        if (state.get() == State.CRASH_RECEIVED) {
             processIntake(intake, metadata, staleEntry)
+            // Only seal the service if the payload is the crashing session's last session part, after which we take in no more
+            // telemetry and let the process die.
+            if (metadata.isCrashingPartForCurrentProcess()) {
+                state.set(State.SEALED)
+            }
             return immediateFuture()
         }
 
@@ -152,6 +165,12 @@ class IntakeServiceImpl(
 
     private fun StoredTelemetryMetadata.isCrashTerminatingProcess(): Boolean =
         payloadType == PayloadType.JVM_CRASH || payloadType == PayloadType.REACT_NATIVE_CRASH
+
+    /**
+     * Returns true if the metadata is for a session part payload for the current process that is crashing.
+     */
+    private fun StoredTelemetryMetadata.isCrashingPartForCurrentProcess(): Boolean =
+        envelopeType == SESSION && complete && processIdentifier == crashingProcessingIdentifier.get()
 
     private enum class State {
         ACTIVE,

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImpl.kt
@@ -44,7 +44,8 @@ class IntakeServiceImpl(
     // that is being ended by the JVM crash. In the case of the former, we process it normally. In the case of the latter,
     // we process it on the current thread (which should be the main thread) because we know it's going to crash anyway, and we
     // want to ensure that it is successfully persisted.
-    private val crashingProcessingIdentifier = AtomicReference<String?>(null)
+    @Volatile
+    private var crashingProcessingIdentifier: String? = null
 
     override fun shutdown() {
         worker.shutdownAndWait(shutdownTimeoutMs)
@@ -59,7 +60,7 @@ class IntakeServiceImpl(
 
         if (metadata.isCrashTerminatingProcess() && metadata.complete) {
             if (state.compareAndSet(State.ACTIVE, State.CRASH_RECEIVED)) {
-                crashingProcessingIdentifier.set(metadata.processIdentifier)
+                crashingProcessingIdentifier = metadata.processIdentifier
                 schedulingService.shutdown()
                 // non-blocking shutdown: reject subsequent submissions but defer the drain to
                 // payloadStore.handleCrash's later intakeService.shutdown() call
@@ -170,7 +171,7 @@ class IntakeServiceImpl(
      * Returns true if the metadata is for a session part payload for the current process that is crashing.
      */
     private fun StoredTelemetryMetadata.isCrashingPartForCurrentProcess(): Boolean =
-        envelopeType == SESSION && complete && processIdentifier == crashingProcessingIdentifier.get()
+        envelopeType == SESSION && complete && processIdentifier == crashingProcessingIdentifier
 
     private enum class State {
         ACTIVE,

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImplTest.kt
@@ -638,6 +638,107 @@ class IntakeServiceImplTest {
     }
 
     @Test
+    fun `resurrected session part from another process should not seal the intake service`() {
+        // crash occurs in the current process, moving intake into CRASH_RECEIVED
+        // it is persisted synchronously, by passing the background worker that may not run before the process dies
+        val jvmCrashMetadata = StoredTelemetryMetadata(
+            timestamp = clock.tick(),
+            uuid = "crash-uuid",
+            processIdentifier = PROCESS_ID,
+            envelopeType = CRASH,
+            complete = true,
+            payloadType = PayloadType.JVM_CRASH
+        )
+        intakeService.take(logEnvelope, jvmCrashMetadata)
+        assertEquals(1, payloadStorageService.storedPayloadCount())
+        assertEquals(0, executorService.tasksBlockedCount())
+
+        // a complete SESSION resurrected from a different process arrives during teardown
+        // it is persisted synchronously but doesn't seal the intake service
+        val resurrectedSessionMetadata = StoredTelemetryMetadata(
+            timestamp = clock.tick(),
+            uuid = "resurrected-session",
+            processIdentifier = "old-pid",
+            envelopeType = SESSION,
+            complete = true,
+        )
+        intakeService.take(sessionEnvelope, resurrectedSessionMetadata)
+        assertEquals(2, payloadStorageService.storedPayloadCount())
+        assertEquals(0, executorService.tasksBlockedCount())
+
+        // because the resurrected session did not seal, the crashing process's own session part will be persisted and seals the service
+        val crashSessionMetadata = StoredTelemetryMetadata(
+            timestamp = clock.tick(),
+            uuid = "crash-session",
+            processIdentifier = PROCESS_ID,
+            envelopeType = SESSION,
+            complete = true,
+        )
+        intakeService.take(sessionEnvelope, crashSessionMetadata)
+        assertEquals(3, payloadStorageService.storedPayloadCount())
+        assertEquals(0, executorService.tasksBlockedCount())
+
+        // the crash session sealed the intake, so a subsequent payload is dropped
+        assertIntakeRejected(
+            logEnvelope,
+            StoredTelemetryMetadata(
+                timestamp = clock.tick(),
+                uuid = "post-seal-log",
+                processIdentifier = PROCESS_ID,
+                envelopeType = LOG,
+                complete = true,
+                payloadType = PayloadType.LOG
+            )
+        )
+    }
+
+    @Test
+    fun `all payloads arriving during crash teardown before sealing are persisted, not dropped`() {
+        val jvmCrashMetadata = StoredTelemetryMetadata(
+            timestamp = clock.tick(),
+            uuid = "crash-uuid",
+            processIdentifier = PROCESS_ID,
+            envelopeType = CRASH,
+            complete = true,
+            payloadType = PayloadType.JVM_CRASH
+        )
+        intakeService.take(logEnvelope, jvmCrashMetadata)
+        assertEquals(1, payloadStorageService.storedPayloadCount())
+
+        val logInWindow = StoredTelemetryMetadata(
+            timestamp = clock.tick(),
+            uuid = "log-in-window",
+            processIdentifier = PROCESS_ID,
+            envelopeType = LOG,
+            complete = true,
+            payloadType = PayloadType.LOG
+        )
+        val attachmentInWindow = StoredTelemetryMetadata(
+            timestamp = clock.tick(),
+            uuid = "attachment-in-window",
+            processIdentifier = PROCESS_ID,
+            envelopeType = ATTACHMENT,
+            complete = true,
+            payloadType = PayloadType.ATTACHMENT
+        )
+        intakeService.take(logEnvelope, logInWindow)
+        intakeService.take(attachmentEnvelope, attachmentInWindow)
+        assertEquals(3, payloadStorageService.storedPayloadCount())
+        assertEquals(0, executorService.tasksBlockedCount())
+
+        // the crashing process's own session part seals the intake (persisted synchronously)
+        val crashSessionMetadata = StoredTelemetryMetadata(
+            timestamp = clock.tick(),
+            uuid = "crash-session",
+            processIdentifier = PROCESS_ID,
+            envelopeType = SESSION,
+            complete = true
+        )
+        intakeService.take(sessionEnvelope, crashSessionMetadata)
+        assertEquals(4, payloadStorageService.storedPayloadCount())
+    }
+
+    @Test
     fun `duplicate cache takes will result in the first future being canceled`() {
         val f1 = intakeService.take(sessionEnvelope, sessionMetadata.copy(complete = false))
         assertFalse(f1.isDone)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
@@ -1,14 +1,17 @@
 package io.embrace.android.embracesdk.testcases.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.PropertyScope
 import io.embrace.android.embracesdk.assertions.assertMatches
 import io.embrace.android.embracesdk.assertions.assertOtelLogReceived
 import io.embrace.android.embracesdk.assertions.getLastLog
+import io.embrace.android.embracesdk.assertions.getSessionId
+import io.embrace.android.embracesdk.assertions.getStartTime
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.config.FakeProjectConfig
-import io.embrace.android.embracesdk.PropertyScope
 import io.embrace.android.embracesdk.internal.EmbraceInternalApi
 import io.embrace.android.embracesdk.internal.arch.attrs.toEmbraceAttributeName
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
@@ -16,7 +19,6 @@ import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.delivery.PayloadType
-import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LegacyExceptionInfo
@@ -26,15 +28,18 @@ import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.serialization.toJson
 import io.embrace.android.embracesdk.internal.session.getSessionSpan
 import io.embrace.android.embracesdk.internal.utils.getSafeStackTrace
+import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.semconv.EmbAndroidAttributes
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
+import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule.Companion.DEFAULT_SDK_START_TIME_MS
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.opentelemetry.kotlin.logging.SeverityNumber
 import io.opentelemetry.kotlin.semconv.LogAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -50,8 +55,13 @@ internal class JvmCrashFeatureTest {
     @Rule
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
-        EmbraceSetupInterface(fakeStorageLayer = true).apply {
+        EmbraceSetupInterface(
+            fakeStorageLayer = true,
+            workersToFake = listOf(Worker.Background.NonIoRegWorker, Worker.Background.IoRegWorker),
+        ).apply {
             getEmbLogger().throwOnInternalError = false
+            getFakedWorkerExecutor(Worker.Background.NonIoRegWorker).blockingMode = false
+            getFakedWorkerExecutor(Worker.Background.IoRegWorker).blockingMode = false
         }.also {
             payloadStorageService = checkNotNull(it.fakePayloadStorageService)
         }
@@ -123,6 +133,48 @@ internal class JvmCrashFeatureTest {
                 payloadStorageService.getPersistedCrashLog().getLastLog().assertCrash(
                     crashIdFromSession = null,
                     crashTimeMs = crashTimeMs,
+                )
+            }
+        )
+    }
+
+    @Test
+    fun `resurrected session part is preserved when a JVM crash happens after startup`() {
+        lateinit var ioWorker: BlockingScheduledExecutorService
+        lateinit var nonIoWorker: BlockingScheduledExecutorService
+        val resurrectedSessionId = "aabbccdd11223344aabbccdd11223344"
+        testRule.runTest(
+            persistedRemoteConfig = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(100f)),
+            setupAction = {
+                persistExpiredUserSession(
+                    sdkStartTimeMs = DEFAULT_SDK_START_TIME_MS - 100_0000,
+                    userSessionId = resurrectedSessionId,
+                    cacheIncompletePartPayload = true,
+                )
+                ioWorker = getFakedWorkerExecutor(Worker.Background.IoRegWorker)
+                nonIoWorker = getFakedWorkerExecutor(Worker.Background.NonIoRegWorker)
+            },
+            testCaseAction = {
+                crashTimeMs = clock.now()
+                ioWorker.runCurrentlyBlocked()
+                nonIoWorker.runCurrentlyBlocked()
+                simulateJvmUncaughtException(testException)
+                ioWorker.runCurrentlyBlocked()
+                nonIoWorker.runCurrentlyBlocked()
+            },
+            assertAction = {
+                // The resurrected session is delivered normally and is not associated with the crash.
+                val resurrectedSession = getSingleSessionEnvelope(AppState.FOREGROUND)
+                assertEquals(resurrectedSessionId, resurrectedSession.getSessionId())
+                assertNull(resurrectedSession.getSessionSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID))
+
+                // The crashing process's own session part is held back during teardown, persisted, and carries the crash id.
+                val ba = payloadStorageService.getPersistedSession(AppState.BACKGROUND)
+                assertEquals(crashTimeMs, ba.getStartTime())
+                payloadStorageService.getPersistedCrashLog().getLastLog().assertCrash(
+                    crashIdFromSession = ba.getCrashedId(),
+                    crashTimeMs = crashTimeMs,
+                    hasSession = true,
                 )
             }
         )


### PR DESCRIPTION
The workflow to shut down the delivery layer to prepare for a JVM crash takes two payloads: the crash log, and the crashed session part. But if there are payloads that arrive between these two, some assumptions get broken. This addresses the issues exposed by synchronously persisting all payloads intaken after the crash log arrives, but only seal the intake service when we get the crashed session part payload.

There's still a potential gap when a payload is received AFTER the intake service has been sealed. I will sort out if this is actually: 1) a problem; and 2) something we can prevent after this is merged.