### PR TITLE
Use the right type of *session* ID for the right thing

### DIFF
--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
@@ -253,6 +253,7 @@ class FakeEmbraceSdkSpan(
             endTimeMs: Long? = null,
             sessionProperties: Map<String, String>? = null,
             processIdentifier: String = "fake-process-id",
+            sessionPartId: String = "fakeSessionPartId",
         ): FakeEmbraceSdkSpan =
             FakeEmbraceSdkSpan(
                 name = "emb-session",
@@ -267,6 +268,8 @@ class FakeEmbraceSdkSpan(
                 }
 
                 setSystemAttribute(SessionAttributes.SESSION_ID, sessionId)
+                setSystemAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID, sessionId)
+                setSystemAttribute(EmbSessionAttributes.EMB_SESSION_PART_ID, sessionPartId)
                 setSystemAttribute(EmbSessionAttributes.EMB_PROCESS_IDENTIFIER, processIdentifier)
                 setSystemAttribute(EmbSessionAttributes.EMB_STATE, "foreground")
                 setSystemAttribute(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionAeiGoldenFileTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionAeiGoldenFileTest.kt
@@ -2,8 +2,8 @@ package io.embrace.android.embracesdk.testcases
 
 import android.app.ApplicationExitInfo
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.assertions.getOtelSessionId
 import io.embrace.android.embracesdk.assertions.getSessionPartId
+import io.embrace.android.embracesdk.assertions.getUserSessionId
 import io.embrace.android.embracesdk.fakes.TestAeiData
 import io.embrace.android.embracesdk.fakes.setupFakeAeiData
 import io.embrace.android.embracesdk.internal.worker.Worker
@@ -40,7 +40,7 @@ internal class UserSessionAeiGoldenFileTest {
                 val sessionEnvelope = getSingleSessionEnvelope()
                 assertLogPayloadMatchesGoldenFile(
                     envelope = getSingleLogEnvelope(),
-                    expectedUserSessionId = sessionEnvelope.getOtelSessionId(),
+                    expectedUserSessionId = sessionEnvelope.getUserSessionId(),
                     expectedSessionPartId = sessionEnvelope.getSessionPartId(),
                     goldenFile = "user_session_aei_log_active.json",
                 )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/InternalErrorLogTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/InternalErrorLogTest.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.opentelemetry.kotlin.semconv.ExceptionAttributes
+import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Rule
@@ -50,7 +51,7 @@ internal class InternalErrorLogTest {
                         attrs.findAttributeValue(ExceptionAttributes.EXCEPTION_TYPE)
                     )
                     assertNotNull(attrs.findAttributeValue("log.record.uid"))
-                    assertNotNull(attrs.findAttributeValue("session.id"))
+                    assertNotNull(attrs.findAttributeValue(SessionAttributes.SESSION_ID))
                     checkNotNull(attrs.findAttributeValue(ExceptionAttributes.EXCEPTION_STACKTRACE))
                 }
             }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
@@ -5,8 +5,8 @@ import io.embrace.android.embracesdk.PropertyScope
 import io.embrace.android.embracesdk.assertions.assertMatches
 import io.embrace.android.embracesdk.assertions.assertOtelLogReceived
 import io.embrace.android.embracesdk.assertions.getLastLog
-import io.embrace.android.embracesdk.assertions.getOtelSessionId
 import io.embrace.android.embracesdk.assertions.getStartTime
+import io.embrace.android.embracesdk.assertions.getUserSessionId
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
@@ -172,7 +172,7 @@ internal class JvmCrashFeatureTest {
             assertAction = {
                 // The resurrected session is delivered normally and is not associated with the crash.
                 val resurrectedSession = getSingleSessionEnvelope(AppState.FOREGROUND)
-                assertEquals(resurrectedSessionId, resurrectedSession.getOtelSessionId())
+                assertEquals(resurrectedSessionId, resurrectedSession.getUserSessionId())
                 assertNull(resurrectedSession.getSessionSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID))
 
                 // The crashing process's own session part is held back during teardown, persisted, and carries the crash id.

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionResurrectionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionResurrectionTest.kt
@@ -6,7 +6,6 @@ import android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.getLastLog
 import io.embrace.android.embracesdk.assertions.getLogOfType
-import io.embrace.android.embracesdk.assertions.getOtelSessionId
 import io.embrace.android.embracesdk.assertions.getStartTime
 import io.embrace.android.embracesdk.assertions.getUserSessionId
 import io.embrace.android.embracesdk.assertions.isBackgroundOnlyPart
@@ -76,8 +75,7 @@ internal class UserSessionResurrectionTest {
                 val sessions = getSessionEnvelopes(2)
                 val resurrected = sessions.first()
                 val live = sessions.last()
-                assertEquals(DEFAULT_EXPIRED_USER_SESSION_ID, resurrected.getOtelSessionId())
-                assertNotEquals(DEFAULT_EXPIRED_USER_SESSION_ID, live.getOtelSessionId())
+                assertEquals(DEFAULT_EXPIRED_USER_SESSION_ID, resurrected.getUserSessionId())
                 assertNotEquals(DEFAULT_EXPIRED_USER_SESSION_ID, live.getUserSessionId())
                 assertNotNull(live.getUserSessionId())
             },
@@ -101,7 +99,7 @@ internal class UserSessionResurrectionTest {
                 simulateConnectionTypeChange(ConnectionType.WIFI)
             },
             assertAction = {
-                val resurrected = getSessionEnvelopes(2).single { it.getOtelSessionId() == FAKE_USER_SESSION_ID }
+                val resurrected = getSessionEnvelopes(2).single { it.getUserSessionId() == FAKE_USER_SESSION_ID }
 
                 assertTrue(resurrected.isBackgroundOnlyPart())
                 resurrected.assertFinalPart(EmbSessionAttributes.EmbUserSessionTerminationReasonValues.MAX_DURATION_REACHED)
@@ -131,8 +129,7 @@ internal class UserSessionResurrectionTest {
                 val sessions = getSessionEnvelopes(2)
                 val resurrected = sessions.first()
                 val live = sessions.last()
-                assertEquals(DEFAULT_EXPIRED_USER_SESSION_ID, resurrected.getOtelSessionId())
-                assertNotEquals(DEFAULT_EXPIRED_USER_SESSION_ID, live.getOtelSessionId())
+                assertEquals(DEFAULT_EXPIRED_USER_SESSION_ID, resurrected.getUserSessionId())
                 assertNotEquals(DEFAULT_EXPIRED_USER_SESSION_ID, live.getUserSessionId())
 
                 getSingleLogEnvelope().getLastLog().assertSessionIds(DEFAULT_EXPIRED_USER_SESSION_ID, DEFAULT_DEAD_SESSION_PART_ID)
@@ -223,8 +220,7 @@ internal class UserSessionResurrectionTest {
                 val currentLaunchPart = sessions[1]
 
                 // both parts belong to the one continued user session
-                assertEquals(persistedId, priorLaunchPart.getOtelSessionId())
-                assertEquals(persistedId, currentLaunchPart.getOtelSessionId())
+                assertEquals(persistedId, priorLaunchPart.getUserSessionId())
                 assertEquals(persistedId, currentLaunchPart.getUserSessionId())
 
                 fun Envelope<SessionPartPayload>.processId() =

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/assertions/PayloadGoldenFileAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/assertions/PayloadGoldenFileAssertions.kt
@@ -1,8 +1,8 @@
 package io.embrace.android.embracesdk.testframework.assertions
 
 import io.embrace.android.embracesdk.assertions.findSessionSpan
-import io.embrace.android.embracesdk.assertions.getOtelSessionId
 import io.embrace.android.embracesdk.assertions.getSessionPartId
+import io.embrace.android.embracesdk.assertions.getUserSessionId
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
@@ -50,7 +50,7 @@ internal fun EmbracePayloadAssertionInterface.assertPayloadsMatchGoldenFiles(
 
     userSessions.forEach { userSession ->
         // Use the first part's userSessionId as the correct one for all the payloads
-        val userSessionId: String = userSession.partDiffs.first().envelope.getOtelSessionId().also { newId ->
+        val userSessionId: String = userSession.partDiffs.first().envelope.getUserSessionId().also { newId ->
             assertFalse(
                 "Unexpected user session ID. Duplicate of a previously seen one",
                 alreadySeenUserSessions.contains(newId)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/ExportedSpanValidator.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/ExportedSpanValidator.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.testframework.export
 import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.opentelemetry.kotlin.aliases.OtelJavaSpanData
+import io.opentelemetry.kotlin.semconv.SessionAttributes
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -66,7 +67,7 @@ internal class ExportedSpanValidator {
             EmbSessionAttributes.EMB_PRIVATE_SEQUENCE_ID,
             EmbSessionAttributes.EMB_SESSION_PART_ID,
             EmbSessionAttributes.EMB_USER_SESSION_ID,
-            "session.id",
+            SessionAttributes.SESSION_ID,
         )
         val attrs: Map<String, String> = attributes.asMap().map {
             it.key.key to it.value.toString()

--- a/embrace-test-fakes/gradle.properties
+++ b/embrace-test-fakes/gradle.properties
@@ -1,2 +1,3 @@
 io.embrace.android.embracesdk.semconv.optIn=true
 io.opentelemetry.kotlin.optIn=true
+io.opentelemetry.kotlin.semconv.optIn=true

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SessionPartPayloadAssertions.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SessionPartPayloadAssertions.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.session.getSessionSpan
 import io.embrace.android.embracesdk.internal.session.getStateSpan
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
+import io.opentelemetry.kotlin.semconv.SessionAttributes
 
 /**
  * Returns the Session Span
@@ -24,7 +25,7 @@ fun Envelope<SessionPartPayload>.findSessionSpan(): Span {
  * Return the user session ID from the session span in the payload
  */
 fun Envelope<SessionPartPayload>.getOtelSessionId(): String {
-    return checkNotNull(findSessionSpan().attributes?.findAttributeValue("session.id")) {
+    return checkNotNull(findSessionSpan().attributes?.findAttributeValue(SessionAttributes.SESSION_ID)) {
         "No session id found in session payload"
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionPart.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionPart.kt
@@ -21,13 +21,15 @@ fun fakeSessionPartToken(): SessionPartToken = SessionPartToken(
 )
 
 fun fakeSessionEnvelope(
-    sessionId: String = "fakeSessionPartId",
+    sessionId: String = "fakeUserSessionId",
+    sessionPartId: String = "fakeSessionPartId",
     startMs: Long = 160000000000L,
     endMs: Long = 161000400000L,
     sessionProperties: Map<String, String>? = null,
 ): Envelope<SessionPartPayload> {
     val sessionSpan = FakeEmbraceSdkSpan.sessionSpan(
         sessionId = sessionId,
+        sessionPartId = sessionPartId,
         startTimeMs = startMs,
         lastHeartbeatTimeMs = endMs,
         endTimeMs = endMs,
@@ -50,6 +52,7 @@ fun fakeSessionEnvelope(
 
 fun fakeIncompleteSessionEnvelope(
     sessionId: String = "fakeIncompleteSessionId",
+    sessionPartId: String = "fakeIncompleteSessionPartId",
     processIdentifier: String = "fakeIncompleteSessionProcessId",
     startMs: Long = 1691000000000L,
     lastHeartbeatTimeMs: Long = 1691000300000L,
@@ -60,6 +63,7 @@ fun fakeIncompleteSessionEnvelope(
     val fakeClock = FakeClock(currentTime = startMs)
     val incompleteSessionSpan = FakeEmbraceSdkSpan.sessionSpan(
         sessionId = sessionId,
+        sessionPartId = sessionPartId,
         startTimeMs = startMs,
         lastHeartbeatTimeMs = lastHeartbeatTimeMs,
         sessionProperties = sessionProperties,


### PR DESCRIPTION
Use the proper method that returns the expected type of ID that the underlying code and validation expects. Add all the IDs to fakes so that the assertions will work correctly.