### PR TITLE
Rename internal usage of sessionSpan to sessionPartSpan

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/session/EmbraceUserSessionProperties.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/session/EmbraceUserSessionProperties.kt
@@ -97,7 +97,7 @@ internal class EmbraceUserSessionProperties(
     /**
      * Adds all user session properties to the session span.
      */
-    fun addPropsForNewSessionSpan() {
+    fun addPropsForNewSessionPartSpan() {
         synchronized(lock) {
             properties.forEach { (key, entry) ->
                 if (entry.scope != PropertyScope.USER_SESSION) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/session/UserSessionPropertiesServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/session/UserSessionPropertiesServiceImpl.kt
@@ -68,7 +68,7 @@ internal class UserSessionPropertiesServiceImpl(
     }
 
     override fun prepareForNewSession() {
-        props.addPropsForNewSessionSpan()
+        props.addPropsForNewSessionPartSpan()
     }
 
     override fun addChangeListener(listener: (Map<String, String>) -> Unit) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
@@ -48,7 +48,7 @@ class UserSessionOrchestrationModuleImpl(
             essentialServiceModule.userSessionPropertiesService
         )
 
-        val sessionSpanAttrPopulator = SessionPartSpanAttrPopulatorImpl(
+        val sessionPartSpanAttrPopulator = SessionPartSpanAttrPopulatorImpl(
             essentialServiceModule.telemetryDestination,
             startupDurationProvider,
             logModule.logLimitingService,
@@ -66,7 +66,7 @@ class UserSessionOrchestrationModuleImpl(
             deliveryModule?.payloadCachingService,
             instrumentationModule.instrumentationRegistry,
             essentialServiceModule.telemetryDestination,
-            sessionSpanAttrPopulator,
+            sessionPartSpanAttrPopulator,
             coreModule.ordinalStore,
             UserSessionMetadataStore(coreModule.store),
             initModule.logger,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
@@ -27,7 +27,7 @@ import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.serialization.fromJson
 import io.embrace.android.embracesdk.internal.session.UserSessionRestoreDecision
-import io.embrace.android.embracesdk.internal.session.getSessionSpan
+import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
 import io.embrace.android.embracesdk.internal.session.getUserSessionProperties
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
@@ -315,7 +315,7 @@ internal class PayloadResurrectionServiceImpl(
         isBackgroundOnly: Boolean,
     ): Envelope<SessionPartPayload> {
         val deadPart = serializer.fromJson<Envelope<SessionPartPayload>>(payloadStream)
-        val deadSessionPartSpan = deadPart.getSessionSpan()
+        val deadSessionPartSpan = deadPart.getSessionPartSpan()
         val sessionPartId = deadSessionPartSpan?.resolveSessionPartIdForCrashMatch()
         val appState = deadSessionPartSpan?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_STATE)
         val nativeCrash = if (nativeCrashService != null && sessionPartId != null) {
@@ -375,25 +375,25 @@ internal class PayloadResurrectionServiceImpl(
             ?.map { it.toFailedSpan(endTimeMs = getFailedSpanEndTimeMs(this)) }
             ?: emptyList()
         val completedSpans = (data.spans ?: emptyList()) + failedSpans
-        val sessionSpan = completedSpans.singleOrNull { it.hasEmbraceAttribute(EmbType.Ux.Session) } ?: return null
+        val sessionPartSpan = completedSpans.singleOrNull { it.hasEmbraceAttribute(EmbType.Ux.Session) } ?: return null
 
         val attributesToAttach = buildList {
             if (isBackgroundOnly) {
-                addAll(sessionSpan.backgroundOnlyAttributes())
+                addAll(sessionPartSpan.backgroundOnlyAttributes())
             }
             if (userSessionTerminationReason != null) {
-                addAll(sessionSpan.finalSessionPartAttributes(userSessionTerminationReason))
+                addAll(sessionPartSpan.finalSessionPartAttributes(userSessionTerminationReason))
             }
             if (nativeCrashData != null) {
-                addAll(sessionSpan.crashAttributes(nativeCrashData))
+                addAll(sessionPartSpan.crashAttributes(nativeCrashData))
             }
         }
 
         val spans = if (attributesToAttach.isEmpty()) {
             completedSpans
         } else {
-            val updatedSessionSpan = sessionSpan.copy(attributes = (sessionSpan.attributes ?: emptyList()) + attributesToAttach)
-            completedSpans.minus(sessionSpan).plus(updatedSessionSpan)
+            val updatedSessionPartSpan = sessionPartSpan.copy(attributes = (sessionPartSpan.attributes ?: emptyList()) + attributesToAttach)
+            completedSpans.minus(sessionPartSpan).plus(updatedSessionPartSpan)
         }
 
         return copy(
@@ -466,10 +466,10 @@ internal class PayloadResurrectionServiceImpl(
      * time, so we just leave it at 0.
      */
     private fun getFailedSpanEndTimeMs(envelope: Envelope<SessionPartPayload>): Long {
-        val sessionSpan = envelope.getSessionSpan() ?: return 0L
-        val endTimeMs = sessionSpan.endTimeNanos ?: 0L
+        val sessionPartSpan = envelope.getSessionPartSpan() ?: return 0L
+        val endTimeMs = sessionPartSpan.endTimeNanos ?: 0L
         val lastHeartbeatTimeMs =
-            sessionSpan.attributes?.findAttributeValue(EmbSessionAttributes.EMB_HEARTBEAT_TIME_UNIX_NANO)?.toLongOrNull() ?: 0L
+            sessionPartSpan.attributes?.findAttributeValue(EmbSessionAttributes.EMB_HEARTBEAT_TIME_UNIX_NANO)?.toLongOrNull() ?: 0L
         return max(endTimeMs, lastHeartbeatTimeMs).nanosToMillis()
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/EnvelopeExt.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/EnvelopeExt.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
 import io.embrace.android.embracesdk.internal.payload.Span
 
-fun Envelope<SessionPartPayload>.getSessionSpan(): Span? {
+fun Envelope<SessionPartPayload>.getSessionPartSpan(): Span? {
     return data.spans?.singleOrNull { it.hasEmbraceAttribute(EmbType.Ux.Session) }
         ?: data.spanSnapshots?.singleOrNull { it.hasEmbraceAttribute(EmbType.Ux.Session) }
 }
@@ -17,7 +17,7 @@ fun Envelope<SessionPartPayload>.getStateSpan(spanName: String): Span? {
 }
 
 fun Envelope<SessionPartPayload>.getUserSessionProperties(): Map<String, String> {
-    return getSessionSpan()?.getUserSessionProperties() ?: emptyMap()
+    return getSessionPartSpan()?.getUserSessionProperties() ?: emptyMap()
 }
 
 @Suppress("UNCHECKED_CAST")

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -52,7 +52,7 @@ internal class SessionOrchestratorImpl(
     private val payloadCachingService: PayloadCachingService?,
     instrumentationRegistry: InstrumentationRegistry,
     private val destination: TelemetryDestination,
-    private val sessionSpanAttrPopulator: SessionPartSpanAttrPopulator,
+    private val sessionPartSpanAttrPopulator: SessionPartSpanAttrPopulator,
     private val ordinalStore: OrdinalStore,
     private val metadataStore: UserSessionMetadataStore,
     private val logger: InternalLogger,
@@ -350,7 +350,7 @@ internal class SessionOrchestratorImpl(
 
             val endingSession = sessionTracker.getActiveSessionPart()
             if (endingSession != null) {
-                sessionSpanAttrPopulator.populateSessionSpanEndAttrs(
+                sessionPartSpanAttrPopulator.populateSessionPartSpanEndAttrs(
                     endType = transitionType.lifeEventType(state),
                     crashId = crashId,
                     coldStart = endingSession.isColdStart,
@@ -401,7 +401,7 @@ internal class SessionOrchestratorImpl(
                     }
                 }
                 boundaryDelegate.prepareForNewSession()
-                sessionSpanAttrPopulator.populateSessionSpanStartAttrs(newSessionPart, userSession)
+                sessionPartSpanAttrPopulator.populateSessionPartSpanStartAttrs(newSessionPart, userSession)
                 if (transitionType != TransitionType.CRASH) {
                     // initiate periodic caching of the payload if a new session has started
                     EmbTrace.start("initiate-periodic-caching")

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulator.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulator.kt
@@ -12,12 +12,12 @@ interface SessionPartSpanAttrPopulator {
     /**
      * Populates session span attributes at the start of the session.
      */
-    fun populateSessionSpanStartAttrs(sessionPart: SessionPartToken, userSession: UserSessionMetadata?)
+    fun populateSessionPartSpanStartAttrs(sessionPart: SessionPartToken, userSession: UserSessionMetadata?)
 
     /**
      * Populates session span attributes at the end of the session.
      */
-    fun populateSessionSpanEndAttrs(
+    fun populateSessionPartSpanEndAttrs(
         endType: LifeEventType?,
         crashId: String?,
         coldStart: Boolean,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImpl.kt
@@ -18,7 +18,7 @@ internal class SessionPartSpanAttrPopulatorImpl(
     private val metadataService: MetadataService,
 ) : SessionPartSpanAttrPopulator {
 
-    override fun populateSessionSpanStartAttrs(sessionPart: SessionPartToken, userSession: UserSessionMetadata?) {
+    override fun populateSessionPartSpanStartAttrs(sessionPart: SessionPartToken, userSession: UserSessionMetadata?) {
         with(destination) {
             addSessionPartAttribute(EmbSessionAttributes.EMB_COLD_START, sessionPart.isColdStart.toString())
             addSessionPartAttribute(EmbSessionAttributes.EMB_STATE, sessionPart.appState.name.lowercase(Locale.US))
@@ -44,7 +44,7 @@ internal class SessionPartSpanAttrPopulatorImpl(
         }
     }
 
-    override fun populateSessionSpanEndAttrs(
+    override fun populateSessionPartSpanEndAttrs(
         endType: LifeEventType?,
         crashId: String?,
         coldStart: Boolean,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImpl.kt
@@ -50,7 +50,7 @@ internal class CurrentSessionPartSpanImpl(
     private var sessionPartState: SessionPartState? = null
 
     @Volatile
-    private var lastSessionSpan: EmbraceSdkSpan? = null
+    private var lastSessionPartSpan: EmbraceSdkSpan? = null
 
     override fun initializeService(sdkInitStartTimeMs: Long) {
         if (!initialized) {
@@ -117,9 +117,9 @@ internal class CurrentSessionPartSpanImpl(
                 }
             }
 
-            currentSessionPartSpan?.spanContext?.let { sessionSpanContext ->
+            currentSessionPartSpan?.spanContext?.let { sessionPartSpanContext ->
                 spanToStop?.addSystemLink(
-                    linkedSpanContext = sessionSpanContext,
+                    linkedSpanContext = sessionPartSpanContext,
                     type = LinkType.EndSession,
                     attributes = linkAttrs
                 )
@@ -132,11 +132,11 @@ internal class CurrentSessionPartSpanImpl(
             synchronized(sessionTransitionLock) {
                 if (sessionPartState == null) {
                     sessionPartState = startSessionPartSpan(openTelemetryClock.now().nanosToMillis())
-                    return sessionSpanReady()
+                    return sessionPartSpanReady()
                 }
             }
         }
-        return sessionSpanReady()
+        return sessionPartSpanReady()
     }
 
     override fun endSession(
@@ -144,19 +144,19 @@ internal class CurrentSessionPartSpanImpl(
         appTerminationCause: AppTerminationCause?,
     ): List<EmbraceSpanData> {
         synchronized(sessionTransitionLock) {
-            val endingSessionSpan = sessionPartState?.span
-            return if (endingSessionSpan != null && endingSessionSpan.isRecording) {
+            val endingSessionPartSpan = sessionPartState?.span
+            return if (endingSessionPartSpan != null && endingSessionPartSpan.isRecording) {
                 // Right now, session spans don't survive native crashes and sudden process terminations,
                 // so telemetry will not be recorded in those cases, for now.
                 val telemetryAttributes = telemetryService.getAndClearTelemetryAttributes()
 
                 telemetryAttributes.forEach {
-                    endingSessionSpan.addAttribute(it.key, it.value)
+                    endingSessionPartSpan.addAttribute(it.key, it.value)
                 }
 
                 if (appTerminationCause == null) {
-                    endingSessionSpan.stop()
-                    lastSessionSpan = endingSessionSpan
+                    endingSessionPartSpan.stop()
+                    lastSessionPartSpan = endingSessionPartSpan
                     spanRepository.clearCompletedSpans()
                     sessionPartState = if (startNewSession) {
                         startSessionPartSpan(openTelemetryClock.now().nanosToMillis())
@@ -166,11 +166,11 @@ internal class CurrentSessionPartSpanImpl(
                 } else {
                     val crashTime = openTelemetryClock.now().nanosToMillis()
                     spanRepository.failActiveSpans(crashTime)
-                    endingSessionSpan.setSystemAttribute(
+                    endingSessionPartSpan.setSystemAttribute(
                         appTerminationCause.key,
                         appTerminationCause.value
                     )
-                    endingSessionSpan.stop(errorCode = ErrorCode.FAILURE, endTimeMs = crashTime)
+                    endingSessionPartSpan.stop(errorCode = ErrorCode.FAILURE, endTimeMs = crashTime)
                 }
                 spanSink.flushSpans()
             } else {
@@ -199,19 +199,19 @@ internal class CurrentSessionPartSpanImpl(
         ).apply {
             start(startTimeMs = startTimeMs)
             setSystemAttribute(EmbSessionAttributes.EMB_SESSION_PART_ID, sessionPartId)
-            val previousSessionSpan = lastSessionSpan
-            previousSessionSpan?.spanContext?.let {
+            val previousSessionPartSpan = lastSessionPartSpan
+            previousSessionPartSpan?.spanContext?.let {
                 addSystemLink(
                     linkedSpanContext = it,
                     type = LinkType.PreviousSession,
-                    attributes = previousSessionSpan.partLinkAttrs()
+                    attributes = previousSessionPartSpan.partLinkAttrs()
                 )
             }
         }
         return SessionPartState(span, sessionPartId)
     }
 
-    private fun sessionSpanReady() = sessionPartState?.isReady == true
+    private fun sessionPartSpanReady() = sessionPartState?.isReady == true
 
     /**
      * Encapsulates the current session span and the current trace counts for limit enforcement.

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/session/EmbraceUserSessionPropertiesTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/session/EmbraceUserSessionPropertiesTest.kt
@@ -132,13 +132,13 @@ internal class EmbraceUserSessionPropertiesTest {
     }
 
     @Test
-    fun `addPropsForNewSessionSpan includes permanent and process but not session`() {
+    fun `addPropsForNewSessionPartSpan includes permanent and process but not session`() {
         props.add("permKey", "permVal", PropertyScope.PERMANENT)
         props.add("procKey", "procVal", PropertyScope.PROCESS)
         props.add("sessKey", "sessVal", PropertyScope.USER_SESSION)
 
         destination.attributes.clear()
-        props.addPropsForNewSessionSpan()
+        props.addPropsForNewSessionPartSpan()
 
         val keys = destination.attributes.keys.map { it.removePrefix("emb.properties.") }
         assertTrue("permanent prop missing", keys.contains("permKey"))
@@ -372,7 +372,7 @@ internal class EmbraceUserSessionPropertiesTest {
         val apiCaller = Thread {
             repeat(iterations) {
                 try {
-                    props.addPropsForNewSessionSpan()
+                    props.addPropsForNewSessionPartSpan()
                 } catch (e: ConcurrentModificationException) {
                     errors.incrementAndGet()
                 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPartPayloadSourceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPartPayloadSourceImplTest.kt
@@ -38,7 +38,7 @@ internal class SessionPartPayloadSourceImplTest {
         }
         activeSpan = FakeEmbraceSdkSpan.started()
         spanRepository = SpanRepository()
-        spanRepository.trackStartedSpan(checkNotNull(currentSessionPartSpan.sessionSpan))
+        spanRepository.trackStartedSpan(checkNotNull(currentSessionPartSpan.sessionPartSpan))
         spanRepository.trackStartedSpan(activeSpan)
         impl = SessionPartPayloadSourceImpl(
             mapOf("armeabi-v7a" to "my-symbols"),

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
@@ -52,7 +52,7 @@ import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.session.UserSessionRestoreDecision
-import io.embrace.android.embracesdk.internal.session.getSessionSpan
+import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
 import io.embrace.android.embracesdk.internal.toEmbraceSpanData
 import io.embrace.android.embracesdk.internal.worker.PriorityWorker
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
@@ -142,12 +142,12 @@ class PayloadResurrectionServiceImplTest {
         assertEquals(0, cacheStorageService.storedPayloadCount())
 
         val sessionEnvelope = getStoredParts().single()
-        val sessionSpan = checkNotNull(sessionEnvelope.getSessionSpan())
+        val sessionPartSpan = checkNotNull(sessionEnvelope.getSessionPartSpan())
         val expectedStartTimeMs = deadSessionEnvelope.getStartTime()
         val expectedEndTimeMs = deadSessionEnvelope.getLastHeartbeatTimeMs()
 
         assertEmbraceSpanData(
-            span = sessionSpan,
+            span = sessionPartSpan,
             expectedStartTimeMs = expectedStartTimeMs,
             expectedEndTimeMs = expectedEndTimeMs,
             expectedParentId = OtelIds.INVALID_SPAN_ID,
@@ -271,10 +271,10 @@ class PayloadResurrectionServiceImplTest {
         assertEquals(2, sentSession.data.spans?.size)
         assertEquals(0, sentSession.data.spanSnapshots?.size)
 
-        val sessionSpan = checkNotNull(sentSession.getSessionSpan())
+        val sessionPartSpan = checkNotNull(sentSession.getSessionPartSpan())
         val spanSnapshot =
             checkNotNull(
-                deadSessionEnvelope.data.spanSnapshots?.filterNot { it.spanId == sessionSpan.spanId }
+                deadSessionEnvelope.data.spanSnapshots?.filterNot { it.spanId == sessionPartSpan.spanId }
                     ?.single()
             )
         val resurrectedSnapshot = sentSession.findSpansByName(checkNotNull(spanSnapshot.name)).single()
@@ -282,7 +282,7 @@ class PayloadResurrectionServiceImplTest {
         assertEmbraceSpanData(
             span = resurrectedSnapshot,
             expectedStartTimeMs = checkNotNull(spanSnapshot.startTimeNanos?.nanosToMillis()),
-            expectedEndTimeMs = checkNotNull(sessionSpan.endTimeNanos?.nanosToMillis()),
+            expectedEndTimeMs = checkNotNull(sessionPartSpan.endTimeNanos?.nanosToMillis()),
             expectedParentId = OtelIds.INVALID_SPAN_ID,
             expectedErrorCode = ErrorCode.FAILURE,
             expectedCustomAttributes = mapOf(
@@ -311,8 +311,8 @@ class PayloadResurrectionServiceImplTest {
         )
         deadSessionEnvelope.resurrectPayload()
 
-        val sessionSpan = getStoredParts().single().getSessionSpan()
-        assertEquals("dead-session-native-crash", sessionSpan?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID))
+        val sessionPartSpan = getStoredParts().single().getSessionPartSpan()
+        assertEquals("dead-session-native-crash", sessionPartSpan?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID))
 
         // clear snapshots before running second scenario
         payloadStorageService.clearStorage()
@@ -325,7 +325,7 @@ class PayloadResurrectionServiceImplTest {
         deadSessionEnvelope.resurrectPayload()
 
         val attributes =
-            checkNotNull(getStoredParts().last().getSessionSpan()?.attributes)
+            checkNotNull(getStoredParts().last().getSessionPartSpan()?.attributes)
         assertNull(attributes.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID))
     }
 
@@ -345,10 +345,10 @@ class PayloadResurrectionServiceImplTest {
 
         resurrectInBackground()
 
-        val sessionSpan = getStoredParts().single().getSessionSpan()
+        val sessionPartSpan = getStoredParts().single().getSessionPartSpan()
         assertEquals(
             "legacy-native-crash",
-            sessionSpan?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID)
+            sessionPartSpan?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID)
         )
     }
 
@@ -363,7 +363,7 @@ class PayloadResurrectionServiceImplTest {
             )
         )
 
-        val attributes = checkNotNull(getStoredParts().single().getSessionSpan()?.attributes)
+        val attributes = checkNotNull(getStoredParts().single().getSessionPartSpan()?.attributes)
         assertEquals("1", attributes.findAttributeValue(EmbSessionAttributes.EMB_IS_FINAL_SESSION_PART))
         assertEquals(
             EmbUserSessionTerminationReasonValues.INACTIVITY,
@@ -376,7 +376,7 @@ class PayloadResurrectionServiceImplTest {
         cacheStorageService.addPayload(metadata = sessionMetadata, data = deadSessionEnvelope)
         resurrectInBackground()
 
-        val attributes = checkNotNull(getStoredParts().single().getSessionSpan()?.attributes)
+        val attributes = checkNotNull(getStoredParts().single().getSessionPartSpan()?.attributes)
         assertNull(attributes.findAttributeValue(EmbSessionAttributes.EMB_IS_FINAL_SESSION_PART))
         assertNull(attributes.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_TERMINATION_REASON))
     }
@@ -392,7 +392,7 @@ class PayloadResurrectionServiceImplTest {
             )
         )
 
-        val attributes = checkNotNull(getStoredParts().single().getSessionSpan()?.attributes)
+        val attributes = checkNotNull(getStoredParts().single().getSessionPartSpan()?.attributes)
         assertNull(attributes.findAttributeValue(EmbSessionAttributes.EMB_IS_FINAL_SESSION_PART))
         assertNull(attributes.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_TERMINATION_REASON))
     }
@@ -426,14 +426,14 @@ class PayloadResurrectionServiceImplTest {
         )
 
         val parts = getStoredParts().associateBy { it.getUserSessionId() }
-        val laterAttrs = checkNotNull(parts.getValue("later-part").getSessionSpan()?.attributes)
+        val laterAttrs = checkNotNull(parts.getValue("later-part").getSessionPartSpan()?.attributes)
         assertEquals("1", laterAttrs.findAttributeValue(EmbSessionAttributes.EMB_IS_FINAL_SESSION_PART))
         assertEquals(
             EmbUserSessionTerminationReasonValues.MAX_DURATION_REACHED,
             laterAttrs.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_TERMINATION_REASON)
         )
 
-        val earlierAttrs = checkNotNull(parts.getValue("earlier-part").getSessionSpan()?.attributes)
+        val earlierAttrs = checkNotNull(parts.getValue("earlier-part").getSessionPartSpan()?.attributes)
         assertNull(earlierAttrs.findAttributeValue(EmbSessionAttributes.EMB_IS_FINAL_SESSION_PART))
         assertNull(earlierAttrs.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_TERMINATION_REASON))
     }
@@ -449,7 +449,7 @@ class PayloadResurrectionServiceImplTest {
             )
         )
 
-        val attributes = checkNotNull(getStoredParts().single().getSessionSpan()?.attributes)
+        val attributes = checkNotNull(getStoredParts().single().getSessionPartSpan()?.attributes)
         assertEquals("1", attributes.findAttributeValue(EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART))
     }
 
@@ -463,7 +463,7 @@ class PayloadResurrectionServiceImplTest {
             )
         )
 
-        val attributes = checkNotNull(getStoredParts().single().getSessionSpan()?.attributes)
+        val attributes = checkNotNull(getStoredParts().single().getSessionPartSpan()?.attributes)
         assertEquals("1", attributes.findAttributeValue(EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART))
         assertNull(attributes.findAttributeValue(EmbSessionAttributes.EMB_IS_FINAL_SESSION_PART))
     }
@@ -478,7 +478,7 @@ class PayloadResurrectionServiceImplTest {
             )
         )
 
-        val attributes = checkNotNull(getStoredParts().single().getSessionSpan()?.attributes)
+        val attributes = checkNotNull(getStoredParts().single().getSessionPartSpan()?.attributes)
         assertNull(attributes.findAttributeValue(EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART))
     }
 
@@ -493,13 +493,13 @@ class PayloadResurrectionServiceImplTest {
             )
         )
 
-        val attributes = checkNotNull(getStoredParts().single().getSessionSpan()?.attributes)
+        val attributes = checkNotNull(getStoredParts().single().getSessionPartSpan()?.attributes)
         assertNull(attributes.findAttributeValue(EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART))
     }
 
     @Test
     fun `session payload that doesn't contain session span will not be resurrected`() {
-        noSessionSpanEnvelope.resurrectPayload()
+        noSessionPartSpanEnvelope.resurrectPayload()
         assertResurrectionFailure()
     }
 
@@ -573,7 +573,7 @@ class PayloadResurrectionServiceImplTest {
 
     @Test
     fun `session payload that contains more than one span will not be resurrected`() {
-        multipleSessionSpanEnvelope.resurrectPayload()
+        multipleSessionPartSpanEnvelope.resurrectPayload()
         assertResurrectionFailure()
     }
 
@@ -631,11 +631,11 @@ class PayloadResurrectionServiceImplTest {
             assertEquals(deadSessionEnvelope.getUserSessionId(), getUserSessionId())
             assertEquals(
                 "native-crash-1",
-                getSessionSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID)
+                getSessionPartSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID)
             )
             assertEquals(
                 "foreground",
-                getSessionSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_STATE)
+                getSessionPartSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_STATE)
             )
         }
 
@@ -646,11 +646,11 @@ class PayloadResurrectionServiceImplTest {
             assertEquals(earlierDeadSession.getUserSessionId(), getUserSessionId())
             assertEquals(
                 "native-crash-2",
-                getSessionSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID)
+                getSessionPartSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID)
             )
             assertEquals(
                 "foreground",
-                getSessionSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_STATE)
+                getSessionPartSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_STATE)
             )
         }
 
@@ -739,8 +739,8 @@ class PayloadResurrectionServiceImplTest {
         val storedMetadata = payloadStorageService.storedPayloadMetadata().single()
         assertEquals(fakeCachedSessionStoredTelemetryMetadata.copy(complete = true), storedMetadata)
         assertEquals(0, cacheStorageService.storedPayloadCount())
-        val sessionSpan = checkNotNull(getStoredParts().single().getSessionSpan())
-        assertNull(checkNotNull(sessionSpan.attributes).findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID))
+        val sessionPartSpan = checkNotNull(getStoredParts().single().getSessionPartSpan())
+        assertNull(checkNotNull(sessionPartSpan.attributes).findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID))
     }
 
     @Test
@@ -920,16 +920,16 @@ class PayloadResurrectionServiceImplTest {
                 )
             )
         }
-        val noSessionSpanEnvelope = deadSessionEnvelope.copy(
+        val noSessionPartSpanEnvelope = deadSessionEnvelope.copy(
             data = deadSessionEnvelope.data.copy(
                 spanSnapshots = emptyList()
             )
         )
-        val multipleSessionSpanEnvelope = deadSessionEnvelope.copy(
+        val multipleSessionPartSpanEnvelope = deadSessionEnvelope.copy(
             data = deadSessionEnvelope.data.copy(
                 spanSnapshots = deadSessionEnvelope.data.spanSnapshots?.plus(
                     checkNotNull(
-                        FakeEmbraceSdkSpan.sessionSpan(
+                        FakeEmbraceSdkSpan.sessionPartSpan(
                             userSessionId = "fake-session-span-id",
                             startTimeMs = deadSessionEnvelope.getStartTime() + 1001L,
                             lastHeartbeatTimeMs = deadSessionEnvelope.getStartTime() + 1001L,

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -133,12 +133,12 @@ internal class SessionOrchestratorTest {
         createOrchestrator(AppState.BACKGROUND)
         clock.tick()
         val foregroundTime = clock.now()
-        val sessionSpan = currentSessionPartSpan.sessionSpan
+        val sessionPartSpan = currentSessionPartSpan.sessionPartSpan
         val initialUserSession = activeUserSession()
         orchestrator.onForeground()
         assertEquals(1, fakeDataSource.enableDataCaptureCount)
         validateSession(
-            sessionSpan = sessionSpan,
+            sessionPartSpan = sessionPartSpan,
             endTimeMs = foregroundTime,
             endType = LifeEventType.BKGND_STATE
         )
@@ -154,10 +154,10 @@ internal class SessionOrchestratorTest {
         createOrchestrator(AppState.FOREGROUND)
         clock.tick()
         val backgroundTime = clock.now()
-        val sessionSpan = currentSessionPartSpan.sessionSpan
+        val sessionPartSpan = currentSessionPartSpan.sessionPartSpan
         orchestrator.onBackground()
         validateSession(
-            sessionSpan = sessionSpan,
+            sessionPartSpan = sessionPartSpan,
             endTimeMs = backgroundTime,
             endType = LifeEventType.STATE
         )
@@ -217,10 +217,10 @@ internal class SessionOrchestratorTest {
         createOrchestrator(AppState.FOREGROUND)
         clock.tick(10000)
         val endTimeMs = clock.now()
-        val sessionSpan = currentSessionPartSpan.sessionSpan
+        val sessionPartSpan = currentSessionPartSpan.sessionPartSpan
         orchestrator.endSessionWithManual()
         validateSession(
-            sessionSpan = sessionSpan,
+            sessionPartSpan = sessionPartSpan,
             endTimeMs = endTimeMs,
             endType = LifeEventType.MANUAL
         )
@@ -1783,7 +1783,7 @@ internal class SessionOrchestratorTest {
     }
 
     private fun validateSession(
-        sessionSpan: EmbraceSdkSpan?,
+        sessionPartSpan: EmbraceSdkSpan?,
         endTimeMs: Long,
         endType: LifeEventType,
     ) {
@@ -1791,6 +1791,6 @@ internal class SessionOrchestratorTest {
             endType.toString().lowercase(Locale.US),
             destination.attributes[EmbSessionAttributes.EMB_SESSION_END_TYPE],
         )
-        assertEquals(endTimeMs, checkNotNull(sessionSpan).snapshot()?.endTimeNanos?.nanosToMillis())
+        assertEquals(endTimeMs, checkNotNull(sessionPartSpan).snapshot()?.endTimeNanos?.nanosToMillis())
     }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
@@ -46,7 +46,7 @@ internal class SessionPartSpanAttrPopulatorImplTest {
 
     @Test
     fun `start attributes populated with user session`() {
-        populator.populateSessionSpanStartAttrs(zygote, userSession)
+        populator.populateSessionPartSpanStartAttrs(zygote, userSession)
 
         val attrs = destination.attributes
         assertEquals("false", attrs[EmbSessionAttributes.EMB_COLD_START])
@@ -68,7 +68,7 @@ internal class SessionPartSpanAttrPopulatorImplTest {
 
     @Test
     fun `background-only marker stamped on session part span`() {
-        populator.populateSessionSpanStartAttrs(zygote, backgroundOnlyUserSession)
+        populator.populateSessionPartSpanStartAttrs(zygote, backgroundOnlyUserSession)
 
         val attrs = destination.attributes
         assertEquals("1", attrs[EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART])
@@ -78,7 +78,7 @@ internal class SessionPartSpanAttrPopulatorImplTest {
 
     @Test
     fun `start attributes populated without user session`() {
-        populator.populateSessionSpanStartAttrs(zygote, userSession = null)
+        populator.populateSessionPartSpanStartAttrs(zygote, userSession = null)
 
         val attrs = destination.attributes
         assertEquals("false", attrs[EmbSessionAttributes.EMB_COLD_START])
@@ -100,7 +100,7 @@ internal class SessionPartSpanAttrPopulatorImplTest {
 
     @Test
     fun `end attributes populated`() {
-        populator.populateSessionSpanEndAttrs(LifeEventType.STATE, "crashId", false, emptyMap())
+        populator.populateSessionPartSpanEndAttrs(LifeEventType.STATE, "crashId", false, emptyMap())
 
         val attrs = destination.attributes
         val expected = mapOf(
@@ -116,7 +116,7 @@ internal class SessionPartSpanAttrPopulatorImplTest {
 
     @Test
     fun `end attributes - final session part`() {
-        populator.populateSessionSpanEndAttrs(
+        populator.populateSessionPartSpanEndAttrs(
             LifeEventType.STATE,
             null,
             false,
@@ -154,7 +154,7 @@ internal class SessionPartSpanAttrPopulatorImplTest {
             metadataService,
         )
 
-        populator.populateSessionSpanEndAttrs(LifeEventType.STATE, "crashId", false, emptyMap())
+        populator.populateSessionPartSpanEndAttrs(LifeEventType.STATE, "crashId", false, emptyMap())
 
         val attrs = destination.attributes
         val expected = mapOf(

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanAttributeTests.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanAttributeTests.kt
@@ -37,7 +37,7 @@ internal class CurrentSessionPartSpanAttributeTests {
         assertEquals("emb-session", span.name)
 
         // assert attributes added by default
-        span.assertCommonSessionSpanAttrs()
+        span.assertCommonSessionPartSpanAttrs()
     }
 
     @Test
@@ -48,10 +48,10 @@ internal class CurrentSessionPartSpanAttributeTests {
         assertEquals("emb-session", span.name)
 
         // assert attributes added by default
-        span.assertCommonSessionSpanAttrs()
+        span.assertCommonSessionPartSpanAttrs()
     }
 
-    private fun EmbraceSpanData.assertCommonSessionSpanAttrs() {
+    private fun EmbraceSpanData.assertCommonSessionPartSpanAttrs() {
         assertNotNull(attributes.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID))
         assertEquals("ux.session", attributes.findAttributeValue("emb.type"))
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImplTests.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImplTests.kt
@@ -72,21 +72,21 @@ internal class CurrentSessionPartSpanImplTests {
     @Test
     fun `session span ready when initialized`() {
         assertTrue(currentSessionPartSpan.initialized())
-        currentSessionPartSpan.assertSessionSpan()
+        currentSessionPartSpan.assertSessionPartSpan()
     }
 
     @Test
     fun `cannot create span before session is created`() {
         val uninitialized = FakeInitModule(clock = clock).openTelemetryModule.currentSessionPartSpan
         assertFalse(uninitialized.initialized())
-        uninitialized.assertNoSessionSpan()
+        uninitialized.assertNoSessionPartSpan()
     }
 
     @Test
     fun `cannot create spans or add data to current span if no current span exists`() {
         currentSessionPartSpan.endSession(startNewSession = false)
         assertTrue(currentSessionPartSpan.initialized())
-        currentSessionPartSpan.assertNoSessionSpan()
+        currentSessionPartSpan.assertNoSessionPartSpan()
     }
 
     @Test
@@ -381,9 +381,9 @@ internal class CurrentSessionPartSpanImplTests {
         AppTerminationCause::class.sealedSubclasses.forEach {
             val cause = checkNotNull(it.objectInstance)
             val module = FakeInitModule(clock = clock)
-            val sessionSpan = module.openTelemetryModule.currentSessionPartSpan
+            val sessionPartSpan = module.openTelemetryModule.currentSessionPartSpan
             module.openTelemetryModule.spanService.initializeService(clock.now())
-            val flushedSpans = sessionSpan.endSession(true, cause)
+            val flushedSpans = sessionPartSpan.endSession(true, cause)
             assertEquals(1, flushedSpans.size)
 
             val lastFlushedSpan = flushedSpans[0]
@@ -441,30 +441,30 @@ internal class CurrentSessionPartSpanImplTests {
 
     @Test
     fun `new session started after ending has correct metadata`() {
-        val originalSessionSpan = checkNotNull(spanRepository.getActiveSpans().single().snapshot())
+        val originalSessionPartSpan = checkNotNull(spanRepository.getActiveSpans().single().snapshot())
         val originalSessionId = currentSessionPartSpan.getId()
         currentSessionPartSpan.endSession(startNewSession = true)
         with(spanRepository.getActiveSpans().single()) {
             assertTrue(hasEmbraceAttribute(EmbType.Ux.Session))
-            assertNotEquals(originalSessionSpan.spanId, spanId)
-            checkNotNull(snapshot()?.links?.single()).validatePreviousSessionPartLink(originalSessionSpan, originalSessionId)
+            assertNotEquals(originalSessionPartSpan.spanId, spanId)
+            checkNotNull(snapshot()?.links?.single()).validatePreviousSessionPartLink(originalSessionPartSpan, originalSessionId)
         }
     }
 
     @Test
     fun `previous session link includes user session and session part ids when set`() {
-        val originalSessionSpan = checkNotNull(spanRepository.getActiveSpans().single())
+        val originalSessionPartSpan = checkNotNull(spanRepository.getActiveSpans().single())
         val originalUserSessionId = "previous-user-session"
         val originalSessionPartId = "previous-session-part"
-        originalSessionSpan.setSystemAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID, originalUserSessionId)
-        originalSessionSpan.setSystemAttribute(EmbSessionAttributes.EMB_SESSION_PART_ID, originalSessionPartId)
-        val originalSnapshot = checkNotNull(originalSessionSpan.snapshot())
+        originalSessionPartSpan.setSystemAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID, originalUserSessionId)
+        originalSessionPartSpan.setSystemAttribute(EmbSessionAttributes.EMB_SESSION_PART_ID, originalSessionPartId)
+        val originalSnapshot = checkNotNull(originalSessionPartSpan.snapshot())
 
         currentSessionPartSpan.endSession(startNewSession = true)
 
         with(spanRepository.getActiveSpans().single()) {
             checkNotNull(snapshot()?.links?.single()).validatePreviousSessionPartLink(
-                previousSessionSpan = originalSnapshot,
+                previousSessionPartSpan = originalSnapshot,
                 previousSessionPartId = originalSessionPartId,
                 previousUserSessionId = originalUserSessionId,
             )
@@ -481,21 +481,21 @@ internal class CurrentSessionPartSpanImplTests {
     @Test
     fun `calling readySession creates a session span if not present`() {
         currentSessionPartSpan.endSession(startNewSession = false)
-        currentSessionPartSpan.assertNoSessionSpan()
+        currentSessionPartSpan.assertNoSessionPartSpan()
         assertTrue(currentSessionPartSpan.readySession())
-        currentSessionPartSpan.assertSessionSpan()
+        currentSessionPartSpan.assertSessionPartSpan()
     }
 
     @Test
     fun `readySession will not replace existing session span`() {
-        val originalSessionSpanId = spanRepository.getActiveSpans().single().spanId
+        val originalSessionPartSpanId = spanRepository.getActiveSpans().single().spanId
         assertTrue(currentSessionPartSpan.readySession())
-        assertEquals(originalSessionSpanId, spanRepository.getActiveSpans().single().spanId)
+        assertEquals(originalSessionPartSpanId, spanRepository.getActiveSpans().single().spanId)
     }
 
     @Test
     fun `readySession will return false if session span is not recording`() {
-        val sessionSpan = CurrentSessionPartSpanImpl(
+        val sessionPartSpan = CurrentSessionPartSpanImpl(
             openTelemetryClock = FakeOtelKotlinClock(),
             telemetryService = telemetryService,
             spanRepository = spanRepository,
@@ -505,7 +505,7 @@ internal class CurrentSessionPartSpanImplTests {
             openTelemetrySupplier = ::openTelemetry,
             uuidSource = TestUuidSource(),
         )
-        assertFalse(sessionSpan.readySession())
+        assertFalse(sessionPartSpan.readySession())
     }
 
     @Test
@@ -543,17 +543,17 @@ internal class CurrentSessionPartSpanImplTests {
 
     @Test
     fun `span stop callback creates the correct span links`() {
-        val sessionSpan = checkNotNull(spanRepository.getActiveSpans().single())
+        val sessionPartSpan = checkNotNull(spanRepository.getActiveSpans().single())
         val userSessionId = "user-session-uuid"
         val sessionPartId = "session-part-uuid"
-        sessionSpan.setSystemAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID, userSessionId)
-        sessionSpan.setSystemAttribute(EmbSessionAttributes.EMB_SESSION_PART_ID, sessionPartId)
+        sessionPartSpan.setSystemAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID, userSessionId)
+        sessionPartSpan.setSystemAttribute(EmbSessionAttributes.EMB_SESSION_PART_ID, sessionPartId)
         val span = spanService.startSpan("test").apply {
             stop()
         }
 
         val spanSnapshot = checkNotNull(span.snapshot())
-        val sessionSpanSnapshot = checkNotNull(sessionSpan.snapshot())
+        val sessionPartSpanSnapshot = checkNotNull(sessionPartSpan.snapshot())
 
         val expectedPartLinkAttrs = mapOf(
             EmbSessionAttributes.EMB_SESSION_PART_ID to sessionPartId,
@@ -561,11 +561,11 @@ internal class CurrentSessionPartSpanImplTests {
             SessionAttributes.SESSION_ID to userSessionId,
         )
         checkNotNull(spanSnapshot.links).single().validateSystemLink(
-            linkedSpan = sessionSpanSnapshot,
+            linkedSpan = sessionPartSpanSnapshot,
             type = LinkType.EndSession,
             expectedAttributes = expectedPartLinkAttrs
         )
-        checkNotNull(sessionSpanSnapshot.links).single().validateSystemLink(
+        checkNotNull(sessionPartSpanSnapshot.links).single().validateSystemLink(
             linkedSpan = spanSnapshot,
             type = LinkType.EndedIn,
             expectedAttributes = expectedPartLinkAttrs,
@@ -574,19 +574,19 @@ internal class CurrentSessionPartSpanImplTests {
 
     @Test
     fun `session ending will not create span link to its own session span`() {
-        val sessionSpan = checkNotNull(spanRepository.getActiveSpans().single())
+        val sessionPartSpan = checkNotNull(spanRepository.getActiveSpans().single())
         currentSessionPartSpan.endSession(startNewSession = true)
-        val sessionSpanSnapshot = checkNotNull(sessionSpan.snapshot())
-        assertEquals(0, sessionSpanSnapshot.links?.size)
+        val sessionPartSpanSnapshot = checkNotNull(sessionPartSpan.snapshot())
+        assertEquals(0, sessionPartSpanSnapshot.links?.size)
     }
 
     @Test
     fun `span stop callback will not create links for untracked span`() {
-        val sessionSpan = checkNotNull(spanRepository.getActiveSpans().single())
+        val sessionPartSpan = checkNotNull(spanRepository.getActiveSpans().single())
         currentSessionPartSpan.spanStopCallback(checkNotNull(FakeEmbraceSdkSpan.started().spanId))
 
-        val sessionSpanSnapshot = checkNotNull(sessionSpan.snapshot())
-        assertEquals(0, sessionSpanSnapshot.links?.size)
+        val sessionPartSpanSnapshot = checkNotNull(sessionPartSpan.snapshot())
+        assertEquals(0, sessionPartSpanSnapshot.links?.size)
     }
 
     @Test
@@ -600,13 +600,13 @@ internal class CurrentSessionPartSpanImplTests {
         assertEquals(0, spanSnapshot.links?.size)
     }
 
-    private fun CurrentSessionPartSpan.assertNoSessionSpan() {
+    private fun CurrentSessionPartSpan.assertNoSessionPartSpan() {
         assertEquals("", getId())
         assertFalse(canStartNewSpan(parent = null, internal = true))
         assertTrue(endSession(true).isEmpty())
     }
 
-    private fun CurrentSessionPartSpan.assertSessionSpan() {
+    private fun CurrentSessionPartSpan.assertSessionPartSpan() {
         assertTrue(getId().isNotBlank())
         assertTrue(canStartNewSpan(parent = null, internal = true))
     }

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/LinkAssertions.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/LinkAssertions.kt
@@ -11,7 +11,7 @@ import io.opentelemetry.kotlin.tracing.SpanContext
 import org.junit.Assert.assertTrue
 
 fun Link.validatePreviousSessionPartLink(
-    previousSessionSpan: Span,
+    previousSessionPartSpan: Span,
     previousSessionPartId: String,
     previousUserSessionId: String? = null,
 ) {
@@ -23,7 +23,7 @@ fun Link.validatePreviousSessionPartLink(
         }
     }
     validateSystemLink(
-        linkedSpan = previousSessionSpan,
+        linkedSpan = previousSessionPartSpan,
         type = LinkType.PreviousSession,
         expectedAttributes = expected
     )

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
@@ -37,8 +37,8 @@ fun Span.findEventsOfType(telemetryType: EmbType): List<SpanEvent> {
     }
 }
 
-fun Span.assertPreviousSessionPart(previousSessionSpan: Span, previousSessionPartId: String) {
-    findLinkOfType(LinkType.PreviousSession).validatePreviousSessionPartLink(previousSessionSpan, previousSessionPartId)
+fun Span.assertPreviousSessionPart(previousSessionPartSpan: Span, previousSessionPartId: String) {
+    findLinkOfType(LinkType.PreviousSession).validatePreviousSessionPartLink(previousSessionPartSpan, previousSessionPartId)
 }
 
 fun Span.assertNoPreviousSession() =

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
@@ -246,7 +246,7 @@ class FakeEmbraceSdkSpan(
                 stop()
             }
 
-        fun sessionSpan(
+        fun sessionPartSpan(
             userSessionId: String,
             startTimeMs: Long,
             lastHeartbeatTimeMs: Long?,

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanExt.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanExt.kt
@@ -19,10 +19,10 @@ fun Span.hasEmbraceAttributeValue(key: String, value: Any): Boolean {
 }
 
 fun Span.toFailedSpan(endTimeMs: Long): Span {
-    val isSessionSpan = hasEmbraceAttribute(EmbType.Ux.Session)
+    val isSessionPartSpan = hasEmbraceAttribute(EmbType.Ux.Session)
     val newAttributes = mutableMapOf<String, String>().apply {
         setEmbraceAttribute(ErrorCodeAttribute.Failure)
-        if (isSessionSpan) {
+        if (isSessionPartSpan) {
             setEmbraceAttribute(AppTerminationCause.Crash)
         }
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
@@ -21,7 +21,7 @@ import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
 import io.embrace.android.embracesdk.internal.payload.Span
-import io.embrace.android.embracesdk.internal.session.getSessionSpan
+import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
 import io.embrace.android.embracesdk.internal.toEmbracePayload
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
@@ -507,7 +507,7 @@ internal class AppStartupTraceTest {
                 )
             }
             .single { envelope ->
-                envelope.getSessionSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID) != null
+                envelope.getSessionPartSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID) != null
             }
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PushNotificationApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/PushNotificationApiTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.testcases
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.findEventOfType
-import io.embrace.android.embracesdk.assertions.findSessionSpan
+import io.embrace.android.embracesdk.assertions.findSessionPartSpan
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
@@ -98,8 +98,8 @@ internal class PushNotificationApiTest {
             },
             assertAction = {
                 val payload = getSingleSessionEnvelope()
-                val sessionSpan = payload.findSessionSpan()
-                val event = sessionSpan.findEventOfType(EmbType.System.PushNotification)
+                val sessionPartSpan = payload.findSessionPartSpan()
+                val event = sessionPartSpan.findEventOfType(EmbType.System.PushNotification)
                 assertTrue(checkNotNull(event.timestampNanos) > 0)
                 event.attributes?.assertMatches(mapOf(
                     EmbType.System.PushNotification.asPair(),
@@ -115,8 +115,8 @@ internal class PushNotificationApiTest {
     }
 
     private fun Envelope<SessionPartPayload>.assertNotification(type: String) {
-        val sessionSpan = findSessionSpan()
-        val event = sessionSpan.findEventOfType(EmbType.System.PushNotification)
+        val sessionPartSpan = findSessionPartSpan()
+        val event = sessionPartSpan.findEventOfType(EmbType.System.PushNotification)
         assertTrue(checkNotNull(event.timestampNanos) > 0)
         event.attributes?.assertMatches(mapOf(
             EmbType.System.PushNotification.asPair(),

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -31,7 +31,7 @@ import io.embrace.android.embracesdk.internal.otel.spans.NoopEmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
-import io.embrace.android.embracesdk.internal.session.getSessionSpan
+import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
 import io.embrace.android.embracesdk.internal.toEmbraceSpanData
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -174,7 +174,7 @@ internal class TracingApiTest {
                     testRule.setup.getSpanSink().completedSpans().map(EmbraceSpanData::toEmbracePayload)
 
                 val spansMap = allSpans.associateBy { it.name }
-                val sessionSpan = checkNotNull(spansMap["emb-session"])
+                val sessionPartSpan = checkNotNull(spansMap["emb-session"])
                 val traceRootSpan = checkNotNull(spansMap["test-trace-root"])
 
                 results.add("\nAll spans to validate: ${allSpans.map { it.name }}")
@@ -268,7 +268,7 @@ internal class TracingApiTest {
                 )
 
                 assertEmbraceSpanData(
-                    span = sessionSpan,
+                    span = sessionPartSpan,
                     expectedStartTimeMs = sessionStartTimeMs,
                     expectedEndTimeMs = sessionEndTimeMs,
                     expectedParentId = OtelIds.INVALID_SPAN_ID,
@@ -296,8 +296,8 @@ internal class TracingApiTest {
                 )
             },
             otelExportAssertion = {
-                val sessionSpan = awaitSpansWithType(2, EmbType.Ux.Session).last().toEmbraceSpanData().toEmbracePayload()
-                val otelSessionId = checkNotNull(sessionSpan.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
+                val sessionPartSpan = awaitSpansWithType(2, EmbType.Ux.Session).last().toEmbraceSpanData().toEmbracePayload()
+                val otelSessionId = checkNotNull(sessionPartSpan.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
                 val span = awaitSpans(1) { it.name == "test-trace-root" }.single().toEmbraceSpanData().toEmbracePayload()
                 assertEquals(otelSessionId, span.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
             }
@@ -380,7 +380,7 @@ internal class TracingApiTest {
                 with(getSingleSessionEnvelope()) {
                     val op = findSpanByName(name = "my-op")
                     val op2 = findSpanByName(name = "my-op-2")
-                    op2.hasLinkToEmbraceSpan(checkNotNull(getSessionSpan()), LinkType.EndedIn)
+                    op2.hasLinkToEmbraceSpan(checkNotNull(getSessionPartSpan()), LinkType.EndedIn)
 
                     val links = checkNotNull(op2.findCustomLinks())
                     links[0].validateLinkToSpan(linkedSpan = op, expectedAttributes = mapOf("test" to "value"))
@@ -388,10 +388,10 @@ internal class TracingApiTest {
                 }
             },
             otelExportAssertion = {
-                val sessionSpan = awaitSpansWithType(1, EmbType.Ux.Session).single().toEmbraceSpanData().toEmbracePayload()
+                val sessionPartSpan = awaitSpansWithType(1, EmbType.Ux.Session).single().toEmbraceSpanData().toEmbracePayload()
                 val linkedToSpan = awaitSpans(1) { it.name == "my-op" }.single().toEmbraceSpanData().toEmbracePayload()
                 val spanWithLinks = awaitSpans(1) { it.name == "my-op-2" }.single().toEmbraceSpanData().toEmbracePayload()
-                spanWithLinks.hasLinkToEmbraceSpan(sessionSpan, LinkType.EndedIn)
+                spanWithLinks.hasLinkToEmbraceSpan(sessionPartSpan, LinkType.EndedIn)
 
                 val links = checkNotNull(spanWithLinks.findCustomLinks())
                 links[0].validateLinkToSpan(linkedSpan = linkedToSpan, expectedAttributes = mapOf("test" to "value"))
@@ -432,8 +432,8 @@ internal class TracingApiTest {
             },
             otelExportAssertion = {
                 // Get the session ID from a session span exported via OTel
-                val sessionSpan = awaitSpansWithType(2, EmbType.Ux.Session).first().toEmbraceSpanData().toEmbracePayload()
-                val expectedOtelSessionId = checkNotNull(sessionSpan.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
+                val sessionPartSpan = awaitSpansWithType(2, EmbType.Ux.Session).first().toEmbraceSpanData().toEmbracePayload()
+                val expectedOtelSessionId = checkNotNull(sessionPartSpan.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
                 val span1 = awaitSpans(1) { it.name == "span1" }.single().toEmbraceSpanData().toEmbracePayload()
                 val span2 = awaitSpans(1) { it.name == "span2" }.single().toEmbraceSpanData().toEmbracePayload()
                 assertEquals(expectedOtelSessionId, span1.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionApiTest.kt
@@ -59,11 +59,11 @@ internal class UserSessionApiTest {
 
                 // validate session span
                 val spans = checkNotNull(message.data.spans)
-                val sessionSpan = spans.single { it.name == "emb-session" }
-                assertEquals(startTime, sessionSpan.startTimeNanos?.nanosToMillis())
-                assertNotNull(sessionSpan.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
+                val sessionPartSpan = spans.single { it.name == "emb-session" }
+                assertEquals(startTime, sessionPartSpan.startTimeNanos?.nanosToMillis())
+                assertNotNull(sessionPartSpan.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
 
-                val attrs = checkNotNull(sessionSpan.attributes)
+                val attrs = checkNotNull(sessionPartSpan.attributes)
                 val attributeKeys = attrs.map { it.key }
                 validateExistenceOnly.forEach { key ->
                     assertTrue("'$key' not found in attrs", attributeKeys.contains(key))

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/BreadcrumbFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/BreadcrumbFeatureTest.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.testcases.features
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.assertMatches
 import io.embrace.android.embracesdk.assertions.findEventOfType
-import io.embrace.android.embracesdk.assertions.findSessionSpan
+import io.embrace.android.embracesdk.assertions.findSessionPartSpan
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
@@ -45,7 +45,7 @@ internal class BreadcrumbFeatureTest {
     }
 
     private fun Envelope<SessionPartPayload>.assertBreadcrumbWithMessage(message: String) {
-        findSessionSpan().findEventOfType(EmbType.System.Breadcrumb).attributes?.assertMatches(mapOf(
+        findSessionPartSpan().findEventOfType(EmbType.System.Breadcrumb).attributes?.assertMatches(mapOf(
             EmbBreadcrumbAttributes.MESSAGE to message
         ))
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/DataCaptureLimitTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/DataCaptureLimitTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.testcases.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.findEventsOfType
-import io.embrace.android.embracesdk.assertions.findSessionSpan
+import io.embrace.android.embracesdk.assertions.findSessionPartSpan
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
@@ -44,8 +44,8 @@ internal class DataCaptureLimitTest {
     }
 
     private fun assertBreadcrumbsMatchLimit(envelope: Envelope<SessionPartPayload>) {
-        val sessionSpan = envelope.findSessionSpan()
-        val crumbs = sessionSpan.findEventsOfType(EmbType.System.Breadcrumb)
+        val sessionPartSpan = envelope.findSessionPartSpan()
+        val crumbs = sessionPartSpan.findEventsOfType(EmbType.System.Breadcrumb)
         assertEquals(100, crumbs.size)
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
@@ -26,7 +26,7 @@ import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.serialization.toJson
-import io.embrace.android.embracesdk.internal.session.getSessionSpan
+import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
 import io.embrace.android.embracesdk.internal.utils.getSafeStackTrace
 import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.semconv.EmbAndroidAttributes
@@ -173,7 +173,7 @@ internal class JvmCrashFeatureTest {
                 // The resurrected session is delivered normally and is not associated with the crash.
                 val resurrectedSession = getSingleSessionEnvelope(AppState.FOREGROUND)
                 assertEquals(resurrectedSessionId, resurrectedSession.getUserSessionId())
-                assertNull(resurrectedSession.getSessionSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID))
+                assertNull(resurrectedSession.getSessionPartSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID))
 
                 // The crashing process's own session part is held back during teardown, persisted, and carries the crash id.
                 val ba = payloadStorageService.getPersistedSession(AppState.BACKGROUND)
@@ -264,7 +264,7 @@ internal class JvmCrashFeatureTest {
                 val expectedJsException = "{\"n\":\"name\",\"m\":\"message\",\"t\":\"type\",\"st\":\"stacktrace\"}"
 
                 val message = payloadStorageService.getPersistedSession()
-                val crashId = message.getSessionSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID)
+                val crashId = message.getSessionPartSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID)
                 assertNotNull(crashId)
                 log.attributes?.assertMatches(
                     mapOf(
@@ -292,14 +292,14 @@ internal class JvmCrashFeatureTest {
                 )
             }
             .single { envelope ->
-                val attrs = envelope.getSessionSpan()?.attributes
+                val attrs = envelope.getSessionPartSpan()?.attributes
                 attrs?.findAttributeValue(EmbSessionAttributes.EMB_STATE) == expectedState &&
                     attrs.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID) != null
             }
     }
 
     private fun Envelope<SessionPartPayload>.getCrashedId(): String {
-        val crashId = checkNotNull(getSessionSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID))
+        val crashId = checkNotNull(getSessionPartSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID))
         assertFalse(crashId.isBlank())
         return crashId
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LowPowerFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LowPowerFeatureTest.kt
@@ -16,7 +16,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.instrumentation.powersave.PowerStateDataSource
-import io.embrace.android.embracesdk.internal.session.getSessionSpan
+import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
 import io.embrace.android.embracesdk.internal.session.getStateSpan
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import org.junit.Assert.assertEquals
@@ -105,10 +105,10 @@ internal class LowPowerFeatureTest {
             },
             assertAction = {
                 val message = getSingleSessionEnvelope()
-                val sessionSpan = checkNotNull(message.getSessionSpan())
+                val sessionPartSpan = checkNotNull(message.getSessionPartSpan())
                 with(checkNotNull(message.getStateSpan("emb-state-power"))) {
                     assertEquals(transitions[0].first, checkNotNull(startTimeNanos).nanosToMillis())
-                    assertEquals(sessionSpan.endTimeNanos, endTimeNanos)
+                    assertEquals(sessionPartSpan.endTimeNanos, endTimeNanos)
                     with(checkNotNull(events)) {
                         assertEquals(2, size)
                         repeat(size) { i ->

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NetworkStateFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NetworkStateFeatureTest.kt
@@ -9,7 +9,7 @@ import io.embrace.android.embracesdk.internal.capture.connectivity.ConnectionTyp
 import io.embrace.android.embracesdk.internal.capture.connectivity.ConnectivityStatus
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkStateDataSource
-import io.embrace.android.embracesdk.internal.session.getSessionSpan
+import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
 import io.embrace.android.embracesdk.internal.session.getStateSpan
 import io.embrace.android.embracesdk.semconv.EmbStateTransitionAttributes
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
@@ -58,14 +58,14 @@ internal class NetworkStateFeatureTest {
             },
             assertAction = {
                 val message = getSingleSessionEnvelope()
-                val sessionSpan = checkNotNull(message.getSessionSpan())
+                val sessionPartSpan = checkNotNull(message.getSessionPartSpan())
                 val stateSpan = message.getStateSpan("emb-state-network")
                 with(checkNotNull(stateSpan)) {
                     assertEquals(
-                        checkNotNull(sessionSpan.startTimeNanos).nanosToMillis() + LIFECYCLE_EVENT_GAP,
+                        checkNotNull(sessionPartSpan.startTimeNanos).nanosToMillis() + LIFECYCLE_EVENT_GAP,
                         checkNotNull(startTimeNanos).nanosToMillis()
                     )
-                    assertEquals(sessionSpan.endTimeNanos, endTimeNanos)
+                    assertEquals(sessionPartSpan.endTimeNanos, endTimeNanos)
                     with(checkNotNull(events)) {
                         assertEquals(3, size)
                         assertEquals(transitions.size, size)
@@ -110,14 +110,14 @@ internal class NetworkStateFeatureTest {
             },
             assertAction = {
                 val message = getSingleSessionEnvelope()
-                val sessionSpan = checkNotNull(message.getSessionSpan())
+                val sessionPartSpan = checkNotNull(message.getSessionPartSpan())
                 val stateSpan = checkNotNull(message.getStateSpan("emb-state-network"))
                 with(stateSpan) {
                     assertEquals(
-                        checkNotNull(sessionSpan.startTimeNanos).nanosToMillis() + LIFECYCLE_EVENT_GAP,
+                        checkNotNull(sessionPartSpan.startTimeNanos).nanosToMillis() + LIFECYCLE_EVENT_GAP,
                         checkNotNull(startTimeNanos).nanosToMillis()
                     )
-                    assertEquals(sessionSpan.endTimeNanos, endTimeNanos)
+                    assertEquals(sessionPartSpan.endTimeNanos, endTimeNanos)
                     checkNotNull(stateSpan.attributes).none { it.key == EmbStateTransitionAttributes.EMB_STATE_DROPPED_BY_INSTRUMENTATION }
                     with(checkNotNull(events)) {
                         assertEquals(5, size)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PruningFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PruningFeatureTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.testcases.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.assertions.findSessionSpan
+import io.embrace.android.embracesdk.assertions.findSessionPartSpan
 import io.embrace.android.embracesdk.fixtures.fakeSessionStoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.capture.connectivity.ConnectionType
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
@@ -46,8 +46,8 @@ internal class PruningFeatureTest {
                 assertEquals(STORAGE_LIMIT, sessionEnvelopes.size)
 
                 val breadcrumbs = sessionEnvelopes.map { envelope ->
-                    val sessionSpan = envelope.findSessionSpan()
-                    val breadcrumbEvent = checkNotNull(sessionSpan.events?.single {
+                    val sessionPartSpan = envelope.findSessionPartSpan()
+                    val breadcrumbEvent = checkNotNull(sessionPartSpan.events?.single {
                         it.name == "emb-breadcrumb"
                     })
                     checkNotNull(breadcrumbEvent.attributes?.findAttributeValue("message")).toInt()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/StateFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/StateFeatureTest.kt
@@ -21,7 +21,7 @@ import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttributeKey
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttributeValue
 import io.embrace.android.embracesdk.internal.otel.spans.hasEmbraceAttributeValue
-import io.embrace.android.embracesdk.internal.session.getSessionSpan
+import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
 import io.embrace.android.embracesdk.internal.session.getStateSpan
 import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.semconv.EmbStateTransitionAttributes
@@ -123,10 +123,10 @@ internal class StateFeatureTest {
                             this[j].assertStateTransition(event.first, event.second)
                         }
                     }
-                    val sessionSpan = checkNotNull(sessions[i].getSessionSpan())
-                    sessionSpan.hasLinkToEmbraceSpan(stateSpan, LinkType.State)
-                    assertEquals(sessionSpan.startTimeNanos, stateSpan.startTimeNanos)
-                    assertEquals(sessionSpan.endTimeNanos, stateSpan.endTimeNanos)
+                    val sessionPartSpan = checkNotNull(sessions[i].getSessionPartSpan())
+                    sessionPartSpan.hasLinkToEmbraceSpan(stateSpan, LinkType.State)
+                    assertEquals(sessionPartSpan.startTimeNanos, stateSpan.startTimeNanos)
+                    assertEquals(sessionPartSpan.endTimeNanos, stateSpan.endTimeNanos)
                     stateSpan.attributes?.hasEmbraceAttributeValue(EmbStateTransitionAttributes.EMB_STATE_INITIAL_VALUE, initialStateValue)
                     initialStateValue = stateUpdates[i]
                 }
@@ -194,7 +194,7 @@ internal class StateFeatureTest {
             },
             assertAction = {
                 val sessionPayload = getSingleSessionEnvelope()
-                val sessionSpan = checkNotNull(sessionPayload.getSessionSpan())
+                val sessionPartSpan = checkNotNull(sessionPayload.getSessionPartSpan())
                 val stateSpan = checkNotNull(sessionPayload.getStateSpan("emb-state-test"))
                 with(checkNotNull(stateSpan.events)) {
                     assertEquals(stateUpdates.size, size)
@@ -207,10 +207,10 @@ internal class StateFeatureTest {
                     }
                 }
                 assertEquals(
-                    checkNotNull(sessionSpan.startTimeNanos).nanosToMillis() + LIFECYCLE_EVENT_GAP,
+                    checkNotNull(sessionPartSpan.startTimeNanos).nanosToMillis() + LIFECYCLE_EVENT_GAP,
                     checkNotNull(stateSpan.startTimeNanos).nanosToMillis()
                 )
-                assertEquals(sessionSpan.endTimeNanos, stateSpan.endTimeNanos)
+                assertEquals(sessionPartSpan.endTimeNanos, stateSpan.endTimeNanos)
             }
         )
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UserSessionPropertiesTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UserSessionPropertiesTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.testcases.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.PropertyScope
-import io.embrace.android.embracesdk.assertions.findSessionSpan
+import io.embrace.android.embracesdk.assertions.findSessionPartSpan
 import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.internal.api.SdkApi
@@ -40,27 +40,27 @@ internal class UserSessionPropertiesTest {
                 val sessions = getSessionEnvelopes(3)
                 val bas = getSessionEnvelopes(3, AppState.BACKGROUND)
 
-                bas[0].findSessionSpan().assertPropertyExistence(
+                bas[0].findSessionPartSpan().assertPropertyExistence(
                     exist = listOf(EXISTING_KEY_2, EXISTING_KEY_3, PERM_KEY, TEMP_KEY),
                     missing = listOf(EXISTING_KEY_1)
                 )
-                sessions[0].findSessionSpan().assertPropertyExistence(
+                sessions[0].findSessionPartSpan().assertPropertyExistence(
                     exist = listOf(EXISTING_KEY_3, PERM_KEY, PERM_KEY_2, TEMP_KEY_2),
                     missing = listOf(EXISTING_KEY_1, EXISTING_KEY_2)
                 )
-                bas[1].findSessionSpan().assertPropertyExistence(
+                bas[1].findSessionPartSpan().assertPropertyExistence(
                     exist = listOf(EXISTING_KEY_3, PERM_KEY_2),
                     missing = listOf(EXISTING_KEY_1, EXISTING_KEY_2, PERM_KEY, PERM_KEY_3, TEMP_KEY_3)
                 )
-                sessions[1].findSessionSpan().assertPropertyExistence(
+                sessions[1].findSessionPartSpan().assertPropertyExistence(
                     exist = listOf(EXISTING_KEY_3, PERM_KEY_2),
                     missing = listOf(EXISTING_KEY_1, EXISTING_KEY_2, PERM_KEY, PERM_KEY_3, TEMP_KEY_3)
                 )
-                bas[2].findSessionSpan().assertPropertyExistence(
+                bas[2].findSessionPartSpan().assertPropertyExistence(
                     exist = listOf(EXISTING_KEY_3, PERM_KEY_2),
                     missing = listOf(EXISTING_KEY_1, EXISTING_KEY_2, PERM_KEY, PERM_KEY_3, TEMP_KEY_3)
                 )
-                sessions[2].findSessionSpan().assertPropertyExistence(
+                sessions[2].findSessionPartSpan().assertPropertyExistence(
                     exist = listOf(EXISTING_KEY_3, PERM_KEY_2),
                     missing = listOf(EXISTING_KEY_1, EXISTING_KEY_2, PERM_KEY, PERM_KEY_3, TEMP_KEY_3)
                 )
@@ -79,17 +79,17 @@ internal class UserSessionPropertiesTest {
             },
             assertAction = {
                 val sessions = getSessionEnvelopes(3)
-                sessions[0].findSessionSpan().assertPropertyExistence(
+                sessions[0].findSessionPartSpan().assertPropertyExistence(
                     exist = listOf(EXISTING_KEY_3, PERM_KEY, PERM_KEY_2, TEMP_KEY, TEMP_KEY_2),
                     missing = listOf(EXISTING_KEY_1, EXISTING_KEY_2)
                 )
-                sessions[1].findSessionSpan().assertPropertyExistence(
+                sessions[1].findSessionPartSpan().assertPropertyExistence(
                     exist = listOf(EXISTING_KEY_3, PERM_KEY_2),
                     missing = listOf(
                         EXISTING_KEY_1, EXISTING_KEY_2, PERM_KEY, PERM_KEY_3, TEMP_KEY, TEMP_KEY_2, TEMP_KEY_3
                     )
                 )
-                sessions[2].findSessionSpan().assertPropertyExistence(
+                sessions[2].findSessionPartSpan().assertPropertyExistence(
                     exist = listOf(EXISTING_KEY_3, PERM_KEY_2),
                     missing = listOf(
                         EXISTING_KEY_1, EXISTING_KEY_2, PERM_KEY, PERM_KEY_3, TEMP_KEY, TEMP_KEY_2, TEMP_KEY_3

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/WebviewFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/WebviewFeatureTest.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.testcases.features
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.assertMatches
 import io.embrace.android.embracesdk.assertions.findEventsOfType
-import io.embrace.android.embracesdk.assertions.findSessionSpan
+import io.embrace.android.embracesdk.assertions.findSessionPartSpan
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.instrumentation.webview.WebViewUrlDataSource
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
@@ -30,7 +30,7 @@ internal class WebviewFeatureTest {
             },
             assertAction = {
                 val message = getSingleSessionEnvelope()
-                val events = message.findSessionSpan().findEventsOfType(EmbType.System.WebViewInfo)
+                val events = message.findSessionPartSpan().findEventsOfType(EmbType.System.WebViewInfo)
                 assertEquals(1, events.size)
 
                 val event = events[0]

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityCaptureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityCaptureTest.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.testcases.session
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.assertMatches
 import io.embrace.android.embracesdk.assertions.findEventsOfType
-import io.embrace.android.embracesdk.assertions.findSessionSpan
+import io.embrace.android.embracesdk.assertions.findSessionPartSpan
 import io.embrace.android.embracesdk.assertions.getLogsOfType
 import io.embrace.android.embracesdk.assertions.getOtelSessionId
 import io.embrace.android.embracesdk.assertions.getSessionPartId
@@ -143,7 +143,7 @@ internal class BackgroundActivityCaptureTest {
                 }
 
                 with(secondSession) {
-                    with(findSessionSpan()) {
+                    with(findSessionPartSpan()) {
                         with(findEventsOfType(EmbType.System.Breadcrumb)) {
                             assertEquals(1, size)
                             single().attributes?.assertMatches(
@@ -197,21 +197,21 @@ internal class BackgroundActivityCaptureTest {
                 assertEquals(session1.version, session2.version)
                 assertEquals(session1.type, session2.type)
 
-                val sessionSpan1 = session1.findSessionSpan()
-                val sessionSpan2 = session2.findSessionSpan()
+                val sessionPartSpan1 = session1.findSessionPartSpan()
+                val sessionPartSpan2 = session2.findSessionPartSpan()
 
                 // each part carries all three session ids, present and consistent (session.id == emb.user_session_id)
                 session1.assertSessionIds()
                 session2.assertSessionIds()
 
-                sessionSpan1.assertExpectedSessionSpanAttributes(
+                sessionPartSpan1.assertExpectedSessionPartSpanAttributes(
                     startMs = session1StartMs,
                     endMs = session1EndMs,
                     sequenceId = 1,
                     coldStart = true,
                 )
 
-                sessionSpan2.assertExpectedSessionSpanAttributes(
+                sessionPartSpan2.assertExpectedSessionPartSpanAttributes(
                     startMs = session2StartMs,
                     endMs = session2EndMs,
                     sequenceId = 13,
@@ -219,19 +219,19 @@ internal class BackgroundActivityCaptureTest {
                 )
 
                 assertNotEquals(
-                    sessionSpan1.attributes?.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID),
-                    sessionSpan2.attributes?.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID)
+                    sessionPartSpan1.attributes?.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID),
+                    sessionPartSpan2.attributes?.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID)
                 )
 
                 assertEquals(
-                    sessionSpan1.attributes?.findAttributeValue(EmbSessionAttributes.EMB_PROCESS_IDENTIFIER),
-                    sessionSpan2.attributes?.findAttributeValue(EmbSessionAttributes.EMB_PROCESS_IDENTIFIER)
+                    sessionPartSpan1.attributes?.findAttributeValue(EmbSessionAttributes.EMB_PROCESS_IDENTIFIER),
+                    sessionPartSpan2.attributes?.findAttributeValue(EmbSessionAttributes.EMB_PROCESS_IDENTIFIER)
                 )
             }
         )
     }
 
-    private fun Span.assertExpectedSessionSpanAttributes(
+    private fun Span.assertExpectedSessionPartSpanAttributes(
         startMs: Long,
         endMs: Long,
         sequenceId: Int,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/ManualUserSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/ManualUserSessionTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.testcases.session
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.assertions.findSessionSpan
+import io.embrace.android.embracesdk.assertions.findSessionPartSpan
 import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.SessionRemoteConfig
@@ -37,8 +37,8 @@ internal class ManualUserSessionTest {
                 val messages = getSessionEnvelopes(2)
                 val stateSession = messages[0] // started via state, ended manually
                 val manualSession = messages[1] // started manually, ended via state
-                checkNotNull(stateSession.findSessionSpan())
-                checkNotNull(manualSession.findSessionSpan())
+                checkNotNull(stateSession.findSessionPartSpan())
+                checkNotNull(manualSession.findSessionPartSpan())
             }
         )
     }
@@ -55,7 +55,7 @@ internal class ManualUserSessionTest {
             },
             assertAction = {
                 val message = getSingleSessionEnvelope()
-                checkNotNull(message.findSessionSpan())
+                checkNotNull(message.findSessionPartSpan())
             }
         )
     }
@@ -71,7 +71,7 @@ internal class ManualUserSessionTest {
                 }
             },
             assertAction = {
-                checkNotNull(getSingleSessionEnvelope().findSessionSpan())
+                checkNotNull(getSingleSessionEnvelope().findSessionPartSpan())
             }
         )
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/PeriodicSessionPartCacheTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/PeriodicSessionPartCacheTest.kt
@@ -2,7 +2,7 @@ package io.embrace.android.embracesdk.testcases.session
 
 import android.os.Build.VERSION_CODES.TIRAMISU
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.assertions.findSessionSpan
+import io.embrace.android.embracesdk.assertions.findSessionPartSpan
 import io.embrace.android.embracesdk.assertions.findSpanSnapshotOfType
 import io.embrace.android.embracesdk.assertions.returnIfConditionMet
 import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
@@ -72,7 +72,7 @@ internal class PeriodicPartCacheTest {
                     )
                 )
                 val completedMessage = getSingleSessionEnvelope()
-                val completedSpan = completedMessage.findSessionSpan()
+                val completedSpan = completedMessage.findSessionPartSpan()
                 assertEquals("Passed", completedSpan.getSessionProperty("Test"))
                 completedSpan.attributes?.assertMatches(
                     mapOf(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionPartIdentityTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionPartIdentityTest.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.testcases.session
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.assertions.assertSessionIds
-import io.embrace.android.embracesdk.assertions.findSessionSpan
+import io.embrace.android.embracesdk.assertions.findSessionPartSpan
 import io.embrace.android.embracesdk.assertions.getLogOfType
 import io.embrace.android.embracesdk.assertions.getSessionPartId
 import io.embrace.android.embracesdk.assertions.getSessionPartNumber
@@ -53,16 +53,16 @@ internal class SessionPartIdentityTest {
                 recordSession()
             },
             assertAction = {
-                val attrMap = checkNotNull(getSingleSessionEnvelope().findSessionSpan().attributes?.toMap())
-                assertFirstSessionSpanAttributes(attrMap)
+                val attrMap = checkNotNull(getSingleSessionEnvelope().findSessionPartSpan().attributes?.toMap())
+                assertFirstSessionPartSpanAttributes(attrMap)
             },
             otelExportAssertion = {
-                assertFirstSessionSpanAttributes(awaitSpansWithType(1, EmbType.Ux.Session).single().attributes.toStringMap())
+                assertFirstSessionPartSpanAttributes(awaitSpansWithType(1, EmbType.Ux.Session).single().attributes.toStringMap())
             },
         )
     }
 
-    private fun assertFirstSessionSpanAttributes(attrs: Map<String, String>) {
+    private fun assertFirstSessionPartSpanAttributes(attrs: Map<String, String>) {
         attrs.assertSessionIds()
         assertEquals("1", attrs[EMB_USER_SESSION_NUMBER])
         assertEquals("1", attrs[EMB_USER_SESSION_PART_INDEX])

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionPartPayloadTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionPartPayloadTest.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.PropertyScope
 import io.embrace.android.embracesdk.assertions.assertMatches
 import io.embrace.android.embracesdk.assertions.assertNoPreviousSession
 import io.embrace.android.embracesdk.assertions.assertPreviousSessionPart
-import io.embrace.android.embracesdk.assertions.findSessionSpan
+import io.embrace.android.embracesdk.assertions.findSessionPartSpan
 import io.embrace.android.embracesdk.assertions.getOtelSessionId
 import io.embrace.android.embracesdk.assertions.getSessionPartId
 import io.embrace.android.embracesdk.assertions.hasLinkToEmbraceSpan
@@ -23,7 +23,7 @@ import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.session.LifeEventType
 import io.embrace.android.embracesdk.internal.session.getSessionProperty
-import io.embrace.android.embracesdk.internal.session.getSessionSpan
+import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import java.util.Locale
@@ -90,11 +90,11 @@ internal class SessionPartPayloadTest {
                 val sessions = getSessionEnvelopes(2)
 
                 // validate info added to first session
-                val span = sessions[0].findSessionSpan()
+                val span = sessions[0].findSessionPartSpan()
                 assertEquals("bar", span.getSessionProperty("foo"))
 
                 // confirm info not added to next session
-                val nextSpan = sessions[1].findSessionSpan()
+                val nextSpan = sessions[1].findSessionPartSpan()
                 assertNull(nextSpan.getSessionProperty("foo"))
             }
         )
@@ -135,7 +135,7 @@ internal class SessionPartPayloadTest {
             },
             assertAction = {
                 val session = getSingleSessionEnvelope()
-                assertEquals(100, session.getSessionSpan()?.events?.size)
+                assertEquals(100, session.getSessionPartSpan()?.events?.size)
             }
         )
     }
@@ -161,21 +161,21 @@ internal class SessionPartPayloadTest {
                 val sessions = getSessionEnvelopes(2)
                 val firstSession = sessions[0]
                 val secondSession = sessions[1]
-                val firstSessionSpan = checkNotNull(firstSession.getSessionSpan())
+                val firstSessionPartSpan = checkNotNull(firstSession.getSessionPartSpan())
                 val startAndEndInSession = checkNotNull(firstSession.data.spans?.single { it.name == "startAndEndInSession"})
 
-                assertTrue(firstSessionSpan.hasLinkToEmbraceSpan(startAndEndInSession, LinkType.EndedIn))
-                assertFalse(firstSessionSpan.hasLinkToEmbraceSpan(firstSessionSpan, LinkType.EndedIn))
-                assertTrue(startAndEndInSession.hasLinkToEmbraceSpan(firstSessionSpan, LinkType.EndSession))
+                assertTrue(firstSessionPartSpan.hasLinkToEmbraceSpan(startAndEndInSession, LinkType.EndedIn))
+                assertFalse(firstSessionPartSpan.hasLinkToEmbraceSpan(firstSessionPartSpan, LinkType.EndedIn))
+                assertTrue(startAndEndInSession.hasLinkToEmbraceSpan(firstSessionPartSpan, LinkType.EndSession))
 
-                val secondSessionSpan = checkNotNull(secondSession.getSessionSpan())
+                val secondSessionPartSpan = checkNotNull(secondSession.getSessionPartSpan())
                 val startInSessionEndInBackground =
                     checkNotNull(secondSession.data.spans?.single { it.name == "startInSessionEndInBackground"})
                 val startAndEndInDifferentSessions =
                     checkNotNull(secondSession.data.spans?.single { it.name == "startAndEndInDifferentSessions"})
-                assertTrue(secondSessionSpan.hasLinkToEmbraceSpan(startAndEndInDifferentSessions, LinkType.EndedIn))
-                assertFalse(secondSessionSpan.hasLinkToEmbraceSpan(secondSessionSpan, LinkType.EndedIn))
-                assertTrue(startAndEndInDifferentSessions.hasLinkToEmbraceSpan(secondSessionSpan, LinkType.EndSession))
+                assertTrue(secondSessionPartSpan.hasLinkToEmbraceSpan(startAndEndInDifferentSessions, LinkType.EndedIn))
+                assertFalse(secondSessionPartSpan.hasLinkToEmbraceSpan(secondSessionPartSpan, LinkType.EndedIn))
+                assertTrue(startAndEndInDifferentSessions.hasLinkToEmbraceSpan(secondSessionPartSpan, LinkType.EndSession))
                 assertEquals(0, startInSessionEndInBackground.links?.size)
             }
         )
@@ -196,7 +196,7 @@ internal class SessionPartPayloadTest {
                 // verify first session
                 val messages = getSessionEnvelopes(2)
                 val first = messages[0]
-                first.findSessionSpan().attributes?.assertMatches(mapOf(
+                first.findSessionPartSpan().attributes?.assertMatches(mapOf(
                     EmbSessionAttributes.EMB_SESSION_START_TYPE to LifeEventType.STATE.name.lowercase(Locale.ENGLISH),
                     EmbSessionAttributes.EMB_SESSION_END_TYPE to LifeEventType.STATE.name.lowercase(Locale.ENGLISH),
                     EmbSessionAttributes.EMB_ERROR_LOG_COUNT to 0
@@ -230,34 +230,34 @@ internal class SessionPartPayloadTest {
                 val secondSession = sessions[1]
                 val thirdSession = sessions[2]
 
-                val firstBaSessionSpan = firstBa.getValidatedSessionSpan()
+                val firstBaSessionPartSpan = firstBa.getValidatedSessionPartSpan()
 
-                val firstSessionSpan = firstSession.getValidatedSessionSpan(
-                    previousSessionSpan = firstBaSessionSpan,
+                val firstSessionPartSpan = firstSession.getValidatedSessionPartSpan(
+                    previousSessionPartSpan = firstBaSessionPartSpan,
                     previousSessionPartId = firstBa.getSessionPartId()
                 )
 
-                val secondBaSessionSpan = secondBa.getValidatedSessionSpan(
+                val secondBaSessionPartSpan = secondBa.getValidatedSessionPartSpan(
                     isColdStart = false,
-                    previousSessionSpan = firstSessionSpan,
+                    previousSessionPartSpan = firstSessionPartSpan,
                     previousSessionPartId = firstSession.getSessionPartId()
                 )
 
-                val secondSessionSpan = secondSession.getValidatedSessionSpan(
+                val secondSessionPartSpan = secondSession.getValidatedSessionPartSpan(
                     isColdStart = false,
-                    previousSessionSpan = secondBaSessionSpan,
+                    previousSessionPartSpan = secondBaSessionPartSpan,
                     previousSessionPartId = secondBa.getSessionPartId()
                 )
 
-                val thirdBaSessionSpan = thirdBa.getValidatedSessionSpan(
+                val thirdBaSessionPartSpan = thirdBa.getValidatedSessionPartSpan(
                     isColdStart = false,
-                    previousSessionSpan = secondSessionSpan,
+                    previousSessionPartSpan = secondSessionPartSpan,
                     previousSessionPartId = secondSession.getSessionPartId()
                 )
 
-                thirdSession.getValidatedSessionSpan(
+                thirdSession.getValidatedSessionPartSpan(
                     isColdStart = false,
-                    previousSessionSpan = thirdBaSessionSpan,
+                    previousSessionPartSpan = thirdBaSessionPartSpan,
                     previousSessionPartId = thirdBa.getSessionPartId()
                 )
             }
@@ -278,43 +278,43 @@ internal class SessionPartPayloadTest {
                 val second = sessions[1]
                 val third = sessions[2]
 
-                val firstSessionSpan = first.getValidatedSessionSpan()
+                val firstSessionPartSpan = first.getValidatedSessionPartSpan()
 
-                val secondSessionSpan = second.getValidatedSessionSpan(
+                val secondSessionPartSpan = second.getValidatedSessionPartSpan(
                     isColdStart = false,
-                    previousSessionSpan = firstSessionSpan,
+                    previousSessionPartSpan = firstSessionPartSpan,
                     previousSessionPartId = first.getSessionPartId()
                 )
 
-                third.getValidatedSessionSpan(
+                third.getValidatedSessionPartSpan(
                     isColdStart = false,
-                    previousSessionSpan = secondSessionSpan,
+                    previousSessionPartSpan = secondSessionPartSpan,
                     previousSessionPartId = second.getSessionPartId()
                 )
             }
         )
     }
 
-    private fun Envelope<SessionPartPayload>.getValidatedSessionSpan(
+    private fun Envelope<SessionPartPayload>.getValidatedSessionPartSpan(
         isColdStart: Boolean = true,
-        previousSessionSpan: Span? = null,
+        previousSessionPartSpan: Span? = null,
         previousSessionPartId: String? = null,
     ): Span {
-        val sessionSpan = findSessionSpan()
+        val sessionPartSpan = findSessionPartSpan()
         assertFalse(hasSpanSnapshotsOfType(EmbType.Ux.Session))
-        with(sessionSpan) {
+        with(sessionPartSpan) {
             checkNotNull(attributes).assertMatches(
                 mapOf(
                     EmbSessionAttributes.EMB_COLD_START to isColdStart
                 )
             )
 
-            if (previousSessionSpan != null && previousSessionPartId != null) {
-                assertPreviousSessionPart(previousSessionSpan, previousSessionPartId)
+            if (previousSessionPartSpan != null && previousSessionPartId != null) {
+                assertPreviousSessionPart(previousSessionPartSpan, previousSessionPartId)
             } else {
                 assertNoPreviousSession()
             }
         }
-        return sessionSpan
+        return sessionPartSpan
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionIdPropagationTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionIdPropagationTest.kt
@@ -10,7 +10,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.Severity
 import io.embrace.android.embracesdk.assertions.SessionIds
 import io.embrace.android.embracesdk.assertions.assertSessionIds
-import io.embrace.android.embracesdk.assertions.findSessionSpan
+import io.embrace.android.embracesdk.assertions.findSessionPartSpan
 import io.embrace.android.embracesdk.assertions.getLastLog
 import io.embrace.android.embracesdk.assertions.getLogOfType
 import io.embrace.android.embracesdk.assertions.getLogsOfType
@@ -30,7 +30,7 @@ import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
-import io.embrace.android.embracesdk.internal.session.getSessionSpan
+import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
 import io.embrace.android.embracesdk.internal.toStringMap
 import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.semconv.EmbAeiAttributes.AEI_SESSION_PART_ID
@@ -471,7 +471,7 @@ internal class UserSessionIdPropagationTest {
             },
             assertAction = {
                 val sessions = getSessionEnvelopes(2)
-                val sessionSpanFromOldPart = checkNotNull(sessions[0].getSessionSpan())
+                val sessionPartSpanFromOldPart = checkNotNull(sessions[0].getSessionPartSpan())
                 val oldUserSessionId = sessions[0].getUserSessionId()
                 val newUserSessionId = sessions[1].getUserSessionId()
                 assertNotEquals(oldUserSessionId, newUserSessionId)
@@ -479,7 +479,7 @@ internal class UserSessionIdPropagationTest {
                 val log = getSingleLogEnvelope().getLastLog()
                 val logSessionId = log.attributes?.findAttributeValue(SESSION_ID)
                 assertEquals(oldUserSessionId, logSessionId)
-                assertTrue(checkNotNull(log.timeUnixNano) <= checkNotNull(sessionSpanFromOldPart.endTimeNanos))
+                assertTrue(checkNotNull(log.timeUnixNano) <= checkNotNull(sessionPartSpanFromOldPart.endTimeNanos))
             },
         )
     }
@@ -514,7 +514,7 @@ internal class UserSessionIdPropagationTest {
     }
 
     private fun Envelope<SessionPartPayload>.assertSessionIds(): SessionIds =
-        checkNotNull(findSessionSpan().attributes).toMap().assertSessionIds()
+        checkNotNull(findSessionPartSpan().attributes).toMap().assertSessionIds()
 
     private fun Log.assertSessionIds(): SessionIds =
         checkNotNull(attributes).toMap().assertSessionIds()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionLifecycleTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionLifecycleTest.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.testcases.session
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.assertions.findSessionSpan
+import io.embrace.android.embracesdk.assertions.findSessionPartSpan
 import io.embrace.android.embracesdk.assertions.findSpansOfType
 import io.embrace.android.embracesdk.assertions.getOtelSessionId
 import io.embrace.android.embracesdk.assertions.getUserSessionId
@@ -75,8 +75,8 @@ internal class UserSessionLifecycleTest {
 
                 // the pre-foreground part belongs to the user session created eagerly at process start and classified as regular
                 // when the app entered the foreground
-                val bgSessionSpan = bgSession.findSessionSpan()
-                val bgAttrs = bgSessionSpan.attributes
+                val bgSessionPartSpan = bgSession.findSessionPartSpan()
+                val bgAttrs = bgSessionPartSpan.attributes
                 assertEquals(fgSession.getUserSessionId(), bgAttrs?.findAttributeValue(EMB_USER_SESSION_ID))
                 assertFalse(bgAttrs?.findAttributeValue(EMB_SESSION_PART_ID).isNullOrBlank())
                 assertEquals("1", bgAttrs?.findAttributeValue(EMB_USER_SESSION_NUMBER))
@@ -84,10 +84,10 @@ internal class UserSessionLifecycleTest {
                 assertNotNull(bgAttrs?.findAttributeValue(EMB_USER_SESSION_START_TS))
                 assertFalse(bgSession.isBackgroundOnlyPart())
 
-                val fgSessionSpan = fgSession.findSessionSpan()
+                val fgSessionPartSpan = fgSession.findSessionPartSpan()
                 assertNotNull(fgSession.getUserSessionId())
                 assertEquals(fgSession.getUserSessionId(), fgSession.getOtelSessionId())
-                assertEquals("1", fgSessionSpan.attributes?.findAttributeValue(EMB_USER_SESSION_NUMBER))
+                assertEquals("1", fgSessionPartSpan.attributes?.findAttributeValue(EMB_USER_SESSION_NUMBER))
                 fgSession.assertNotFinalPart()
 
                 val perfSpanNames = fgSession.findSpansOfType(EmbType.Performance.Default).map { it.name }
@@ -113,13 +113,13 @@ internal class UserSessionLifecycleTest {
 
                 // The pre-foreground part is the background-only session (number 1): it carries the
                 // marker and ends with the background-only termination reason when the app foregrounds.
-                val bgAttrs = bgSession.findSessionSpan().attributes
+                val bgAttrs = bgSession.findSessionPartSpan().attributes
                 assertTrue(bgSession.isBackgroundOnlyPart())
                 assertEquals("1", bgAttrs?.findAttributeValue(EMB_USER_SESSION_NUMBER))
                 bgSession.assertFinalPart(BACKGROUND_ONLY_USER_SESSION_FOREGROUNDED)
 
                 // The foreground part is a distinct, regular user session (number 2) - no marker.
-                val fgAttrs = fgSession.findSessionSpan().attributes
+                val fgAttrs = fgSession.findSessionPartSpan().attributes
                 assertDistinctUserSessions(bgSession, fgSession)
                 assertFalse(fgSession.isBackgroundOnlyPart())
                 assertEquals("2", fgAttrs?.findAttributeValue(EMB_USER_SESSION_NUMBER))
@@ -333,10 +333,10 @@ internal class UserSessionLifecycleTest {
             assertAction = {
                 val sessions = getSessionEnvelopes(2)
                 val bgActivities = getSessionEnvelopes(2, state = AppState.BACKGROUND)
-                val firstBg = bgActivities[0].findSessionSpan()
-                val secondBg = bgActivities[1].findSessionSpan()
-                val firstSession = sessions[0].findSessionSpan()
-                val secondSession = sessions[1].findSessionSpan()
+                val firstBg = bgActivities[0].findSessionPartSpan()
+                val secondBg = bgActivities[1].findSessionPartSpan()
+                val firstSession = sessions[0].findSessionPartSpan()
+                val secondSession = sessions[1].findSessionPartSpan()
 
                 assertDistinctUserSessions(sessions[0], sessions[1])
                 // the cold-start background part belongs to the first user session, created
@@ -383,7 +383,7 @@ internal class UserSessionLifecycleTest {
                 val userSessionIds = (fgSessions + bgSessions).map { it.getUserSessionId() }.toSet()
                 assertEquals(3, userSessionIds.size)
 
-                val span = longBackgroundPart.findSessionSpan()
+                val span = longBackgroundPart.findSessionPartSpan()
                 val partDurationMs = checkNotNull(span.endTimeNanos).nanosToMillis() - checkNotNull(span.startTimeNanos).nanosToMillis()
                 assertTrue(partDurationMs > maxDurationMs)
                 assertTrue(longBackgroundPart.isFinalSessionPart())

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionResurrectionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionResurrectionTest.kt
@@ -23,7 +23,7 @@ import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
-import io.embrace.android.embracesdk.internal.session.getSessionSpan
+import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.testcases.features.createNativeSymbolsForCurrentArch
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
@@ -224,7 +224,7 @@ internal class UserSessionResurrectionTest {
                 assertEquals(persistedId, currentLaunchPart.getUserSessionId())
 
                 fun Envelope<SessionPartPayload>.processId() =
-                    getSessionSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_PROCESS_IDENTIFIER)
+                    getSessionPartSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_PROCESS_IDENTIFIER)
                 assertEquals(priorProcessId, priorLaunchPart.processId())
                 assertNotEquals(priorProcessId, currentLaunchPart.processId())
                 assertTrue(priorLaunchPart.getStartTime() < currentLaunchPart.getStartTime())

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePayloadAssertionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePayloadAssertionInterface.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.assertions.assertMatches
-import io.embrace.android.embracesdk.assertions.findSessionSpan
+import io.embrace.android.embracesdk.assertions.findSessionPartSpan
 import io.embrace.android.embracesdk.assertions.getOtelSessionId
 import io.embrace.android.embracesdk.assertions.getUserSessionId
 import io.embrace.android.embracesdk.assertions.returnIfConditionMet
@@ -22,7 +22,7 @@ import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.serialization.fromJson
 import io.embrace.android.embracesdk.internal.serialization.toJson
-import io.embrace.android.embracesdk.internal.session.getSessionSpan
+import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
 import io.embrace.android.embracesdk.semconv.EmbAndroidAttributes
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.testframework.assertions.JsonComparator.compare
@@ -160,8 +160,8 @@ internal class EmbracePayloadAssertionInterface(
             val sessions: List<Map<String, String?>> = envelopes.map {
                 mapOf(
                     "otelSessionId" to it.getOtelSessionId(),
-                    "cleanExit" to it.findSessionSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_CLEAN_EXIT),
-                    "state" to it.findSessionSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_STATE)
+                    "cleanExit" to it.findSessionPartSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_CLEAN_EXIT),
+                    "state" to it.findSessionPartSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_STATE)
                 )
             }
             throwPayloadErrMsg(expectedSize, envelopes.filter { it.findAppState() == appState }.size, sessions, exc)
@@ -169,7 +169,7 @@ internal class EmbracePayloadAssertionInterface(
     }
 
     private fun Envelope<SessionPartPayload>.findAppState(): AppState {
-        val attrs = findSessionSpan().attributes
+        val attrs = findSessionPartSpan().attributes
         val state = checkNotNull(attrs?.findAttributeValue(EmbSessionAttributes.EMB_STATE)) {
             "AppState not found in session payload."
         }
@@ -233,7 +233,7 @@ internal class EmbracePayloadAssertionInterface(
     }
 
     fun Envelope<SessionPartPayload>.assertDeadPartResurrected(crashData: StoredNativeCrashData?) {
-        with(checkNotNull(getSessionSpan())) {
+        with(checkNotNull(getSessionPartSpan())) {
             assertEquals(Span.Status.ERROR, status)
 
             if (crashData != null) {
@@ -289,8 +289,8 @@ internal class EmbracePayloadAssertionInterface(
 
     private fun assertSessionsDeliveredInOrder(envelopes: List<Envelope<SessionPartPayload>>) {
         envelopes.zipWithNext { prev, next ->
-            val prevEnd = prev.findSessionSpan().startTimeNanos ?: return@zipWithNext
-            val nextEnd = next.findSessionSpan().startTimeNanos ?: return@zipWithNext
+            val prevEnd = prev.findSessionPartSpan().startTimeNanos ?: return@zipWithNext
+            val nextEnd = next.findSessionPartSpan().startTimeNanos ?: return@zipWithNext
             assertTrue(
                 "Session payloads delivered out of order. " +
                     "Previous (id=${prev.getOtelSessionId()}) startTimeNanos=$prevEnd, " +

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/assertions/PayloadGoldenFileAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/assertions/PayloadGoldenFileAssertions.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.testframework.assertions
 
-import io.embrace.android.embracesdk.assertions.findSessionSpan
+import io.embrace.android.embracesdk.assertions.findSessionPartSpan
 import io.embrace.android.embracesdk.assertions.getSessionPartId
 import io.embrace.android.embracesdk.assertions.getUserSessionId
 import io.embrace.android.embracesdk.internal.payload.Envelope
@@ -117,7 +117,7 @@ private fun EmbracePayloadAssertionInterface.verifySessionPart(
     expectedSessionPartId: String,
 ) {
     validatePayloadAgainstGoldenFile(
-        payload = sessionPartDiff.envelope.findSessionSpan(),
+        payload = sessionPartDiff.envelope.findSessionPartSpan(),
         goldenFileName = sessionPartDiff.goldenFile,
         placeholders = mapOf(
             Placeholder.USER_SESSION_ID to expectedUserSessionId,

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionPartSpanAttrPopulator.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionPartSpanAttrPopulator.kt
@@ -7,10 +7,10 @@ import io.embrace.android.embracesdk.internal.session.orchestrator.SessionPartSp
 
 class FakeSessionPartSpanAttrPopulator : SessionPartSpanAttrPopulator {
 
-    override fun populateSessionSpanStartAttrs(sessionPart: SessionPartToken, userSession: UserSessionMetadata?) {
+    override fun populateSessionPartSpanStartAttrs(sessionPart: SessionPartToken, userSession: UserSessionMetadata?) {
     }
 
-    override fun populateSessionSpanEndAttrs(
+    override fun populateSessionPartSpanEndAttrs(
         endType: LifeEventType?,
         crashId: String?,
         coldStart: Boolean,

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SessionPartPayloadAssertions.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SessionPartPayloadAssertions.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.internal.otel.spans.hasEmbraceAttribute
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
 import io.embrace.android.embracesdk.internal.payload.Span
-import io.embrace.android.embracesdk.internal.session.getSessionSpan
+import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
 import io.embrace.android.embracesdk.internal.session.getStateSpan
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.opentelemetry.kotlin.semconv.SessionAttributes
@@ -15,8 +15,8 @@ import io.opentelemetry.kotlin.semconv.SessionAttributes
 /**
  * Returns the Session Span
  */
-fun Envelope<SessionPartPayload>.findSessionSpan(): Span {
-    return checkNotNull(getSessionSpan()) {
+fun Envelope<SessionPartPayload>.findSessionPartSpan(): Span {
+    return checkNotNull(getSessionPartSpan()) {
         "No session span found in session payload"
     }
 }
@@ -25,7 +25,7 @@ fun Envelope<SessionPartPayload>.findSessionSpan(): Span {
  * Return the user session ID from the session span in the payload
  */
 fun Envelope<SessionPartPayload>.getOtelSessionId(): String {
-    return checkNotNull(findSessionSpan().attributes?.findAttributeValue(SessionAttributes.SESSION_ID)) {
+    return checkNotNull(findSessionPartSpan().attributes?.findAttributeValue(SessionAttributes.SESSION_ID)) {
         "No session id found in session payload"
     }
 }
@@ -34,7 +34,7 @@ fun Envelope<SessionPartPayload>.getOtelSessionId(): String {
  * Return the user session ID from the emb.user_session_id attribute in the session span.
  */
 fun Envelope<SessionPartPayload>.getUserSessionId(): String {
-    return checkNotNull(findSessionSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID)) {
+    return checkNotNull(findSessionPartSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID)) {
         "No user session id found in session payload"
     }
 }
@@ -43,7 +43,7 @@ fun Envelope<SessionPartPayload>.getUserSessionId(): String {
  * Return the session part ID from the session span in the payload. Unique per session part.
  */
 fun Envelope<SessionPartPayload>.getSessionPartId(): String {
-    return checkNotNull(findSessionSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID)) {
+    return checkNotNull(findSessionPartSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID)) {
         "No session part id found in session payload"
     }
 }
@@ -52,43 +52,43 @@ fun Envelope<SessionPartPayload>.getSessionPartId(): String {
  * Return the value of the `emb.user_session_termination_reason` attribute on the session span
  */
 fun Envelope<SessionPartPayload>.getUserSessionTerminationReason(): String? =
-    findSessionSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_TERMINATION_REASON)
+    findSessionPartSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_TERMINATION_REASON)
 
 /**
  * Whether the `emb.is_final_session_part` attribute is present (and set to "1") on the session
  */
 fun Envelope<SessionPartPayload>.isFinalSessionPart(): Boolean =
-    findSessionSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_IS_FINAL_SESSION_PART) == "1"
+    findSessionPartSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_IS_FINAL_SESSION_PART) == "1"
 
 /**
  * Whether the `emb.is_background_only_part` marker is present (and set to "1") on the session.
  */
 fun Envelope<SessionPartPayload>.isBackgroundOnlyPart(): Boolean =
-    findSessionSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART) == "1"
+    findSessionPartSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART) == "1"
 
 /**
  * Return the value of the `emb.user_session_number` attribute (the user-session ordinal) on the session span.
  */
 fun Envelope<SessionPartPayload>.getUserSessionNumber(): String? =
-    findSessionSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_NUMBER)
+    findSessionPartSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_NUMBER)
 
 /**
  * Return the value of the `emb.user_session_part_index` attribute (part index within the user session) on the session span.
  */
 fun Envelope<SessionPartPayload>.getUserSessionPartIndex(): String? =
-    findSessionSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_PART_INDEX)
+    findSessionPartSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_PART_INDEX)
 
 /**
  * Return the value of the `emb.session_part_number` attribute (install-lifetime monotonic counter) on the session span.
  */
 fun Envelope<SessionPartPayload>.getSessionPartNumber(): String? =
-    findSessionSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_NUMBER)
+    findSessionPartSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_NUMBER)
 
 /**
  * Return the session start time in milliseconds from the session span in the payload
  */
 fun Envelope<SessionPartPayload>.getStartTime(): Long {
-    return checkNotNull(findSessionSpan().startTimeNanos?.nanosToMillis()) {
+    return checkNotNull(findSessionPartSpan().startTimeNanos?.nanosToMillis()) {
         "No start time found in session payload"
     }
 }
@@ -98,7 +98,7 @@ fun Envelope<SessionPartPayload>.getStartTime(): Long {
  */
 fun Envelope<SessionPartPayload>.getLastHeartbeatTimeMs(): Long {
     return checkNotNull(
-        findSessionSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_HEARTBEAT_TIME_UNIX_NANO)?.toLongOrNull()
+        findSessionPartSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_HEARTBEAT_TIME_UNIX_NANO)?.toLongOrNull()
             ?.nanosToMillis()
     ) {
         "No last heartbeat time found in session payload"

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCurrentSessionPartSpan.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeCurrentSessionPartSpan.kt
@@ -16,16 +16,16 @@ class FakeCurrentSessionPartSpan(
     val attributes = mutableMapOf<String, String>()
     val stoppedSpans = mutableSetOf<String>()
     var initializedCallCount: Int = 0
-    var sessionSpan: FakeEmbraceSdkSpan? = null
+    var sessionPartSpan: FakeEmbraceSdkSpan? = null
 
     private val sessionIteration = AtomicInteger(1)
 
     override fun initializeService(sdkInitStartTimeMs: Long) {
-        sessionSpan = newSessionSpan(sdkInitStartTimeMs)
+        sessionPartSpan = newSessionPartSpan(sdkInitStartTimeMs)
     }
 
     override fun current(): EmbraceSdkSpan? {
-        return sessionSpan
+        return sessionPartSpan
     }
 
     override fun initialized(): Boolean {
@@ -34,7 +34,7 @@ class FakeCurrentSessionPartSpan(
     }
 
     override fun readySession(): Boolean {
-        sessionSpan = newSessionSpan(clock.now())
+        sessionPartSpan = newSessionPartSpan(clock.now())
         return true
     }
 
@@ -42,16 +42,16 @@ class FakeCurrentSessionPartSpan(
         startNewSession: Boolean,
         appTerminationCause: AppTerminationCause?,
     ): List<EmbraceSpanData> {
-        val endingSessionSpan = checkNotNull(sessionSpan)
+        val endingSessionPartSpan = checkNotNull(sessionPartSpan)
         val errorCode = if (appTerminationCause != null) {
             ErrorCode.FAILURE
         } else {
             null
         }
-        endingSessionSpan.stop(errorCode, clock.now())
-        val payload = listOf(checkNotNull(endingSessionSpan.snapshot()).toEmbracePayload())
+        endingSessionPartSpan.stop(errorCode, clock.now())
+        val payload = listOf(checkNotNull(endingSessionPartSpan.snapshot()).toEmbracePayload())
         sessionIteration.incrementAndGet()
-        sessionSpan = if (appTerminationCause == null) newSessionSpan(clock.now()) else null
+        sessionPartSpan = if (appTerminationCause == null) newSessionPartSpan(clock.now()) else null
         return payload
     }
 
@@ -67,8 +67,8 @@ class FakeCurrentSessionPartSpan(
         stoppedSpans.add(spanId)
     }
 
-    private fun newSessionSpan(startTimeMs: Long) =
-        FakeEmbraceSdkSpan.sessionSpan(
+    private fun newSessionPartSpan(startTimeMs: Long) =
+        FakeEmbraceSdkSpan.sessionPartSpan(
             userSessionId = "fake-session-span-id",
             startTimeMs = startTimeMs,
             lastHeartbeatTimeMs = startTimeMs

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionPart.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionPart.kt
@@ -27,7 +27,7 @@ fun fakeSessionEnvelope(
     endMs: Long = 161000400000L,
     sessionProperties: Map<String, String>? = null,
 ): Envelope<SessionPartPayload> {
-    val sessionSpan = FakeEmbraceSdkSpan.sessionSpan(
+    val sessionPartSpan = FakeEmbraceSdkSpan.sessionPartSpan(
         userSessionId = userSessionId,
         sessionPartId = sessionPartId,
         startTimeMs = startMs,
@@ -35,7 +35,7 @@ fun fakeSessionEnvelope(
         endTimeMs = endMs,
         sessionProperties = sessionProperties,
     )
-    val spans = listOf(testSpan, checkNotNull(sessionSpan.snapshot()))
+    val spans = listOf(testSpan, checkNotNull(sessionPartSpan.snapshot()))
     val spanSnapshots = listOfNotNull(FakeEmbraceSdkSpan.started().snapshot())
 
     return Envelope(
@@ -61,7 +61,7 @@ fun fakeIncompleteSessionEnvelope(
     metadata: EnvelopeMetadata = fakeEnvelopeMetadata,
 ): Envelope<SessionPartPayload> {
     val fakeClock = FakeClock(currentTime = startMs)
-    val incompleteSessionSpan = FakeEmbraceSdkSpan.sessionSpan(
+    val incompleteSessionPartSpan = FakeEmbraceSdkSpan.sessionPartSpan(
         userSessionId = userSessionId,
         sessionPartId = sessionPartId,
         startTimeMs = startMs,
@@ -76,7 +76,7 @@ fun fakeIncompleteSessionEnvelope(
         type = "spans",
         data = SessionPartPayload(
             spanSnapshots = listOfNotNull(
-                incompleteSessionSpan.snapshot(),
+                incompleteSessionPartSpan.snapshot(),
                 FakeEmbraceSdkSpan.started(clock = fakeClock).snapshot()
             )
         )


### PR DESCRIPTION
Straightup rename of usages of `sessionSpan` to `sessionPartSpan` for additional clarity. There is no such thing as a "session span" now as the span created is now 1-1 with a session and represents its metadata.