### PR TITLE
Rename ambiguous uses of sessionId in internal interfaces

### DIFF
--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationArgs.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationArgs.kt
@@ -32,7 +32,7 @@ class FakeInstrumentationArgs(
     override val telemetryService: TelemetryService = FakeTelemetryService(),
     val backgroundWorkerSupplier: (worker: Worker.Background) -> BackgroundWorker = { fakeBackgroundWorker() },
     val priorityWorkerSupplier: (worker: Worker.Priority) -> PriorityWorker<*> = { fakePriorityWorker<Any>() },
-    val sessionIdSupplier: () -> String? = { null },
+    val sessionPartIdSupplier: () -> String? = { null },
     val userSessionIdSupplier: () -> String? = { null },
     val activeSessionIdsSupplier: () -> SessionIdsSnapshot = { SessionIdsSnapshot("", "") },
     val sessionChangeListeners: MutableList<SessionPartChangeListener> = mutableListOf(),
@@ -50,7 +50,7 @@ class FakeInstrumentationArgs(
     @Suppress("UNCHECKED_CAST")
     override fun <T> systemService(name: String): T? = systemServiceSupplier(name) as? T
 
-    override fun sessionPartId(): String? = sessionIdSupplier()
+    override fun sessionPartId(): String? = sessionPartIdSupplier()
 
     override fun userSessionId(): String? = userSessionIdSupplier()
 

--- a/embrace-android-instrumentation-crash-ndk/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImplTest.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImplTest.kt
@@ -55,7 +55,7 @@ class NativeCrashHandlerInstallerImplTest {
             configService = fakeConfigService,
             logger = FakeInternalLogger(false),
             backgroundWorkerSupplier = { BackgroundWorker(executorService) },
-            sessionIdSupplier = { sessionId },
+            sessionPartIdSupplier = { sessionId },
             userSessionIdSupplier = { userSessionId },
             activeSessionIdsSupplier = {
                 SessionIdsSnapshot(

--- a/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkCaptureDataSourceImpl.kt
+++ b/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkCaptureDataSourceImpl.kt
@@ -90,7 +90,7 @@ class NetworkCaptureDataSourceImpl(
                     responseHeaders = requestBody.responseHeaders,
                     responseSize = requestBody.responseBodySize,
                     responseStatus = statusCode,
-                    sessionId = args.sessionPartId(),
+                    sessionPartId = args.sessionPartId(),
                     startTime = startTime,
                     url = url,
                     errorMessage = errorMessage
@@ -127,7 +127,7 @@ class NetworkCaptureDataSourceImpl(
                     responseHeaders = call.responseHeaders,
                     responseSize = call.responseSize,
                     responseStatus = call.responseStatus,
-                    sessionId = call.sessionId,
+                    sessionPartId = call.sessionPartId,
                     startTime = call.startTime,
                     url = call.url,
                     errorMessage = call.errorMessage,

--- a/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/FakeNetworkCapturedCall.kt
+++ b/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/FakeNetworkCapturedCall.kt
@@ -19,7 +19,7 @@ fun fakeNetworkCapturedCall(): NetworkCapturedCall {
         responseHeaders = mapOf("response-header" to "value"),
         responseSize = 300,
         responseStatus = 200,
-        sessionId = "fake-session-id",
+        sessionPartId = "fake-session-id",
         startTime = 1713452000,
         url = "https://httpbin.org/get",
         errorMessage = "",

--- a/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkCaptureDataSourceTest.kt
+++ b/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkCaptureDataSourceTest.kt
@@ -218,7 +218,7 @@ internal class NetworkCaptureDataSourceTest {
         assertEquals(mapOf("response-header" to "value"), capturedCall.responseHeaders)
         assertEquals(300, capturedCall.responseSize)
         assertEquals(200, capturedCall.responseStatus)
-        assertEquals("fake-session-id", capturedCall.sessionId)
+        assertEquals("fake-session-id", capturedCall.sessionPartId)
         assertEquals(1713452000L, capturedCall.startTime)
         assertEquals("https://httpbin.org/get", capturedCall.url)
         assertEquals("", capturedCall.errorMessage)

--- a/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
+++ b/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
@@ -199,7 +199,8 @@ sealed class SchemaType(
         responseHeaders: Map<String, String>?,
         responseSize: Int?,
         responseStatus: Int?,
-        sessionId: String?,
+        // FIXME: this is populated with the session part ID but is used to populate session.id, which is a mismatch
+        sessionPartId: String?,
         startTime: Long?,
         url: String?,
         errorMessage: String?,
@@ -223,7 +224,7 @@ sealed class SchemaType(
             HttpAttributes.HTTP_RESPONSE_HEADER to responseHeaders.toString(),
             EmbNetworkCapturedRequestAttributes.RESPONSE_SIZE to responseSize.toString(),
             HttpAttributes.HTTP_RESPONSE_STATUS_CODE to responseStatus.toString(),
-            SessionAttributes.SESSION_ID to sessionId,
+            SessionAttributes.SESSION_ID to sessionPartId,
             EmbNetworkCapturedRequestAttributes.START_TIME to startTime.toString(),
             EmbNetworkCapturedRequestAttributes.URL to url,
             ExceptionAttributes.EXCEPTION_MESSAGE to errorMessage,

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/NetworkCapturedCall.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/NetworkCapturedCall.kt
@@ -97,10 +97,10 @@ data class NetworkCapturedCall(
     val responseStatus: Int? = null,
 
     /**
-     * Session ID that the network request occurred during.
+     * Session part ID that the network request occurred during.
      */
     @SerialName("sid")
-    val sessionId: String? = null,
+    val sessionPartId: String? = null,
 
     /**
      * The start time of the request.


### PR DESCRIPTION
Some internal interfaces like parameter and variable names were still using "sessionId" in an ambigous way. Give the the proper contextualized named to reveal mismatches that should be fixed later.