### PR TITLE
Use and validate the right session IDs in network capture instrumentation

### DIFF
--- a/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkCaptureDataSourceImpl.kt
+++ b/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkCaptureDataSourceImpl.kt
@@ -127,7 +127,6 @@ class NetworkCaptureDataSourceImpl(
                     responseHeaders = call.responseHeaders,
                     responseSize = call.responseSize,
                     responseStatus = call.responseStatus,
-                    sessionPartId = call.sessionPartId,
                     startTime = call.startTime,
                     url = call.url,
                     errorMessage = call.errorMessage,

--- a/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkCaptureDataSourceTest.kt
+++ b/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkCaptureDataSourceTest.kt
@@ -6,12 +6,16 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
 import io.embrace.android.embracesdk.fakes.FakeTelemetryDestination
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
+import io.embrace.android.embracesdk.fakes.behavior.FakeNetworkBehavior
 import io.embrace.android.embracesdk.fakes.createNetworkBehavior
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.telemetry.AppliedLimitType
+import io.embrace.android.embracesdk.semconv.EmbNetworkCapturedRequestAttributes
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -80,7 +84,7 @@ internal class NetworkCaptureDataSourceTest {
         val result = service.getNetworkCaptureRules("https://embrace.io/changelog", "GET")
         assertEquals(1, result.size)
         args.store.edit {
-            putInt(NetworkCaptureDataSourceImpl.Companion.NETWORK_CAPTURE_RULE_PREFIX_KEY + rule.id, 0)
+            putInt(NetworkCaptureDataSourceImpl.NETWORK_CAPTURE_RULE_PREFIX_KEY + rule.id, 0)
         }
         val emptyRule = service.getNetworkCaptureRules("https://embrace.io/changelog", "GET")
         assertEquals(0, emptyRule.size)
@@ -92,7 +96,7 @@ internal class NetworkCaptureDataSourceTest {
         cfg = RemoteConfig(networkCaptureRules = setOf(rule))
         val service = getService()
         args.store.edit {
-            putInt(NetworkCaptureDataSourceImpl.Companion.NETWORK_CAPTURE_RULE_PREFIX_KEY + rule.id, 0)
+            putInt(NetworkCaptureDataSourceImpl.NETWORK_CAPTURE_RULE_PREFIX_KEY + rule.id, 0)
         }
         val emptyRule = service.getNetworkCaptureRules("https://embrace.io/changelog", "GET")
         assertEquals(0, emptyRule.size)
@@ -226,6 +230,48 @@ internal class NetworkCaptureDataSourceTest {
     }
 
     @Test
+    fun `network body is encrypted into a single opaque attribute with no plaintext content when encryption enabled`() {
+        configService = FakeConfigService(
+            networkBehavior = FakeNetworkBehavior(
+                rules = setOf(getDefaultRule()),
+                captureBodyEncryptionEnabled = true,
+                publicKey = fakeNetworkBodyPublicKey,
+            )
+        )
+        args = FakeInstrumentationArgs(
+            application = ApplicationProvider.getApplicationContext(),
+            configService = configService,
+        )
+        destination = args.destination
+
+        NetworkCaptureDataSourceImpl(args).recordNetworkRequest(
+            HttpNetworkRequest(
+                url = "https://embrace.io/changelog",
+                httpMethod = "GET",
+                statusCode = 200,
+                startTime = 0,
+                endTime = 1000,
+                body = HttpNetworkRequest.HttpRequestBody(
+                    requestHeaders = mapOf("req-header" to "value"),
+                    requestQueryParams = "trackMe=noooooo",
+                    capturedRequestBody = "request-body-plaintext".toByteArray(),
+                    responseHeaders = mapOf("res-header" to "value"),
+                    capturedResponseBody = "response-body-plaintext".toByteArray(),
+                    dataCaptureErrorMessage = null,
+                ),
+            )
+        )
+
+        assertEquals(1, destination.logEvents.size)
+        val attrs = destination.logEvents[0].schemaType.attributes()
+        assertFalse(checkNotNull(attrs[EmbNetworkCapturedRequestAttributes.ENCRYPTED_PAYLOAD]).isBlank())
+        assertNull(attrs[EmbNetworkCapturedRequestAttributes.REQUEST_BODY])
+        assertNull(attrs[EmbNetworkCapturedRequestAttributes.RESPONSE_BODY])
+        assertNull(attrs[EmbNetworkCapturedRequestAttributes.REQUEST_QUERY])
+        assertNull(attrs[EmbNetworkCapturedRequestAttributes.URL])
+    }
+
+    @Test
     fun `test telemetry tracked when network body is truncated`() {
         cfg = RemoteConfig(networkCaptureRules = setOf(getDefaultRule(maxSize = 2)))
         val telemetryService = FakeTelemetryService()
@@ -264,7 +310,7 @@ internal class NetworkCaptureDataSourceTest {
             configService = configService
         )
         destination = args.destination
-        return NetworkCaptureDataSourceImpl(args,)
+        return NetworkCaptureDataSourceImpl(args)
     }
 
     private fun getDefaultRule(
@@ -287,4 +333,13 @@ internal class NetworkCaptureDataSourceTest {
             maxCount = maxCount,
             statusCodes = statusCodes
         )
+
+    private val fakeNetworkBodyPublicKey: String =
+        "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuAZAv5tzK9Ab/DsVpNaY\n" +
+            "iuslKQsOHjz4N4haZLT8VaVIrlVjtkd5nPrVgEKStQf6PKnQ+1C0Tp069b6aPUkG\n" +
+            "22UL96nCKQ1eCIwRUT+Da7ac2YVuL21+HTs1KxLEWgN7qGy1uYNonrpsiY3XqzDv\n" +
+            "YMo65oFzbBV+yctuGHDFaulULJiLL8cE3/Rg3T0RfHK+C5/PqC8FBj6kn3FP9FZJ\n" +
+            "M4cty3nzbNWknj8r7+ikmOwma6CHEZz2u1gwPhIchNxNKuUF+4vxcBre9V/96LYO\n" +
+            "jSOGSDJmJN6ehUJjUpu7YSuGCki8YoLHAyoD/mYy7N/hYSeZwHiNjM+r44lZHNQT\n" +
+            "pwIDAQAB"
 }

--- a/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
+++ b/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
@@ -199,8 +199,6 @@ sealed class SchemaType(
         responseHeaders: Map<String, String>?,
         responseSize: Int?,
         responseStatus: Int?,
-        // FIXME: this is populated with the session part ID but is used to populate session.id, which is a mismatch
-        sessionPartId: String?,
         startTime: Long?,
         url: String?,
         errorMessage: String?,
@@ -224,7 +222,6 @@ sealed class SchemaType(
             HttpAttributes.HTTP_RESPONSE_HEADER to responseHeaders.toString(),
             EmbNetworkCapturedRequestAttributes.RESPONSE_SIZE to responseSize.toString(),
             HttpAttributes.HTTP_RESPONSE_STATUS_CODE to responseStatus.toString(),
-            SessionAttributes.SESSION_ID to sessionPartId,
             EmbNetworkCapturedRequestAttributes.START_TIME to startTime.toString(),
             EmbNetworkCapturedRequestAttributes.URL to url,
             ExceptionAttributes.EXCEPTION_MESSAGE to errorMessage,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
@@ -1,21 +1,31 @@
 package io.embrace.android.embracesdk.testcases
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.assertions.assertMatches
+import io.embrace.android.embracesdk.assertions.getLogOfType
+import io.embrace.android.embracesdk.assertions.getSessionPartId
+import io.embrace.android.embracesdk.assertions.getUserSessionId
+import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.arch.schema.SendMode
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.network.http.NetworkCaptureData
-import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
+import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.network.http.HttpMethod
+import io.embrace.android.embracesdk.semconv.EmbNetworkCapturedRequestAttributes
+import io.embrace.android.embracesdk.semconv.EmbNetworkRequestAttributes
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbracePayloadAssertionInterface
-import io.embrace.android.embracesdk.assertions.assertMatches
-import io.embrace.android.embracesdk.semconv.EmbNetworkRequestAttributes
+import io.embrace.android.embracesdk.testframework.assertions.assertSessionIds
 import io.opentelemetry.kotlin.semconv.ExceptionAttributes
 import io.opentelemetry.kotlin.semconv.HttpAttributes
+import io.opentelemetry.kotlin.semconv.UrlAttributes
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -270,6 +280,74 @@ internal class NetworkRequestApiTest {
                     "Unexpected number of requests in sent session: ${spans.size}",
                     2,
                     spans.size
+                )
+            }
+        )
+    }
+
+    @Test
+    fun `captured network body log carries expected attributes`() {
+        testRule.runTest(
+            persistedRemoteConfig = RemoteConfig(
+                networkCaptureRules = setOf(
+                    NetworkCaptureRuleRemoteConfig(
+                        id = "test",
+                        duration = 0,
+                        method = "GET",
+                        urlRegex = "embrace.io",
+                        expiresIn = 10000,
+                        statusCodes = setOf(200),
+                    )
+                )
+            ),
+            testCaseAction = {
+                recordSession {
+                    embrace.recordNetworkRequest(
+                        EmbraceNetworkRequest.fromCompletedRequest(
+                            URL,
+                            HttpMethod.GET,
+                            START_TIME,
+                            END_TIME,
+                            BYTES_SENT,
+                            BYTES_RECEIVED,
+                            200,
+                            networkCaptureData = NETWORK_CAPTURE_DATA,
+                        )
+                    )
+                }
+            },
+            assertAction = {
+                val session = getSingleSessionEnvelope()
+                val capturedLog = getSingleLogEnvelope().getLogOfType(EmbType.System.NetworkCapturedRequest)
+                val attrs = checkNotNull(capturedLog.attributes)
+
+                // the captured request body and metadata
+                attrs.assertMatches(
+                    mapOf(
+                        EmbNetworkCapturedRequestAttributes.DURATION to END_TIME - START_TIME,
+                        EmbNetworkCapturedRequestAttributes.START_TIME to START_TIME,
+                        EmbNetworkCapturedRequestAttributes.END_TIME to END_TIME,
+                        EmbNetworkCapturedRequestAttributes.URL to URL,
+                        EmbNetworkCapturedRequestAttributes.REQUEST_BODY to "haha",
+                        EmbNetworkCapturedRequestAttributes.REQUEST_SIZE to 4,
+                        EmbNetworkCapturedRequestAttributes.REQUEST_QUERY to "trackMe=noooooo",
+                        EmbNetworkCapturedRequestAttributes.RESPONSE_BODY to "woohoo",
+                        EmbNetworkCapturedRequestAttributes.RESPONSE_SIZE to 6,
+                        EmbSessionAttributes.EMB_PRIVATE_SEND_MODE to SendMode.IMMEDIATE,
+                        HttpAttributes.HTTP_REQUEST_HEADER to mapOf("x-emb-test" to "holla").toString(),
+                        HttpAttributes.HTTP_REQUEST_METHOD to "GET",
+                        HttpAttributes.HTTP_REQUEST_BODY_SIZE to 4,
+                        HttpAttributes.HTTP_RESPONSE_STATUS_CODE to 200,
+                        HttpAttributes.HTTP_RESPONSE_BODY_SIZE to 6,
+                        HttpAttributes.HTTP_RESPONSE_HEADER to mapOf("x-emb-response-header" to "alloh").toString(),
+                        UrlAttributes.URL_FULL to "embrace.io",
+                    )
+                )
+
+                assertFalse(attrs.findAttributeValue(EmbNetworkCapturedRequestAttributes.NETWORK_ID).isNullOrBlank())
+                capturedLog.assertSessionIds(
+                    expectedUserSessionId = session.getUserSessionId(),
+                    expectedSessionPartId = session.getSessionPartId(),
                 )
             }
         )


### PR DESCRIPTION
Rely on existing infra to attach session related IDs to network request capture instrumentation, and add integration test to validate this end to end.