### PR TITLE
Use emb.user_session_id when approrprite and assert == session.id

### DIFF
--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
@@ -4,9 +4,9 @@ import io.embrace.android.embracesdk.assertions.assertEmbraceSpanData
 import io.embrace.android.embracesdk.assertions.findAttributeValue
 import io.embrace.android.embracesdk.assertions.findSpansByName
 import io.embrace.android.embracesdk.assertions.getLastHeartbeatTimeMs
-import io.embrace.android.embracesdk.assertions.getOtelSessionId
 import io.embrace.android.embracesdk.assertions.getSessionPartId
 import io.embrace.android.embracesdk.assertions.getStartTime
+import io.embrace.android.embracesdk.assertions.getUserSessionId
 import io.embrace.android.embracesdk.concurrency.BlockableExecutorService
 import io.embrace.android.embracesdk.fakes.FakeCachedLogEnvelopeStore
 import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
@@ -425,7 +425,7 @@ class PayloadResurrectionServiceImplTest {
             )
         )
 
-        val parts = getStoredParts().associateBy { it.getOtelSessionId() }
+        val parts = getStoredParts().associateBy { it.getUserSessionId() }
         val laterAttrs = checkNotNull(parts.getValue("later-part").getSessionSpan()?.attributes)
         assertEquals("1", laterAttrs.findAttributeValue(EmbSessionAttributes.EMB_IS_FINAL_SESSION_PART))
         assertEquals(
@@ -628,7 +628,7 @@ class PayloadResurrectionServiceImplTest {
             assertEquals(sessionMetadata.copy(complete = true), this)
         }
         with(sessionEnvelopes.first()) {
-            assertEquals(deadSessionEnvelope.getOtelSessionId(), getOtelSessionId())
+            assertEquals(deadSessionEnvelope.getUserSessionId(), getUserSessionId())
             assertEquals(
                 "native-crash-1",
                 getSessionSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID)
@@ -643,7 +643,7 @@ class PayloadResurrectionServiceImplTest {
             assertEquals(earlierDeadSessionMetadata.copy(complete = true), this)
         }
         with(sessionEnvelopes.last()) {
-            assertEquals(earlierDeadSession.getOtelSessionId(), getOtelSessionId())
+            assertEquals(earlierDeadSession.getUserSessionId(), getUserSessionId())
             assertEquals(
                 "native-crash-2",
                 getSessionSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -21,26 +21,25 @@ import io.embrace.android.embracesdk.fixtures.TOO_LONG_ATTRIBUTE_VALUE
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.LinkType
 import io.embrace.android.embracesdk.internal.arch.stacktrace.compatThreadId
+import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.otel.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanData
+import io.embrace.android.embracesdk.internal.otel.spans.NoopEmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.internal.session.getSessionSpan
-import io.embrace.android.embracesdk.internal.arch.state.AppState
-import io.embrace.android.embracesdk.internal.otel.spans.NoopEmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.toEmbraceSpanData
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbracePayloadAssertionInterface
+import io.embrace.android.embracesdk.testframework.assertions.assertSessionIds
 import io.opentelemetry.kotlin.aliases.OtelJavaContext
 import io.opentelemetry.kotlin.semconv.SessionAttributes
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
@@ -50,6 +49,8 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
 internal class TracingApiTest {
@@ -417,6 +418,7 @@ internal class TracingApiTest {
             },
             assertAction = {
                 val sessions = getSessionEnvelopes(2)
+                sessions.forEach { it.assertSessionIds() }
                 // Different session parts have unique part IDs
                 assertNotEquals(sessions.first().getSessionPartId(), sessions.last().getSessionPartId())
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/InternalErrorLogTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/InternalErrorLogTest.kt
@@ -6,8 +6,8 @@ import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
+import io.embrace.android.embracesdk.testframework.assertions.assertSessionIdsConsistent
 import io.opentelemetry.kotlin.semconv.ExceptionAttributes
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Rule
@@ -51,7 +51,7 @@ internal class InternalErrorLogTest {
                         attrs.findAttributeValue(ExceptionAttributes.EXCEPTION_TYPE)
                     )
                     assertNotNull(attrs.findAttributeValue("log.record.uid"))
-                    assertNotNull(attrs.findAttributeValue(SessionAttributes.SESSION_ID))
+                    assertSessionIdsConsistent()
                     checkNotNull(attrs.findAttributeValue(ExceptionAttributes.EXCEPTION_STACKTRACE))
                 }
             }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityCaptureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityCaptureTest.kt
@@ -19,6 +19,7 @@ import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
+import io.embrace.android.embracesdk.testframework.assertions.assertSessionIds
 import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -198,6 +199,11 @@ internal class BackgroundActivityCaptureTest {
 
                 val sessionSpan1 = session1.findSessionSpan()
                 val sessionSpan2 = session2.findSessionSpan()
+
+                // each part carries all three session ids, present and consistent (session.id == emb.user_session_id)
+                session1.assertSessionIds()
+                session2.assertSessionIds()
+
                 sessionSpan1.assertExpectedSessionSpanAttributes(
                     startMs = session1StartMs,
                     endMs = session1EndMs,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePayloadAssertionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePayloadAssertionInterface.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.assertions.assertMatches
 import io.embrace.android.embracesdk.assertions.findSessionSpan
 import io.embrace.android.embracesdk.assertions.getOtelSessionId
+import io.embrace.android.embracesdk.assertions.getUserSessionId
 import io.embrace.android.embracesdk.assertions.returnIfConditionMet
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.state.AppState
@@ -236,7 +237,7 @@ internal class EmbracePayloadAssertionInterface(
             assertEquals(Span.Status.ERROR, status)
 
             if (crashData != null) {
-                assertEquals(checkNotNull(crashData.partEnvelope).getOtelSessionId(), getOtelSessionId())
+                assertEquals(checkNotNull(crashData.partEnvelope).getUserSessionId(), getUserSessionId())
                 assertEquals(crashData.lastHeartbeatMs, endTimeNanos?.nanosToMillis())
                 assertEquals(
                     crashData.nativeCrash.nativeCrashId,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/assertions/SessionAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/assertions/SessionAssertions.kt
@@ -1,5 +1,8 @@
 package io.embrace.android.embracesdk.testframework.assertions
 
+import io.embrace.android.embracesdk.assertions.SessionIds
+import io.embrace.android.embracesdk.assertions.getOtelSessionId
+import io.embrace.android.embracesdk.assertions.getSessionPartId
 import io.embrace.android.embracesdk.assertions.getUserSessionId
 import io.embrace.android.embracesdk.assertions.getUserSessionTerminationReason
 import io.embrace.android.embracesdk.assertions.isFinalSessionPart
@@ -11,6 +14,7 @@ import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 
@@ -56,4 +60,31 @@ fun Log.assertSessionIds(expectedUserSessionId: String, expectedSessionPartId: S
     assertEquals(expectedUserSessionId, attrs.findAttributeValue(SessionAttributes.SESSION_ID))
     assertEquals(expectedUserSessionId, attrs.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID))
     assertEquals(expectedSessionPartId, attrs.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID))
+}
+
+/**
+ * Asserts the session part payload's session span has all session-related IDs: emb.user_session_id, session.id, and emb.session_part_id
+ * The first two are always equal, while the session part ID should not equal the other two.
+ */
+fun Envelope<SessionPartPayload>.assertSessionIds(): SessionIds {
+    val otelSessionId = getOtelSessionId()
+    val userSessionId = getUserSessionId()
+    val sessionPartId = getSessionPartId()
+    assertEquals("session.id must equal emb.user_session_id", userSessionId, otelSessionId)
+    assertNotEquals("emb.session_part_id must not equal emb.user_session_id", sessionPartId, userSessionId)
+    return SessionIds(userSessionId = userSessionId, partId = sessionPartId)
+}
+
+/**
+ * Asserts a log has session.id and emb.user_session_id which are the same value.
+ */
+fun Log.assertSessionIdsConsistent() {
+    val attrs = checkNotNull(attributes) { "no attributes found on log" }
+    val otelSessionId = attrs.findAttributeValue(SessionAttributes.SESSION_ID)
+    assertFalse("session.id must be present on the log", otelSessionId.isNullOrBlank())
+    assertEquals(
+        "session.id must equal emb.user_session_id on the log",
+        otelSessionId,
+        attrs.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID)
+    )
 }


### PR DESCRIPTION
`session.id` and `emb.user_session_id` should always be the same value, but we should ask for what we want instead of willy-nilly asking for one when we mean to ask for the other. Correct that here.