### PR TITLE
Fall back to using session.id when matching native crashes with old data

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
@@ -31,6 +31,7 @@ import io.embrace.android.embracesdk.internal.session.getSessionSpan
 import io.embrace.android.embracesdk.internal.session.getUserSessionProperties
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
+import io.opentelemetry.kotlin.semconv.SessionAttributes
 import java.io.InputStream
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeUnit
@@ -314,10 +315,9 @@ internal class PayloadResurrectionServiceImpl(
         isBackgroundOnly: Boolean,
     ): Envelope<SessionPartPayload> {
         val deadPart = serializer.fromJson<Envelope<SessionPartPayload>>(payloadStream)
-        val deadPartAttrs = deadPart.getSessionSpan()?.attributes
-
-        val sessionPartId = deadPartAttrs?.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID)
-        val appState = deadPartAttrs?.findAttributeValue(EmbSessionAttributes.EMB_STATE)
+        val deadSessionPartSpan = deadPart.getSessionSpan()
+        val sessionPartId = deadSessionPartSpan?.resolveSessionPartIdForCrashMatch()
+        val appState = deadSessionPartSpan?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_STATE)
         val nativeCrash = if (nativeCrashService != null && sessionPartId != null) {
             nativeCrashProvider(sessionPartId)?.apply {
                 val nativeCrashEnvelopeMetadata = createNativeCrashEnvelopeMetadata(
@@ -430,12 +430,25 @@ internal class PayloadResurrectionServiceImpl(
     /**
      * Attributes attaching the native crash to this session span if its session part id matches, or empty otherwise.
      */
-    private fun Span.crashAttributes(nativeCrashData: NativeCrashData): List<Attribute> =
-        if (attributes?.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID) == nativeCrashData.sessionPartId) {
+    private fun Span.crashAttributes(nativeCrashData: NativeCrashData): List<Attribute> {
+        val sessionPartId = resolveSessionPartIdForCrashMatch()
+        return if (sessionPartId != null && sessionPartId == nativeCrashData.sessionPartId) {
             listOf(Attribute(EmbSessionAttributes.EMB_CRASH_ID, nativeCrashData.nativeCrashId))
         } else {
             emptyList()
         }
+    }
+
+    /**
+     * Resolves the session part id used to match a native crash to this session part.
+     *
+     * A current-SDK session part span always has [EmbSessionAttributes.EMB_SESSION_PART_ID] so its presence means no fallback, so we take
+     * whatever value it defines. Lacking that, it means it was created with a version of the SDK that predates user session, so we
+     * get the ID defined in [SessionAttributes.SESSION_ID]. If neither exists, this session part span is not valid, so we return null.
+     */
+    private fun Span.resolveSessionPartIdForCrashMatch(): String? =
+        attributes?.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID)
+            ?: attributes?.findAttributeValue(SessionAttributes.SESSION_ID)
 
     private fun StoredTelemetryMetadata.loadDecompressedPayload(): InputStream? =
         cacheStorageService.loadPayloadAsStream(this)?.let {

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
@@ -50,6 +50,7 @@ import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
+import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.session.UserSessionRestoreDecision
 import io.embrace.android.embracesdk.internal.session.getSessionSpan
 import io.embrace.android.embracesdk.internal.toEmbraceSpanData
@@ -57,6 +58,7 @@ import io.embrace.android.embracesdk.internal.worker.PriorityWorker
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbUserSessionTerminationReasonValues
 import io.embrace.android.embracesdk.spans.ErrorCode
+import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -325,6 +327,29 @@ class PayloadResurrectionServiceImplTest {
         val attributes =
             checkNotNull(getStoredParts().last().getSessionSpan()?.attributes)
         assertNull(attributes.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID))
+    }
+
+    @Test
+    fun `native crash attaches to a legacy session part that carries only session id`() {
+        val legacySessionId = "legacy-session-id"
+        nativeCrashService.addNativeCrashData(
+            createNativeCrashData(
+                nativeCrashId = "legacy-native-crash",
+                sessionPartId = legacySessionId,
+            )
+        )
+        cacheStorageService.addPayload(
+            metadata = sessionMetadata.copy(userSessionId = "", sessionPartId = ""),
+            data = deadSessionEnvelope.asPreUserSessionPayload(legacySessionId),
+        )
+
+        resurrectInBackground()
+
+        val sessionSpan = getStoredParts().single().getSessionSpan()
+        assertEquals(
+            "legacy-native-crash",
+            sessionSpan?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID)
+        )
     }
 
     @Test
@@ -741,7 +766,7 @@ class PayloadResurrectionServiceImplTest {
             override fun take(
                 intake: Envelope<*>,
                 metadata: StoredTelemetryMetadata,
-                staleEntry: StoredTelemetryMetadata?
+                staleEntry: StoredTelemetryMetadata?,
             ): Future<*> {
                 return object : Future<Unit> {
                     override fun cancel(mayInterruptIfRunning: Boolean) = false
@@ -788,6 +813,7 @@ class PayloadResurrectionServiceImplTest {
         thread.start()
         thread.join(5000)
     }
+
     private fun Envelope<SessionPartPayload>.resurrectPayload() {
         cacheStorageService.addPayload(
             metadata = sessionMetadata,
@@ -795,6 +821,35 @@ class PayloadResurrectionServiceImplTest {
         )
         resurrectInBackground()
     }
+
+    /**
+     * Rewrites a session payload to look like one from an SDK that predates the user session concept
+     */
+    private fun Envelope<SessionPartPayload>.asPreUserSessionPayload(
+        legacySessionId: String
+    ): Envelope<SessionPartPayload> {
+        return copy(
+            data = data.copy(
+                spans = data.spans.toPreUserSessionSpan(legacySessionId),
+                spanSnapshots = data.spanSnapshots.toPreUserSessionSpan(legacySessionId),
+            )
+        )
+    }
+
+    private fun List<Span>?.toPreUserSessionSpan(legacySessionId: String): List<Span>? =
+        this?.map { span ->
+            span.copy(
+                attributes = checkNotNull(span.attributes)
+                    .filterNot { it.key == EmbSessionAttributes.EMB_SESSION_PART_ID || it.key == EmbSessionAttributes.EMB_USER_SESSION_ID }
+                    .map {
+                        if (it.key == SessionAttributes.SESSION_ID) {
+                            it.copy(data = legacySessionId)
+                        } else {
+                            it
+                        }
+                    }
+            )
+        }
 
     private fun getStoredParts(): List<Envelope<SessionPartPayload>> {
         return payloadStorageService.storedPayloads().map { bytes ->
@@ -832,7 +887,7 @@ class PayloadResurrectionServiceImplTest {
     ) = NativeCrashData(
         nativeCrashId = nativeCrashId,
         sessionPartId = sessionPartId,
-        userSessionId = "",
+        userSessionId = "fake-user-session-id",
         timestamp = 0L,
         crash = null,
         symbols = null,


### PR DESCRIPTION
Fallback to using the old definition of `session.id` for resurrected session spans written in by old SDK versions. We detect this by the absence of an `emb.session_part_id` attribute.