### PR TITLE
Use the session part ID when linking to session part spans

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImpl.kt
@@ -47,7 +47,7 @@ internal class CurrentSessionPartSpanImpl(
      * Encapsulation of the current session span (if there is one) and its trace counts.
      */
     @Volatile
-    private var sessionState: SessionState? = null
+    private var sessionPartState: SessionPartState? = null
 
     @Volatile
     private var lastSessionSpan: EmbraceSdkSpan? = null
@@ -56,8 +56,8 @@ internal class CurrentSessionPartSpanImpl(
         if (!initialized) {
             synchronized(sessionTransitionLock) {
                 if (!initialized) {
-                    sessionState = SessionState(startSessionSpan(sdkInitStartTimeMs))
-                    initialized = sessionState != null
+                    sessionPartState = startSessionPartSpan(sdkInitStartTimeMs)
+                    initialized = sessionPartState != null
                 }
             }
         }
@@ -71,7 +71,7 @@ internal class CurrentSessionPartSpanImpl(
      * be counted as such towards the limits, so make sure there's no case afterwards where a Span is not created.
      */
     override fun canStartNewSpan(parent: EmbraceSpan?, internal: Boolean): Boolean {
-        val state = sessionState ?: return false
+        val state = sessionPartState ?: return false
         if (!state.isReady || (parent != null && parent.spanId == null)) {
             return false
         }
@@ -92,42 +92,46 @@ internal class CurrentSessionPartSpanImpl(
         }
     }
 
-    override fun getId(): String = sessionState?.sessionId ?: ""
+    override fun getId(): String = sessionPartState?.sessionPartId ?: ""
 
     override fun spanStopCallback(spanId: String) {
-        val currentSessionPartSpan = sessionState?.span
+        val currentSessionPartSpan = sessionPartState?.span
         val spanToStop = spanRepository.getSpan(spanId)
 
         if (currentSessionPartSpan != spanToStop) {
-            val sessionIds = currentSessionPartSpan?.userSessionIdAttrs() ?: emptyMap()
-
+            val linkAttrs = currentSessionPartSpan?.partLinkAttrs() ?: emptyMap()
             spanToStop?.spanContext?.let { spanToStopContext ->
                 if (currentSessionPartSpan != null) {
-                    currentSessionPartSpan.addSystemLink(spanToStopContext, LinkType.EndedIn, sessionIds)
+                    currentSessionPartSpan.addSystemLink(
+                        linkedSpanContext = spanToStopContext,
+                        type = LinkType.EndedIn,
+                        attributes = linkAttrs
+                    )
                     if (spanToStop.hasEmbraceAttribute(EmbType.State)) {
-                        currentSessionPartSpan.addSystemLink(spanToStopContext, LinkType.State, sessionIds)
+                        currentSessionPartSpan.addSystemLink(
+                            linkedSpanContext = spanToStopContext,
+                            type = LinkType.State,
+                            attributes = linkAttrs
+                        )
                     }
                 }
             }
 
-            val otelSessionId = currentSessionPartSpan?.getSystemAttribute(SessionAttributes.SESSION_ID)
-            if (otelSessionId != null) {
-                currentSessionPartSpan.spanContext?.let { sessionSpanContext ->
-                    spanToStop?.addSystemLink(
-                        linkedSpanContext = sessionSpanContext,
-                        type = LinkType.EndSession,
-                        attributes = mapOf(SessionAttributes.SESSION_ID to otelSessionId) + sessionIds
-                    )
-                }
+            currentSessionPartSpan?.spanContext?.let { sessionSpanContext ->
+                spanToStop?.addSystemLink(
+                    linkedSpanContext = sessionSpanContext,
+                    type = LinkType.EndSession,
+                    attributes = linkAttrs
+                )
             }
         }
     }
 
     override fun readySession(): Boolean {
-        if (sessionState == null) {
+        if (sessionPartState == null) {
             synchronized(sessionTransitionLock) {
-                if (sessionState == null) {
-                    sessionState = SessionState(startSessionSpan(openTelemetryClock.now().nanosToMillis()))
+                if (sessionPartState == null) {
+                    sessionPartState = startSessionPartSpan(openTelemetryClock.now().nanosToMillis())
                     return sessionSpanReady()
                 }
             }
@@ -140,7 +144,7 @@ internal class CurrentSessionPartSpanImpl(
         appTerminationCause: AppTerminationCause?,
     ): List<EmbraceSpanData> {
         synchronized(sessionTransitionLock) {
-            val endingSessionSpan = sessionState?.span
+            val endingSessionSpan = sessionPartState?.span
             return if (endingSessionSpan != null && endingSessionSpan.isRecording) {
                 // Right now, session spans don't survive native crashes and sudden process terminations,
                 // so telemetry will not be recorded in those cases, for now.
@@ -154,8 +158,8 @@ internal class CurrentSessionPartSpanImpl(
                     endingSessionSpan.stop()
                     lastSessionSpan = endingSessionSpan
                     spanRepository.clearCompletedSpans()
-                    sessionState = if (startNewSession) {
-                        SessionState(startSessionSpan(openTelemetryClock.now().nanosToMillis()))
+                    sessionPartState = if (startNewSession) {
+                        startSessionPartSpan(openTelemetryClock.now().nanosToMillis())
                     } else {
                         null
                     }
@@ -175,13 +179,15 @@ internal class CurrentSessionPartSpanImpl(
         }
     }
 
-    override fun current(): EmbraceSdkSpan? = sessionState?.span
+    override fun current(): EmbraceSdkSpan? = sessionPartState?.span
 
     /**
-     * This method should always be used when starting a new session span
+     * This method should always be used when starting a new session part span. It creates a UUID for the session part and
+     * puts it in the span. This is the one true place for creating a new session part and its persisted metadata.
      */
-    private fun startSessionSpan(startTimeMs: Long): EmbraceSdkSpan {
-        return embraceSpanFactorySupplier().create(
+    private fun startSessionPartSpan(startTimeMs: Long): SessionPartState {
+        val sessionPartId = uuidSource.createUuid()
+        val span = embraceSpanFactorySupplier().create(
             OtelSpanStartArgs(
                 name = "session",
                 type = EmbType.Ux.Session,
@@ -192,39 +198,41 @@ internal class CurrentSessionPartSpanImpl(
             )
         ).apply {
             start(startTimeMs = startTimeMs)
-            setSystemAttribute(SessionAttributes.SESSION_ID, uuidSource.createUuid())
+            setSystemAttribute(EmbSessionAttributes.EMB_SESSION_PART_ID, sessionPartId)
             val previousSessionSpan = lastSessionSpan
             previousSessionSpan?.spanContext?.let {
-                val previousOtelSessionId = previousSessionSpan.getSystemAttribute(SessionAttributes.SESSION_ID) ?: ""
                 addSystemLink(
                     linkedSpanContext = it,
                     type = LinkType.PreviousSession,
-                    attributes = mapOf(SessionAttributes.SESSION_ID to previousOtelSessionId) +
-                        previousSessionSpan.userSessionIdAttrs()
+                    attributes = previousSessionSpan.partLinkAttrs()
                 )
             }
         }
+        return SessionPartState(span, sessionPartId)
     }
 
-    private fun sessionSpanReady() = sessionState?.isReady == true
+    private fun sessionSpanReady() = sessionPartState?.isReady == true
 
     /**
      * Encapsulates the current session span and the current trace counts for limit enforcement.
      */
-    private class SessionState(val span: EmbraceSdkSpan) {
+    private class SessionPartState(val span: EmbraceSdkSpan, val sessionPartId: String) {
         val traceCount: AtomicInteger = AtomicInteger(0)
         val internalTraceCount: AtomicInteger = AtomicInteger(0)
 
-        val sessionId: String? get() = span.getSystemAttribute(SessionAttributes.SESSION_ID)
         val isReady: Boolean get() = span.isRecording
     }
 
-    private fun EmbraceSdkSpan.userSessionIdAttrs(): Map<String, String> = buildMap {
-        getSystemAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID)?.let {
-            put(EmbSessionAttributes.EMB_USER_SESSION_ID, it)
-        }
+    /**
+     * Attributes for a span link that references the session part represented by this span.
+     */
+    private fun EmbraceSdkSpan.partLinkAttrs(): Map<String, String> = buildMap {
         getSystemAttribute(EmbSessionAttributes.EMB_SESSION_PART_ID)?.let {
             put(EmbSessionAttributes.EMB_SESSION_PART_ID, it)
+        }
+        getSystemAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID)?.let {
+            put(EmbSessionAttributes.EMB_USER_SESSION_ID, it)
+            put(SessionAttributes.SESSION_ID, it)
         }
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanAttributeTests.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanAttributeTests.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSpanData
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
 import io.embrace.android.embracesdk.internal.otel.spans.SpanSink
-import io.opentelemetry.kotlin.semconv.SessionAttributes
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
@@ -52,7 +52,7 @@ internal class CurrentSessionPartSpanAttributeTests {
     }
 
     private fun EmbraceSpanData.assertCommonSessionSpanAttrs() {
-        assertNotNull(attributes.findAttributeValue(SessionAttributes.SESSION_ID))
+        assertNotNull(attributes.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID))
         assertEquals("ux.session", attributes.findAttributeValue("emb.type"))
     }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImplTests.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImplTests.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.assertions.assertEmbraceSpanData
 import io.embrace.android.embracesdk.assertions.assertError
 import io.embrace.android.embracesdk.assertions.assertHasEmbraceAttribute
 import io.embrace.android.embracesdk.assertions.assertIsType
-import io.embrace.android.embracesdk.assertions.validatePreviousSessionLink
+import io.embrace.android.embracesdk.assertions.validatePreviousSessionPartLink
 import io.embrace.android.embracesdk.assertions.validateSystemLink
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
@@ -447,7 +447,7 @@ internal class CurrentSessionPartSpanImplTests {
         with(spanRepository.getActiveSpans().single()) {
             assertTrue(hasEmbraceAttribute(EmbType.Ux.Session))
             assertNotEquals(originalSessionSpan.spanId, spanId)
-            checkNotNull(snapshot()?.links?.single()).validatePreviousSessionLink(originalSessionSpan, originalSessionId)
+            checkNotNull(snapshot()?.links?.single()).validatePreviousSessionPartLink(originalSessionSpan, originalSessionId)
         }
     }
 
@@ -458,17 +458,15 @@ internal class CurrentSessionPartSpanImplTests {
         val originalSessionPartId = "previous-session-part"
         originalSessionSpan.setSystemAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID, originalUserSessionId)
         originalSessionSpan.setSystemAttribute(EmbSessionAttributes.EMB_SESSION_PART_ID, originalSessionPartId)
-        val originalSessionId = currentSessionPartSpan.getId()
         val originalSnapshot = checkNotNull(originalSessionSpan.snapshot())
 
         currentSessionPartSpan.endSession(startNewSession = true)
 
         with(spanRepository.getActiveSpans().single()) {
-            checkNotNull(snapshot()?.links?.single()).validatePreviousSessionLink(
+            checkNotNull(snapshot()?.links?.single()).validatePreviousSessionPartLink(
                 previousSessionSpan = originalSnapshot,
-                previousOtelSessionId = originalSessionId,
-                previousUserSessionId = originalUserSessionId,
                 previousSessionPartId = originalSessionPartId,
+                previousUserSessionId = originalUserSessionId,
             )
         }
     }
@@ -546,7 +544,6 @@ internal class CurrentSessionPartSpanImplTests {
     @Test
     fun `span stop callback creates the correct span links`() {
         val sessionSpan = checkNotNull(spanRepository.getActiveSpans().single())
-        val otelSessionId = checkNotNull(sessionSpan.getSystemAttribute(SessionAttributes.SESSION_ID))
         val userSessionId = "user-session-uuid"
         val sessionPartId = "session-part-uuid"
         sessionSpan.setSystemAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID, userSessionId)
@@ -558,19 +555,20 @@ internal class CurrentSessionPartSpanImplTests {
         val spanSnapshot = checkNotNull(span.snapshot())
         val sessionSpanSnapshot = checkNotNull(sessionSpan.snapshot())
 
-        val expectedOtelSessionIds = mapOf(
-            EmbSessionAttributes.EMB_USER_SESSION_ID to userSessionId,
+        val expectedPartLinkAttrs = mapOf(
             EmbSessionAttributes.EMB_SESSION_PART_ID to sessionPartId,
+            EmbSessionAttributes.EMB_USER_SESSION_ID to userSessionId,
+            SessionAttributes.SESSION_ID to userSessionId,
         )
         checkNotNull(spanSnapshot.links).single().validateSystemLink(
             linkedSpan = sessionSpanSnapshot,
             type = LinkType.EndSession,
-            expectedAttributes = mapOf(SessionAttributes.SESSION_ID to otelSessionId) + expectedOtelSessionIds
+            expectedAttributes = expectedPartLinkAttrs
         )
         checkNotNull(sessionSpanSnapshot.links).single().validateSystemLink(
             linkedSpan = spanSnapshot,
             type = LinkType.EndedIn,
-            expectedAttributes = expectedOtelSessionIds,
+            expectedAttributes = expectedPartLinkAttrs,
         )
     }
 

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/LinkAssertions.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/LinkAssertions.kt
@@ -10,16 +10,17 @@ import io.opentelemetry.kotlin.semconv.SessionAttributes
 import io.opentelemetry.kotlin.tracing.SpanContext
 import org.junit.Assert.assertTrue
 
-fun Link.validatePreviousSessionLink(
+fun Link.validatePreviousSessionPartLink(
     previousSessionSpan: Span,
-    previousOtelSessionId: String,
+    previousSessionPartId: String,
     previousUserSessionId: String? = null,
-    previousSessionPartId: String? = null,
 ) {
     val expected = buildMap {
-        put(SessionAttributes.SESSION_ID, previousOtelSessionId)
-        previousUserSessionId?.let { put(EmbSessionAttributes.EMB_USER_SESSION_ID, it) }
-        previousSessionPartId?.let { put(EmbSessionAttributes.EMB_SESSION_PART_ID, it) }
+        put(EmbSessionAttributes.EMB_SESSION_PART_ID, previousSessionPartId)
+        previousUserSessionId?.let {
+            put(EmbSessionAttributes.EMB_USER_SESSION_ID, it)
+            put(SessionAttributes.SESSION_ID, it)
+        }
     }
     validateSystemLink(
         linkedSpan = previousSessionSpan,

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
@@ -37,8 +37,8 @@ fun Span.findEventsOfType(telemetryType: EmbType): List<SpanEvent> {
     }
 }
 
-fun Span.assertPreviousSession(previousSessionSpan: Span, previousOtelSessionId: String) {
-    findLinkOfType(LinkType.PreviousSession).validatePreviousSessionLink(previousSessionSpan, previousOtelSessionId)
+fun Span.assertPreviousSessionPart(previousSessionSpan: Span, previousSessionPartId: String) {
+    findLinkOfType(LinkType.PreviousSession).validatePreviousSessionPartLink(previousSessionSpan, previousSessionPartId)
 }
 
 fun Span.assertNoPreviousSession() =

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionPartPayloadTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionPartPayloadTest.kt
@@ -4,7 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.PropertyScope
 import io.embrace.android.embracesdk.assertions.assertMatches
 import io.embrace.android.embracesdk.assertions.assertNoPreviousSession
-import io.embrace.android.embracesdk.assertions.assertPreviousSession
+import io.embrace.android.embracesdk.assertions.assertPreviousSessionPart
 import io.embrace.android.embracesdk.assertions.findSessionSpan
 import io.embrace.android.embracesdk.assertions.getOtelSessionId
 import io.embrace.android.embracesdk.assertions.getSessionPartId
@@ -234,31 +234,31 @@ internal class SessionPartPayloadTest {
 
                 val firstSessionSpan = firstSession.getValidatedSessionSpan(
                     previousSessionSpan = firstBaSessionSpan,
-                    previousOtelSessionId = firstBa.getOtelSessionId()
+                    previousSessionPartId = firstBa.getSessionPartId()
                 )
 
                 val secondBaSessionSpan = secondBa.getValidatedSessionSpan(
                     isColdStart = false,
                     previousSessionSpan = firstSessionSpan,
-                    previousOtelSessionId = firstSession.getOtelSessionId()
+                    previousSessionPartId = firstSession.getSessionPartId()
                 )
 
                 val secondSessionSpan = secondSession.getValidatedSessionSpan(
                     isColdStart = false,
                     previousSessionSpan = secondBaSessionSpan,
-                    previousOtelSessionId = secondBa.getOtelSessionId()
+                    previousSessionPartId = secondBa.getSessionPartId()
                 )
 
                 val thirdBaSessionSpan = thirdBa.getValidatedSessionSpan(
                     isColdStart = false,
                     previousSessionSpan = secondSessionSpan,
-                    previousOtelSessionId = secondSession.getOtelSessionId()
+                    previousSessionPartId = secondSession.getSessionPartId()
                 )
 
                 thirdSession.getValidatedSessionSpan(
                     isColdStart = false,
                     previousSessionSpan = thirdBaSessionSpan,
-                    previousOtelSessionId = thirdBa.getOtelSessionId()
+                    previousSessionPartId = thirdBa.getSessionPartId()
                 )
             }
         )
@@ -283,13 +283,13 @@ internal class SessionPartPayloadTest {
                 val secondSessionSpan = second.getValidatedSessionSpan(
                     isColdStart = false,
                     previousSessionSpan = firstSessionSpan,
-                    previousOtelSessionId = first.getOtelSessionId()
+                    previousSessionPartId = first.getSessionPartId()
                 )
 
                 third.getValidatedSessionSpan(
                     isColdStart = false,
                     previousSessionSpan = secondSessionSpan,
-                    previousOtelSessionId = second.getOtelSessionId()
+                    previousSessionPartId = second.getSessionPartId()
                 )
             }
         )
@@ -298,7 +298,7 @@ internal class SessionPartPayloadTest {
     private fun Envelope<SessionPartPayload>.getValidatedSessionSpan(
         isColdStart: Boolean = true,
         previousSessionSpan: Span? = null,
-        previousOtelSessionId: String? = null,
+        previousSessionPartId: String? = null,
     ): Span {
         val sessionSpan = findSessionSpan()
         assertFalse(hasSpanSnapshotsOfType(EmbType.Ux.Session))
@@ -309,8 +309,8 @@ internal class SessionPartPayloadTest {
                 )
             )
 
-            if (previousSessionSpan != null && previousOtelSessionId != null) {
-                assertPreviousSession(previousSessionSpan, previousOtelSessionId)
+            if (previousSessionSpan != null && previousSessionPartId != null) {
+                assertPreviousSessionPart(previousSessionSpan, previousSessionPartId)
             } else {
                 assertNoPreviousSession()
             }


### PR DESCRIPTION
SpanLinks that reference the session part a span ended in, or which session part was previous to the existing one, should use the session part ID and not the user session ID.