### PR TITLE
Rename parameter and variable names with unqualified use of session

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpan.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpan.kt
@@ -30,7 +30,7 @@ interface CurrentSessionPartSpan : Initializable {
     fun canStartNewSpan(parent: EmbraceSpan?, internal: Boolean): Boolean
 
     /**
-     * Returns the current session ID
+     * Returns the current session part ID
      */
     fun getId(): String
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImpl.kt
@@ -110,13 +110,13 @@ internal class CurrentSessionPartSpanImpl(
                 }
             }
 
-            val sessionId = currentSessionPartSpan?.getSystemAttribute(SessionAttributes.SESSION_ID)
-            if (sessionId != null) {
+            val otelSessionId = currentSessionPartSpan?.getSystemAttribute(SessionAttributes.SESSION_ID)
+            if (otelSessionId != null) {
                 currentSessionPartSpan.spanContext?.let { sessionSpanContext ->
                     spanToStop?.addSystemLink(
                         linkedSpanContext = sessionSpanContext,
                         type = LinkType.EndSession,
-                        attributes = mapOf(SessionAttributes.SESSION_ID to sessionId) + sessionIds
+                        attributes = mapOf(SessionAttributes.SESSION_ID to otelSessionId) + sessionIds
                     )
                 }
             }
@@ -195,11 +195,11 @@ internal class CurrentSessionPartSpanImpl(
             setSystemAttribute(SessionAttributes.SESSION_ID, uuidSource.createUuid())
             val previousSessionSpan = lastSessionSpan
             previousSessionSpan?.spanContext?.let {
-                val prevSessionId = previousSessionSpan.getSystemAttribute(SessionAttributes.SESSION_ID) ?: ""
+                val previousOtelSessionId = previousSessionSpan.getSystemAttribute(SessionAttributes.SESSION_ID) ?: ""
                 addSystemLink(
                     linkedSpanContext = it,
                     type = LinkType.PreviousSession,
-                    attributes = mapOf(SessionAttributes.SESSION_ID to prevSessionId) +
+                    attributes = mapOf(SessionAttributes.SESSION_ID to previousOtelSessionId) +
                         previousSessionSpan.userSessionIdAttrs()
                 )
             }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/schema/TelemetryAttributesTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/schema/TelemetryAttributesTest.kt
@@ -12,24 +12,24 @@ internal class TelemetryAttributesTest {
 
     private lateinit var customAttributes: Map<String, String>
     private lateinit var telemetryAttributes: TelemetryAttributes
-    private lateinit var sessionId: String
+    private lateinit var otelSessionId: String
 
     @Before
     fun setup() {
         customAttributes = mapOf("custom" to "attributeValue")
-        sessionId = TestUuidSource().createUuid()
+        otelSessionId = TestUuidSource().createUuid()
     }
 
     @Test
     fun `only schema properties`() {
         telemetryAttributes = TelemetryAttributes()
-        telemetryAttributes.setAttribute(SessionAttributes.SESSION_ID, sessionId)
+        telemetryAttributes.setAttribute(SessionAttributes.SESSION_ID, otelSessionId)
         telemetryAttributes.setAttribute(ExceptionAttributes.EXCEPTION_TYPE, "exceptionValue")
         val attributes = telemetryAttributes.snapshot()
         assertEquals(2, attributes.size)
-        assertEquals(sessionId, attributes[SessionAttributes.SESSION_ID])
+        assertEquals(otelSessionId, attributes[SessionAttributes.SESSION_ID])
         assertEquals("exceptionValue", attributes[ExceptionAttributes.EXCEPTION_TYPE])
-        assertEquals(sessionId, telemetryAttributes.getAttribute(SessionAttributes.SESSION_ID))
+        assertEquals(otelSessionId, telemetryAttributes.getAttribute(SessionAttributes.SESSION_ID))
         assertEquals("exceptionValue", telemetryAttributes.getAttribute(ExceptionAttributes.EXCEPTION_TYPE))
     }
 
@@ -38,37 +38,37 @@ internal class TelemetryAttributesTest {
         telemetryAttributes = TelemetryAttributes(
             customAttributes = customAttributes
         )
-        val sessionIdKey = SessionAttributes.SESSION_ID
-        telemetryAttributes.setAttribute(sessionIdKey, sessionId)
+        val otelSessionIdKey = SessionAttributes.SESSION_ID
+        telemetryAttributes.setAttribute(otelSessionIdKey, otelSessionId)
 
         val attributes = telemetryAttributes.snapshot()
         assertEquals("attributeValue", attributes["custom"])
-        assertEquals(sessionId, attributes[sessionIdKey])
+        assertEquals(otelSessionId, attributes[otelSessionIdKey])
     }
 
     @Test
     fun `overwritten values returned`() {
-        val newSessionId = TestUuidSource().createUuid()
+        val newOtelSessionId = TestUuidSource().createUuid()
         telemetryAttributes = TelemetryAttributes()
-        val sessionIdKey = SessionAttributes.SESSION_ID
-        telemetryAttributes.setAttribute(sessionIdKey, sessionId)
-        telemetryAttributes.setAttribute(sessionIdKey, newSessionId)
+        val otelSessionIdKey = SessionAttributes.SESSION_ID
+        telemetryAttributes.setAttribute(otelSessionIdKey, otelSessionId)
+        telemetryAttributes.setAttribute(otelSessionIdKey, newOtelSessionId)
 
         val attributes = telemetryAttributes.snapshot()
         assertEquals(1, attributes.size)
-        assertEquals(newSessionId, attributes[sessionIdKey])
+        assertEquals(newOtelSessionId, attributes[otelSessionIdKey])
     }
 
     @Test
     fun `schema attribute values take priority if the same key is used`() {
-        val newSessionId = TestUuidSource().createUuid()
+        val newOtelSessionId = TestUuidSource().createUuid()
         telemetryAttributes = TelemetryAttributes(
-            customAttributes = mapOf(SessionAttributes.SESSION_ID to sessionId)
+            customAttributes = mapOf(SessionAttributes.SESSION_ID to otelSessionId)
         )
-        telemetryAttributes.setAttribute(SessionAttributes.SESSION_ID, newSessionId)
+        telemetryAttributes.setAttribute(SessionAttributes.SESSION_ID, newOtelSessionId)
         val attributes = telemetryAttributes.snapshot()
         assertEquals(1, attributes.size)
-        assertEquals(newSessionId, attributes[SessionAttributes.SESSION_ID])
+        assertEquals(newOtelSessionId, attributes[SessionAttributes.SESSION_ID])
     }
 
     @Test
@@ -76,7 +76,7 @@ internal class TelemetryAttributesTest {
         telemetryAttributes = TelemetryAttributes(
             customAttributes = customAttributes
         )
-        telemetryAttributes.setAttribute(SessionAttributes.SESSION_ID, sessionId)
+        telemetryAttributes.setAttribute(SessionAttributes.SESSION_ID, otelSessionId)
 
         val attributes = telemetryAttributes.snapshot()
         assertEquals(2, attributes.size)
@@ -88,17 +88,17 @@ internal class TelemetryAttributesTest {
         val blankishValues = listOf("", " ", "null", "NULL")
 
         // Give me Union types, plz
-        val sessionIdKey = SessionAttributes.SESSION_ID
+        val otelSessionIdKey = SessionAttributes.SESSION_ID
         blankishValues.forEach { value ->
-            telemetryAttributes.setAttribute(sessionIdKey, value, true)
-            assertEquals(value, telemetryAttributes.getAttribute(sessionIdKey))
+            telemetryAttributes.setAttribute(otelSessionIdKey, value, true)
+            assertEquals(value, telemetryAttributes.getAttribute(otelSessionIdKey))
         }
 
-        telemetryAttributes.setAttribute(sessionIdKey, "test")
+        telemetryAttributes.setAttribute(otelSessionIdKey, "test")
 
         blankishValues.forEach { value ->
-            telemetryAttributes.setAttribute(sessionIdKey, value, false)
-            assertEquals("test", telemetryAttributes.getAttribute(sessionIdKey))
+            telemetryAttributes.setAttribute(otelSessionIdKey, value, false)
+            assertEquals("test", telemetryAttributes.getAttribute(otelSessionIdKey))
         }
 
         blankishValues.forEach { value ->

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
@@ -241,7 +241,7 @@ class PayloadResurrectionServiceImplTest {
         // Session B is only in the cache — should be resurrected normally.
         val sessionBMeta = fakeSessionStoredTelemetryMetadata2.copy(complete = false)
         val sessionBEnvelope = fakeIncompleteSessionEnvelope(
-            sessionId = "session-b",
+            userSessionId = "session-b",
             startMs = sessionBMeta.timestamp,
             lastHeartbeatTimeMs = sessionBMeta.timestamp + 1000L
         )
@@ -411,11 +411,11 @@ class PayloadResurrectionServiceImplTest {
         )
         cacheStorageService.addPayload(
             metadata = earlierMeta,
-            data = fakeIncompleteSessionEnvelope(sessionId = "earlier-part")
+            data = fakeIncompleteSessionEnvelope(userSessionId = "earlier-part")
         )
         cacheStorageService.addPayload(
             metadata = laterMeta,
-            data = fakeIncompleteSessionEnvelope(sessionId = "later-part")
+            data = fakeIncompleteSessionEnvelope(userSessionId = "later-part")
         )
         resurrectInBackground(
             restoreDecision = UserSessionRestoreDecision.Terminated(
@@ -592,7 +592,7 @@ class PayloadResurrectionServiceImplTest {
         val oldResource = fakeEnvelopeResource.copy(appVersion = "1.4", sdkVersion = "6.13", osVersion = "10")
         val oldMetadata = fakeEnvelopeMetadata.copy(username = "old-admin")
         val earlierDeadSession = fakeIncompleteSessionEnvelope(
-            sessionId = "anotherFakeSessionId",
+            userSessionId = "anotherFakeSessionId",
             sessionPartId = "anotherFakeSessionPartId",
             startMs = deadSessionEnvelope.getStartTime() - 100_000L,
             lastHeartbeatTimeMs = deadSessionEnvelope.getStartTime() - 90_000L,
@@ -930,7 +930,7 @@ class PayloadResurrectionServiceImplTest {
                 spanSnapshots = deadSessionEnvelope.data.spanSnapshots?.plus(
                     checkNotNull(
                         FakeEmbraceSdkSpan.sessionSpan(
-                            sessionId = "fake-session-span-id",
+                            userSessionId = "fake-session-span-id",
                             startTimeMs = deadSessionEnvelope.getStartTime() + 1001L,
                             lastHeartbeatTimeMs = deadSessionEnvelope.getStartTime() + 1001L,
                         ).snapshot()

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImplTests.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImplTests.kt
@@ -466,7 +466,7 @@ internal class CurrentSessionPartSpanImplTests {
         with(spanRepository.getActiveSpans().single()) {
             checkNotNull(snapshot()?.links?.single()).validatePreviousSessionLink(
                 previousSessionSpan = originalSnapshot,
-                previousSessionId = originalSessionId,
+                previousOtelSessionId = originalSessionId,
                 previousUserSessionId = originalUserSessionId,
                 previousSessionPartId = originalSessionPartId,
             )
@@ -546,7 +546,7 @@ internal class CurrentSessionPartSpanImplTests {
     @Test
     fun `span stop callback creates the correct span links`() {
         val sessionSpan = checkNotNull(spanRepository.getActiveSpans().single())
-        val sessionId = checkNotNull(sessionSpan.getSystemAttribute(SessionAttributes.SESSION_ID))
+        val otelSessionId = checkNotNull(sessionSpan.getSystemAttribute(SessionAttributes.SESSION_ID))
         val userSessionId = "user-session-uuid"
         val sessionPartId = "session-part-uuid"
         sessionSpan.setSystemAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID, userSessionId)
@@ -558,19 +558,19 @@ internal class CurrentSessionPartSpanImplTests {
         val spanSnapshot = checkNotNull(span.snapshot())
         val sessionSpanSnapshot = checkNotNull(sessionSpan.snapshot())
 
-        val expectedSessionIds = mapOf(
+        val expectedOtelSessionIds = mapOf(
             EmbSessionAttributes.EMB_USER_SESSION_ID to userSessionId,
             EmbSessionAttributes.EMB_SESSION_PART_ID to sessionPartId,
         )
         checkNotNull(spanSnapshot.links).single().validateSystemLink(
             linkedSpan = sessionSpanSnapshot,
             type = LinkType.EndSession,
-            expectedAttributes = mapOf(SessionAttributes.SESSION_ID to sessionId) + expectedSessionIds
+            expectedAttributes = mapOf(SessionAttributes.SESSION_ID to otelSessionId) + expectedOtelSessionIds
         )
         checkNotNull(sessionSpanSnapshot.links).single().validateSystemLink(
             linkedSpan = spanSnapshot,
             type = LinkType.EndedIn,
-            expectedAttributes = expectedSessionIds,
+            expectedAttributes = expectedOtelSessionIds,
         )
     }
 

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/debug/DeliveryTracer.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/debug/DeliveryTracer.kt
@@ -83,8 +83,8 @@ class DeliveryTracer {
         addWithThreadInfo(DeliveryTraceState.ServerReceivedRequest(endpoint))
     }
 
-    fun onServerCompletedRequest(endpoint: String, sessionId: String) {
-        addWithThreadInfo(DeliveryTraceState.ServerCompletedRequest(endpoint, sessionId))
+    fun onServerCompletedRequest(endpoint: String, otelSessionId: String) {
+        addWithThreadInfo(DeliveryTraceState.ServerCompletedRequest(endpoint, otelSessionId))
     }
 
     private fun addWithThreadInfo(state: DeliveryTraceState) {

--- a/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImpl.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImpl.kt
@@ -63,8 +63,8 @@ internal class NativeCrashHandlerInstallerImpl(
 
     private fun updateSessionIds() {
         val ids = args.activeSessionIds()
-        val sessionPartId = sanitizeSessionId(ids.sessionPartId)
-        val userSessionId = sanitizeSessionId(ids.userSessionId)
+        val sessionPartId = sanitizeId(ids.sessionPartId)
+        val userSessionId = sanitizeId(ids.userSessionId)
         delegate.onSessionChange(
             sessionPartId,
             userSessionId,
@@ -72,7 +72,7 @@ internal class NativeCrashHandlerInstallerImpl(
         )
     }
 
-    private fun sanitizeSessionId(sid: String?) =
+    private fun sanitizeId(sid: String?) =
         if (sid.isNullOrBlank()) {
             "null"
         } else {

--- a/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/jni/JniDelegate.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/jni/JniDelegate.kt
@@ -6,7 +6,7 @@ interface JniDelegate {
         reportId: String?,
         devLogging: Boolean,
     )
-    fun onSessionChange(sessionId: String, userSessionId: String, reportPath: String)
+    fun onSessionChange(sessionPartId: String, userSessionId: String, reportPath: String)
     fun getCrashReport(path: String): String?
     fun checkForOverwrittenHandlers(): String?
     fun reinstallSignalHandlers(): Boolean

--- a/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/jni/JniDelegateImpl.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/jni/JniDelegateImpl.kt
@@ -7,7 +7,7 @@ class JniDelegateImpl : JniDelegate {
         devLogging: Boolean,
     )
 
-    external override fun onSessionChange(sessionId: String, userSessionId: String, reportPath: String)
+    external override fun onSessionChange(sessionPartId: String, userSessionId: String, reportPath: String)
     external override fun getCrashReport(path: String): String?
     external override fun checkForOverwrittenHandlers(): String?
     external override fun reinstallSignalHandlers(): Boolean

--- a/embrace-android-instrumentation-crash-ndk/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImplTest.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImplTest.kt
@@ -31,7 +31,7 @@ class NativeCrashHandlerInstallerImplTest {
     private lateinit var nativeCrashHandlerInstaller: NativeCrashHandlerInstallerImpl
     private lateinit var executorService: BlockingScheduledExecutorService
     private lateinit var outputDir: File
-    private var sessionId: String? = null
+    private var sessionPartId: String? = null
     private var userSessionId: String? = null
 
     @Before
@@ -45,7 +45,7 @@ class NativeCrashHandlerInstallerImplTest {
         fakeSharedObjectLoader = FakeSharedObjectLoader()
         fakeDelegate = FakeJniDelegate()
         fakeMainThreadHandler = FakeMainThreadHandler()
-        sessionId = null
+        sessionPartId = null
         userSessionId = null
         outputDir = Files.createTempDirectory("test").toFile()
         executorService = BlockingScheduledExecutorService(blockingMode = false)
@@ -55,12 +55,12 @@ class NativeCrashHandlerInstallerImplTest {
             configService = fakeConfigService,
             logger = FakeInternalLogger(false),
             backgroundWorkerSupplier = { BackgroundWorker(executorService) },
-            sessionPartIdSupplier = { sessionId },
+            sessionPartIdSupplier = { sessionPartId },
             userSessionIdSupplier = { userSessionId },
             activeSessionIdsSupplier = {
                 SessionIdsSnapshot(
                     userSessionId = userSessionId.orEmpty(),
-                    sessionPartId = sessionId.orEmpty()
+                    sessionPartId = sessionPartId.orEmpty()
                 )
             },
             processIdentifier = "pid"
@@ -84,8 +84,8 @@ class NativeCrashHandlerInstallerImplTest {
     }
 
     @Test
-    fun `report path containing session ID`() {
-        sessionId = "sid"
+    fun `report path containing session part ID and user session ID`() {
+        sessionPartId = "sid"
         userSessionId = "usid"
         nativeCrashHandlerInstaller.install()
 
@@ -95,11 +95,11 @@ class NativeCrashHandlerInstallerImplTest {
 
     @Test
     fun `session IDs are forwarded to native on install`() {
-        sessionId = "sid"
+        sessionPartId = "sid"
         userSessionId = "usid"
         nativeCrashHandlerInstaller.install()
 
-        assertEquals("sid", fakeDelegate.sessionId)
+        assertEquals("sid", fakeDelegate.sessionPartId)
         assertEquals("usid", fakeDelegate.userSessionId)
     }
 
@@ -107,13 +107,13 @@ class NativeCrashHandlerInstallerImplTest {
     fun `session IDs are updated on session change`() {
         nativeCrashHandlerInstaller.install()
         executorService.runCurrentlyBlocked()
-        assertEquals("null", fakeDelegate.sessionId)
+        assertEquals("null", fakeDelegate.sessionPartId)
         assertEquals("null", fakeDelegate.userSessionId)
 
-        sessionId = "sid2"
+        sessionPartId = "sid2"
         userSessionId = "usid2"
         args.sessionChangeListeners.forEach { it.onPostSessionChange() }
-        assertEquals("sid2", fakeDelegate.sessionId)
+        assertEquals("sid2", fakeDelegate.sessionPartId)
         assertEquals("usid2", fakeDelegate.userSessionId)
     }
 
@@ -125,7 +125,7 @@ class NativeCrashHandlerInstallerImplTest {
 
         // trigger new session and update report path
         args.clock.tick(9000)
-        sessionId = "sid"
+        sessionPartId = "sid"
         userSessionId = "usid"
         args.sessionChangeListeners.forEach { it.onPostSessionChange() }
         assertTrue(fakeDelegate.signalHandlerInstalled)

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/EmbraceSpanDataAssertions.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/EmbraceSpanDataAssertions.kt
@@ -24,7 +24,7 @@ fun assertEmbraceSpanData(
     expectedErrorCode: ErrorCode? = null,
     expectedCustomAttributes: Map<String, String> = emptyMap(),
     expectedEvents: List<SpanEvent> = emptyList(),
-    expectedSessionId: String? = null,
+    expectedOtelSessionId: String? = null,
     private: Boolean = false,
 ) {
     checkNotNull(span)
@@ -50,8 +50,8 @@ fun assertEmbraceSpanData(
         }
         assertEquals(expectedEvents, events)
 
-        if (expectedSessionId != null) {
-            assertEquals(expectedSessionId, attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
+        if (expectedOtelSessionId != null) {
+            assertEquals(expectedOtelSessionId, attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
         }
 
         if (private) {

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/LinkAssertions.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/LinkAssertions.kt
@@ -12,12 +12,12 @@ import org.junit.Assert.assertTrue
 
 fun Link.validatePreviousSessionLink(
     previousSessionSpan: Span,
-    previousSessionId: String,
+    previousOtelSessionId: String,
     previousUserSessionId: String? = null,
     previousSessionPartId: String? = null,
 ) {
     val expected = buildMap {
-        put(SessionAttributes.SESSION_ID, previousSessionId)
+        put(SessionAttributes.SESSION_ID, previousOtelSessionId)
         previousUserSessionId?.let { put(EmbSessionAttributes.EMB_USER_SESSION_ID, it) }
         previousSessionPartId?.let { put(EmbSessionAttributes.EMB_SESSION_PART_ID, it) }
     }

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/LogAssertions.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/LogAssertions.kt
@@ -43,8 +43,8 @@ fun assertOtelLogReceived(
         if (hasSession) {
             assertFalse(log.attributes?.findAttributeValue(SessionAttributes.SESSION_ID).isNullOrBlank())
         } else {
-            val sessionId = log.attributes?.findAttributeValue(SessionAttributes.SESSION_ID)
-            assertEquals("", sessionId ?: "")
+            val otelSessionId = log.attributes?.findAttributeValue(SessionAttributes.SESSION_ID)
+            assertEquals("", otelSessionId ?: "")
         }
         expectedType?.let { assertAttribute(log, EmbAndroidAttributes.EMB_EXCEPTION_HANDLING, it) }
         assertEquals(expectedState, log.attributes?.findAttributeValue(EmbSessionAttributes.EMB_STATE))

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SessionIdAssertions.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SessionIdAssertions.kt
@@ -23,7 +23,7 @@ data class SessionIds(
  */
 fun Map<String, String?>.assertSessionIds(): SessionIds {
     val userSessionId = get(EmbSessionAttributes.EMB_USER_SESSION_ID)
-    val sessionId = get(SessionAttributes.SESSION_ID)
+    val otelSessionId = get(SessionAttributes.SESSION_ID)
     val partId = get(EmbSessionAttributes.EMB_SESSION_PART_ID)
 
     assertTrue(
@@ -31,14 +31,14 @@ fun Map<String, String?>.assertSessionIds(): SessionIds {
         EMB_UUID_REGEX.matches(userSessionId ?: ""),
     )
     assertTrue(
-        "session.id must be a 32-char hex UUID but was: $sessionId",
-        EMB_UUID_REGEX.matches(sessionId ?: ""),
+        "session.id must be a 32-char hex UUID but was: $otelSessionId",
+        EMB_UUID_REGEX.matches(otelSessionId ?: ""),
     )
     assertTrue(
         "emb.session_part_id must be a 32-char hex UUID but was: $partId",
         EMB_UUID_REGEX.matches(partId ?: ""),
     )
-    assertEquals("session.id must equal emb.user_session_id", userSessionId, sessionId)
+    assertEquals("session.id must equal emb.user_session_id", userSessionId, otelSessionId)
     assertNotEquals("emb.session_part_id must not equal emb.user_session_id", partId, userSessionId)
 
     return SessionIds(

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
@@ -37,8 +37,8 @@ fun Span.findEventsOfType(telemetryType: EmbType): List<SpanEvent> {
     }
 }
 
-fun Span.assertPreviousSession(previousSessionSpan: Span, previousSessionId: String) {
-    findLinkOfType(LinkType.PreviousSession).validatePreviousSessionLink(previousSessionSpan, previousSessionId)
+fun Span.assertPreviousSession(previousSessionSpan: Span, previousOtelSessionId: String) {
+    findLinkOfType(LinkType.PreviousSession).validatePreviousSessionLink(previousSessionSpan, previousOtelSessionId)
 }
 
 fun Span.assertNoPreviousSession() =

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
@@ -247,7 +247,7 @@ class FakeEmbraceSdkSpan(
             }
 
         fun sessionSpan(
-            sessionId: String,
+            userSessionId: String,
             startTimeMs: Long,
             lastHeartbeatTimeMs: Long?,
             endTimeMs: Long? = null,
@@ -267,8 +267,8 @@ class FakeEmbraceSdkSpan(
                     )
                 }
 
-                setSystemAttribute(SessionAttributes.SESSION_ID, sessionId)
-                setSystemAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID, sessionId)
+                setSystemAttribute(SessionAttributes.SESSION_ID, userSessionId)
+                setSystemAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID, userSessionId)
                 setSystemAttribute(EmbSessionAttributes.EMB_SESSION_PART_ID, sessionPartId)
                 setSystemAttribute(EmbSessionAttributes.EMB_PROCESS_IDENTIFIER, processIdentifier)
                 setSystemAttribute(EmbSessionAttributes.EMB_STATE, "foreground")

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalLoggerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalLoggerTest.kt
@@ -103,7 +103,7 @@ internal class ExternalLoggerTest {
                 }
             },
             assertAction = {
-                val sessionId = getSingleSessionEnvelope().getOtelSessionId()
+                val otelSessionId = getSingleSessionEnvelope().getOtelSessionId()
                 exportedOTelLog = logExporter.exportedLogs.single()
                 with(exportedOTelLog) {
                     assertOTelLogRecord(
@@ -119,7 +119,7 @@ internal class ExternalLoggerTest {
                         expectedSpanContext = embOpenTelemetry.spanContext.invalid,
                         expectedSeverityNumber = SeverityNumber.FATAL,
                         expectedSeverityText = "DANG",
-                        expectedSessionId = sessionId,
+                        expectedOtelSessionId = otelSessionId,
                         expectedAppState = AppState.FOREGROUND,
                         expectedSessionProperties = mapOf("session-attr" to "blah"),
                         expectedAttributes = mapOf("foo" to "bar"),
@@ -137,7 +137,7 @@ internal class ExternalLoggerTest {
     fun `record an event with otel logging API in the background with a span parent`() {
         var logTime: Long = -1L
         var observedTime: Long = -1L
-        var sessionId = ""
+        var otelSessionId = ""
         var parentContext: SpanContext? = null
         var exportedOTelLog: ReadableLogRecord? = null
         testRule.runTest(
@@ -153,7 +153,7 @@ internal class ExternalLoggerTest {
                 clock.tick()
                 logTime = clock.now().millisToNanos()
                 embrace.addUserSessionProperty("bg-attr", "blah", PropertyScope.PERMANENT)
-                sessionId = testRule.bootstrapper.userSessionOrchestrationModule.sessionIdsProvider.getCurrentUserSessionId()
+                otelSessionId = testRule.bootstrapper.userSessionOrchestrationModule.sessionIdsProvider.getCurrentUserSessionId()
                 val span = embOpenTelemetry.getTracer("").startSpan("my-span")
                 parentContext = span.spanContext
                 embLogger.emit(
@@ -185,7 +185,7 @@ internal class ExternalLoggerTest {
                         expectedSpanContext = checkNotNull(parentContext),
                         expectedSeverityNumber = SeverityNumber.INFO,
                         expectedSeverityText = "",
-                        expectedSessionId = sessionId,
+                        expectedOtelSessionId = otelSessionId,
                         expectedAppState = AppState.BACKGROUND,
                         expectedSessionProperties = mapOf("bg-attr" to "blah"),
                         expectedAttributes = mapOf("foo" to "bar"),
@@ -219,7 +219,7 @@ internal class ExternalLoggerTest {
         expectedSpanContext: SpanContext,
         expectedSeverityNumber: SeverityNumber,
         expectedSeverityText: String?,
-        expectedSessionId: String?,
+        expectedOtelSessionId: String?,
         expectedAppState: AppState,
         expectedSessionProperties: Map<String, String>,
         expectedAttributes: Map<String, String>,
@@ -247,8 +247,8 @@ internal class ExternalLoggerTest {
         assertEquals(expectedSeverityText, severityText)
         with(checkNotNull(attributes.mapValues { it.value.toString() })) {
             assertNotNull(filter { it.key == LogAttributes.LOG_RECORD_UID }.size)
-            if (expectedSessionId != null) {
-                assertEquals(expectedSessionId, this[SessionAttributes.SESSION_ID])
+            if (expectedOtelSessionId != null) {
+                assertEquals(expectedOtelSessionId, this[SessionAttributes.SESSION_ID])
             } else {
                 assertFalse(containsKey(SessionAttributes.SESSION_ID))
             }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalOtelJavaLoggerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalOtelJavaLoggerTest.kt
@@ -102,7 +102,7 @@ internal class ExternalOtelJavaLoggerTest {
                 }
             },
             assertAction = {
-                val sessionId = getSingleSessionEnvelope().getOtelSessionId()
+                val otelSessionId = getSingleSessionEnvelope().getOtelSessionId()
                 exportedOTelLog = logExporter.exportedLogs.single()
                 with(exportedOTelLog) {
                     assertOTelLogRecord(
@@ -118,7 +118,7 @@ internal class ExternalOtelJavaLoggerTest {
                         expectedSpanContext = OtelJavaSpanContext.getInvalid(),
                         expectedSeverity = OtelJavaSeverity.FATAL,
                         expectedSeverityText = "DANG",
-                        expectedSessionId = sessionId,
+                        expectedOtelSessionId = otelSessionId,
                         expectedAppState = AppState.FOREGROUND,
                         expectedSessionProperties = mapOf("session-attr" to "blah"),
                         expectedAttributes = mapOf("foo" to "bar"),
@@ -133,7 +133,7 @@ internal class ExternalOtelJavaLoggerTest {
     fun `record an event with java otel logging API in the background with a span parent`() {
         var logTime: Long = -1L
         var observedTime: Long = -1L
-        var sessionId = ""
+        var otelSessionId = ""
         var parentContext: OtelJavaSpanContext? = null
         var exportedOTelLog: OtelJavaLogRecordData?
         testRule.runTest(
@@ -149,7 +149,7 @@ internal class ExternalOtelJavaLoggerTest {
                 clock.tick()
                 logTime = clock.now().millisToNanos()
                 embrace.addUserSessionProperty("bg-attr", "blah", PropertyScope.PERMANENT)
-                sessionId = testRule.bootstrapper.userSessionOrchestrationModule.sessionIdsProvider.getCurrentUserSessionId()
+                otelSessionId = testRule.bootstrapper.userSessionOrchestrationModule.sessionIdsProvider.getCurrentUserSessionId()
                 val span = embOpenTelemetry.getTracer("").spanBuilder("my-span").startSpan()
                 val logContext = span.storeInContext(OtelJavaContext.root())
                 parentContext = span.spanContext
@@ -182,7 +182,7 @@ internal class ExternalOtelJavaLoggerTest {
                         expectedSpanContext = checkNotNull(parentContext),
                         expectedSeverity = OtelJavaSeverity.INFO,
                         expectedSeverityText = null,
-                        expectedSessionId = sessionId,
+                        expectedOtelSessionId = otelSessionId,
                         expectedAppState = AppState.BACKGROUND,
                         expectedSessionProperties = mapOf("bg-attr" to "blah"),
                         expectedAttributes = mapOf("foo" to "bar"),
@@ -217,7 +217,7 @@ internal class ExternalOtelJavaLoggerTest {
         expectedSpanContext: OtelJavaSpanContext,
         expectedSeverity: OtelJavaSeverity,
         expectedSeverityText: String?,
-        expectedSessionId: String?,
+        expectedOtelSessionId: String?,
         expectedAppState: AppState,
         expectedSessionProperties: Map<String, String>,
         expectedAttributes: Map<String, String>,
@@ -252,8 +252,8 @@ internal class ExternalOtelJavaLoggerTest {
         assertEquals(expectedSeverityText, severityText)
         with(checkNotNull(attributes.toStringMap())) {
             assertNotNull(filter { it.key == LogAttributes.LOG_RECORD_UID }.size)
-            if (expectedSessionId != null) {
-                assertEquals(expectedSessionId, this[SessionAttributes.SESSION_ID])
+            if (expectedOtelSessionId != null) {
+                assertEquals(expectedOtelSessionId, this[SessionAttributes.SESSION_ID])
             } else {
                 assertFalse(containsKey(SessionAttributes.SESSION_ID))
             }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PublicApiTest.kt
@@ -53,7 +53,7 @@ internal class PublicApiTest {
     }
 
     @Test
-    fun `getCurrentUserSessionId returns sessionId when SDK is started and foreground session is active`() {
+    fun `getCurrentUserSessionId returns the user session id when SDK is started and foreground session is active`() {
         testRule.runTest(
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
@@ -65,21 +65,21 @@ internal class PublicApiTest {
     }
 
     @Test
-    fun `getCurrentUserSessionId returns sessionId when SDK is started and background session is active`() {
-        var foregroundSessionId: String? = null
-        var backgroundSessionId: String? = null
+    fun `getCurrentUserSessionId returns the user session id when SDK is started and background session is active`() {
+        var foregroundUserSessionId: String? = null
+        var backgroundUserSessionId: String? = null
         testRule.runTest(
             persistedRemoteConfig = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(100f)),
             instrumentedConfig = instrumentedConfig,
             testCaseAction = {
                 recordSession {
-                    foregroundSessionId = embrace.currentUserSessionId
+                    foregroundUserSessionId = embrace.currentUserSessionId
                 }
-                backgroundSessionId = embrace.currentUserSessionId
+                backgroundUserSessionId = embrace.currentUserSessionId
             },
             assertAction = {
-                assertNotNull(backgroundSessionId)
-                assertEquals(foregroundSessionId, backgroundSessionId)
+                assertNotNull(backgroundUserSessionId)
+                assertEquals(foregroundUserSessionId, backgroundUserSessionId)
             }
         )
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -218,7 +218,7 @@ internal class TracingApiTest {
                             attributes = emptyList()
                         ),
                     ),
-                    expectedSessionId = session.getOtelSessionId()
+                    expectedOtelSessionId = session.getOtelSessionId()
                 )
                 val expectedParentId = traceRootSpan.spanId
                 assertEmbraceSpanData(
@@ -227,7 +227,7 @@ internal class TracingApiTest {
                     expectedEndTimeMs = testStartTimeMs + 100,
                     expectedParentId = checkNotNull(expectedParentId),
                     expectedTraceId = traceRootSpan.traceId,
-                    expectedSessionId = session.getOtelSessionId()
+                    expectedOtelSessionId = session.getOtelSessionId()
                 )
 
                 assertEmbraceSpanData(
@@ -245,7 +245,7 @@ internal class TracingApiTest {
                             attributes = listOf(Attribute("retry", "1"))
                         )
                     ),
-                    expectedSessionId = session.getOtelSessionId()
+                    expectedOtelSessionId = session.getOtelSessionId()
                 )
 
                 assertEmbraceSpanData(
@@ -254,7 +254,7 @@ internal class TracingApiTest {
                     expectedEndTimeMs = testStartTimeMs + 301,
                     expectedParentId = expectedParentId,
                     expectedTraceId = traceRootSpan.traceId,
-                    expectedSessionId = session.getOtelSessionId()
+                    expectedOtelSessionId = session.getOtelSessionId()
                 )
 
                 assertEmbraceSpanData(
@@ -263,7 +263,7 @@ internal class TracingApiTest {
                     expectedEndTimeMs = testStartTimeMs + 600,
                     expectedParentId = expectedParentId,
                     expectedTraceId = traceRootSpan.traceId,
-                    expectedSessionId = session.getOtelSessionId()
+                    expectedOtelSessionId = session.getOtelSessionId()
                 )
 
                 assertEmbraceSpanData(
@@ -271,7 +271,7 @@ internal class TracingApiTest {
                     expectedStartTimeMs = sessionStartTimeMs,
                     expectedEndTimeMs = sessionEndTimeMs,
                     expectedParentId = OtelIds.INVALID_SPAN_ID,
-                    expectedSessionId = session.getOtelSessionId(),
+                    expectedOtelSessionId = session.getOtelSessionId(),
                     private = false
                 )
 
@@ -296,9 +296,9 @@ internal class TracingApiTest {
             },
             otelExportAssertion = {
                 val sessionSpan = awaitSpansWithType(2, EmbType.Ux.Session).last().toEmbraceSpanData().toEmbracePayload()
-                val sessionId = checkNotNull(sessionSpan.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
+                val otelSessionId = checkNotNull(sessionSpan.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
                 val span = awaitSpans(1) { it.name == "test-trace-root" }.single().toEmbraceSpanData().toEmbracePayload()
-                assertEquals(sessionId, span.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
+                assertEquals(otelSessionId, span.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
             }
         )
     }
@@ -431,11 +431,11 @@ internal class TracingApiTest {
             otelExportAssertion = {
                 // Get the session ID from a session span exported via OTel
                 val sessionSpan = awaitSpansWithType(2, EmbType.Ux.Session).first().toEmbraceSpanData().toEmbracePayload()
-                val expectedSessionId = checkNotNull(sessionSpan.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
+                val expectedOtelSessionId = checkNotNull(sessionSpan.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
                 val span1 = awaitSpans(1) { it.name == "span1" }.single().toEmbraceSpanData().toEmbracePayload()
                 val span2 = awaitSpans(1) { it.name == "span2" }.single().toEmbraceSpanData().toEmbracePayload()
-                assertEquals(expectedSessionId, span1.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
-                assertEquals(expectedSessionId, span2.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
+                assertEquals(expectedOtelSessionId, span1.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
+                assertEquals(expectedOtelSessionId, span2.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
             }
         )
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/DeliveryConnectivityFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/DeliveryConnectivityFeatureTest.kt
@@ -89,11 +89,11 @@ internal class DeliveryConnectivityFeatureTest {
                 startMs = fakeClock.now()
                 payloadStorageService.addPayload(
                     fakeSessionStoredTelemetryMetadata.copy(timestamp = startMs),
-                    fakeSessionEnvelope(sessionId = "1", startMs = startMs)
+                    fakeSessionEnvelope(userSessionId = "1", startMs = startMs)
                 )
                 payloadStorageService.addPayload(
                     fakeSessionStoredTelemetryMetadata2,
-                    fakeSessionEnvelope(sessionId = "2", startMs = startMs + 1000)
+                    fakeSessionEnvelope(userSessionId = "2", startMs = startMs + 1000)
                 )
             },
             testCaseAction = {},

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NativeCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NativeCrashFeatureTest.kt
@@ -211,13 +211,13 @@ internal class NativeCrashFeatureTest {
                 val expectedCrashEnvelope = checkNotNull(crashData.cachedCrashEnvelope)
 
                 // crashes sent
-                val crashEnvelope1 = logEnvelopes.single { findMatchingSessionId(it, crashData) }
+                val crashEnvelope1 = logEnvelopes.single { findMatchingSessionPartId(it, crashData) }
                 with(crashEnvelope1) {
                     assertEquals(expectedCrashEnvelope.resource, resource)
                     assertEquals(expectedCrashEnvelope.metadata, metadata)
                 }
 
-                val crashEnvelope2 = logEnvelopes.single { findMatchingSessionId(it, crashData2) }
+                val crashEnvelope2 = logEnvelopes.single { findMatchingSessionPartId(it, crashData2) }
                 with(crashEnvelope2) {
                     assertEquals(fakeLaterEnvelopeResource, resource)
                     assertEquals(fakeLaterEnvelopeMetadata, metadata)
@@ -305,12 +305,12 @@ internal class NativeCrashFeatureTest {
     }
 
     @Test
-    fun `sessionId and crash path properly set up when background activity enabled`() {
+    fun `session ids and crash path properly set up when background activity enabled`() {
         checkNativeMetadata(true)
     }
 
     @Test
-    fun `sessionId and crash path properly set up when background activity disabled`() {
+    fun `session ids and crash path properly set up when background activity disabled`() {
         checkNativeMetadata(false)
     }
 
@@ -367,7 +367,7 @@ internal class NativeCrashFeatureTest {
         nativeSessionMetadata.add(Pair(userSessionId, reportPath))
     }
 
-    private fun findMatchingSessionId(it: Envelope<LogPayload>, data: StoredNativeCrashData): Boolean {
+    private fun findMatchingSessionPartId(it: Envelope<LogPayload>, data: StoredNativeCrashData): Boolean {
         return it.getLogOfType(EmbType.System.NativeCrash).attributes?.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID) == data.nativeCrash.sessionPartId
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionPartPayloadTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionPartPayloadTest.kt
@@ -234,31 +234,31 @@ internal class SessionPartPayloadTest {
 
                 val firstSessionSpan = firstSession.getValidatedSessionSpan(
                     previousSessionSpan = firstBaSessionSpan,
-                    previousSessionId = firstBa.getOtelSessionId()
+                    previousOtelSessionId = firstBa.getOtelSessionId()
                 )
 
                 val secondBaSessionSpan = secondBa.getValidatedSessionSpan(
                     isColdStart = false,
                     previousSessionSpan = firstSessionSpan,
-                    previousSessionId = firstSession.getOtelSessionId()
+                    previousOtelSessionId = firstSession.getOtelSessionId()
                 )
 
                 val secondSessionSpan = secondSession.getValidatedSessionSpan(
                     isColdStart = false,
                     previousSessionSpan = secondBaSessionSpan,
-                    previousSessionId = secondBa.getOtelSessionId()
+                    previousOtelSessionId = secondBa.getOtelSessionId()
                 )
 
                 val thirdBaSessionSpan = thirdBa.getValidatedSessionSpan(
                     isColdStart = false,
                     previousSessionSpan = secondSessionSpan,
-                    previousSessionId = secondSession.getOtelSessionId()
+                    previousOtelSessionId = secondSession.getOtelSessionId()
                 )
 
                 thirdSession.getValidatedSessionSpan(
                     isColdStart = false,
                     previousSessionSpan = thirdBaSessionSpan,
-                    previousSessionId = thirdBa.getOtelSessionId()
+                    previousOtelSessionId = thirdBa.getOtelSessionId()
                 )
             }
         )
@@ -283,13 +283,13 @@ internal class SessionPartPayloadTest {
                 val secondSessionSpan = second.getValidatedSessionSpan(
                     isColdStart = false,
                     previousSessionSpan = firstSessionSpan,
-                    previousSessionId = first.getOtelSessionId()
+                    previousOtelSessionId = first.getOtelSessionId()
                 )
 
                 third.getValidatedSessionSpan(
                     isColdStart = false,
                     previousSessionSpan = secondSessionSpan,
-                    previousSessionId = second.getOtelSessionId()
+                    previousOtelSessionId = second.getOtelSessionId()
                 )
             }
         )
@@ -298,7 +298,7 @@ internal class SessionPartPayloadTest {
     private fun Envelope<SessionPartPayload>.getValidatedSessionSpan(
         isColdStart: Boolean = true,
         previousSessionSpan: Span? = null,
-        previousSessionId: String? = null,
+        previousOtelSessionId: String? = null,
     ): Span {
         val sessionSpan = findSessionSpan()
         assertFalse(hasSpanSnapshotsOfType(EmbType.Ux.Session))
@@ -309,8 +309,8 @@ internal class SessionPartPayloadTest {
                 )
             )
 
-            if (previousSessionSpan != null && previousSessionId != null) {
-                assertPreviousSession(previousSessionSpan, previousSessionId)
+            if (previousSessionSpan != null && previousOtelSessionId != null) {
+                assertPreviousSession(previousSessionSpan, previousOtelSessionId)
             } else {
                 assertNoPreviousSession()
             }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionClockAnomalyTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionClockAnomalyTest.kt
@@ -50,12 +50,12 @@ internal class UserSessionClockAnomalyTest {
     @Test
     fun `clock shifting backwards when loading existing user session terminates existing user session and logs internal error`() {
         // write a session that started in the future
-        val sessionId = "stale-session-id"
+        val staleUserSessionId = "stale-session-id"
         testRule.runTest(
             setupAction = {
                 val futureStartMs = testRule.bootstrapper.initModule.clock.now() + 100_000L
                 persistUserSession(
-                    userSessionId = sessionId,
+                    userSessionId = staleUserSessionId,
                     startMs = futureStartMs,
                     lastActivityMs = futureStartMs,
                 )
@@ -65,8 +65,8 @@ internal class UserSessionClockAnomalyTest {
             },
             assertAction = {
                 val session = getSingleSessionEnvelope()
-                assertNotEquals(sessionId, session.getUserSessionId())
-                assertNotEquals(sessionId, session.getOtelSessionId())
+                assertNotEquals(staleUserSessionId, session.getUserSessionId())
+                assertNotEquals(staleUserSessionId, session.getOtelSessionId())
 
                 val logger = testRule.bootstrapper.initModule.logger as FakeInternalLogger
                 assertTrue(logger.internalErrorMessages.any {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionResurrectionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionResurrectionTest.kt
@@ -203,7 +203,7 @@ internal class UserSessionResurrectionTest {
                         timestamp = DEFAULT_SDK_START_TIME_MS - 900L,
                     ),
                     data = fakeIncompleteSessionEnvelope(
-                        sessionId = persistedId,
+                        userSessionId = persistedId,
                         processIdentifier = priorProcessId,
                         startMs = DEFAULT_SDK_START_TIME_MS - 900L,
                         lastHeartbeatTimeMs = DEFAULT_SDK_START_TIME_MS - 800L,
@@ -262,7 +262,7 @@ internal class UserSessionResurrectionTest {
             storedNativeCrashData.copy(
                 nativeCrash = nativeCrash,
                 partEnvelope = fakeIncompleteSessionEnvelope(
-                    sessionId = userSessionId,
+                    userSessionId = userSessionId,
                     startMs = sessionMetadata.timestamp,
                     lastHeartbeatTimeMs = sessionMetadata.timestamp + 1_000L,
                 )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePayloadAssertionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePayloadAssertionInterface.kt
@@ -158,7 +158,7 @@ internal class EmbracePayloadAssertionInterface(
             val envelopes = checkNotNull(apiServer).getSessionEnvelopes()
             val sessions: List<Map<String, String?>> = envelopes.map {
                 mapOf(
-                    "sessionId" to it.getOtelSessionId(),
+                    "otelSessionId" to it.getOtelSessionId(),
                     "cleanExit" to it.findSessionSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_CLEAN_EXIT),
                     "state" to it.findSessionSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_STATE)
                 )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -291,7 +291,7 @@ internal class EmbraceSetupInterface(
             }.addPayload(
                 metadata = metadata,
                 data = fakeIncompleteSessionEnvelope(
-                    sessionId = userSessionId,
+                    userSessionId = userSessionId,
                     startMs = metadata.timestamp,
                     lastHeartbeatTimeMs = metadata.timestamp + 1_000L,
                     processIdentifier = metadata.processIdentifier

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/StoredNdkData.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/StoredNdkData.kt
@@ -75,7 +75,7 @@ internal fun createStoredNativeCrashData(
             fakeIncompleteSessionEnvelope(
                 startMs = sessionMetadata.timestamp,
                 lastHeartbeatTimeMs = sessionMetadata.timestamp + 1000L,
-                sessionId = nativeCrashData.userSessionId,
+                userSessionId = nativeCrashData.userSessionId,
                 sessionPartId = nativeCrashData.sessionPartId,
                 sessionProperties = mapOf("dead-session-prop" to "some-val"),
                 processIdentifier = sessionMetadata.processIdentifier,

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCurrentSessionPartSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCurrentSessionPartSpan.kt
@@ -69,7 +69,7 @@ class FakeCurrentSessionPartSpan(
 
     private fun newSessionSpan(startTimeMs: Long) =
         FakeEmbraceSdkSpan.sessionSpan(
-            sessionId = "fake-session-span-id",
+            userSessionId = "fake-session-span-id",
             startTimeMs = startTimeMs,
             lastHeartbeatTimeMs = startTimeMs
         )

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeJniDelegate.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeJniDelegate.kt
@@ -6,7 +6,7 @@ class FakeJniDelegate : JniDelegate {
 
     private val rawCrashes: MutableMap<String, String?> = mutableMapOf()
     var culprit: String? = "testCulprit"
-    var sessionId: String? = null
+    var sessionPartId: String? = null
     var userSessionId: String? = null
     var reportPath: String? = null
     var signalHandlerInstalled: Boolean = false
@@ -20,8 +20,8 @@ class FakeJniDelegate : JniDelegate {
         signalHandlerInstalled = true
     }
 
-    override fun onSessionChange(sessionId: String, userSessionId: String, reportPath: String) {
-        this.sessionId = sessionId
+    override fun onSessionChange(sessionPartId: String, userSessionId: String, reportPath: String) {
+        this.sessionPartId = sessionPartId
         this.userSessionId = userSessionId
         this.reportPath = reportPath
     }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeMetadataService.kt
@@ -10,7 +10,7 @@ import io.embrace.android.embracesdk.internal.clock.Clock
  * if you attempt set info about Flutter/Unity/ReactNative on this fake, which is decided for an Android device.
  */
 class FakeMetadataService(
-    sessionId: String? = null,
+    userSessionId: String? = null,
     private val wallClock: Clock = FakeClock(),
     private val networkClock: Clock? = null,
     private val gnssClock: Clock? = null,
@@ -22,13 +22,13 @@ class FakeMetadataService(
         )
     }
 
-    private var appSessionId: String? = null
+    private var appUserSessionId: String? = null
 
     @Volatile
     private var clockDrift: ClockDrift? = null
 
     init {
-        appSessionId = sessionId
+        appUserSessionId = userSessionId
     }
 
     override fun getDiskUsage(): DiskUsage = diskUsage

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionPart.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionPart.kt
@@ -21,14 +21,14 @@ fun fakeSessionPartToken(): SessionPartToken = SessionPartToken(
 )
 
 fun fakeSessionEnvelope(
-    sessionId: String = "fakeUserSessionId",
+    userSessionId: String = "fakeUserSessionId",
     sessionPartId: String = "fakeSessionPartId",
     startMs: Long = 160000000000L,
     endMs: Long = 161000400000L,
     sessionProperties: Map<String, String>? = null,
 ): Envelope<SessionPartPayload> {
     val sessionSpan = FakeEmbraceSdkSpan.sessionSpan(
-        sessionId = sessionId,
+        userSessionId = userSessionId,
         sessionPartId = sessionPartId,
         startTimeMs = startMs,
         lastHeartbeatTimeMs = endMs,
@@ -51,7 +51,7 @@ fun fakeSessionEnvelope(
 }
 
 fun fakeIncompleteSessionEnvelope(
-    sessionId: String = "fakeIncompleteSessionId",
+    userSessionId: String = "fakeIncompleteSessionId",
     sessionPartId: String = "fakeIncompleteSessionPartId",
     processIdentifier: String = "fakeIncompleteSessionProcessId",
     startMs: Long = 1691000000000L,
@@ -62,7 +62,7 @@ fun fakeIncompleteSessionEnvelope(
 ): Envelope<SessionPartPayload> {
     val fakeClock = FakeClock(currentTime = startMs)
     val incompleteSessionSpan = FakeEmbraceSdkSpan.sessionSpan(
-        sessionId = sessionId,
+        userSessionId = userSessionId,
         sessionPartId = sessionPartId,
         startTimeMs = startMs,
         lastHeartbeatTimeMs = lastHeartbeatTimeMs,


### PR DESCRIPTION
Rename a local variable and private function names where sessionId was being used without qualification. This doesn't change logic but might expose mismatches.