### PR TITLE
Don't create background only user sessions when background activity is disabled

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -572,8 +572,8 @@ internal class SessionOrchestratorImpl(
             // User session being ended explicitly - end current one and start a new one based on the expected endAppState.
             transitionType.endsUserSession -> {
                 clearBackgroundStartupWindowTimer()
-                if (endAppState == AppState.BACKGROUND && !configService.backgroundActivityBehavior.isBackgroundActivityCaptureEnabled()
-                ) {
+                if (endAppState == AppState.BACKGROUND &&
+                    !configService.backgroundActivityBehavior.isBackgroundActivityCaptureEnabled()) {
                     terminateActiveUserSession()
                 } else {
                     transitionToNewUserSession(timestamp, endAppState)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -572,7 +572,12 @@ internal class SessionOrchestratorImpl(
             // User session being ended explicitly - end current one and start a new one based on the expected endAppState.
             transitionType.endsUserSession -> {
                 clearBackgroundStartupWindowTimer()
-                transitionToNewUserSession(timestamp, endAppState)
+                if (endAppState == AppState.BACKGROUND && !configService.backgroundActivityBehavior.isBackgroundActivityCaptureEnabled()
+                ) {
+                    terminateActiveUserSession()
+                } else {
+                    transitionToNewUserSession(timestamp, endAppState)
+                }
                 scheduleSessionEndTimers(endAppState)
             }
 
@@ -653,6 +658,19 @@ internal class SessionOrchestratorImpl(
      */
     private fun transitionToNewUserSession(timestamp: Long, endAppState: AppState) {
         // End current user session if it exists
+        terminateActiveUserSession()
+
+        // Start new user session, make it active, and broadcast new user session being active to listeners. The caller is
+        // responsible for scheduling the new session's end timers (see scheduleSessionEndTimers).
+        val newMetadata = createUnclassifiedUserSession(timestamp).classify(isBackgroundOnly = endAppState == AppState.BACKGROUND)
+        setActiveUserSession(newMetadata)
+        notifyListeners(UserSessionActive(newMetadata.userSessionId))
+    }
+
+    /**
+     * Ends the active user session  and leaves the SDK with no active user session ([UserSessionState.Terminated]).
+     */
+    private fun terminateActiveUserSession() {
         currentUserSession()?.let {
             maxDurationTimerState?.cancel()
             maxDurationTimerState = null
@@ -662,12 +680,6 @@ internal class SessionOrchestratorImpl(
             userSessionState = UserSessionState.Terminated
             notifyListeners(UserSessionEnded(it.userSessionId))
         }
-
-        // Start new user session, make it active, and broadcast new user session being active to listeners. The caller is
-        // responsible for scheduling the new session's end timers (see scheduleSessionEndTimers).
-        val newMetadata = createUnclassifiedUserSession(timestamp).classify(isBackgroundOnly = endAppState == AppState.BACKGROUND)
-        setActiveUserSession(newMetadata)
-        notifyListeners(UserSessionActive(newMetadata.userSessionId))
     }
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -572,8 +572,7 @@ internal class SessionOrchestratorImpl(
             // User session being ended explicitly - end current one and start a new one based on the expected endAppState.
             transitionType.endsUserSession -> {
                 clearBackgroundStartupWindowTimer()
-                if (endAppState == AppState.BACKGROUND &&
-                    !configService.backgroundActivityBehavior.isBackgroundActivityCaptureEnabled()) {
+                if (endAppState == AppState.BACKGROUND && !configService.backgroundActivityBehavior.isBackgroundActivityCaptureEnabled()) {
                     terminateActiveUserSession()
                 } else {
                     transitionToNewUserSession(timestamp, endAppState)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -1128,32 +1128,30 @@ internal class SessionOrchestratorTest {
     }
 
     @Test
-    fun `max duration timer fires in background but does not create stranded part when capture disabled`() {
-        // FakeConfigService's default backgroundActivityBehavior has bg capture disabled
+    fun `manual session end in background with capture disabled terminates without creating a new user session or session part`() {
         createOrchestrator(
             startingAppState = AppState.FOREGROUND,
-            configService = sessionLimitsConfigService(customInactivityTimeoutMs = maxDurationMs * 4),
+            configService = sessionLimitsConfigService(),
         )
         val first = activeUserSession()
-        val baCountBefore = payloadCollator.baCount.get()
 
         clock.tick(1_000)
         orchestrator.onBackground()
+        clock.tick(1_000)
+        orchestrator.endSessionWithManual()
 
-        runTimerThread(maxDurationMs)
+        assertNull(orchestrator.currentUserSession())
+        assertNull(sessionTracker.getActiveSessionPart())
 
-        // The user session must still rotate: max-duration is a hard limit independent of capture config.
+        orchestrator.onForeground()
         val second = activeUserSession()
         assertNotEquals(first.userSessionId, second.userSessionId)
-        assertEquals(2L, second.userSessionNumber)
-
-        // No new BG session-part was created — capture is disabled, so the rotation produced no payload.
-        assertEquals(baCountBefore, payloadCollator.baCount.get())
-        assertNull(sessionTracker.getActiveSessionPart())
+        assertEquals(first.userSessionNumber + 1, second.userSessionNumber)
+        assertEquals(false, second.isBackgroundOnly)
     }
 
     @Test
-    fun `inactivity timer fires in background but no part is created when capture disabled`() {
+    fun `inactivity timer fires in background with capture disabled terminates without a phantom user session`() {
         createOrchestrator(
             startingAppState = AppState.FOREGROUND,
             configService = backgroundDisabledConfigService(),
@@ -1165,14 +1163,14 @@ internal class SessionOrchestratorTest {
 
         runTimerThread(inactivityMs)
 
-        val second = activeUserSession()
-        assertNotEquals(first.userSessionId, second.userSessionId)
-        assertEquals(2L, second.userSessionNumber)
-        assertEquals(true, second.isBackgroundOnly)
+        assertNull(orchestrator.currentUserSession())
         assertNull(sessionTracker.getActiveSessionPart())
 
         orchestrator.onForeground()
-        assertEquals(0, payloadCollator.baCount.get())
+        val second = activeUserSession()
+        assertNotEquals(first.userSessionId, second.userSessionId)
+        assertEquals(first.userSessionNumber + 1, second.userSessionNumber)
+        assertEquals(false, second.isBackgroundOnly)
     }
 
     @Test

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
@@ -18,6 +18,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.UserSessionRemoteConfig
 import io.embrace.android.embracesdk.internal.delivery.PayloadType
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.payload.Envelope
@@ -140,6 +141,38 @@ internal class JvmCrashFeatureTest {
                 val userSessionId = attrs.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID)
                 assertFalse(userSessionId.isNullOrBlank())
                 assertEquals(userSessionId, attrs.findAttributeValue(SessionAttributes.SESSION_ID))
+                assertEquals("", attrs.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID) ?: "")
+            }
+        )
+    }
+
+    @Test
+    fun `crash in background after inactivity kills the user session with bg disabled carries empty session ids`() {
+        lateinit var nonIoWorker: BlockingScheduledExecutorService
+        testRule.runTest(
+            persistedRemoteConfig = RemoteConfig(
+                userSession = UserSessionRemoteConfig(inactivityTimeoutSeconds = 30)
+            ),
+            setupAction = {
+                nonIoWorker = getFakedWorkerExecutor(Worker.Background.NonIoRegWorker)
+            },
+            testCaseAction = {
+                recordSession()
+                clock.tick(30L * 1_000L + 1_000L)
+                nonIoWorker.runCurrentlyBlocked()
+                crashTimeMs = clock.now()
+                simulateJvmUncaughtException(testException)
+            },
+            assertAction = {
+                val crashLog = payloadStorageService.getPersistedCrashLog().getLastLog()
+                crashLog.assertCrash(
+                    crashIdFromSession = null,
+                    crashTimeMs = crashTimeMs,
+                    hasSession = false,
+                )
+                val attrs = checkNotNull(crashLog.attributes)
+                assertEquals("", attrs.findAttributeValue(SessionAttributes.SESSION_ID) ?: "")
+                assertEquals("", attrs.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID) ?: "")
                 assertEquals("", attrs.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID) ?: "")
             }
         )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NativeCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NativeCrashFeatureTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.testcases.features
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.getLogOfType
 import io.embrace.android.embracesdk.assertions.getSessionPartId
+import io.embrace.android.embracesdk.assertions.getUserSessionId
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeJniDelegate
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
@@ -312,6 +313,52 @@ internal class NativeCrashFeatureTest {
     @Test
     fun `session ids and crash path properly set up when background activity disabled`() {
         checkNativeMetadata(false)
+    }
+
+    @Test
+    fun `persisted metadata for a native crash when background activity is disabled when there is a user session is correct`() {
+        lateinit var jniDelegate: FakeJniDelegate
+        lateinit var ioWorker: BlockingScheduledExecutorService
+        testRule.runTest(
+            instrumentedConfig = config,
+            setupAction = {
+                jniDelegate = fakeJniDelegate
+                ioWorker = getFakedWorkerExecutor(Worker.Background.IoRegWorker)
+            },
+            testCaseAction = {
+                ioWorker.runCurrentlyBlocked()
+                recordSession()
+                ioWorker.runCurrentlyBlocked()
+            },
+            assertAction = {
+                val userSessionId = getSingleSessionEnvelope().getUserSessionId()
+                assertEquals(userSessionId, jniDelegate.userSessionId)
+                assertEquals("null", jniDelegate.sessionPartId)
+            }
+        )
+    }
+
+    @Test
+    fun `persisted metadata for a native crash when background activity is disabled when there is no user session is correct`() {
+        lateinit var jniDelegate: FakeJniDelegate
+        lateinit var ioWorker: BlockingScheduledExecutorService
+        testRule.runTest(
+            instrumentedConfig = config,
+            setupAction = {
+                jniDelegate = fakeJniDelegate
+                ioWorker = getFakedWorkerExecutor(Worker.Background.IoRegWorker)
+            },
+            testCaseAction = {
+                ioWorker.runCurrentlyBlocked()
+                recordSession()
+                embrace.endUserSession()
+                ioWorker.runCurrentlyBlocked()
+            },
+            assertAction = {
+                assertEquals("null", jniDelegate.userSessionId)
+                assertEquals("null", jniDelegate.sessionPartId)
+            }
+        )
     }
 
     private fun checkNativeMetadata(backgroundActivityEnabled: Boolean) {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/ManualUserSessionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/ManualUserSessionTest.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.assertions.assertDistinctUserSessions
 import io.embrace.android.embracesdk.testframework.assertions.assertFinalPart
 import io.embrace.android.embracesdk.testframework.assertions.assertNotFinalPart
+import io.embrace.android.embracesdk.testframework.assertions.assertUserSessionNumbers
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -39,6 +40,11 @@ internal class ManualUserSessionTest {
                 val manualSession = messages[1] // started manually, ended via state
                 checkNotNull(stateSession.findSessionPartSpan())
                 checkNotNull(manualSession.findSessionPartSpan())
+                assertUserSessionNumbers(
+                    envelopes = messages,
+                    userSessionNumbers = listOf(1, 2),
+                    sessionPartNumbers = listOf(1, 2)
+                )
             }
         )
     }
@@ -95,6 +101,26 @@ internal class ManualUserSessionTest {
     }
 
     @Test
+    fun `manually ending a user session in the background while background activity is disabled does not create a new user session`() {
+        testRule.runTest(
+            testCaseAction = {
+                recordSession()
+                embrace.endUserSession()
+                recordSession()
+            },
+            assertAction = {
+                val sessions = getSessionEnvelopes(2)
+                assertDistinctUserSessions(sessions[0], sessions[1])
+                assertUserSessionNumbers(
+                    envelopes = sessions,
+                    userSessionNumbers = listOf(1, 2),
+                    sessionPartNumbers = listOf(1, 2)
+                )
+            },
+        )
+    }
+
+    @Test
     fun `new user session can be manually created`() {
         testRule.runTest(
             testCaseAction = {
@@ -107,6 +133,11 @@ internal class ManualUserSessionTest {
                 val sessions = getSessionEnvelopes(2)
 
                 assertDistinctUserSessions(sessions[0], sessions[1])
+                assertUserSessionNumbers(
+                    envelopes = sessions,
+                    userSessionNumbers = listOf(1, 2),
+                    sessionPartNumbers = listOf(1, 2)
+                )
                 sessions[0].assertFinalPart(MANUAL)
                 sessions[1].assertNotFinalPart()
             }
@@ -130,6 +161,11 @@ internal class ManualUserSessionTest {
                 val sessions = getSessionEnvelopes(3)
                 assertDistinctUserSessions(sessions[0], sessions[1])
                 assertDistinctUserSessions(sessions[1], sessions[2])
+                assertUserSessionNumbers(
+                    envelopes = sessions,
+                    userSessionNumbers = listOf(1, 2, 3),
+                    sessionPartNumbers = listOf(1, 2, 3)
+                )
                 sessions[0].assertFinalPart(MANUAL)
                 sessions[1].assertFinalPart(MANUAL)
                 sessions[2].assertNotFinalPart()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionLifecycleTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionLifecycleTest.kt
@@ -27,6 +27,7 @@ import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EMB_USER_SESSI
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbUserSessionTerminationReasonValues.BACKGROUND_ONLY_USER_SESSION_FOREGROUNDED
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbUserSessionTerminationReasonValues.INACTIVITY
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbUserSessionTerminationReasonValues.MANUAL
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbUserSessionTerminationReasonValues.MAX_DURATION_REACHED
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule.Companion.DEFAULT_SDK_START_TIME_MS
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
@@ -34,6 +35,8 @@ import io.embrace.android.embracesdk.testframework.assertions.assertDistinctUser
 import io.embrace.android.embracesdk.testframework.assertions.assertFinalPart
 import io.embrace.android.embracesdk.testframework.assertions.assertNotFinalPart
 import io.embrace.android.embracesdk.testframework.assertions.assertSameUserSession
+import io.embrace.android.embracesdk.testframework.assertions.assertSessionOrdinals
+import io.embrace.android.embracesdk.testframework.assertions.assertUserSessionNumbers
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -163,8 +166,11 @@ internal class UserSessionLifecycleTest {
         )
     }
 
+    /**
+     * NOTE: timer thread is not unblocked so the timer never fires
+     */
     @Test
-    fun `new user session can be created via inactivity timeout with background activity disabled`() {
+    fun `inactivity timeout detected at foreground with background activity disabled creates a new user session`() {
         testRule.runTest(
             persistedRemoteConfig = RemoteConfig(
                 userSession = UserSessionRemoteConfig(inactivityTimeoutSeconds = 30)
@@ -179,6 +185,11 @@ internal class UserSessionLifecycleTest {
                 val sessions = getSessionEnvelopes(2)
 
                 assertDistinctUserSessions(sessions[0], sessions[1])
+                assertUserSessionNumbers(
+                    envelopes = sessions,
+                    userSessionNumbers = listOf(1, 2),
+                    sessionPartNumbers = listOf(1, 2)
+                )
 
                 // session orchestrator cannot be sure of final session reason, so does not set it
                 sessions[0].assertNotFinalPart()
@@ -187,8 +198,13 @@ internal class UserSessionLifecycleTest {
         )
     }
 
+    /**
+     * NOTE: this does NOT fire the inactivity timer (no unblockTimerThread). The timeout is detected lazily on the next
+     * foreground (TransitionType.INACTIVITY_FOREGROUND). The timer-driven path is covered separately by
+     * `inactivity timer firing in background with capture enabled advances user session number by one each time`.
+     */
     @Test
-    fun `new user session can be created via inactivity timeout with background activity enabled`() {
+    fun `inactivity timeout detected at foreground with background activity enabled creates a new user session`() {
         testRule.runTest(
             persistedRemoteConfig = RemoteConfig(
                 backgroundActivityConfig = BackgroundActivityRemoteConfig(100f),
@@ -209,6 +225,81 @@ internal class UserSessionLifecycleTest {
                 bgSessions[0].assertNotFinalPart()
                 fgSessions[0].assertNotFinalPart()
                 fgSessions[1].assertNotFinalPart()
+            }
+        )
+    }
+
+    @Test
+    fun `inactivity timer firing in background with capture disabled doesn't create a new user session`() {
+        testRule.runTest(
+            persistedRemoteConfig = RemoteConfig(
+                userSession = UserSessionRemoteConfig(inactivityTimeoutSeconds = 30)
+            ),
+            testCaseAction = {
+                recordSession()
+                clock.tick(30L * 1_000L + 1_000L)
+                unblockTimerThread()
+                recordSession()
+            },
+            assertAction = {
+                val sessionParts = getSessionEnvelopes(2)
+                assertDistinctUserSessions(sessionParts[0], sessionParts[1])
+                assertUserSessionNumbers(
+                    envelopes = sessionParts,
+                    userSessionNumbers = listOf(1, 2),
+                    sessionPartNumbers = listOf(1, 2)
+                )
+            }
+        )
+    }
+
+    @Test
+    fun `max duration detected at foreground with background activity disabled advances user session number by one`() {
+        testRule.runTest(
+            persistedRemoteConfig = RemoteConfig(
+                userSession = UserSessionRemoteConfig(maxDurationSeconds = 3600)
+            ),
+            testCaseAction = {
+                recordSession()
+                clock.tick(3600 * 1_000L + 1_000L + 1)
+                recordSession()
+            },
+            assertAction = {
+                val sessionParts = getSessionEnvelopes(2)
+                assertDistinctUserSessions(sessionParts[0], sessionParts[1])
+                assertUserSessionNumbers(
+                    envelopes = sessionParts,
+                    userSessionNumbers = listOf(1, 2),
+                    sessionPartNumbers = listOf(1, 2)
+                )
+            }
+        )
+    }
+
+    @Test
+    fun `inactivity timer firing in background with capture enabled advances user session number by one each time`() {
+        testRule.runTest(
+            persistedRemoteConfig = RemoteConfig(
+                backgroundActivityConfig = BackgroundActivityRemoteConfig(100f),
+                userSession = UserSessionRemoteConfig(inactivityTimeoutSeconds = 30),
+            ),
+            testCaseAction = {
+                recordSession()
+                clock.tick(30L * 1_000L + 1_000L)
+                unblockTimerThread()
+                clock.tick(10_000L)
+                recordSession()
+            },
+            assertAction = {
+                val fgSessions = getSessionEnvelopes(2, AppState.FOREGROUND)
+                val bgSessionPart = getSessionEnvelopes(expectedSize = 3, state = AppState.BACKGROUND).last()
+                assertDistinctUserSessions(fgSessions[0], bgSessionPart)
+                assertDistinctUserSessions(bgSessionPart, fgSessions[1])
+                assertDistinctUserSessions(fgSessions[0], fgSessions[1])
+
+                fgSessions[0].assertSessionOrdinals(userSessionNumber = 1)
+                bgSessionPart.assertSessionOrdinals(userSessionNumber = 2)
+                fgSessions[1].assertSessionOrdinals(userSessionNumber = 3)
             }
         )
     }
@@ -245,6 +336,10 @@ internal class UserSessionLifecycleTest {
                 val sessions = getSessionEnvelopes(2, AppState.FOREGROUND)
 
                 assertSameUserSession(sessions[0], sessions[1])
+                assertUserSessionNumbers(
+                    envelopes = sessions,
+                    userSessionNumbers = listOf(1, 1)
+                )
                 sessions[0].assertNotFinalPart()
                 sessions[1].assertNotFinalPart()
             }
@@ -313,8 +408,11 @@ internal class UserSessionLifecycleTest {
         )
     }
 
+    /**
+     * NOTE: the timer does not fire because the thread it runs on has not been unblocked
+     */
     @Test
-    fun `new user session can be created via max duration`() {
+    fun `max duration exceeded while backgrounded creates a new user session on the next foreground`() {
         val cfg = UserSessionRemoteConfig(
             maxDurationSeconds = 3600,
             inactivityTimeoutSeconds = 3600,
@@ -408,6 +506,11 @@ internal class UserSessionLifecycleTest {
             assertAction = {
                 val sessions = getSessionEnvelopes(2)
                 assertDistinctUserSessions(sessions[0], sessions[1])
+                assertUserSessionNumbers(
+                    envelopes = sessions,
+                    userSessionNumbers = listOf(1, 2),
+                    sessionPartNumbers = listOf(1, 2)
+                )
             },
         )
     }
@@ -428,6 +531,11 @@ internal class UserSessionLifecycleTest {
             assertAction = {
                 val sessions = getSessionEnvelopes(2)
                 assertDistinctUserSessions(sessions[0], sessions[1])
+                assertUserSessionNumbers(
+                    envelopes = sessions,
+                    userSessionNumbers = listOf(1, 2),
+                    sessionPartNumbers = listOf(1, 2)
+                )
             },
         )
     }
@@ -440,21 +548,27 @@ internal class UserSessionLifecycleTest {
                 userSession = UserSessionRemoteConfig(maxDurationSeconds = maxDurationSeconds),
             ),
             testCaseAction = {
-                recordSession()
-                clock.tick(maxDurationSeconds * 1_000L)
-                unblockTimerThread()
-                recordSession()
+                recordSession {
+                    clock.tick(maxDurationSeconds * 1_000L)
+                    unblockTimerThread()
+                }
             },
             assertAction = {
                 val sessions = getSessionEnvelopes(2)
                 assertDistinctUserSessions(sessions[0], sessions[1])
+                sessions[0].assertFinalPart(MAX_DURATION_REACHED)
+                assertUserSessionNumbers(
+                    envelopes = sessions,
+                    userSessionNumbers = listOf(1, 2),
+                    sessionPartNumbers = listOf(1, 2)
+                )
             },
         )
     }
 
     @Test
     fun `manual end after max duration but before the job is processed terminates with MANUAL`() {
-        val maxDurationSeconds = 600
+        val maxDurationSeconds = 3600
         testRule.runTest(
             persistedRemoteConfig = RemoteConfig(
                 userSession = UserSessionRemoteConfig(maxDurationSeconds = maxDurationSeconds),
@@ -471,6 +585,10 @@ internal class UserSessionLifecycleTest {
                 val sessions = getSessionEnvelopes(3)
                 assertDistinctUserSessions(sessions[0], sessions[1])
                 assertSameUserSession(sessions[1], sessions[2])
+                assertUserSessionNumbers(
+                    envelopes = sessions,
+                    userSessionNumbers = listOf(1, 2, 2)
+                )
                 sessions[0].assertFinalPart(MANUAL)
             },
         )
@@ -483,6 +601,11 @@ internal class UserSessionLifecycleTest {
             partsGapSeconds = 29
         ) { sessions ->
             assertSameUserSession(sessions[0], sessions[1])
+            assertUserSessionNumbers(
+                envelopes = sessions,
+                userSessionNumbers = listOf(1, 1),
+                sessionPartNumbers = listOf(1, 2)
+            )
         }
     }
 
@@ -493,6 +616,11 @@ internal class UserSessionLifecycleTest {
             partsGapSeconds = 60
         ) { sessions ->
             assertDistinctUserSessions(sessions[0], sessions[1])
+            assertUserSessionNumbers(
+                envelopes = sessions,
+                userSessionNumbers = listOf(1, 2),
+                sessionPartNumbers = listOf(1, 2)
+            )
         }
     }
 
@@ -503,6 +631,11 @@ internal class UserSessionLifecycleTest {
             partsGapSeconds = 31
         ) { sessions ->
             assertDistinctUserSessions(sessions[0], sessions[1])
+            assertUserSessionNumbers(
+                envelopes = sessions,
+                userSessionNumbers = listOf(1, 2),
+                sessionPartNumbers = listOf(1, 2)
+            )
         }
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/assertions/SessionAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/assertions/SessionAssertions.kt
@@ -3,7 +3,10 @@ package io.embrace.android.embracesdk.testframework.assertions
 import io.embrace.android.embracesdk.assertions.SessionIds
 import io.embrace.android.embracesdk.assertions.getOtelSessionId
 import io.embrace.android.embracesdk.assertions.getSessionPartId
+import io.embrace.android.embracesdk.assertions.getSessionPartNumber
 import io.embrace.android.embracesdk.assertions.getUserSessionId
+import io.embrace.android.embracesdk.assertions.getUserSessionNumber
+import io.embrace.android.embracesdk.assertions.getUserSessionPartIndex
 import io.embrace.android.embracesdk.assertions.getUserSessionTerminationReason
 import io.embrace.android.embracesdk.assertions.isFinalSessionPart
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
@@ -48,6 +51,51 @@ fun assertDistinctUserSessions(vararg envelopes: Envelope<SessionPartPayload>) {
 fun assertSameUserSession(vararg envelopes: Envelope<SessionPartPayload>) {
     val ids = envelopes.map { it.getUserSessionId() }.toSet()
     assertEquals("expected one user session id but got $ids", 1, ids.size)
+}
+
+/**
+ * Asserts a single session part's user-session number, and optionally its session part number and part index
+ */
+fun Envelope<SessionPartPayload>.assertSessionOrdinals(
+    userSessionNumber: Int,
+    sessionPartNumber: Int? = null,
+    partIndex: Int? = null,
+) {
+    assertEquals("unexpected emb.user_session_number", userSessionNumber.toString(), getUserSessionNumber())
+    if (sessionPartNumber != null) {
+        assertEquals("unexpected emb.session_part_number", sessionPartNumber.toString(), getSessionPartNumber())
+    }
+    if (partIndex != null) {
+        assertEquals("unexpected emb.user_session_part_index", partIndex.toString(), getUserSessionPartIndex())
+    }
+}
+
+/**
+ * Asserts the user session numbers and optionally the session part numbers across a chronologically sorted list of session part envelopes.
+ */
+fun assertUserSessionNumbers(
+    envelopes: List<Envelope<SessionPartPayload>>,
+    userSessionNumbers: List<Int>,
+    sessionPartNumbers: List<Int>? = null,
+) {
+    assertEquals(
+        "expected ${userSessionNumbers.size} session-part envelopes but got ${envelopes.size}",
+        userSessionNumbers.size,
+        envelopes.size,
+    )
+    if (sessionPartNumbers != null) {
+        assertEquals(
+            "envelope count does not match the user session numbers to be asserted",
+            userSessionNumbers.size,
+            sessionPartNumbers.size,
+        )
+    }
+    envelopes.forEachIndexed { index, envelope ->
+        envelope.assertSessionOrdinals(
+            userSessionNumber = userSessionNumbers[index],
+            sessionPartNumber = sessionPartNumbers?.get(index),
+        )
+    }
 }
 
 /**


### PR DESCRIPTION
Only create a new background only user session if background activity is enabled. The runtime difference is that the user session number will not increment if we leave the SDK without a user session when one ends and the app is in the background AND background activity is disabled. This is consistent with the idea that we should only have a user session if the user is active OR if the background activity is enabled.  
  
Added tests to cover various BA-off scenarios, and more broadly assert user session numbers and session part numbers when we can