### PR TITLE
Fix test flakes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,6 +251,16 @@ InitModule -> CoreModule -> EssentialServiceModule -> ...
 - Max heap: 2g
 - Uses AndroidX Test Orchestrator
 
+### Integration-Test Flake Patterns
+
+Two recurring causes of intermittent failures in the `embrace-android-sdk` integration tests. Check for both when a test is flaky, and avoid them when writing new ones.
+
+**1. Asserting delivery *order* against telemetry content instead of payload metadata.**
+Payload **delivery order** is decided by `StoredTelemetryComparator` over the stored **metadata** (`envelopeType → timestamp → uuid → complete`) in `SchedulingServiceImpl.findNextPayload`. But helpers like `assertSessionsDeliveredInOrder` / `assertLogsDeliveredInOrder` assert on a value embedded *inside* the telemetry (e.g. the session-part span's `startTimeNanos`). For **live** sessions the two line up (a session is stored right after it ends, so metadata order tracks span order), so the default `assertOrdering = true` is fine. For **resurrected / bulk-delivered** payloads (crash resurrection, multiple cached sessions flushed together) they decouple: resurrection re-stores via `IntakeService.take(metadata = copy(...))`, which *preserves* the original metadata timestamp, and that has no guaranteed relationship to the embedded span start time. Delivery-by-start-time is **not a contract**. Fix: pass `getSessionEnvelopes(n, assertOrdering = false)` / `getLogEnvelopes(n, logsOrderedByTimestamp = false)` for these scenarios — the real assertions look payloads up by part id / log type, which is order-independent anyway. Don't try to "fix the data" (e.g. force a clock gap) to satisfy the order check; the gap usually already exists in the metadata and isn't what the assertion reads.
+
+**2. Real workers + no synchronization barrier in crash/teardown tests.**
+`SdkIntegrationTestRule.runTest` runs `testCaseAction → assertAction` with no worker drain between them. If the test leaves background workers real, async work (especially the recurring `PeriodicCacheWorker`, which ticks every ~2s on wall-clock time) races the assertion and the order-sensitive crash teardown, producing non-deterministic payload counts/contents (e.g. `NoSuchElementException` when the expected crash session hasn't been persisted yet). Fix: fake the relevant `Worker.Background` workers and set `getFakedWorkerExecutor(worker).blockingMode = false` so their tasks run **inline/synchronously** on the test thread (scheduled/periodic tasks then queue instead of firing on real time). For crash tests fake at least `PeriodicCacheWorker` (the real culprit); the crash session itself is persisted synchronously via the IntakeService `CRASH_RECEIVED` path, so this stays deterministic. Faking serializes timing/observability only — the asserted crash data is set synchronously under the orchestrator lock, so determinism doesn't weaken what the test validates.
+
 ---
 
 ## Public API Compatibility

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
@@ -15,7 +15,6 @@ import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.arch.startup.MAX_COLD_STARTUP_INIT_GAP_MS
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.delivery.PayloadType
-import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
 import io.embrace.android.embracesdk.internal.payload.Envelope
@@ -23,6 +22,7 @@ import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
 import io.embrace.android.embracesdk.internal.toEmbracePayload
+import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -49,7 +49,18 @@ internal class AppStartupTraceTest {
     @Rule
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
-        EmbraceSetupInterface(fakeStorageLayer = true).also {
+        EmbraceSetupInterface(
+            fakeStorageLayer = true,
+            workersToFake = listOf(
+                Worker.Background.NonIoRegWorker,
+                Worker.Background.IoRegWorker,
+                Worker.Background.PeriodicCacheWorker,
+            ),
+        ).apply {
+            getFakedWorkerExecutor(Worker.Background.NonIoRegWorker).blockingMode = false
+            getFakedWorkerExecutor(Worker.Background.IoRegWorker).blockingMode = false
+            getFakedWorkerExecutor(Worker.Background.PeriodicCacheWorker).blockingMode = false
+        }.also {
             payloadStorageService = checkNotNull(it.fakePayloadStorageService)
         }
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NativeCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NativeCrashFeatureTest.kt
@@ -207,8 +207,8 @@ internal class NativeCrashFeatureTest {
             },
             testCaseAction = {},
             assertAction = {
-                val sessionEnvelopes = getSessionEnvelopes(2)
-                val logEnvelopes = getLogEnvelopes(2)
+                val sessionEnvelopes = getSessionEnvelopes(expectedSize = 2, assertOrdering = false)
+                val logEnvelopes = getLogEnvelopes(expectedSize = 2, logsOrderedByTimestamp = false)
                 val expectedCrashEnvelope = checkNotNull(crashData.cachedCrashEnvelope)
 
                 // crashes sent
@@ -255,9 +255,7 @@ internal class NativeCrashFeatureTest {
                 }
             },
             assertAction = {
-                // This means the new and resurrected session as well as an Embrace log were delivered.
-                // Before a native crash log, which would've been delivered if processed.
-                assertEquals(2, getSessionEnvelopes(2).size)
+                assertEquals(2, getSessionEnvelopes(expectedSize = 2, assertOrdering = false).size)
                 assertNotNull(getSingleLogEnvelope().getLogOfType(EmbType.System.Log))
             }
         )
@@ -415,7 +413,8 @@ internal class NativeCrashFeatureTest {
     }
 
     private fun findMatchingSessionPartId(it: Envelope<LogPayload>, data: StoredNativeCrashData): Boolean {
-        return it.getLogOfType(EmbType.System.NativeCrash).attributes?.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID) == data.nativeCrash.sessionPartId
+        return it.getLogOfType(EmbType.System.NativeCrash).attributes
+            ?.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID) == data.nativeCrash.sessionPartId
     }
 
     private fun EmbracePayloadAssertionInterface.assertNoNativeCrashSent(


### PR DESCRIPTION
The two types of flakes we get most often: background threads running indetermistically, and the faulty payload order assertion that looks at the timestamp of the telemetry inside the payload rather than the time the payload was written, which determines the true order.