### PR TITLE
Update the lastActivity timestamp for a user session periodically

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -406,8 +406,15 @@ internal class SessionOrchestratorImpl(
                     // initiate periodic caching of the payload if a new session has started
                     EmbTrace.start("initiate-periodic-caching")
                     updatePeriodicCacheAttrs()
+                    val updateIntervalMs = lastActivityUpdateIntervalMs(userSession)
                     payloadCachingService?.startCaching(newSessionPart, endAppState) { state, timestamp, zygote ->
                         synchronized(lock) {
+                            if (state == AppState.FOREGROUND) {
+                                updateUserSessionActivityIfStale(
+                                    timestamp = timestamp,
+                                    updateIntervalMs = updateIntervalMs
+                                )
+                            }
                             updatePeriodicCacheAttrs()
                             payloadFactory.snapshotPayload(state, timestamp, zygote)
                         }
@@ -543,6 +550,21 @@ internal class SessionOrchestratorImpl(
         destination.addSessionPartAttribute(EmbSessionAttributes.EMB_HEARTBEAT_TIME_UNIX_NANO, now.toString())
         destination.addSessionPartAttribute(EmbSessionAttributes.EMB_TERMINATED, true.toString())
     }
+
+    private fun updateUserSessionActivityIfStale(timestamp: Long, updateIntervalMs: Long) {
+        currentUserSessionIfClassified()?.let { current ->
+            if (timestamp - current.lastActivityMs >= updateIntervalMs) {
+                setActiveUserSession(current.withNewActivity(timestamp))
+            }
+        }
+    }
+
+    private fun lastActivityUpdateIntervalMs(metadata: UserSessionMetadata?): Long =
+        if (metadata == null || metadata.inactivityTimeoutSecs <= SHORT_INACTIVITY_TIMEOUT_CUTOFF_SECS) {
+            LAST_ACTIVITY_UPDATE_SHORT_MS
+        } else {
+            LAST_ACTIVITY_UPDATE_LONG_MS
+        }
 
     /**
      * Decides what to do with the user session at the start of a session-part transition.
@@ -719,4 +741,10 @@ internal class SessionOrchestratorImpl(
 
             else -> true
         }
+
+    private companion object {
+        private const val SHORT_INACTIVITY_TIMEOUT_CUTOFF_SECS = 2 * 60
+        private const val LAST_ACTIVITY_UPDATE_SHORT_MS = 20 * 1000L
+        private const val LAST_ACTIVITY_UPDATE_LONG_MS = 60 * 1000L
+    }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -412,7 +412,7 @@ internal class SessionOrchestratorImpl(
                             if (state == AppState.FOREGROUND) {
                                 updateUserSessionActivityIfStale(
                                     timestamp = timestamp,
-                                    updateIntervalMs = updateIntervalMs
+                                    updateIntervalMs = updateIntervalMs,
                                 )
                             }
                             updatePeriodicCacheAttrs()

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -456,6 +456,53 @@ internal class SessionOrchestratorTest {
     }
 
     @Test
+    fun `user session last activity time is updated every minute for default inactivity timeout`() {
+        createOrchestrator(startingAppState = AppState.FOREGROUND)
+        val initial = activeUserSession().lastActivityMs
+
+        clock.tick(59_000)
+        sessionCacheExecutor.runCurrentlyBlocked()
+        assertEquals(initial, activeUserSession().lastActivityMs)
+
+        clock.tick(2_000)
+        sessionCacheExecutor.runCurrentlyBlocked()
+        assertEquals(clock.now(), activeUserSession().lastActivityMs)
+    }
+
+    @Test
+    fun `user session last activity time is updated every 20s for short inactivity timeouts`() {
+        createOrchestrator(
+            startingAppState = AppState.FOREGROUND,
+            configService = sessionLimitsConfigService(customInactivityTimeoutMs = 60_000L),
+        )
+        val initial = activeUserSession().lastActivityMs
+
+        clock.tick(19_000L)
+        sessionCacheExecutor.runCurrentlyBlocked()
+        assertEquals(initial, activeUserSession().lastActivityMs)
+
+        clock.tick(2_000L)
+        sessionCacheExecutor.runCurrentlyBlocked()
+        assertEquals(clock.now(), activeUserSession().lastActivityMs)
+    }
+
+    @Test
+    fun `user session last activity time does not update when app in the background`() {
+        createOrchestrator(
+            startingAppState = AppState.FOREGROUND,
+            configService = FakeConfigService(
+                backgroundActivityBehavior = backgroundActivityBehavior(true)
+            ),
+        )
+        orchestrator.onBackground()
+        val backgroundedAt = activeUserSession().lastActivityMs
+        clock.tick(2 * 60_000L)
+        orchestrator.onSessionDataUpdate()
+        sessionCacheExecutor.runCurrentlyBlocked()
+        assertEquals(backgroundedAt, activeUserSession().lastActivityMs)
+    }
+
+    @Test
     fun `user session max duration boundary`() {
         createOrchestrator(
             startingAppState = AppState.FOREGROUND,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionLastActivityUpdateTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionLastActivityUpdateTest.kt
@@ -1,0 +1,55 @@
+package io.embrace.android.embracesdk.testcases.session
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.UserSessionRemoteConfig
+import io.embrace.android.embracesdk.internal.store.KeyValueStore
+import io.embrace.android.embracesdk.internal.worker.Worker
+import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
+import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class UserSessionLastActivityUpdateTest {
+
+    @Rule
+    @JvmField
+    val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
+        EmbraceSetupInterface(
+            workersToFake = listOf(Worker.Background.PeriodicCacheWorker),
+        ).apply {
+            getFakedWorkerExecutor(Worker.Background.PeriodicCacheWorker).blockingMode = false
+        }
+    }
+
+    @Test
+    fun `foreground periodic cache task updates user session last activity time`() {
+        lateinit var store: KeyValueStore
+        lateinit var cacheWorker: BlockingScheduledExecutorService
+        val inactivityTimeoutSeconds = 60
+        testRule.runTest(
+            persistedRemoteConfig = RemoteConfig(
+                userSession = UserSessionRemoteConfig(inactivityTimeoutSeconds = inactivityTimeoutSeconds)
+            ),
+            setupAction = {
+                store = getStore()
+                cacheWorker = getFakedWorkerExecutor(Worker.Background.PeriodicCacheWorker)
+            },
+            testCaseAction = {
+                recordSession {
+                    val initialLastActivityMs = store.currentUserSessionLastActivityTimestamp()
+                    clock.tick(90_000)
+                    cacheWorker.runCurrentlyBlocked()
+                    assertTrue(store.currentUserSessionLastActivityTimestamp() > initialLastActivityMs)
+                }
+            },
+        )
+    }
+
+    private fun KeyValueStore.currentUserSessionLastActivityTimestamp(): Long =
+        checkNotNull(getStringMap("embrace.user_session")?.get("emb.user_session_last_activity_ts")).toLong()
+}


### PR DESCRIPTION
The last activity timestamp only being updated when we create or extend a user session means that a long session part that exceeds the inactivity timeout limit that ends in an unexpected process termination will cause a new process startup to start a new session because it perceives the last activity timeout has lapsed. Therefore, we update it periodically, piggybacking off of the periodic session caching task, to update every once in a while (20s if the timeout is 2 mintues or less, or or 60s if it's longer.