### PR TITLE
Stamp all three session ids on the nativeCrashLog fake

### DIFF
--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogEnvelopeSourceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogEnvelopeSourceImplTest.kt
@@ -96,11 +96,13 @@ internal class LogEnvelopeSourceImplTest {
     fun `check native crash envelope`() {
         val crashPayload = LogPayload(logs = listOf(nativeCrashLog))
         val crashLogAttributes = checkNotNull(nativeCrashLog.attributes)
-        val expectedSessionId = crashLogAttributes.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID)
+        val expectedSessionPartId = crashLogAttributes.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID)
+        val expectedUserSessionId = crashLogAttributes.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID)
         val expectedProcessIdentifier = crashLogAttributes.findAttributeValue(EmbSessionAttributes.EMB_PROCESS_IDENTIFIER)
         val cachedCrashEnvelopeMetadata = createNativeCrashEnvelopeMetadata(
-            sessionPartId = expectedSessionId,
+            sessionPartId = expectedSessionPartId,
             processIdentifier = expectedProcessIdentifier,
+            userSessionId = expectedUserSessionId,
         )
         logSource.singleLogPayloadsSource = listOf(
             LogRequest(crashPayload)
@@ -118,7 +120,7 @@ internal class LogEnvelopeSourceImplTest {
 
         with(cachedLogEnvelopeStore.envelopeGetRequest.single()) {
             assertEquals(0L, timestamp)
-            assertEquals(expectedSessionId, uuid)
+            assertEquals(expectedSessionPartId, uuid)
             assertEquals(expectedProcessIdentifier, processIdentifier)
             assertEquals(SupportedEnvelopeType.CRASH, envelopeType)
             assertEquals(PayloadType.NATIVE_CRASH, payloadType)

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/LogTestFixtures.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/LogTestFixtures.kt
@@ -1,11 +1,12 @@
 package io.embrace.android.embracesdk.fixtures
 
 import io.embrace.android.embracesdk.assertions.toPayload
-import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.SendMode
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Log
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
+import io.opentelemetry.kotlin.semconv.SessionAttributes
 
 val testLog: Log = Log(
     traceId = "ceadd56622414a06ae382e4e5a70bcf7",
@@ -43,6 +44,8 @@ val nativeCrashLog = Log(
         Attribute(EmbSessionAttributes.EMB_PRIVATE_SEND_MODE, SendMode.IMMEDIATE.name),
         EmbType.System.NativeCrash.toPayload(),
         Attribute(EmbSessionAttributes.EMB_SESSION_PART_ID, "bb6b5b1ea2ff48928382fe81d7991ced"),
+        Attribute(SessionAttributes.SESSION_ID, "f0e1d2c3b4a5968778695a4b3c2d1e0f"),
+        Attribute(EmbSessionAttributes.EMB_USER_SESSION_ID, "f0e1d2c3b4a5968778695a4b3c2d1e0f"),
         Attribute(EmbSessionAttributes.EMB_PROCESS_IDENTIFIER, "8115ec91-3e5e-4d8a-816d-cc40306f9822"),
     )
 )


### PR DESCRIPTION
Add all the various session IDs to the log test fixture so the tests can validate against the exact right one