### PR TITLE
Ensure initial session part created is always used

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImpl.kt
@@ -177,7 +177,7 @@ internal class CurrentSessionPartSpanImpl(
     /**
      * Creates the current session part span if one does not already exist.
      */
-    private fun ensureInitialSessionPartExists(startTimeMs: () -> Long) {
+    private inline fun ensureInitialSessionPartExists(startTimeMs: () -> Long) {
         if (sessionPartState == null) {
             synchronized(sessionTransitionLock) {
                 if (sessionPartState == null) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImpl.kt
@@ -56,7 +56,7 @@ internal class CurrentSessionPartSpanImpl(
         if (!initialized) {
             synchronized(sessionTransitionLock) {
                 if (!initialized) {
-                    sessionPartState = startSessionPartSpan(sdkInitStartTimeMs)
+                    ensureInitialSessionPartExists { sdkInitStartTimeMs }
                     initialized = sessionPartState != null
                 }
             }
@@ -128,14 +128,7 @@ internal class CurrentSessionPartSpanImpl(
     }
 
     override fun readySession(): Boolean {
-        if (sessionPartState == null) {
-            synchronized(sessionTransitionLock) {
-                if (sessionPartState == null) {
-                    sessionPartState = startSessionPartSpan(openTelemetryClock.now().nanosToMillis())
-                    return sessionPartSpanReady()
-                }
-            }
-        }
+        ensureInitialSessionPartExists { openTelemetryClock.now().nanosToMillis() }
         return sessionPartSpanReady()
     }
 
@@ -180,6 +173,19 @@ internal class CurrentSessionPartSpanImpl(
     }
 
     override fun current(): EmbraceSdkSpan? = sessionPartState?.span
+
+    /**
+     * Creates the current session part span if one does not already exist.
+     */
+    private fun ensureInitialSessionPartExists(startTimeMs: () -> Long) {
+        if (sessionPartState == null) {
+            synchronized(sessionTransitionLock) {
+                if (sessionPartState == null) {
+                    sessionPartState = startSessionPartSpan(startTimeMs())
+                }
+            }
+        }
+    }
 
     /**
      * This method should always be used when starting a new session part span. It creates a UUID for the session part and

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImplTests.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImplTests.kt
@@ -39,6 +39,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -80,6 +81,21 @@ internal class CurrentSessionPartSpanImplTests {
         val uninitialized = FakeInitModule(clock = clock).openTelemetryModule.currentSessionPartSpan
         assertFalse(uninitialized.initialized())
         uninitialized.assertNoSessionPartSpan()
+    }
+
+    @Test
+    fun `initializeService does not clobber a session part span already started by readySession`() {
+        val sessionPartSpan = FakeInitModule(clock = clock).openTelemetryModule.currentSessionPartSpan
+        assertFalse(sessionPartSpan.initialized())
+
+        assertTrue(sessionPartSpan.readySession())
+        val partId = sessionPartSpan.getId()
+        val createdSpan = checkNotNull(sessionPartSpan.current())
+        sessionPartSpan.initializeService(clock.now())
+
+        assertTrue(sessionPartSpan.initialized())
+        assertEquals(partId, sessionPartSpan.getId())
+        assertSame(createdSpan, sessionPartSpan.current())
     }
 
     @Test


### PR DESCRIPTION
Ensure both paths that can theoretically lead to the initial session part being created don't clobber each other.