### PR TITLE
Disable incremental KSP snapshot generate at project level

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,9 @@ org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.problems=fail
 org.gradle.configuration-cache.parallel=true
+# KSP snapshots can get out of sync internally because they aren't part of the build cache and are vulnerable to different bugs
+# Given we don't use it a lot and they build fast, always build from scratch if a part is modified so we're always in sync
+ksp.incremental=false
 version=9.0.0-SNAPSHOT
 android.useAndroidX=true
 android.experimental.enableArtProfiles=true


### PR DESCRIPTION
KSP snapshots being built incrementally can cause the KSP cache to become internally inconsistent/stale. Generating them all if one requires generation gets rid of this problem. Since each task run in a handful of ms, it shouldn't make a difference given low little we leverage KSP now.