### PR TITLE
Rename SessionIdProvider to SessionIdsProvider

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/InstrumentationArgsImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/InstrumentationArgsImpl.kt
@@ -44,7 +44,7 @@ internal class InstrumentationArgsImpl(
     private val workerThreadModule: WorkerThreadModule,
     private val sessionPartTracker: SessionPartTracker,
     private val userSessionPropertiesService: UserSessionPropertiesService,
-    private val userSessionIdProvider: () -> String?,
+    private val userSessionIdsProvider: () -> String?,
     private val activeSessionIdsProvider: () -> SessionIdsSnapshot,
     crashMarkerFileProvider: () -> File,
 ) : InstrumentationArgs {
@@ -67,7 +67,7 @@ internal class InstrumentationArgsImpl(
 
     override fun sessionPartId(): String? = sessionPartTracker.getActiveSessionPartId()
 
-    override fun userSessionId(): String? = userSessionIdProvider()
+    override fun userSessionId(): String? = userSessionIdsProvider()
 
     override fun activeSessionIds(): SessionIdsSnapshot = activeSessionIdsProvider()
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingServiceImpl.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
 import io.embrace.android.embracesdk.internal.session.SessionPartToken
 import io.embrace.android.embracesdk.internal.session.caching.PeriodicSessionPartCacher
-import io.embrace.android.embracesdk.internal.session.id.SessionIdProvider
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsProvider
 import io.embrace.android.embracesdk.internal.session.orchestrator.PayloadStore
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import java.util.concurrent.atomic.AtomicBoolean
@@ -15,7 +15,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 internal class PayloadCachingServiceImpl(
     private val partCacher: PeriodicSessionPartCacher,
     private val clock: Clock,
-    private val sessionIdProvider: SessionIdProvider,
+    private val sessionIdsProvider: SessionIdsProvider,
     private val payloadStore: PayloadStore,
     private val deliveryTracer: DeliveryTracer? = null,
 ) : PayloadCachingService {
@@ -58,7 +58,7 @@ internal class PayloadCachingServiceImpl(
         deliveryTracer?.onSessionCache()
 
         EmbTrace.trace("on-session-cache") {
-            if (initial.sessionPartId != sessionIdProvider.getCurrentSessionPartId()) {
+            if (initial.sessionPartId != sessionIdsProvider.getCurrentSessionPartId()) {
                 return null
             }
             return supplier(endAppState, clock.now(), initial)?.apply {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
@@ -47,7 +47,7 @@ class DeliveryModuleImpl(
             initModule.clock,
             processIdProvider,
             initModule.uuidSource,
-            essentialServiceModule.sessionIdProvider::getActiveSessionIds,
+            essentialServiceModule.sessionIdsProvider::getActiveSessionIds,
         )
     }
 
@@ -78,7 +78,7 @@ class DeliveryModuleImpl(
         PayloadCachingServiceImpl(
             partCacher,
             initModule.clock,
-            essentialServiceModule.sessionIdProvider,
+            essentialServiceModule.sessionIdsProvider,
             payloadStore,
             deliveryTracer
         )

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModule.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.internal.arch.state.AppStateTracker
 import io.embrace.android.embracesdk.internal.capture.connectivity.NetworkConnectivityService
 import io.embrace.android.embracesdk.internal.capture.session.UserSessionPropertiesService
 import io.embrace.android.embracesdk.internal.capture.user.UserService
-import io.embrace.android.embracesdk.internal.session.id.SessionIdProvider
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsProvider
 import io.embrace.android.embracesdk.internal.session.id.SessionPartTracker
 
 /**
@@ -19,7 +19,7 @@ interface EssentialServiceModule {
     val userService: UserService
     val networkConnectivityService: NetworkConnectivityService
     val sessionPartTracker: SessionPartTracker
-    val sessionIdProvider: SessionIdProvider
+    val sessionIdsProvider: SessionIdsProvider
     val userSessionPropertiesService: UserSessionPropertiesService
     val telemetryDestination: TelemetryDestination
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
@@ -17,8 +17,8 @@ import io.embrace.android.embracesdk.internal.capture.user.EmbraceUserService
 import io.embrace.android.embracesdk.internal.capture.user.UserService
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.navigation.NavigationTrackingServiceImpl
-import io.embrace.android.embracesdk.internal.session.id.SessionIdProvider
-import io.embrace.android.embracesdk.internal.session.id.SessionIdProviderImpl
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsProvider
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsProviderImpl
 import io.embrace.android.embracesdk.internal.session.id.SessionPartTracker
 import io.embrace.android.embracesdk.internal.session.id.SessionPartTrackerImpl
 import io.embrace.android.embracesdk.internal.session.lifecycle.AppStateTrackerImpl
@@ -88,8 +88,8 @@ class EssentialServiceModuleImpl(
         )
     }
 
-    override val sessionIdProvider: SessionIdProvider by singleton {
-        SessionIdProviderImpl(sessionOrchestratorProvider, sessionPartTracker)
+    override val sessionIdsProvider: SessionIdsProvider by singleton {
+        SessionIdsProviderImpl(sessionOrchestratorProvider, sessionPartTracker)
     }
 
     override val userSessionPropertiesService: UserSessionPropertiesService by singleton {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InstrumentationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InstrumentationModuleImpl.kt
@@ -16,7 +16,7 @@ class InstrumentationModuleImpl(
     essentialServiceModule: EssentialServiceModule,
     coreModule: CoreModule,
     storageService: StorageService,
-    userSessionIdProvider: () -> String?,
+    userSessionIdsProvider: () -> String?,
     activeSessionIdsProvider: () -> SessionIdsSnapshot,
 ) : InstrumentationModule {
 
@@ -41,7 +41,7 @@ class InstrumentationModuleImpl(
             sessionPartTracker = essentialServiceModule.sessionPartTracker,
             ordinalStore = coreModule.ordinalStore,
             userSessionPropertiesService = essentialServiceModule.userSessionPropertiesService,
-            userSessionIdProvider = userSessionIdProvider,
+            userSessionIdsProvider = userSessionIdsProvider,
             activeSessionIdsProvider = activeSessionIdsProvider,
             processIdentifier = openTelemetryModule.otelSdkConfig.processIdentifier,
             crashMarkerFileProvider = { storageService.getFileForWrite("embrace_crash_marker") },

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModule.kt
@@ -9,7 +9,7 @@ import io.embrace.android.embracesdk.internal.otel.sdk.OtelSdkWrapper
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSink
-import io.embrace.android.embracesdk.internal.session.id.SessionIdProvider
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsProvider
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionPartSpan
 import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
 
@@ -75,5 +75,5 @@ interface OpenTelemetryModule {
     /**
      * Provide the session-related IDs to be stamped on OTel signals
      */
-    fun setSessionIdProvider(sessionIdProvider: SessionIdProvider)
+    fun setSessionIdsProvider(sessionIdsProvider: SessionIdsProvider)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
@@ -20,7 +20,7 @@ import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSink
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSinkImpl
-import io.embrace.android.embracesdk.internal.session.id.SessionIdProvider
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsProvider
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionPartSpan
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionPartSpanImpl
 import io.embrace.android.embracesdk.internal.spans.EmbraceTracer
@@ -35,7 +35,7 @@ class OpenTelemetryModuleImpl(
 
     private val processIdentifierProvider: () -> String by lazy { IdGenerator.Companion::generateLaunchInstanceId }
 
-    private var storedSessionIdProvider: SessionIdProvider? = null
+    private var storedSessionIdsProvider: SessionIdsProvider? = null
 
     private var otelBehavior: OtelBehavior? = null
 
@@ -56,7 +56,7 @@ class OpenTelemetryModuleImpl(
             appVersion = initModule.instrumentedConfig.project.getVersionName() ?: "UNKNOWN",
             packageName = initModule.instrumentedConfig.project.getPackageName() ?: "UNKNOWN",
             systemInfo = initModule.systemInfo,
-            sessionIdProvider = { storedSessionIdProvider },
+            sessionIdsProvider = { storedSessionIdsProvider },
             processIdentifierProvider = processIdentifierProvider,
         )
     }
@@ -91,8 +91,8 @@ class OpenTelemetryModuleImpl(
         setupOtelBehavior(otelBehavior)
     }
 
-    override fun setSessionIdProvider(sessionIdProvider: SessionIdProvider) {
-        storedSessionIdProvider = sessionIdProvider
+    override fun setSessionIdsProvider(sessionIdsProvider: SessionIdsProvider) {
+        storedSessionIdsProvider = sessionIdsProvider
     }
 
     private fun setupOtelBehavior(otelBehavior: OtelBehavior) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SupplierTypealiases.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SupplierTypealiases.kt
@@ -63,7 +63,7 @@ typealias InstrumentationModuleSupplier = (
     essentialServiceModule: EssentialServiceModule,
     coreModule: CoreModule,
     storageService: StorageService,
-    userSessionIdProvider: () -> String?,
+    userSessionIdsProvider: () -> String?,
     activeSessionIdsProvider: () -> SessionIdsSnapshot,
 ) -> InstrumentationModule
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModule.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.injection
 
-import io.embrace.android.embracesdk.internal.session.id.SessionIdProvider
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsProvider
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionOrchestrator
 
 /**
@@ -8,5 +8,5 @@ import io.embrace.android.embracesdk.internal.session.orchestrator.SessionOrches
  */
 interface UserSessionOrchestrationModule {
     val sessionOrchestrator: SessionOrchestrator
-    val sessionIdProvider: SessionIdProvider
+    val sessionIdsProvider: SessionIdsProvider
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.session.UserSessionMetadataStore
-import io.embrace.android.embracesdk.internal.session.id.SessionIdProvider
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsProvider
 import io.embrace.android.embracesdk.internal.session.message.PayloadFactoryImpl
 import io.embrace.android.embracesdk.internal.session.message.PayloadMessageCollatorImpl
 import io.embrace.android.embracesdk.internal.session.orchestrator.OrchestratorBoundaryDelegate
@@ -26,15 +26,15 @@ class UserSessionOrchestrationModuleImpl(
     workerThreadModule: WorkerThreadModule,
 ) : UserSessionOrchestrationModule {
 
-    override val sessionIdProvider: SessionIdProvider by singleton {
-        essentialServiceModule.sessionIdProvider
+    override val sessionIdsProvider: SessionIdsProvider by singleton {
+        essentialServiceModule.sessionIdsProvider
     }
 
     override val sessionOrchestrator: SessionOrchestrator by singleton {
         val payloadMessageCollator = PayloadMessageCollatorImpl(
             EmbTrace.trace("sessionEnvelopeSource") { payloadSourceModule.sessionPartEnvelopeSource },
             openTelemetryModule.currentSessionPartSpan,
-            essentialServiceModule.sessionIdProvider,
+            essentialServiceModule.sessionIdsProvider,
         )
 
         val payloadFactory = PayloadFactoryImpl(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionIdsProviderImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionIdsProviderImpl.kt
@@ -2,10 +2,10 @@ package io.embrace.android.embracesdk.internal.session.id
 
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionOrchestrator
 
-internal class SessionIdProviderImpl(
+internal class SessionIdsProviderImpl(
     private val sessionOrchestratorProvider: () -> SessionOrchestrator?,
     private val sessionPartTracker: SessionPartTracker,
-) : SessionIdProvider {
+) : SessionIdsProvider {
 
     override fun getCurrentUserSessionId(): String =
         sessionOrchestratorProvider()?.currentUserSession()?.userSessionId ?: ""

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImpl.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.internal.envelope.session.SessionPartEnvelo
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
 import io.embrace.android.embracesdk.internal.session.SessionPartToken
-import io.embrace.android.embracesdk.internal.session.id.SessionIdProvider
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsProvider
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionPartSpan
 
 /**
@@ -13,14 +13,14 @@ import io.embrace.android.embracesdk.internal.spans.CurrentSessionPartSpan
 internal class PayloadMessageCollatorImpl(
     private val sessionPartEnvelopeSource: SessionPartEnvelopeSource,
     private val currentSessionPartSpan: CurrentSessionPartSpan,
-    private val sessionIdProvider: SessionIdProvider,
+    private val sessionIdsProvider: SessionIdsProvider,
 ) : PayloadMessageCollator {
 
     override fun buildInitialPart(params: InitialEnvelopeParams): SessionPartToken = with(params) {
         currentSessionPartSpan.readySession()
         SessionPartToken(
             sessionPartId = currentSessionPartSpan.getId(),
-            userSessionId = sessionIdProvider.getCurrentUserSessionId(),
+            userSessionId = sessionIdsProvider.getCurrentUserSessionId(),
             startTime = startTime,
             appState = appState,
             isColdStart = coldStart,

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingServiceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingServiceImplTest.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorServic
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakePayloadStore
-import io.embrace.android.embracesdk.fakes.FakeSessionIdProvider
+import io.embrace.android.embracesdk.fakes.FakeSessionIdsProvider
 import io.embrace.android.embracesdk.fakes.fakeSessionEnvelope
 import io.embrace.android.embracesdk.fakes.fakeSessionPartToken
 import io.embrace.android.embracesdk.internal.arch.state.AppState
@@ -21,19 +21,19 @@ class PayloadCachingServiceImplTest {
 
     private lateinit var executorService: BlockingScheduledExecutorService
     private lateinit var service: PayloadCachingService
-    private lateinit var sessionIdProvider: FakeSessionIdProvider
+    private lateinit var sessionIdsProvider: FakeSessionIdsProvider
     private val zygote = fakeSessionPartToken()
 
     @Before
     fun setUp() {
         executorService = BlockingScheduledExecutorService(FakeClock())
         val cacher = PeriodicSessionPartCacher(BackgroundWorker(executorService), FakeInternalLogger(), INTERVAL)
-        sessionIdProvider = FakeSessionIdProvider(sessionPartId = zygote.sessionPartId)
+        sessionIdsProvider = FakeSessionIdsProvider(sessionPartId = zygote.sessionPartId)
 
         service = PayloadCachingServiceImpl(
             cacher,
             FakeClock(),
-            sessionIdProvider,
+            sessionIdsProvider,
             FakePayloadStore()
         )
     }
@@ -48,7 +48,7 @@ class PayloadCachingServiceImplTest {
 
     @Test
     fun `session id mismatch does not cache`() {
-        sessionIdProvider.sessionPartId = "someOtherId"
+        sessionIdsProvider.sessionPartId = "someOtherId"
         var count = 0
         service.startCaching(zygote, AppState.FOREGROUND) { _, _, _ ->
             count++

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/injection/InstrumentationModuleImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/injection/InstrumentationModuleImplTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeOpenTelemetryModule
-import io.embrace.android.embracesdk.fakes.FakeSessionIdProvider
+import io.embrace.android.embracesdk.fakes.FakeSessionIdsProvider
 import io.embrace.android.embracesdk.fakes.FakeStorageService
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
@@ -29,8 +29,8 @@ internal class InstrumentationModuleImplTest {
             essentialServiceModule = FakeEssentialServiceModule(),
             coreModule = FakeCoreModule(),
             storageService = FakeStorageService(),
-            userSessionIdProvider = { null },
-            activeSessionIdsProvider = { FakeSessionIdProvider().getActiveSessionIds() },
+            userSessionIdsProvider = { null },
+            activeSessionIdsProvider = { FakeSessionIdsProvider().getActiveSessionIds() },
         )
         assertSame(module.instrumentationRegistry, module.instrumentationRegistry)
         assertNotNull(module.instrumentationRegistry)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/PayloadFactoryBaTest.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakeOtelPayloadMapper
-import io.embrace.android.embracesdk.fakes.FakeSessionIdProvider
+import io.embrace.android.embracesdk.fakes.FakeSessionIdsProvider
 import io.embrace.android.embracesdk.fakes.FakeSessionPartTracker
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.createBackgroundActivityBehavior
@@ -123,7 +123,7 @@ internal class PayloadFactoryBaTest {
         val collator = PayloadMessageCollatorImpl(
             payloadSourceModule.sessionPartEnvelopeSource,
             currentSessionPartSpan,
-            FakeSessionIdProvider(),
+            FakeSessionIdsProvider(),
         )
         return PayloadFactoryImpl(collator, payloadSourceModule.logEnvelopeSource, configService, logger).apply {
             if (createInitialSession) {

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/PayloadFactorySessionPartTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/PayloadFactorySessionPartTest.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.fakes.FakeAppStateTracker
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
-import io.embrace.android.embracesdk.fakes.FakeSessionIdProvider
+import io.embrace.android.embracesdk.fakes.FakeSessionIdsProvider
 import io.embrace.android.embracesdk.fakes.FakeSessionPartTracker
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
@@ -100,7 +100,7 @@ internal class PayloadFactorySessionPartTest {
         val collator = PayloadMessageCollatorImpl(
             payloadSourceModule.sessionPartEnvelopeSource,
             currentSessionPartSpan,
-            FakeSessionIdProvider(),
+            FakeSessionIdsProvider(),
         )
         service = PayloadFactoryImpl(collator, payloadSourceModule.logEnvelopeSource, FakeConfigService(), logger)
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionHandlerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionHandlerTest.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
 import io.embrace.android.embracesdk.fakes.FakeMetadataService
 import io.embrace.android.embracesdk.fakes.FakeOtelPayloadMapper
-import io.embrace.android.embracesdk.fakes.FakeSessionIdProvider
+import io.embrace.android.embracesdk.fakes.FakeSessionIdsProvider
 import io.embrace.android.embracesdk.fakes.FakeSessionPartTracker
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.FakeUserSessionPropertiesService
@@ -98,7 +98,7 @@ internal class UserSessionHandlerTest {
                 payloadSource = partPayloadSource
             ),
             currentSessionPartSpan,
-            FakeSessionIdProvider(),
+            FakeSessionIdsProvider(),
         )
         payloadFactory = PayloadFactoryImpl(collator, payloadSourceModule.logEnvelopeSource, configService, logger)
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionIdsProviderImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionIdsProviderImplTest.kt
@@ -8,17 +8,17 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
-internal class SessionIdProviderImplTest {
+internal class SessionIdsProviderImplTest {
 
     private lateinit var sessionOrchestrator: FakeSessionOrchestrator
     private lateinit var sessionPartTracker: FakeSessionPartTracker
-    private lateinit var provider: SessionIdProviderImpl
+    private lateinit var provider: SessionIdsProviderImpl
 
     @Before
     fun setUp() {
         sessionOrchestrator = FakeSessionOrchestrator()
         sessionPartTracker = FakeSessionPartTracker()
-        provider = SessionIdProviderImpl({ sessionOrchestrator }, sessionPartTracker)
+        provider = SessionIdsProviderImpl({ sessionOrchestrator }, sessionPartTracker)
     }
 
     @Test

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImplTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.session.message
 
 import io.embrace.android.embracesdk.fakes.FakeConfigService
-import io.embrace.android.embracesdk.fakes.FakeSessionIdProvider
+import io.embrace.android.embracesdk.fakes.FakeSessionIdsProvider
 import io.embrace.android.embracesdk.fakes.FakeSessionPartPayloadSource
 import io.embrace.android.embracesdk.fakes.createBackgroundActivityBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
@@ -35,7 +35,7 @@ internal class PayloadFactoryImplTest {
         val collator = PayloadMessageCollatorImpl(
             sessionPartEnvelopeSource = payloadSourceModule.sessionPartEnvelopeSource,
             currentSessionPartSpan = initModule.openTelemetryModule.currentSessionPartSpan,
-            sessionIdProvider = FakeSessionIdProvider(),
+            sessionIdsProvider = FakeSessionIdsProvider(),
         )
         factory = PayloadFactoryImpl(
             payloadMessageCollator = collator,

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImplTest.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.session.message
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
-import io.embrace.android.embracesdk.fakes.FakeSessionIdProvider
+import io.embrace.android.embracesdk.fakes.FakeSessionIdsProvider
 import io.embrace.android.embracesdk.fakes.FakeSessionPartPayloadSource
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.arch.state.AppState
@@ -45,7 +45,7 @@ internal class PayloadMessageCollatorImplTest {
         collator = PayloadMessageCollatorImpl(
             sessionPartEnvelopeSource = sessionPartEnvelopeSource,
             currentSessionPartSpan = currentSessionPartSpan,
-            sessionIdProvider = FakeSessionIdProvider(),
+            sessionIdsProvider = FakeSessionIdsProvider(),
         )
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorListenerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorListenerTest.kt
@@ -39,7 +39,7 @@ import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.session.UserSessionMetadata
 import io.embrace.android.embracesdk.internal.session.UserSessionMetadataStore
 import io.embrace.android.embracesdk.internal.session.caching.PeriodicSessionPartCacher
-import io.embrace.android.embracesdk.internal.session.id.SessionIdProvider
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsProvider
 import io.embrace.android.embracesdk.internal.session.id.SessionIdsSnapshot
 import io.embrace.android.embracesdk.internal.session.id.SessionPartTracker
 import io.embrace.android.embracesdk.internal.session.id.SessionPartTrackerImpl
@@ -307,7 +307,7 @@ internal class SessionOrchestratorListenerTest {
                 logger
             ),
             clock,
-            object : SessionIdProvider {
+            object : SessionIdsProvider {
                 override fun getCurrentSessionPartId(): String = sessionTracker.getActiveSessionPartId() ?: ""
                 override fun getCurrentUserSessionId(): String = ""
                 override fun getActiveSessionIds(): SessionIdsSnapshot =

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -41,7 +41,7 @@ import io.embrace.android.embracesdk.internal.session.UserSessionMetadata
 import io.embrace.android.embracesdk.internal.session.UserSessionMetadataStore
 import io.embrace.android.embracesdk.internal.session.UserSessionRestoreDecision
 import io.embrace.android.embracesdk.internal.session.caching.PeriodicSessionPartCacher
-import io.embrace.android.embracesdk.internal.session.id.SessionIdProvider
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsProvider
 import io.embrace.android.embracesdk.internal.session.id.SessionIdsSnapshot
 import io.embrace.android.embracesdk.internal.session.id.SessionPartTracker
 import io.embrace.android.embracesdk.internal.session.id.SessionPartTrackerImpl
@@ -954,7 +954,7 @@ internal class SessionOrchestratorTest {
                 logger
             ),
             clock,
-            object : SessionIdProvider {
+            object : SessionIdsProvider {
                 override fun getCurrentSessionPartId(): String = sessionTracker.getActiveSessionPartId() ?: ""
                 override fun getCurrentUserSessionId(): String = ""
                 override fun getActiveSessionIds(): SessionIdsSnapshot =

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStoreTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStoreTest.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.session.orchestrator
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeIntakeService
 import io.embrace.android.embracesdk.fakes.FakePayloadIntake
-import io.embrace.android.embracesdk.fakes.FakeSessionIdProvider
+import io.embrace.android.embracesdk.fakes.FakeSessionIdsProvider
 import io.embrace.android.embracesdk.fakes.FakeUuidSource
 import io.embrace.android.embracesdk.fakes.fakeSessionEnvelope
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
@@ -29,18 +29,18 @@ class V2PayloadStoreTest {
 
     private lateinit var store: PayloadStoreImpl
     private lateinit var intakeService: FakeIntakeService
-    private lateinit var sessionIdProvider: FakeSessionIdProvider
+    private lateinit var sessionIdsProvider: FakeSessionIdsProvider
 
     @Before
     fun setUp() {
         intakeService = FakeIntakeService()
-        sessionIdProvider = FakeSessionIdProvider(userSessionId = USER_SESSION_ID, sessionPartId = SESSION_PART_ID)
+        sessionIdsProvider = FakeSessionIdsProvider(userSessionId = USER_SESSION_ID, sessionPartId = SESSION_PART_ID)
         store = PayloadStoreImpl(
             intakeService,
             FakeClock(),
             { "fakeProcessId" },
             FakeUuidSource(),
-            sessionIdProvider::getActiveSessionIds,
+            sessionIdsProvider::getActiveSessionIds,
         )
     }
 

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionIdsProvider.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionIdsProvider.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.session.id
 /**
  * Used to obtain the current user session ID and session part ID.
  */
-interface SessionIdProvider {
+interface SessionIdsProvider {
 
     /**
      * Returns the ID of the current user session.

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionIdsProvider.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionIdsProvider.kt
@@ -1,12 +1,12 @@
 package io.embrace.android.embracesdk.fakes
 
-import io.embrace.android.embracesdk.internal.session.id.SessionIdProvider
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsProvider
 import io.embrace.android.embracesdk.internal.session.id.SessionIdsSnapshot
 
-class FakeSessionIdProvider(
+class FakeSessionIdsProvider(
     var userSessionId: String = "",
     var sessionPartId: String = "",
-) : SessionIdProvider {
+) : SessionIdsProvider {
     override fun getCurrentUserSessionId(): String = userSessionId
     override fun getCurrentSessionPartId(): String = sessionPartId
     override fun getActiveSessionIds(): SessionIdsSnapshot =

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.internal.otel.sdk.IdGenerator
 import io.embrace.android.embracesdk.internal.otel.spans.DefaultSpanExporter
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanProcessor
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSink
-import io.embrace.android.embracesdk.internal.session.id.SessionIdProvider
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsProvider
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.logging.export.LogRecordExporter
@@ -30,7 +30,7 @@ class OtelSdkConfig(
     val appVersion: String,
     val packageName: String,
     private val systemInfo: SystemInfo,
-    private val sessionIdProvider: () -> SessionIdProvider? = { null },
+    private val sessionIdsProvider: () -> SessionIdsProvider? = { null },
     private val processIdentifierProvider: () -> String = IdGenerator.Companion::generateLaunchInstanceId,
 ) {
 
@@ -86,7 +86,7 @@ class OtelSdkConfig(
     }
     val spanProcessor: SpanProcessor by lazy {
         EmbraceSpanProcessor(
-            sessionIdProvider,
+            sessionIdsProvider,
             processIdentifier,
             spanExporter
         )

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanProcessor.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanProcessor.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.internal.otel.spans
 
-import io.embrace.android.embracesdk.internal.session.id.SessionIdProvider
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsProvider
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.export.OperationResultCode
@@ -13,7 +13,7 @@ import kotlinx.coroutines.runBlocking
 import java.util.concurrent.atomic.AtomicLong
 
 class EmbraceSpanProcessor(
-    private val sessionIdProvider: () -> SessionIdProvider?,
+    private val sessionIdsProvider: () -> SessionIdsProvider?,
     private val processIdentifier: String,
     private val spanExporter: SpanExporter,
 ) : SpanProcessor {
@@ -23,7 +23,7 @@ class EmbraceSpanProcessor(
     override fun onStart(span: ReadWriteSpan, parentContext: Context) {
         span.setStringAttribute(EmbSessionAttributes.EMB_PRIVATE_SEQUENCE_ID, counter.getAndIncrement().toString())
         span.setStringAttribute(EmbSessionAttributes.EMB_PROCESS_IDENTIFIER, processIdentifier)
-        sessionIdProvider()?.let { provider ->
+        sessionIdsProvider()?.let { provider ->
             val ids = provider.getActiveSessionIds()
             span.setStringAttribute(EmbSessionAttributes.EMB_SESSION_PART_ID, ids.sessionPartId)
             span.setStringAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID, ids.userSessionId)

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanProcessorTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanProcessorTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.otel.spans
 
 import io.embrace.android.embracesdk.fakes.FakeReadWriteSpan
-import io.embrace.android.embracesdk.fakes.FakeSessionIdProvider
+import io.embrace.android.embracesdk.fakes.FakeSessionIdsProvider
 import io.embrace.android.embracesdk.fakes.FakeSpanExporter
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.opentelemetry.kotlin.NoopOpenTelemetry
@@ -14,7 +14,7 @@ class EmbraceSpanProcessorTest {
     @Test
     fun `test export`() {
         val spanExporter = FakeSpanExporter()
-        val provider = FakeSessionIdProvider(userSessionId = "user-sid", sessionPartId = "part-sid")
+        val provider = FakeSessionIdsProvider(userSessionId = "user-sid", sessionPartId = "part-sid")
         val processor = EmbraceSpanProcessor({ provider }, "pid", spanExporter)
         val span = FakeReadWriteSpan()
         processor.onStart(span, NoopOpenTelemetry.context.implicit())
@@ -32,7 +32,7 @@ class EmbraceSpanProcessorTest {
     @Test
     fun `empty string set for session attributes when ids are absent`() {
         val spanExporter = FakeSpanExporter()
-        val provider = FakeSessionIdProvider(userSessionId = "", sessionPartId = "")
+        val provider = FakeSessionIdsProvider(userSessionId = "", sessionPartId = "")
         val processor = EmbraceSpanProcessor({ provider }, "pid", spanExporter)
         val span = FakeReadWriteSpan()
         processor.onStart(span, NoopOpenTelemetry.context.implicit())
@@ -45,7 +45,7 @@ class EmbraceSpanProcessorTest {
     @Test
     fun `empty string set for user session id when only session part id is absent`() {
         val spanExporter = FakeSpanExporter()
-        val provider = FakeSessionIdProvider(userSessionId = "", sessionPartId = "part-sid")
+        val provider = FakeSessionIdsProvider(userSessionId = "", sessionPartId = "part-sid")
         val processor = EmbraceSpanProcessor({ provider }, "pid", spanExporter)
         val span = FakeReadWriteSpan()
         processor.onStart(span, NoopOpenTelemetry.context.implicit())

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanServiceTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanServiceTest.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeEmbraceSpanFactory
 import io.embrace.android.embracesdk.fakes.FakeEventService
 import io.embrace.android.embracesdk.fakes.FakeOtelKotlinClock
-import io.embrace.android.embracesdk.fakes.FakeSessionIdProvider
+import io.embrace.android.embracesdk.fakes.FakeSessionIdsProvider
 import io.embrace.android.embracesdk.fakes.FakeSpanService
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.TestConstants.TESTS_DEFAULT_USE_KOTLIN_SDK
@@ -49,7 +49,7 @@ internal class EmbraceSpanServiceTest {
             appVersion = "1.0.0",
             packageName = "com.test.app",
             systemInfo = SystemInfo(),
-            sessionIdProvider = { FakeSessionIdProvider(userSessionId = "fake-session-id") },
+            sessionIdsProvider = { FakeSessionIdsProvider(userSessionId = "fake-session-id") },
             processIdentifierProvider = { "fake-pid" }
         )
         val otelSdkWrapper = OtelSdkWrapper(

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
@@ -9,7 +9,7 @@ import io.embrace.android.embracesdk.assertions.assertNotPrivateSpan
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeEventService
 import io.embrace.android.embracesdk.fakes.FakeOtelKotlinClock
-import io.embrace.android.embracesdk.fakes.FakeSessionIdProvider
+import io.embrace.android.embracesdk.fakes.FakeSessionIdsProvider
 import io.embrace.android.embracesdk.fakes.FakeSpanService
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.TestConstants.TESTS_DEFAULT_USE_KOTLIN_SDK
@@ -623,7 +623,7 @@ internal class SpanServiceImplTest {
             appVersion = "1.0.0",
             packageName = "com.test.app",
             systemInfo = SystemInfo(),
-            sessionIdProvider = { FakeSessionIdProvider(userSessionId = "fake-session-id") },
+            sessionIdsProvider = { FakeSessionIdsProvider(userSessionId = "fake-session-id") },
             processIdentifierProvider = { "fake-pid" }
         )
         val otelSdkWrapper = OtelSdkWrapper(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalLoggerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalLoggerTest.kt
@@ -153,7 +153,7 @@ internal class ExternalLoggerTest {
                 clock.tick()
                 logTime = clock.now().millisToNanos()
                 embrace.addUserSessionProperty("bg-attr", "blah", PropertyScope.PERMANENT)
-                sessionId = testRule.bootstrapper.userSessionOrchestrationModule.sessionIdProvider.getCurrentUserSessionId()
+                sessionId = testRule.bootstrapper.userSessionOrchestrationModule.sessionIdsProvider.getCurrentUserSessionId()
                 val span = embOpenTelemetry.getTracer("").startSpan("my-span")
                 parentContext = span.spanContext
                 embLogger.emit(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalOtelJavaLoggerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalOtelJavaLoggerTest.kt
@@ -149,7 +149,7 @@ internal class ExternalOtelJavaLoggerTest {
                 clock.tick()
                 logTime = clock.now().millisToNanos()
                 embrace.addUserSessionProperty("bg-attr", "blah", PropertyScope.PERMANENT)
-                sessionId = testRule.bootstrapper.userSessionOrchestrationModule.sessionIdProvider.getCurrentUserSessionId()
+                sessionId = testRule.bootstrapper.userSessionOrchestrationModule.sessionIdsProvider.getCurrentUserSessionId()
                 val span = embOpenTelemetry.getTracer("").spanBuilder("my-span").startSpan()
                 val logContext = span.storeInContext(OtelJavaContext.root())
                 parentContext = span.spanContext

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -172,7 +172,7 @@ internal class EmbraceSetupInterface(
                 essentialServiceModule,
                 coreModule,
                 storageModule,
-                userSessionIdProvider,
+                userSessionIdsProvider,
                 activeSessionIdsProvider,
             ->
             val impl = InstrumentationModuleImpl(
@@ -183,7 +183,7 @@ internal class EmbraceSetupInterface(
                 essentialServiceModule,
                 coreModule,
                 storageModule,
-                userSessionIdProvider,
+                userSessionIdsProvider,
                 activeSessionIdsProvider,
             )
             object : InstrumentationModule {

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegate.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegate.kt
@@ -10,8 +10,8 @@ internal class SdkStateApiDelegate(
     private val sdkCallChecker: SdkCallChecker,
 ) : SdkStateApi {
 
-    private val sessionIdProvider by embraceImplInject(sdkCallChecker) {
-        bootstrapper.userSessionOrchestrationModule.sessionIdProvider
+    private val sessionIdsProvider by embraceImplInject(sdkCallChecker) {
+        bootstrapper.userSessionOrchestrationModule.sessionIdsProvider
     }
     private val deviceIdentifier by embraceImplInject(sdkCallChecker) {
         bootstrapper.configService.deviceId
@@ -32,9 +32,9 @@ internal class SdkStateApiDelegate(
 
     override val currentUserSessionId: String?
         get() {
-            val localSessionIdProvider = sessionIdProvider
-            if (localSessionIdProvider != null && sdkCallChecker.check("get_current_session_id")) {
-                return localSessionIdProvider.getCurrentUserSessionId()
+            val localSessionIdsProvider = sessionIdsProvider
+            if (localSessionIdsProvider != null && sdkCallChecker.check("get_current_session_id")) {
+                return localSessionIdsProvider.getCurrentUserSessionId()
             }
             return null
         }

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
@@ -94,8 +94,8 @@ internal class InitializedModuleGraph(
             essentialServiceModule,
             coreModule,
             storageService,
-            { userSessionOrchestrationModule.sessionIdProvider.getCurrentUserSessionId() },
-            { userSessionOrchestrationModule.sessionIdProvider.getActiveSessionIds() },
+            { userSessionOrchestrationModule.sessionIdsProvider.getCurrentUserSessionId() },
+            { userSessionOrchestrationModule.sessionIdsProvider.getActiveSessionIds() },
         )
     }
 

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -128,7 +128,7 @@ internal class ModuleInitBootstrapper(
             essentialServiceModule: EssentialServiceModule,
             coreModule: CoreModule,
             storageService: StorageService,
-            userSessionIdProvider,
+            userSessionIdsProvider,
             activeSessionIdsProvider,
         ->
         InstrumentationModuleImpl(
@@ -139,7 +139,7 @@ internal class ModuleInitBootstrapper(
             essentialServiceModule,
             coreModule,
             storageService,
-            userSessionIdProvider,
+            userSessionIdsProvider,
             activeSessionIdsProvider,
         )
     },

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
@@ -49,7 +49,7 @@ internal fun ModuleGraph.postInit() {
     essentialServiceModule.telemetryDestination.currentStatesProvider =
         instrumentationModule.instrumentationRegistry::getCurrentStates
 
-    openTelemetryModule.setSessionIdProvider(userSessionOrchestrationModule.sessionIdProvider)
+    openTelemetryModule.setSessionIdsProvider(userSessionOrchestrationModule.sessionIdsProvider)
 
     // Start the orchestrator and create the first session part once all the module dependencies have been created and wired up
     userSessionOrchestrationModule.sessionOrchestrator.start()
@@ -189,7 +189,7 @@ private fun ModuleGraph.eventMetadataSupplierProvider(): Provider<Map<String, St
         mutableMapOf<String, String>().apply {
             val sessionPart = essentialServiceModule.sessionPartTracker.getActiveSessionPart()
             val sessionState = sessionPart?.appState ?: essentialServiceModule.appStateTracker.getAppState()
-            val sessionIds = userSessionOrchestrationModule.sessionIdProvider.getActiveSessionIds()
+            val sessionIds = userSessionOrchestrationModule.sessionIdsProvider.getActiveSessionIds()
 
             put(EmbSessionAttributes.EMB_SESSION_PART_ID, sessionIds.sessionPartId)
             put(EmbSessionAttributes.EMB_USER_SESSION_ID, sessionIds.userSessionId)

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegateTest.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.LastRunEndState
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeLogService
-import io.embrace.android.embracesdk.fakes.FakeSessionIdProvider
+import io.embrace.android.embracesdk.fakes.FakeSessionIdsProvider
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.TestUuidSource
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
@@ -26,7 +26,7 @@ internal class SdkStateApiDelegateTest {
     private lateinit var delegate: SdkStateApiDelegate
     private lateinit var logService: FakeLogService
     private lateinit var configService: FakeConfigService
-    private lateinit var sessionIdProvider: FakeSessionIdProvider
+    private lateinit var sessionIdsProvider: FakeSessionIdsProvider
     private lateinit var sdkCallChecker: SdkCallChecker
     private lateinit var logger: FakeInternalLogger
 
@@ -34,7 +34,7 @@ internal class SdkStateApiDelegateTest {
     fun setUp() {
         logService = FakeLogService()
         configService = FakeConfigService(deviceId = TestUuidSource().createUuid())
-        sessionIdProvider = FakeSessionIdProvider()
+        sessionIdsProvider = FakeSessionIdsProvider()
         val moduleInitBootstrapper = ModuleInitBootstrapper(
             FakeInitModule(),
             configServiceSupplier = { _, _, _, _ ->
@@ -47,7 +47,7 @@ internal class SdkStateApiDelegateTest {
                 FakeLogModule(logService = logService)
             },
             userSessionOrchestrationModuleSupplier = { _, _, _, _, _, _, _, _, _, _, _ ->
-                FakeUserSessionOrchestrationModule(sessionIdProvider = sessionIdProvider)
+                FakeUserSessionOrchestrationModule(sessionIdsProvider = sessionIdsProvider)
             },
         )
         moduleInitBootstrapper.init(ApplicationProvider.getApplicationContext())
@@ -78,7 +78,7 @@ internal class SdkStateApiDelegateTest {
 
     @Test
     fun getCurrentSessionId() {
-        sessionIdProvider.userSessionId = "test"
+        sessionIdsProvider.userSessionId = "test"
         assertEquals("test", delegate.currentUserSessionId)
     }
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.config.behavior.OtelBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehavior
 import io.embrace.android.embracesdk.internal.injection.OpenTelemetryModule
-import io.embrace.android.embracesdk.internal.session.id.SessionIdProvider
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsProvider
 import io.embrace.android.embracesdk.internal.otel.config.OtelSdkConfig
 import io.embrace.android.embracesdk.internal.otel.logs.EventService
 import io.embrace.android.embracesdk.internal.otel.logs.LogSink
@@ -59,7 +59,7 @@ class FakeOpenTelemetryModule(
         // no-op
     }
 
-    override fun setSessionIdProvider(sessionIdProvider: SessionIdProvider) {
+    override fun setSessionIdsProvider(sessionIdsProvider: SessionIdsProvider) {
         // no-op
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeEssentialServiceModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeEssentialServiceModule.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.fakes.injection
 import io.embrace.android.embracesdk.fakes.FakeAppStateTracker
 import io.embrace.android.embracesdk.fakes.FakeNavigationTrackingService
 import io.embrace.android.embracesdk.fakes.FakeNetworkConnectivityService
-import io.embrace.android.embracesdk.fakes.FakeSessionIdProvider
+import io.embrace.android.embracesdk.fakes.FakeSessionIdsProvider
 import io.embrace.android.embracesdk.fakes.FakeSessionPartTracker
 import io.embrace.android.embracesdk.fakes.FakeTelemetryDestination
 import io.embrace.android.embracesdk.fakes.FakeUserService
@@ -14,14 +14,14 @@ import io.embrace.android.embracesdk.internal.arch.state.AppStateTracker
 import io.embrace.android.embracesdk.internal.capture.connectivity.NetworkConnectivityService
 import io.embrace.android.embracesdk.internal.capture.user.UserService
 import io.embrace.android.embracesdk.internal.injection.EssentialServiceModule
-import io.embrace.android.embracesdk.internal.session.id.SessionIdProvider
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsProvider
 import io.embrace.android.embracesdk.internal.session.id.SessionPartTracker
 
 class FakeEssentialServiceModule(
     override val appStateTracker: AppStateTracker = FakeAppStateTracker(),
     override val navigationTrackingService: NavigationTrackingService = FakeNavigationTrackingService(),
     override val sessionPartTracker: SessionPartTracker = FakeSessionPartTracker(),
-    override val sessionIdProvider: SessionIdProvider = FakeSessionIdProvider(),
+    override val sessionIdsProvider: SessionIdsProvider = FakeSessionIdsProvider(),
     override val userService: UserService = FakeUserService(),
     override val networkConnectivityService: NetworkConnectivityService = FakeNetworkConnectivityService(),
     override val telemetryDestination: TelemetryDestination = FakeTelemetryDestination(),

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeUserSessionOrchestrationModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeUserSessionOrchestrationModule.kt
@@ -1,12 +1,12 @@
 package io.embrace.android.embracesdk.fakes.injection
 
-import io.embrace.android.embracesdk.fakes.FakeSessionIdProvider
+import io.embrace.android.embracesdk.fakes.FakeSessionIdsProvider
 import io.embrace.android.embracesdk.fakes.FakeSessionOrchestrator
 import io.embrace.android.embracesdk.internal.injection.UserSessionOrchestrationModule
-import io.embrace.android.embracesdk.internal.session.id.SessionIdProvider
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsProvider
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionOrchestrator
 
 class FakeUserSessionOrchestrationModule(
     override val sessionOrchestrator: SessionOrchestrator = FakeSessionOrchestrator(),
-    override val sessionIdProvider: SessionIdProvider = FakeSessionIdProvider(),
+    override val sessionIdsProvider: SessionIdsProvider = FakeSessionIdsProvider(),
 ) : UserSessionOrchestrationModule


### PR DESCRIPTION
Rename the providers of the user session and session part IDs appropriately. This touches a lot of files, but it is simple rename change.