### PR TITLE
Enforce trailing commas in detekt and editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ ij_java_class_count_to_use_import_on_demand = 99
 
 [{*.kt,*.kts}] 
 ij_kotlin_allow_trailing_comma = true
-ij_kotlin_allow_trailing_comma_on_call_site = false
+ij_kotlin_allow_trailing_comma_on_call_site = true
 
 [*.json]
 insert_final_newline = false

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -40,9 +40,9 @@ formatting:
     maxLineLength: 140
   MaximumLineLength:
     maxLineLength: 140
-  useTrailingCommaOnCallSite:
+  TrailingCommaOnCallSite:
     active: true
-  useTrailingCommaOnDeclarationSite:
+  TrailingCommaOnDeclarationSite:
     active: true
 potential-bugs:
   ElseCaseInsteadOfExhaustiveWhen:

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/LastRunEndState.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/LastRunEndState.kt
@@ -17,5 +17,5 @@ public enum class LastRunEndState(public val value: Int) {
     /**
      * The last run did not result in a crash.
      */
-    CLEAN_EXIT(2)
+    CLEAN_EXIT(2),
 }

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/SessionStateEvent.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/SessionStateEvent.kt
@@ -8,7 +8,7 @@ public sealed class SessionStateEvent(
     /**
      * ID representing the user session.
      */
-    public val userSessionId: String
+    public val userSessionId: String,
 ) {
 
     /**

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/Severity.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/Severity.kt
@@ -18,5 +18,5 @@ public enum class Severity {
     /**
      * Reports log messages with error level severity.
      */
-    ERROR
+    ERROR,
 }

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/LogsApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/LogsApi.kt
@@ -132,7 +132,7 @@ public interface LogsApi {
      */
     @Deprecated(
         "This API is deprecated and will be removed in a future release." +
-            "Use logMessage() instead."
+            "Use logMessage() instead.",
     )
     public fun logPushNotification(
         title: String?,

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/network/EmbraceNetworkRequest.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/network/EmbraceNetworkRequest.kt
@@ -124,7 +124,7 @@ public class EmbraceNetworkRequest private constructor(
                 null,
                 traceId,
                 w3cTraceparent,
-                networkCaptureData
+                networkCaptureData,
             )
         }
 
@@ -168,7 +168,7 @@ public class EmbraceNetworkRequest private constructor(
                 errorMessage,
                 traceId,
                 w3cTraceparent,
-                networkCaptureData
+                networkCaptureData,
             )
         }
 

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/network/http/HttpMethod.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/network/http/HttpMethod.kt
@@ -15,7 +15,8 @@ public enum class HttpMethod {
     CONNECT,
     OPTIONS,
     TRACE,
-    PATCH;
+    PATCH,
+    ;
 
     public companion object {
         /**

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/spans/EmbraceSpanEvent.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/spans/EmbraceSpanEvent.kt
@@ -33,7 +33,7 @@ public class EmbraceSpanEvent internal constructor(
             return EmbraceSpanEvent(
                 name = name,
                 timestampNanos = TimeUnit.MILLISECONDS.toNanos(timestampMs),
-                attributes = attributes ?: emptyMap()
+                attributes = attributes ?: emptyMap(),
             )
         }
     }

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/spans/ErrorCode.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/spans/ErrorCode.kt
@@ -17,5 +17,5 @@ public enum class ErrorCode {
     /**
      * The reason for the unsuccessful termination is unknown
      */
-    UNKNOWN
+    UNKNOWN,
 }

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
@@ -83,7 +83,7 @@ class ConfigServiceImpl(
         CombinedRemoteConfigSource(
             store = remoteConfigStore,
             httpSource = lazy { checkNotNull(remoteConfigSource) },
-            worker = worker
+            worker = worker,
         )
     }
 
@@ -105,7 +105,7 @@ class ConfigServiceImpl(
                 instrumentedConfig,
                 sdkVersion,
                 apiLevel,
-            )
+            ),
         )
     }
 

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/CpuAbi.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/CpuAbi.kt
@@ -9,7 +9,8 @@ enum class CpuAbi(
     ARM64_V8A("arm64-v8a", false),
     X86("x86", true),
     X86_64("x86_64", false),
-    UNKNOWN("unknown", false);
+    UNKNOWN("unknown", false),
+    ;
 
     companion object {
         fun current(abis: Array<String>) = fromArchName(abis[0])

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehaviorImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehaviorImpl.kt
@@ -27,7 +27,7 @@ class NetworkBehaviorImpl(
             "\\r",
             "\\n",
             "\\t",
-            " "
+            " ",
         )
     }
 
@@ -45,7 +45,7 @@ class NetworkBehaviorImpl(
     override val domainCountLimiter: DomainCountLimiter by lazy {
         EmbraceDomainCountLimiter(
             defaultLimitSupplier = ::getRequestLimitPerDomain,
-            domainLimitsSupplier = ::getLimitsByDomain
+            domainLimitsSupplier = ::getLimitsByDomain,
         )
     }
 
@@ -61,7 +61,7 @@ class NetworkBehaviorImpl(
 
     override fun getRequestLimitPerDomain(): Int = min(
         remote?.networkConfig?.defaultCaptureLimit ?: DEFAULT_NETWORK_CALL_LIMIT,
-        cfg.getRequestLimitPerDomain()
+        cfg.getRequestLimitPerDomain(),
     )
 
     override fun isUrlEnabled(url: String): Boolean {

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/UserSessionBehaviorImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/UserSessionBehaviorImpl.kt
@@ -40,7 +40,7 @@ class UserSessionBehaviorImpl(private val remote: RemoteConfig?) : UserSessionBe
 
     override fun getMaxUserSessionProperties(): Int = min(
         remote?.maxUserSessionProperties ?: SESSION_PROPERTY_LIMIT,
-        SESSION_PROPERTY_MAX_LIMIT
+        SESSION_PROPERTY_MAX_LIMIT,
     )
 
     override fun getMaxSessionDurationMs(): Long = maxSessionDurationSeconds * 1000L

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/source/CombinedRemoteConfigSource.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/source/CombinedRemoteConfigSource.kt
@@ -9,7 +9,7 @@ internal class CombinedRemoteConfigSource(
     private val store: RemoteConfigStore,
     httpSource: Lazy<RemoteConfigSource>,
     private val worker: BackgroundWorker,
-    private val intervalMs: Long = 60 * 60 * 1000
+    private val intervalMs: Long = 60 * 60 * 1000,
 ) {
 
     private val httpSource: RemoteConfigSource by httpSource
@@ -28,7 +28,7 @@ internal class CombinedRemoteConfigSource(
             ::attemptConfigRequest,
             0,
             intervalMs,
-            TimeUnit.MILLISECONDS
+            TimeUnit.MILLISECONDS,
         )
     }
 

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeRemoteConfigSource.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeRemoteConfigSource.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.internal.config.source.ConfigHttpResponse
 import io.embrace.android.embracesdk.internal.config.source.RemoteConfigSource
 
 class FakeRemoteConfigSource(
-    var cfg: ConfigHttpResponse? = null
+    var cfg: ConfigHttpResponse? = null,
 ) : RemoteConfigSource {
 
     var callCount: Int = 0

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/NativeSymbolTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/NativeSymbolTest.kt
@@ -23,7 +23,7 @@ class NativeSymbolTest {
         "armeabi-v7a" to mapOf("symbol" to "armeabi-v7a-value"),
         "arm64-v8a" to mapOf("symbol" to "arm64-v8a-value"),
         "x86" to mapOf("symbol" to "x86-value"),
-        "x86_64" to mapOf("symbol" to "x86_64-value")
+        "x86_64" to mapOf("symbol" to "x86_64-value"),
     )
 
     private val serializer = TestPlatformSerializer()

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/OkHttpRemoteConfigSourceTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/OkHttpRemoteConfigSourceTest.kt
@@ -29,7 +29,7 @@ class OkHttpRemoteConfigSourceTest {
     private lateinit var source: OkHttpRemoteConfigSource
 
     private val remoteConfig = RemoteConfig(
-        backgroundActivityConfig = BackgroundActivityRemoteConfig(100f)
+        backgroundActivityConfig = BackgroundActivityRemoteConfig(100f),
     )
     private lateinit var configResponseBuffer: Buffer
 
@@ -55,18 +55,18 @@ class OkHttpRemoteConfigSourceTest {
                 FakeInstrumentedConfig(
                     baseUrls = FakeBaseUrlConfig(
                         configImpl = baseUrl,
-                    )
+                    ),
                 ),
                 "1.0.0",
-                36
-            )
+                36,
+            ),
         )
     }
 
     @Test
     fun `test config 2xx`() {
         val (cfg, request) = executeRequest(
-            MockResponse().setResponseCode(200).setBody(configResponseBuffer)
+            MockResponse().setResponseCode(200).setBody(configResponseBuffer),
         )
         assertConfigRequestReceived(request)
         assertConfigResponseDeserialized(cfg)
@@ -75,7 +75,7 @@ class OkHttpRemoteConfigSourceTest {
     @Test
     fun `test config 4xx`() {
         val (cfg, request) = executeRequest(
-            MockResponse().setResponseCode(400)
+            MockResponse().setResponseCode(400),
         )
         assertConfigRequestReceived(request)
         assertConfigResponseNotDeserialized(cfg)
@@ -84,7 +84,7 @@ class OkHttpRemoteConfigSourceTest {
     @Test
     fun `test config 5xx`() {
         val (cfg, request) = executeRequest(
-            MockResponse().setResponseCode(500)
+            MockResponse().setResponseCode(500),
         )
         assertConfigRequestReceived(request)
         assertConfigResponseNotDeserialized(cfg)
@@ -101,7 +101,7 @@ class OkHttpRemoteConfigSourceTest {
     @Test
     fun `test invalid response from server`() {
         val (cfg, request) = executeRequest(
-            MockResponse().setResponseCode(200).setBody("{")
+            MockResponse().setResponseCode(200).setBody("{"),
         )
         assertConfigRequestReceived(request)
         assertConfigResponseNotDeserialized(cfg)
@@ -113,7 +113,7 @@ class OkHttpRemoteConfigSourceTest {
         val (cfg, request) = executeRequest(
             MockResponse().setResponseCode(200)
                 .setBody(configResponseBuffer)
-                .setHeader("etag", etagValue)
+                .setHeader("etag", etagValue),
         )
         assertConfigRequestReceived(request)
         assertNull(request?.getHeader("If-None-Match"))
@@ -122,7 +122,7 @@ class OkHttpRemoteConfigSourceTest {
         // second request with etag
         val (secondCfg, secondRequest) = executeRequest(
             MockResponse().setResponseCode(304)
-                .setHeader("etag", etagValue)
+                .setHeader("etag", etagValue),
         )
         assertConfigRequestReceived(secondRequest)
         assertEquals(etagValue, secondRequest?.getHeader("If-None-Match"))

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AppExitInfoBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AppExitInfoBehaviorImplTest.kt
@@ -10,7 +10,7 @@ import org.junit.Test
 internal class AppExitInfoBehaviorImplTest {
 
     private val remote = RemoteConfig(
-        appExitInfoConfig = AppExitInfoConfig(55209, 100f)
+        appExitInfoConfig = AppExitInfoConfig(55209, 100f),
     )
 
     @Test

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
@@ -67,15 +67,15 @@ internal class AutoDataCaptureBehaviorImplTest {
         val remoteComposeKillSwitchOff = RemoteConfig(
             killSwitchConfig = KillSwitchRemoteConfig(
                 sigHandlerDetection = false,
-                jetpackCompose = true
-            )
+                jetpackCompose = true,
+            ),
         )
 
         // Jetpack Compose enabled remotely
         with(
             createAutoDataCaptureBehavior(
-                remoteCfg = remoteComposeKillSwitchOff
-            )
+                remoteCfg = remoteComposeKillSwitchOff,
+            ),
         ) {
             assertTrue(isComposeClickCaptureEnabled())
         }
@@ -86,7 +86,7 @@ internal class AutoDataCaptureBehaviorImplTest {
         val behavior = createBehavior(
             localUiLoadTracingEnabled = true,
             localUiLoadTracingTraceAllEnabled = true,
-            remote = remote.copy(uiLoadInstrumentationEnabled = false)
+            remote = remote.copy(uiLoadInstrumentationEnabled = false),
         )
 
         assertFalse(behavior.isUiLoadTracingEnabled())
@@ -98,7 +98,7 @@ internal class AutoDataCaptureBehaviorImplTest {
         val behavior = createBehavior(
             localUiLoadTracingEnabled = false,
             localUiLoadTracingTraceAllEnabled = false,
-            remote = remote.copy(uiLoadInstrumentationEnabled = true)
+            remote = remote.copy(uiLoadInstrumentationEnabled = true),
         )
 
         assertFalse(behavior.isUiLoadTracingEnabled())
@@ -110,7 +110,7 @@ internal class AutoDataCaptureBehaviorImplTest {
         val behavior = createBehavior(
             localUiLoadTracingEnabled = true,
             localUiLoadTracingTraceAllEnabled = false,
-            remote = remote.copy(uiLoadInstrumentationEnabled = true)
+            remote = remote.copy(uiLoadInstrumentationEnabled = true),
         )
 
         assertTrue(behavior.isUiLoadTracingEnabled())
@@ -122,7 +122,7 @@ internal class AutoDataCaptureBehaviorImplTest {
         val behavior = createBehavior(
             localUiLoadTracingEnabled = true,
             localUiLoadTracingTraceAllEnabled = false,
-            remote = remote.copy(uiLoadInstrumentationEnabled = true)
+            remote = remote.copy(uiLoadInstrumentationEnabled = true),
         )
 
         assertTrue(behavior.isUiLoadTracingEnabled())
@@ -134,7 +134,7 @@ internal class AutoDataCaptureBehaviorImplTest {
         val behavior = createBehavior(
             localUiLoadTracingEnabled = true,
             localUiLoadTracingTraceAllEnabled = true,
-            remote = remote.copy(pctStateCaptureEnabledV2 = 100.0f)
+            remote = remote.copy(pctStateCaptureEnabledV2 = 100.0f),
         )
 
         assertTrue(behavior.isStateCaptureEnabled())
@@ -145,7 +145,7 @@ internal class AutoDataCaptureBehaviorImplTest {
         val behavior = createBehavior(
             localUiLoadTracingEnabled = true,
             localUiLoadTracingTraceAllEnabled = true,
-            remote = remote.copy(pctStateCaptureEnabledV2 = 0.0f)
+            remote = remote.copy(pctStateCaptureEnabledV2 = 0.0f),
         )
 
         assertFalse(behavior.isStateCaptureEnabled())
@@ -160,8 +160,8 @@ internal class AutoDataCaptureBehaviorImplTest {
     fun `isNetworkCallbackConnectivityServiceEnabled true when pct is 100`() {
         assertTrue(
             createAutoDataCaptureBehavior(
-                remoteCfg = RemoteConfig(pctNetworkCallbackConnectivityServiceEnabled = 100.0f)
-            ).isNetworkCallbackConnectivityServiceEnabled()
+                remoteCfg = RemoteConfig(pctNetworkCallbackConnectivityServiceEnabled = 100.0f),
+            ).isNetworkCallbackConnectivityServiceEnabled(),
         )
     }
 
@@ -169,8 +169,8 @@ internal class AutoDataCaptureBehaviorImplTest {
     fun `isNetworkCallbackConnectivityServiceEnabled false when pct is 0`() {
         assertFalse(
             createAutoDataCaptureBehavior(
-                remoteCfg = RemoteConfig(pctNetworkCallbackConnectivityServiceEnabled = 0.0f)
-            ).isNetworkCallbackConnectivityServiceEnabled()
+                remoteCfg = RemoteConfig(pctNetworkCallbackConnectivityServiceEnabled = 0.0f),
+            ).isNetworkCallbackConnectivityServiceEnabled(),
         )
     }
 
@@ -178,8 +178,8 @@ internal class AutoDataCaptureBehaviorImplTest {
     fun `navigation state capture enabled when pct is 100`() {
         assertTrue(
             createBehavior(
-                remote = RemoteConfig(pctNavigationStateCaptureEnabled = 100.0f)
-            ).isNavigationStateCaptureEnabled()
+                remote = RemoteConfig(pctNavigationStateCaptureEnabled = 100.0f),
+            ).isNavigationStateCaptureEnabled(),
         )
     }
 
@@ -187,8 +187,8 @@ internal class AutoDataCaptureBehaviorImplTest {
     fun `navigation state capture disabled when pct is 0`() {
         assertFalse(
             createBehavior(
-                remote = RemoteConfig(pctNavigationStateCaptureEnabled = 0.0f)
-            ).isNavigationStateCaptureEnabled()
+                remote = RemoteConfig(pctNavigationStateCaptureEnabled = 0.0f),
+            ).isNavigationStateCaptureEnabled(),
         )
     }
 
@@ -202,8 +202,8 @@ internal class AutoDataCaptureBehaviorImplTest {
             enabledFeatures = FakeEnabledFeatureConfig(
                 uiLoadTracingTraceAll = localUiLoadTracingTraceAllEnabled,
                 uiLoadTracingEnabled = localUiLoadTracingEnabled,
-            )
+            ),
         ),
-        remote = remote
+        remote = remote,
     )
 }

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BackgroundActivityBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BackgroundActivityBehaviorImplTest.kt
@@ -10,7 +10,7 @@ import org.junit.Test
 internal class BackgroundActivityBehaviorImplTest {
 
     private val remote = BackgroundActivityRemoteConfig(
-        0f
+        0f,
     )
 
     @Test

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BreadcrumbBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BreadcrumbBehaviorImplTest.kt
@@ -15,8 +15,8 @@ internal class BreadcrumbBehaviorImplTest {
             99,
             98,
             97,
-            96
-        )
+            96,
+        ),
     )
 
     @Test
@@ -25,7 +25,7 @@ internal class BreadcrumbBehaviorImplTest {
             BreadcrumbBehaviorImpl(
                 InstrumentedConfigImpl,
                 null,
-            )
+            ),
         ) {
             assertEquals(100, getCustomBreadcrumbLimit())
             assertEquals(100, getTapBreadcrumbLimit())
@@ -45,7 +45,7 @@ internal class BreadcrumbBehaviorImplTest {
             BreadcrumbBehaviorImpl(
                 InstrumentedConfigImpl,
                 remote,
-            )
+            ),
         ) {
             assertEquals(99, getCustomBreadcrumbLimit())
             assertEquals(98, getTapBreadcrumbLimit())

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/LogMessageBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/LogMessageBehaviorImplTest.kt
@@ -13,8 +13,8 @@ internal class LogMessageBehaviorImplTest {
             256,
             200,
             300,
-            400
-        )
+            400,
+        ),
     )
 
     @Test

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehaviorImplTest.kt
@@ -19,8 +19,8 @@ internal class NetworkBehaviorImplTest {
         networkConfig = NetworkRemoteConfig(
             defaultCaptureLimit = 409,
             domainLimits = mapOf(
-                "google.com" to 50
-            )
+                "google.com" to 50,
+            ),
         ),
         disabledUrlPatterns = setOf("example.com"),
         networkCaptureRules = setOf(
@@ -29,8 +29,8 @@ internal class NetworkBehaviorImplTest {
                 5000,
                 "GET",
                 "google.com",
-            )
-        )
+            ),
+        ),
     )
 
     @Test
@@ -63,7 +63,7 @@ internal class NetworkBehaviorImplTest {
                     "GET",
                     "google.com",
                 ),
-                getNetworkCaptureRules().single()
+                getNetworkCaptureRules().single(),
             )
         }
     }

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/NetworkSpanForwardingBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/NetworkSpanForwardingBehaviorImplTest.kt
@@ -26,11 +26,11 @@ internal class NetworkSpanForwardingBehaviorImplTest {
                 TraceparentInjectionBehaviorImpl(
                     thresholdCheck = thresholdCheck,
                     local = local,
-                    remote = null
+                    remote = null,
                 ),
                 thresholdCheck = thresholdCheck,
                 local = local,
-                remote = null
+                remote = null,
             )
         assertFalse(behavior.isNetworkSpanForwardingEnabled())
         assertFalse(behavior.shouldForwardForDomain("anything.com"))
@@ -67,44 +67,44 @@ internal class NetworkSpanForwardingBehaviorImplTest {
         assertTrue(
             behavior(
                 allowedDomains = null,
-                localNsfEnabled = true
-            ).shouldForwardForDomain("test.com")
+                localNsfEnabled = true,
+            ).shouldForwardForDomain("test.com"),
         )
 
         assertFalse(
             behavior(
                 localInjectionEnabled = false,
                 allowedDomains = null,
-                localNsfEnabled = true
-            ).shouldForwardForDomain("test.com")
+                localNsfEnabled = true,
+            ).shouldForwardForDomain("test.com"),
         )
 
         assertFalse(
             behavior(
                 allowedDomains = emptyList(),
-                localNsfEnabled = true
-            ).shouldForwardForDomain("test.com")
+                localNsfEnabled = true,
+            ).shouldForwardForDomain("test.com"),
         )
 
         assertTrue(
             behavior(
                 allowedDomains = listOf("test.com"),
-                localNsfEnabled = true
-            ).shouldForwardForDomain("test.com")
+                localNsfEnabled = true,
+            ).shouldForwardForDomain("test.com"),
         )
 
         assertTrue(
             behavior(
                 allowedDomains = listOf(".test.com"),
-                localNsfEnabled = true
-            ).shouldForwardForDomain("foo.test.com")
+                localNsfEnabled = true,
+            ).shouldForwardForDomain("foo.test.com"),
         )
 
         assertFalse(
             behavior(
                 allowedDomains = listOf("test.com"),
-                localNsfEnabled = true
-            ).shouldForwardForDomain("foo.com")
+                localNsfEnabled = true,
+            ).shouldForwardForDomain("foo.com"),
         )
     }
 
@@ -158,11 +158,11 @@ internal class NetworkSpanForwardingBehaviorImplTest {
             TraceparentInjectionBehaviorImpl(
                 thresholdCheck = thresholdCheck,
                 local = local,
-                remote = remote
+                remote = remote,
             ),
             thresholdCheck = thresholdCheck,
             local = local,
-            remote = remote
+            remote = remote,
         )
     }
 }

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SdkModeBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SdkModeBehaviorImplTest.kt
@@ -22,8 +22,8 @@ internal class SdkModeBehaviorImplTest {
     fun testDefaults() {
         with(
             createSdkModeBehavior(
-                thresholdCheck = disabled
-            )
+                thresholdCheck = disabled,
+            ),
         ) {
             assertFalse(isSdkDisabled())
         }
@@ -35,7 +35,7 @@ internal class SdkModeBehaviorImplTest {
         assertEquals(100.0f, disabled.getNormalizedDeviceId())
         var behavior = createSdkModeBehavior(
             thresholdCheck = disabled,
-            remoteCfg = RemoteConfig(threshold = 99)
+            remoteCfg = RemoteConfig(threshold = 99),
         )
         assertTrue(behavior.isSdkDisabled())
 
@@ -43,14 +43,14 @@ internal class SdkModeBehaviorImplTest {
         assertEquals(0.0f, enabled.getNormalizedDeviceId())
         behavior = createSdkModeBehavior(
             thresholdCheck = enabled,
-            remoteCfg = RemoteConfig(threshold = 0)
+            remoteCfg = RemoteConfig(threshold = 0),
         )
         assertTrue(behavior.isSdkDisabled())
 
         // SDK enabled
         behavior = createSdkModeBehavior(
             thresholdCheck = enabled,
-            remoteCfg = RemoteConfig(threshold = 100)
+            remoteCfg = RemoteConfig(threshold = 100),
         )
         assertFalse(behavior.isSdkDisabled())
 
@@ -58,14 +58,14 @@ internal class SdkModeBehaviorImplTest {
         assertEquals(50.000008f, halfEnabled.getNormalizedDeviceId())
         behavior = createSdkModeBehavior(
             thresholdCheck = halfEnabled,
-            remoteCfg = RemoteConfig(threshold = 30)
+            remoteCfg = RemoteConfig(threshold = 30),
         )
         assertTrue(behavior.isSdkDisabled())
 
         // SDK 51% enabled
         behavior = createSdkModeBehavior(
             thresholdCheck = halfEnabled,
-            remoteCfg = RemoteConfig(threshold = 51)
+            remoteCfg = RemoteConfig(threshold = 51),
         )
         assertFalse(behavior.isSdkDisabled())
     }

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SensitiveKeysBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SensitiveKeysBehaviorImplTest.kt
@@ -64,7 +64,7 @@ internal class SensitiveKeysBehaviorImplTest {
     fun `sensitive list is truncated to 10000 keys`() {
         // given a sensitive list with more than 10000 keys
         val behavior = SensitiveKeysBehaviorImpl(
-            (List(10000) { it.toString() } + "password").toConfig()
+            (List(10000) { it.toString() } + "password").toConfig(),
         )
 
         // when checking a key present in the 10001st position

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/ThreadBlockageBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/ThreadBlockageBehaviorImplTest.kt
@@ -17,7 +17,7 @@ internal class ThreadBlockageBehaviorImplTest {
         stacktraceFrameLimit = 300,
         intervalsPerSession = 10,
         minDuration = 2000,
-        monitorThreadPriority = 3
+        monitorThreadPriority = 3,
     )
 
     @Test

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/TraceparentInjectionBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/TraceparentInjectionBehaviorImplTest.kt
@@ -20,7 +20,7 @@ internal class TraceparentInjectionBehaviorImplTest {
         val behavior = TraceparentInjectionBehaviorImpl(
             thresholdCheck = thresholdCheck,
             local = local,
-            remote = null
+            remote = null,
         )
         with(behavior) {
             assertFalse(isTraceparentInjectionEnabled())
@@ -51,49 +51,49 @@ internal class TraceparentInjectionBehaviorImplTest {
         assertTrue(
             behavior(
                 allowedDomains = null,
-            ).shouldInjectTraceparent("test.com")
+            ).shouldInjectTraceparent("test.com"),
         )
 
         assertFalse(
             behavior(
                 allowedDomains = emptyList(),
-            ).shouldInjectTraceparent("test.com")
+            ).shouldInjectTraceparent("test.com"),
         )
 
         assertTrue(
             behavior(
                 allowedDomains = listOf("test.com"),
-            ).shouldInjectTraceparent("test.com")
+            ).shouldInjectTraceparent("test.com"),
         )
 
         assertTrue(
             behavior(
                 allowedDomains = listOf(".test.com"),
-            ).shouldInjectTraceparent("foo.test.com")
+            ).shouldInjectTraceparent("foo.test.com"),
         )
 
         assertTrue(
             behavior(
                 allowedDomains = listOf(".TEST.com"),
-            ).shouldInjectTraceparent("foo.test.com")
+            ).shouldInjectTraceparent("foo.test.com"),
         )
 
         assertTrue(
             behavior(
                 allowedDomains = listOf(".test.com"),
-            ).shouldInjectTraceparent("foo.TEST.com")
+            ).shouldInjectTraceparent("foo.TEST.com"),
         )
 
         assertFalse(
             behavior(
                 allowedDomains = listOf("test.com"),
-            ).shouldInjectTraceparent(null)
+            ).shouldInjectTraceparent(null),
         )
 
         assertFalse(
             behavior(
                 allowedDomains = listOf("test.com"),
-            ).shouldInjectTraceparent("foo.com")
+            ).shouldInjectTraceparent("foo.com"),
         )
     }
 

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/source/CombinedRemoteConfigSourceTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/source/CombinedRemoteConfigSourceTest.kt
@@ -28,7 +28,7 @@ class CombinedRemoteConfigSourceTest {
         source = CombinedRemoteConfigSource(
             remoteConfigStore,
             lazy { remoteConfigSource },
-            BackgroundWorker(executorService)
+            BackgroundWorker(executorService),
         )
     }
 
@@ -43,7 +43,7 @@ class CombinedRemoteConfigSourceTest {
         source = CombinedRemoteConfigSource(
             FakeRemoteConfigStore(StoredConfigResponse(cfg, null, null)),
             lazy { remoteConfigSource },
-            BackgroundWorker(executorService)
+            BackgroundWorker(executorService),
         )
         assertEquals(cfg, source.getConfig())
     }
@@ -58,7 +58,7 @@ class CombinedRemoteConfigSourceTest {
         source = CombinedRemoteConfigSource(
             FakeRemoteConfigStore(StoredConfigResponse(RemoteConfig(), null, "cached-device-id")),
             lazy { remoteConfigSource },
-            BackgroundWorker(executorService)
+            BackgroundWorker(executorService),
         )
         assertEquals("cached-device-id", source.getDeviceId())
     }

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/store/RemoteConfigStoreImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/store/RemoteConfigStoreImplTest.kt
@@ -152,7 +152,7 @@ internal class RemoteConfigStoreImplTest {
         store = RemoteConfigStoreImpl(
             TestPlatformSerializer(),
             dir,
-            { error("device id unavailable") }
+            { error("device id unavailable") },
         )
 
         val config = RemoteConfig(50)

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/utils/NetworkUtilsTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/utils/NetworkUtilsTest.kt
@@ -17,7 +17,7 @@ internal class NetworkUtilsTest {
         "[::1]",
         "[2001::]",
         "[2001:4860:4860]:8888]",
-        "[2001:4860:4860:0:0:0:0]"
+        "[2001:4860:4860:0:0:0:0]",
     )
 
     private val invalidIpAddresses = arrayOf(
@@ -26,7 +26,7 @@ internal class NetworkUtilsTest {
         "foo.google.com",
         "bar.foo.google.com",
         "baz.bar.foo.google.com",
-        "baz.bar.foo.google.co.uk"
+        "baz.bar.foo.google.co.uk",
     )
 
     private val invalidURLs = arrayOf(
@@ -39,7 +39,7 @@ internal class NetworkUtilsTest {
         "http://192.168.1.256",
         "http://-1.2.3.4",
         "http://3...3",
-        "http://127.1"
+        "http://127.1",
     )
 
     private val validURLs = arrayOf(
@@ -55,7 +55,7 @@ internal class NetworkUtilsTest {
         arrayOf("http://[::1]", "::1"),
         arrayOf("http://[2001::]", "2001::"),
         arrayOf("http://[2001:4860:4860]:8888]", "2001:4860:4860"),
-        arrayOf("http://[2001:4860:4860:0:0:0:0]", "2001:4860:4860:0:0:0:0")
+        arrayOf("http://[2001:4860:4860:0:0:0:0]", "2001:4860:4860:0:0:0:0"),
     )
 
     private val urlsToStrip = arrayOf(
@@ -68,7 +68,7 @@ internal class NetworkUtilsTest {
         arrayOf("http://www.example.org/foo.html#bar", "http://www.example.org/foo.html"),
         arrayOf(
             "http://example.com/index.html#:words:some-context-for-a-(search-term)",
-            "http://example.com/index.html"
+            "http://example.com/index.html",
         ),
     )
 
@@ -91,7 +91,7 @@ internal class NetworkUtilsTest {
         for (url in invalidURLs) {
             assertNull(
                 "$url should not be a valid domain",
-                getDomain(url)
+                getDomain(url),
             )
         }
     }
@@ -109,7 +109,7 @@ internal class NetworkUtilsTest {
                 assertEquals(
                     "Domain for $url should be $expected not $domain",
                     domain,
-                    expected
+                    expected,
                 )
             }
         }
@@ -133,7 +133,7 @@ internal class NetworkUtilsTest {
 
         assertEquals(
             traceIdMoreEqualAllowedLength,
-            NetworkUtils.getValidTraceId(traceIdMoreThanAllowedLength)
+            NetworkUtils.getValidTraceId(traceIdMoreThanAllowedLength),
         )
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/TelemetryDestinationImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/TelemetryDestinationImpl.kt
@@ -61,7 +61,7 @@ class TelemetryDestinationImpl(
             context = null,
             severityNumber = severityNumber,
             severityText = getSeverityText(severityNumber),
-            addCurrentMetadata = addCurrentSessionInfo
+            addCurrentMetadata = addCurrentSessionInfo,
         ) {
             if (isPrivate) {
                 setStringAttribute(PrivateSpan.key, PrivateSpan.value)
@@ -94,7 +94,7 @@ class TelemetryDestinationImpl(
             startTimeMs = startTimeMs,
             autoTerminationMode = mode,
             private = private,
-            type = schemaType.telemetryType
+            type = schemaType.telemetryType,
         ).apply {
             schemaType.attributes().forEach {
                 addAttribute(it.key, it.value)
@@ -130,11 +130,11 @@ class TelemetryDestinationImpl(
         val spanToken = startSpanCapture(
             schemaType = state,
             startTimeMs = clock.now(),
-            private = true
+            private = true,
         )
 
         return SessionPartStateTokenImpl(
-            spanToken = spanToken
+            spanToken = spanToken,
         )
     }
 
@@ -171,7 +171,7 @@ class TelemetryDestinationImpl(
         return currentSession.addSystemEvent(
             schemaType.fixedObjectName.toEmbraceObjectName(),
             startTimeMs,
-            schemaType.attributes() + schemaType.telemetryType.asPair()
+            schemaType.attributes() + schemaType.telemetryType.asPair(),
         ).also {
             sessionUpdateAction?.invoke()
         }
@@ -233,7 +233,7 @@ class TelemetryDestinationImpl(
             span.addSystemEvent(
                 name = name,
                 timestampMs = eventTimeMs,
-                attributes = attributes
+                attributes = attributes,
             )
         }
     }
@@ -265,14 +265,14 @@ class TelemetryDestinationImpl(
                         if (unrecordedTransitions.droppedByInstrumentation > 0) {
                             setEmbraceAttribute(
                                 EmbStateTransitionAttributes.EMB_STATE_DROPPED_BY_INSTRUMENTATION,
-                                unrecordedTransitions.droppedByInstrumentation
+                                unrecordedTransitions.droppedByInstrumentation,
                             )
                         }
-                    }.toMap()
+                    }.toMap(),
             )
             spanToken.setSystemAttribute(
                 EmbStateTransitionAttributes.EMB_STATE_TRANSITION_COUNT,
-                transitionCount.incrementAndGet().toString()
+                transitionCount.incrementAndGet().toString(),
             )
             return true
         }
@@ -281,13 +281,13 @@ class TelemetryDestinationImpl(
             if (unrecordedTransitions.notInSession > 0) {
                 spanToken.setSystemAttribute(
                     EmbStateTransitionAttributes.EMB_STATE_NOT_IN_SESSION,
-                    unrecordedTransitions.notInSession.toString()
+                    unrecordedTransitions.notInSession.toString(),
                 )
             }
             if (unrecordedTransitions.droppedByInstrumentation > 0) {
                 spanToken.setSystemAttribute(
                     EmbStateTransitionAttributes.EMB_STATE_DROPPED_BY_INSTRUMENTATION,
-                    unrecordedTransitions.droppedByInstrumentation.toString()
+                    unrecordedTransitions.droppedByInstrumentation.toString(),
                 )
             }
             spanToken.stop()

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/NetworkCallbackConnectivityService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/NetworkCallbackConnectivityService.kt
@@ -52,7 +52,7 @@ internal class NetworkCallbackConnectivityService(
                             updateNetwork(defaultNetwork)
                             updateStatus(
                                 updatedNetwork = defaultNetwork,
-                                networkCapabilities = connectivityManager.getNetworkCapabilities(defaultNetwork)
+                                networkCapabilities = connectivityManager.getNetworkCapabilities(defaultNetwork),
                             )
                         }
                     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/BreadcrumbDataSource.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/BreadcrumbDataSource.kt
@@ -14,7 +14,7 @@ class BreadcrumbDataSource(
 ) : DataSourceImpl(
     args = args,
     limitStrategy = UpToLimitStrategy(args.configService.breadcrumbBehavior::getCustomBreadcrumbLimit),
-    instrumentationName = "breadcrumb_data_source"
+    instrumentationName = "breadcrumb_data_source",
 ) {
 
     fun logCustom(message: String, timestamp: Long) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
@@ -60,7 +60,7 @@ internal class EmbraceMetadataService(
                 val deviceDiskAppUsage = getDeviceDiskAppUsage(
                     storageStatsManager.value,
                     context.packageManager,
-                    context.packageName
+                    context.packageName,
                 )
                 if (deviceDiskAppUsage != null) {
                     diskUsage = DiskUsage(deviceDiskAppUsage, free)
@@ -85,7 +85,7 @@ internal class EmbraceMetadataService(
                 val stats = storageStatsManager.queryStatsForPackage(
                     StorageManager.UUID_DEFAULT,
                     packageInfo.packageName,
-                    Process.myUserHandle()
+                    Process.myUserHandle(),
                 )
                 return stats.appBytes + stats.dataBytes + stats.cacheBytes
             }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/session/EmbraceUserSessionProperties.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/session/EmbraceUserSessionProperties.kt
@@ -31,7 +31,7 @@ internal class EmbraceUserSessionProperties(
                 SESSION_PROPERTIES_KEY,
                 properties.entries
                     .filter { it.value.scope == PropertyScope.PERMANENT }
-                    .associate { it.key to it.value.value }
+                    .associate { it.key to it.value.value },
             )
         }
     }
@@ -53,7 +53,7 @@ internal class EmbraceUserSessionProperties(
             }
             destination.addSessionPartAttribute(
                 sanitizedKey.toEmbraceAttributeName(),
-                sanitizedValue
+                sanitizedValue,
             )
             return true
         }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/telemetry/InternalErrorDataSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/telemetry/InternalErrorDataSourceImpl.kt
@@ -16,7 +16,7 @@ internal class InternalErrorDataSourceImpl(
     DataSourceImpl(
         args,
         limitStrategy = UpToLimitStrategy { 10 },
-        instrumentationName = "internal_error_data_source"
+        instrumentationName = "internal_error_data_source",
     ) {
 
     override fun trackInternalError(type: InternalErrorType, throwable: Throwable) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/user/EmbraceUserService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/user/EmbraceUserService.kt
@@ -225,7 +225,7 @@ internal class EmbraceUserService(
             userId = "",
             email = "",
             username = "",
-            personas = emptySet()
+            personas = emptySet(),
         )
 
         const val USER_IDENTIFIER_KEY = "io.embrace.userid"

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogEnvelopeSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogEnvelopeSourceImpl.kt
@@ -42,7 +42,7 @@ internal class LogEnvelopeSourceImpl(
                     sessionPartId = nativeCrash?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID),
                     processIdentifier = nativeCrash?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_PROCESS_IDENTIFIER),
                     userSessionId = nativeCrash?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID),
-                )
+                ),
             )
 
             if (envelope != null) {
@@ -52,7 +52,7 @@ internal class LogEnvelopeSourceImpl(
 
         return payload.createLogEnvelope(
             resource = resourceSource.getEnvelopeResource(),
-            metadata = metadataSource.getEnvelopeMetadata()
+            metadata = metadataSource.getEnvelopeMetadata(),
         )
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogPayloadSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogPayloadSourceImpl.kt
@@ -10,7 +10,7 @@ internal class LogPayloadSourceImpl(
 
     override fun getBatchedLogPayload(): LogPayload {
         return LogPayload(
-            logs = logSink.flushBatch()
+            logs = logSink.flushBatch(),
         )
     }
 
@@ -22,8 +22,8 @@ internal class LogPayloadSourceImpl(
             logRequests.add(
                 LogRequest(
                     payload = LogPayload(logs = listOf(logRequest.payload)),
-                    defer = logRequest.defer
-                )
+                    defer = logRequest.defer,
+                ),
             )
             logRequest = if (logRequests.size < MAX_PAYLOADS) {
                 logSink.pollUnbatchedLog()

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPartEnvelopeSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPartEnvelopeSourceImpl.kt
@@ -22,7 +22,7 @@ internal class SessionPartEnvelopeSourceImpl(
             metadataSource.getEnvelopeMetadata(),
             "0.1.0",
             "spans",
-            payloadSource.getSessionPartPayload(endType, startNewSession, crashId)
+            payloadSource.getSessionPartPayload(endType, startNewSession, crashId),
         )
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPartPayloadSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPartPayloadSourceImpl.kt
@@ -52,7 +52,7 @@ internal class SessionPartPayloadSourceImpl(
         return SessionPartPayload(
             spans = spans,
             spanSnapshots = snapshots,
-            sharedLibSymbolMapping = symbolMap
+            sharedLibSymbolMapping = symbolMap,
         )
     }
 
@@ -71,7 +71,7 @@ internal class SessionPartPayloadSourceImpl(
                     otelPayloadMapper?.record()
                     val spans = currentSessionPartSpan.endSession(
                         startNewSession = startNewSession,
-                        appTerminationCause = appTerminationCause
+                        appTerminationCause = appTerminationCause,
                     )
                     spans.map(EmbraceSpanData::toEmbracePayload)
                 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CoreModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CoreModuleImpl.kt
@@ -29,9 +29,9 @@ class CoreModuleImpl(
     override val store: KeyValueStore by singleton {
         SharedPrefsStore(
             PreferenceManager.getDefaultSharedPreferences(
-                context
+                context,
             ),
-            initModule.jsonSerializer
+            initModule.jsonSerializer,
         )
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
@@ -63,14 +63,14 @@ class DeliveryModuleImpl(
             initModule.logger,
             initModule.jsonSerializer,
             dataPersistenceWorker,
-            deliveryTracer
+            deliveryTracer,
         )
     }
 
     private val partCacher: PeriodicSessionPartCacher by singleton {
         PeriodicSessionPartCacher(
             workerThreadModule.backgroundWorker(Worker.Background.PeriodicCacheWorker),
-            initModule.logger
+            initModule.logger,
         )
     }
 
@@ -80,7 +80,7 @@ class DeliveryModuleImpl(
             initModule.clock,
             essentialServiceModule.sessionIdsProvider,
             payloadStore,
-            deliveryTracer
+            deliveryTracer,
         )
     }
 
@@ -89,7 +89,7 @@ class DeliveryModuleImpl(
             val location = StorageLocation.PAYLOAD.asFile(
                 logger = initModule.logger,
                 rootDirSupplier = { coreModule.context.filesDir },
-                fallbackDirSupplier = { coreModule.context.cacheDir }
+                fallbackDirSupplier = { coreModule.context.cacheDir },
             )
             PayloadStorageServiceImpl(
                 location,
@@ -97,7 +97,7 @@ class DeliveryModuleImpl(
                 processIdProvider,
                 initModule.logger,
                 initModule.clock,
-                deliveryTracer
+                deliveryTracer,
             )
         }
     }
@@ -107,7 +107,7 @@ class DeliveryModuleImpl(
             val location = StorageLocation.CACHE.asFile(
                 logger = initModule.logger,
                 rootDirSupplier = { coreModule.context.filesDir },
-                fallbackDirSupplier = { coreModule.context.cacheDir }
+                fallbackDirSupplier = { coreModule.context.cacheDir },
             )
             PayloadStorageServiceImpl(
                 location,
@@ -115,7 +115,7 @@ class DeliveryModuleImpl(
                 processIdProvider,
                 initModule.logger,
                 initModule.clock,
-                deliveryTracer
+                deliveryTracer,
             )
         }
     }
@@ -124,7 +124,7 @@ class DeliveryModuleImpl(
         val location = StorageLocation.ENVELOPE.asFile(
             logger = initModule.logger,
             rootDirSupplier = { coreModule.context.filesDir },
-            fallbackDirSupplier = { coreModule.context.cacheDir }
+            fallbackDirSupplier = { coreModule.context.cacheDir },
         )
         CachedLogEnvelopeStoreImpl(
             outputDir = location,
@@ -149,7 +149,7 @@ class DeliveryModuleImpl(
                 appId,
                 BuildConfig.VERSION_NAME,
                 initModule.logger,
-                deliveryTracer
+                deliveryTracer,
             )
         }
     }
@@ -162,7 +162,7 @@ class DeliveryModuleImpl(
             workerThreadModule.backgroundWorker(Worker.Background.HttpRequestWorker),
             initModule.clock,
             initModule.logger,
-            deliveryTracer
+            deliveryTracer,
         )
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
@@ -54,7 +54,7 @@ class EssentialServiceModuleImpl(
             EmbraceUserService(
                 coreModule.store,
                 initModule.clock,
-                initModule.logger
+                initModule.logger,
             )
         }
     }
@@ -84,7 +84,7 @@ class EssentialServiceModuleImpl(
     override val sessionPartTracker: SessionPartTracker by singleton {
         SessionPartTrackerImpl(
             coreModule.context.getSystemServiceSafe(Context.ACTIVITY_SERVICE),
-            initModule.logger
+            initModule.logger,
         )
     }
 
@@ -98,7 +98,7 @@ class EssentialServiceModuleImpl(
                 store = coreModule.store,
                 configService = configService,
                 destination = telemetryDestination,
-                telemetryService = initModule.telemetryService
+                telemetryService = initModule.telemetryService,
             )
         }
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/FeatureModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/FeatureModuleImpl.kt
@@ -20,7 +20,7 @@ class FeatureModuleImpl(
         DataSourceState(
             factory = {
                 BreadcrumbDataSource(instrumentationModule.instrumentationArgs)
-            }
+            },
         ).apply {
             instrumentationModule.instrumentationRegistry.add(this)
         }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitModuleImpl.kt
@@ -30,7 +30,7 @@ class InitModuleImpl(
 
     override val telemetryService: TelemetryService by singleton {
         EmbraceTelemetryService(
-            systemInfo = systemInfo
+            systemInfo = systemInfo,
         )
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InstrumentationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InstrumentationModuleImpl.kt
@@ -22,7 +22,7 @@ class InstrumentationModuleImpl(
 
     override val instrumentationRegistry: InstrumentationRegistry by singleton {
         InstrumentationRegistryImpl(
-            initModule.logger
+            initModule.logger,
         )
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/LogModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/LogModuleImpl.kt
@@ -22,7 +22,7 @@ class LogModuleImpl(
 
     override val logLimitingService: LogLimitingService by singleton {
         LogLimitingServiceImpl(
-            configService
+            configService,
         )
     }
 
@@ -31,7 +31,7 @@ class LogModuleImpl(
             essentialServiceModule.telemetryDestination,
             configService,
             logLimitingService,
-            initModule.telemetryService
+            initModule.telemetryService,
         )
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
@@ -29,8 +29,8 @@ import io.embrace.android.embracesdk.internal.utils.EmbTrace
 class OpenTelemetryModuleImpl(
     private val initModule: InitModule,
     private val openTelemetryClock: EmbClock = EmbClock(
-        embraceClock = initModule.clock
-    )
+        embraceClock = initModule.clock,
+    ),
 ) : OpenTelemetryModule {
 
     private val processIdentifierProvider: () -> String by lazy { IdGenerator.Companion::generateLaunchInstanceId }
@@ -77,7 +77,7 @@ class OpenTelemetryModuleImpl(
                     "Please enable library desugaring in your project to use the Embrace SDK. " +
                         "This is required if you target API levels below 24. For instructions, please see " +
                         "https://developer.android.com/studio/write/java8-support#library-desugaring",
-                    exc
+                    exc,
                 )
             }
         }
@@ -109,7 +109,7 @@ class OpenTelemetryModuleImpl(
 
     private val dataValidator: DataValidator = DataValidator(
         bypassValidation = ::bypassLimitsValidation,
-        telemetryService = initModule.telemetryService
+        telemetryService = initModule.telemetryService,
     )
 
     private val embraceSpanFactory: EmbraceSpanFactory by singleton {
@@ -119,7 +119,7 @@ class OpenTelemetryModuleImpl(
             dataValidator = dataValidator,
             stopCallback = ::spanStopCallbackWrapper,
             redactionFunction = ::redactionFunction,
-            telemetryService = initModule.telemetryService
+            telemetryService = initModule.telemetryService,
         )
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
@@ -52,7 +52,7 @@ class PayloadSourceModuleImpl(
             coreModule.context,
             configService,
             coreModule.store,
-            workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker)
+            workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker),
         )
     }
 
@@ -66,7 +66,7 @@ class PayloadSourceModuleImpl(
                 otelPayloadMapper,
                 essentialServiceModule.appStateTracker,
                 initModule.clock,
-                initModule.logger
+                initModule.logger,
             )
         }
     }
@@ -121,12 +121,12 @@ class PayloadSourceModuleImpl(
                         coreModule.store,
                         workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker),
                         initModule.systemInfo,
-                        initModule.logger
+                        initModule.logger,
                     )
                 },
                 rnBundleIdProvider = { rnBundleIdTracker.getReactNativeBundleId() },
                 versionName = BuildConfig.VERSION_NAME,
-                versionCode = BuildConfig.VERSION_CODE.toIntOrNull()
+                versionCode = BuildConfig.VERSION_CODE.toIntOrNull(),
             )
         }
     }
@@ -146,7 +146,7 @@ class PayloadSourceModuleImpl(
                 configService,
                 coreModule.store,
                 initModule.clock,
-                workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker)
+                workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker),
             )
         }
     }
@@ -159,7 +159,7 @@ class PayloadSourceModuleImpl(
             cacheStorageService = deliveryModule.cacheStorageService,
             cachedLogEnvelopeStore = deliveryModule.cachedLogEnvelopeStore,
             logger = initModule.logger,
-            serializer = initModule.jsonSerializer
+            serializer = initModule.jsonSerializer,
         )
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
@@ -41,18 +41,18 @@ class UserSessionOrchestrationModuleImpl(
             EmbTrace.trace("payloadMessageCollator") { payloadMessageCollator },
             EmbTrace.trace("logEnvelopeSource") { payloadSourceModule.logEnvelopeSource },
             EmbTrace.trace("configService") { configService },
-            initModule.logger
+            initModule.logger,
         )
 
         val boundaryDelegate = OrchestratorBoundaryDelegate(
-            essentialServiceModule.userSessionPropertiesService
+            essentialServiceModule.userSessionPropertiesService,
         )
 
         val sessionPartSpanAttrPopulator = SessionPartSpanAttrPopulatorImpl(
             essentialServiceModule.telemetryDestination,
             startupDurationProvider,
             logModule.logLimitingService,
-            payloadSourceModule.metadataService
+            payloadSourceModule.metadataService,
         )
 
         SessionOrchestratorImpl(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImpl.kt
@@ -51,7 +51,7 @@ class WorkerThreadModuleImpl : WorkerThreadModule, RejectedExecutionHandler {
                     this,
                     1,
                     1,
-                    storedTelemetryRunnableComparator
+                    storedTelemetryRunnableComparator,
                 )
             } else {
                 ScheduledThreadPoolExecutor(1, threadFactory, this)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogLimitingServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogLimitingServiceImpl.kt
@@ -9,7 +9,7 @@ class LogLimitingServiceImpl(
     private val logCounters = mapOf(
         LogSeverity.INFO to LogCounter(configService.logMessageBehavior::getInfoLogLimit),
         LogSeverity.WARNING to LogCounter(configService.logMessageBehavior::getWarnLogLimit),
-        LogSeverity.ERROR to LogCounter(configService.logMessageBehavior::getErrorLogLimit)
+        LogSeverity.ERROR to LogCounter(configService.logMessageBehavior::getErrorLogLimit),
     )
 
     override fun getCount(logSeverity: LogSeverity): Int = logCounters.getValue(logSeverity).getCount()

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogOrchestratorImpl.kt
@@ -86,7 +86,7 @@ internal class LogOrchestratorImpl(
         scheduledCheckFuture = worker.schedule<Unit>(
             ::sendLogsIfNeeded,
             min(nextBatchCheck, nextInactivityCheck),
-            TimeUnit.MILLISECONDS
+            TimeUnit.MILLISECONDS,
         )
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogServiceImpl.kt
@@ -42,11 +42,11 @@ class LogServiceImpl(
         destination.addLog(
             schemaType = schemaProvider(
                 TelemetryAttributes(
-                    customAttributes = redactSensitiveAttributes(attributes, telemetryType)
-                )
+                    customAttributes = redactSensitiveAttributes(attributes, telemetryType),
+                ),
             ),
             severity = severity,
-            message = trimToMaxLength(message, telemetryType)
+            message = trimToMaxLength(message, telemetryType),
         )
     }
 
@@ -75,7 +75,7 @@ class LogServiceImpl(
         return sanitizeAttributes(
             attributes = attributes,
             telemetryType = telemetryType,
-            bypassPropertyLimit = bypassLimitsValidation
+            bypassPropertyLimit = bypassLimitsValidation,
         ).mapValues { (key, value) ->
             when {
                 configService.sensitiveKeysBehavior.isSensitiveKey(key) -> REDACTED_LABEL

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/attachments/Attachment.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/attachments/Attachment.kt
@@ -24,7 +24,7 @@ sealed class Attachment(val id: String) {
         errorCode: AttachmentErrorCode? = null,
     ): Map<String, String> = mapOf(
         EmbAttachmentAttributes.EMB_ATTACHMENT_ID to id,
-        EmbAttachmentAttributes.EMB_ATTACHMENT_ERROR_CODE to errorCode?.name
+        EmbAttachmentAttributes.EMB_ATTACHMENT_ERROR_CODE to errorCode?.name,
     ).toNonNullMap()
 
     /**
@@ -34,7 +34,7 @@ sealed class Attachment(val id: String) {
         val bytes: ByteArray,
         counter: () -> Boolean,
     ) : Attachment(
-        UUID.randomUUID().toString()
+        UUID.randomUUID().toString(),
     ) {
 
         private val size: Long = bytes.size.toLong()
@@ -69,7 +69,7 @@ sealed class Attachment(val id: String) {
         }
 
         override val attributes: Map<String, String> = constructAttributes(id, errorCode).plus(
-            EmbAttachmentAttributes.EMB_ATTACHMENT_URL to url
+            EmbAttachmentAttributes.EMB_ATTACHMENT_URL to url,
         )
 
         private fun isNotUuid(): Boolean = try {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/attachments/AttachmentErrorCode.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/attachments/AttachmentErrorCode.kt
@@ -6,5 +6,5 @@ package io.embrace.android.embracesdk.internal.logs.attachments
 enum class AttachmentErrorCode {
     ATTACHMENT_TOO_LARGE,
     OVER_MAX_ATTACHMENTS,
-    UNKNOWN
+    UNKNOWN,
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/attachments/AttachmentService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/attachments/AttachmentService.kt
@@ -19,7 +19,7 @@ class AttachmentService(private val limit: Int = 5) : SessionPartChangeListener 
     ): UserHosted = UserHosted(
         attachmentId,
         attachmentUrl,
-        ::incrementAndCheckAttachmentLimit
+        ::incrementAndCheckAttachmentLimit,
     )
 
     private val count: AtomicInteger = AtomicInteger(0)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/navigation/NavigationTrackingServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/navigation/NavigationTrackingServiceImpl.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.internal.arch.navigation.NavigationTracking
 
 internal class NavigationTrackingServiceImpl(
     override var navigationTrackingInitListener: NavigationTrackingInitListener = NoopNavigationTrackingInitListener,
-    override var navigationControllerEventListener: NavigationControllerEventListener = NoopNavigationControllerEventListener
+    override var navigationControllerEventListener: NavigationControllerEventListener = NoopNavigationControllerEventListener,
 ) : NavigationTrackingService {
 
     override fun trackNavigation(activity: Activity, controller: Any?) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
@@ -112,7 +112,7 @@ internal class PayloadResurrectionServiceImpl(
             }.onFailure {
                 logger.trackInternalError(
                     type = InternalErrorType.PayloadResurrectionPayloadFail,
-                    throwable = it
+                    throwable = it,
                 )
             }
 
@@ -173,7 +173,7 @@ internal class PayloadResurrectionServiceImpl(
                 } else {
                     logger.trackInternalError(
                         type = InternalErrorType.NativeCrashResurrectionError,
-                        throwable = IllegalStateException("Cached native crash envelope data not found")
+                        throwable = IllegalStateException("Cached native crash envelope data not found"),
                     )
                 }
                 nativeCrashService.sendNativeCrash(
@@ -187,7 +187,7 @@ internal class PayloadResurrectionServiceImpl(
             if (sessionlessNativeCrashes.size > 1) {
                 logger.trackInternalError(
                     type = InternalErrorType.NativeCrashResurrectionError,
-                    throwable = IllegalStateException("Multiple sessionless native crashes found.")
+                    throwable = IllegalStateException("Multiple sessionless native crashes found."),
                 )
             }
         }
@@ -329,7 +329,7 @@ internal class PayloadResurrectionServiceImpl(
                 cachedLogEnvelopeStore.create(
                     storedTelemetryMetadata = nativeCrashEnvelopeMetadata,
                     resource = deadPart.resource ?: EnvelopeResource(),
-                    metadata = deadPart.metadata ?: EnvelopeMetadata()
+                    metadata = deadPart.metadata ?: EnvelopeMetadata(),
                 )
 
                 nativeCrashService.sendNativeCrash(
@@ -338,7 +338,7 @@ internal class PayloadResurrectionServiceImpl(
                     metadata = if (appState != null) {
                         mapOf(
                             EmbSessionAttributes.EMB_STATE to appState,
-                            EmbSessionAttributes.EMB_PROCESS_IDENTIFIER to processIdentifier
+                            EmbSessionAttributes.EMB_PROCESS_IDENTIFIER to processIdentifier,
                         )
                     } else {
                         emptyMap()
@@ -356,7 +356,7 @@ internal class PayloadResurrectionServiceImpl(
             userSessionTerminationReason = userSessionTerminationReason,
             isBackgroundOnly = isBackgroundOnly,
         ) ?: throw IllegalArgumentException(
-            "Session resurrection failed. Payload does not contain exactly one session part span."
+            "Session resurrection failed. Payload does not contain exactly one session part span.",
         )
     }
 
@@ -400,7 +400,7 @@ internal class PayloadResurrectionServiceImpl(
             data = data.copy(
                 spans = spans,
                 spanSnapshots = emptyList(),
-            )
+            ),
         )
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/LifeEventType.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/LifeEventType.kt
@@ -11,5 +11,5 @@ enum class LifeEventType {
 
     /* Background activity values */
     BKGND_STATE,
-    BKGND_MANUAL
+    BKGND_MANUAL,
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadata.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadata.kt
@@ -123,7 +123,7 @@ sealed interface UserSessionMetadata {
          */
         fun classify(
             isBackgroundOnly: Boolean,
-            updatedLastActivityMs: Long = lastActivityMs
+            updatedLastActivityMs: Long = lastActivityMs,
         ): Classified = Classified(
             startTimeMs = startTimeMs,
             userSessionId = userSessionId,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/caching/PeriodicSessionPartCacher.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/caching/PeriodicSessionPartCacher.kt
@@ -30,7 +30,7 @@ class PeriodicSessionPartCacher(
             onPeriodicCache(provider),
             0,
             intervalMs,
-            TimeUnit.MILLISECONDS
+            TimeUnit.MILLISECONDS,
         )
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionPartTracker.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionPartTracker.kt
@@ -23,7 +23,7 @@ interface SessionPartTracker {
     fun newActiveSessionPart(
         endSessionPartCallback: SessionPartToken.() -> Unit,
         startSessionPartCallback: () -> SessionPartToken?,
-        postTransitionAppState: AppState
+        postTransitionAppState: AppState,
     ): SessionPartToken?
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImpl.kt
@@ -81,7 +81,7 @@ internal class PayloadFactoryImpl(
                 appState = state,
                 userSessionPartIndex = userSessionPartIndex(),
                 sessionPartNumber = sessionPartNumber(),
-            )
+            ),
         )
     }
 
@@ -92,7 +92,7 @@ internal class PayloadFactoryImpl(
                 endType = SessionPartSnapshotType.NORMAL_END,
                 logger = logger,
                 continueMonitoring = true,
-            )
+            ),
         )
     }
 
@@ -114,7 +114,7 @@ internal class PayloadFactoryImpl(
                 appState = AppState.FOREGROUND,
                 userSessionPartIndex = userSessionPartIndex(),
                 sessionPartNumber = sessionPartNumber(),
-            )
+            ),
         )
     }
 
@@ -142,7 +142,7 @@ internal class PayloadFactoryImpl(
                 appState = AppState.BACKGROUND,
                 userSessionPartIndex = userSessionPartIndex(),
                 sessionPartNumber = sessionPartNumber(),
-            )
+            ),
         )
     }
 
@@ -153,7 +153,7 @@ internal class PayloadFactoryImpl(
                 endType = SessionPartSnapshotType.NORMAL_END,
                 logger = logger,
                 continueMonitoring = isBackgroundActivityEnabled(),
-            )
+            ),
         )
     }
 
@@ -170,7 +170,7 @@ internal class PayloadFactoryImpl(
                 endType = SessionPartSnapshotType.NORMAL_END,
                 logger = logger,
                 continueMonitoring = true,
-            )
+            ),
         )
     }
 
@@ -184,8 +184,8 @@ internal class PayloadFactoryImpl(
                 endType = SessionPartSnapshotType.JVM_CRASH,
                 logger = logger,
                 continueMonitoring = false,
-                crashId = crashId
-            )
+                crashId = crashId,
+            ),
         )
     }
 
@@ -202,8 +202,8 @@ internal class PayloadFactoryImpl(
                 endType = SessionPartSnapshotType.JVM_CRASH,
                 logger = logger,
                 continueMonitoring = false,
-                crashId = crashId
-            )
+                crashId = crashId,
+            ),
         )
     }
 
@@ -216,8 +216,8 @@ internal class PayloadFactoryImpl(
                 initial = initial,
                 endType = SessionPartSnapshotType.PERIODIC_CACHE,
                 logger = logger,
-                continueMonitoring = true
-            )
+                continueMonitoring = true,
+            ),
         )
     }
 
@@ -230,8 +230,8 @@ internal class PayloadFactoryImpl(
                 initial = initial,
                 endType = SessionPartSnapshotType.PERIODIC_CACHE,
                 logger = logger,
-                continueMonitoring = true
-            )
+                continueMonitoring = true,
+            ),
         )
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImpl.kt
@@ -34,14 +34,14 @@ internal class PayloadMessageCollatorImpl(
         val envelope = sessionPartEnvelopeSource.getEnvelope(
             endType = params.endType,
             startNewSession = params.startNewSession,
-            crashId = params.crashId
+            crashId = params.crashId,
         )
         return Envelope(
             resource = envelope.resource,
             metadata = envelope.metadata,
             data = envelope.data,
             version = envelope.version,
-            type = envelope.type
+            type = envelope.type,
         )
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/PayloadStoreImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/PayloadStoreImpl.kt
@@ -34,8 +34,8 @@ internal class PayloadStoreImpl(
             intake = envelope,
             metadata = createMetadata(
                 type = SupportedEnvelopeType.SESSION,
-                payloadType = PayloadType.SESSION
-            )
+                payloadType = PayloadType.SESSION,
+            ),
         )
     }
 
@@ -45,8 +45,8 @@ internal class PayloadStoreImpl(
             metadata = createMetadata(
                 type = SupportedEnvelopeType.SESSION,
                 complete = false,
-                payloadType = PayloadType.SESSION
-            )
+                payloadType = PayloadType.SESSION,
+            ),
         )
     }
 
@@ -59,8 +59,8 @@ internal class PayloadStoreImpl(
             metadata = createMetadata(
                 type = type,
                 payloadType = payloadType,
-                payloadTypesHeader = payloadTypesHeader
-            )
+                payloadTypesHeader = payloadTypesHeader,
+            ),
         )
     }
 
@@ -69,8 +69,8 @@ internal class PayloadStoreImpl(
             intake = envelope,
             metadata = createMetadata(
                 type = SupportedEnvelopeType.ATTACHMENT,
-                payloadType = PayloadType.ATTACHMENT
-            )
+                payloadType = PayloadType.ATTACHMENT,
+            ),
         )
     }
 
@@ -80,8 +80,8 @@ internal class PayloadStoreImpl(
             metadata = createMetadata(
                 type = SupportedEnvelopeType.CRASH,
                 complete = false,
-                payloadType = PayloadType.UNKNOWN
-            )
+                payloadType = PayloadType.UNKNOWN,
+            ),
         )
     }
 
@@ -129,7 +129,7 @@ internal class PayloadStoreImpl(
      * Returns the payload type for the given [Envelope].
      */
     private fun getPayloadType(envelope: Envelope<LogPayload>) = fromValue(
-        envelope.data.logs?.firstOrNull()?.attributes?.findAttributeValue("emb.type")
+        envelope.data.logs?.firstOrNull()?.attributes?.findAttributeValue("emb.type"),
     )
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -110,8 +110,8 @@ internal class SessionOrchestratorImpl(
                         logger.trackInternalError(
                             InternalErrorType.ClockBackwardsShift,
                             IllegalStateException(
-                                "Clock shifted backwards from previous user session."
-                            )
+                                "Clock shifted backwards from previous user session.",
+                            ),
                         )
                         metadataStore.clear()
                         userSessionRestoreDecision = stored.toTerminatedDecision(EmbUserSessionTerminationReasonValues.CLOCK_MISMATCH)
@@ -140,7 +140,7 @@ internal class SessionOrchestratorImpl(
                                 EmbUserSessionTerminationReasonValues.MAX_DURATION_REACHED
                             } else {
                                 EmbUserSessionTerminationReasonValues.INACTIVITY
-                            }
+                            },
                         )
                         UserSessionState.NoActiveSession
                     }
@@ -170,7 +170,7 @@ internal class SessionOrchestratorImpl(
                     userSessionPartIndex = ::incrementPartIndex,
                     sessionPartNumber = ::incrementSessionPartNumber,
                 )
-            }
+            },
         )
     }
 
@@ -210,7 +210,7 @@ internal class SessionOrchestratorImpl(
                 },
                 earlyTerminationCondition = {
                     return@transitionState shouldRunOnForeground(state)
-                }
+                },
             )
             coldStart = false
         }
@@ -235,7 +235,7 @@ internal class SessionOrchestratorImpl(
             },
             earlyTerminationCondition = {
                 return@transitionState shouldRunOnBackground(state)
-            }
+            },
         )
     }
 
@@ -263,7 +263,7 @@ internal class SessionOrchestratorImpl(
                     currentUserSession()?.startTimeMs,
                     lastManualEndMs,
                 )
-            }
+            },
         )
     }
 
@@ -275,7 +275,7 @@ internal class SessionOrchestratorImpl(
             oldSessionAction = { initial: SessionPartToken ->
                 payloadFactory.endPayloadWithCrash(state, timestamp, initial, crashId)
             },
-            crashId = crashId
+            crashId = crashId,
         )
     }
 
@@ -383,7 +383,7 @@ internal class SessionOrchestratorImpl(
                         newSessionAction?.invoke()
                     }
                 },
-                postTransitionAppState = endAppState
+                postTransitionAppState = endAppState,
             )
 
             // update the current state of the SDK
@@ -439,7 +439,7 @@ internal class SessionOrchestratorImpl(
                     ::onInactivityTimeout,
                     metadata.inactivityTimeoutSecs,
                     TimeUnit.SECONDS,
-                )
+                ),
             )
         }
     }
@@ -454,7 +454,7 @@ internal class SessionOrchestratorImpl(
                     ::onMaxDurationTimeout,
                     delay,
                     TimeUnit.SECONDS,
-                )
+                ),
             )
         }
     }
@@ -586,7 +586,7 @@ internal class SessionOrchestratorImpl(
                             ::makeCurrentUserSessionBackgroundOnly,
                             BACKGROUND_STARTUP_WINDOW_MS,
                             TimeUnit.MILLISECONDS,
-                        )
+                        ),
                     )
                 }
             }
@@ -611,8 +611,8 @@ internal class SessionOrchestratorImpl(
                     is UserSessionMetadata.Unclassified -> setActiveUserSession(
                         current.classify(
                             isBackgroundOnly = endAppState == AppState.BACKGROUND,
-                            updatedLastActivityMs = timestamp
-                        )
+                            updatedLastActivityMs = timestamp,
+                        ),
                     )
 
                     is UserSessionMetadata.Classified ->
@@ -729,7 +729,7 @@ internal class SessionOrchestratorImpl(
             timestamp < startTimeMs -> {
                 logger.trackInternalError(
                     InternalErrorType.ClockBackwardsShift,
-                    IllegalStateException("Clock shifted backwards from user session start time.")
+                    IllegalStateException("Clock shifted backwards from user session start time."),
                 )
                 false
             }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSnapshotType.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSnapshotType.kt
@@ -31,5 +31,5 @@ enum class SessionPartSnapshotType(
     /**
      * The end session is being constructed because of a JVM crash.
      */
-    JVM_CRASH(endedCleanly = false, forceQuit = false)
+    JVM_CRASH(endedCleanly = false, forceQuit = false),
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/TransitionType.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/TransitionType.kt
@@ -48,7 +48,8 @@ enum class TransitionType(
     BACKGROUND_ONLY_SESSION_END(
         userSessionTerminationReason = EmbUserSessionTerminationReasonValues.BACKGROUND_ONLY_USER_SESSION_FOREGROUNDED,
         nextAppState = AppState.FOREGROUND,
-    );
+    ),
+    ;
 
     /**
      * True if this session part transition always terminates the active user session

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImpl.kt
@@ -105,13 +105,13 @@ internal class CurrentSessionPartSpanImpl(
                     currentSessionPartSpan.addSystemLink(
                         linkedSpanContext = spanToStopContext,
                         type = LinkType.EndedIn,
-                        attributes = linkAttrs
+                        attributes = linkAttrs,
                     )
                     if (spanToStop.hasEmbraceAttribute(EmbType.State)) {
                         currentSessionPartSpan.addSystemLink(
                             linkedSpanContext = spanToStopContext,
                             type = LinkType.State,
-                            attributes = linkAttrs
+                            attributes = linkAttrs,
                         )
                     }
                 }
@@ -121,7 +121,7 @@ internal class CurrentSessionPartSpanImpl(
                 spanToStop?.addSystemLink(
                     linkedSpanContext = sessionPartSpanContext,
                     type = LinkType.EndSessionPart,
-                    attributes = linkAttrs
+                    attributes = linkAttrs,
                 )
             }
         }
@@ -161,7 +161,7 @@ internal class CurrentSessionPartSpanImpl(
                     spanRepository.failActiveSpans(crashTime)
                     endingSessionPartSpan.setSystemAttribute(
                         appTerminationCause.key,
-                        appTerminationCause.value
+                        appTerminationCause.value,
                     )
                     endingSessionPartSpan.stop(errorCode = ErrorCode.FAILURE, endTimeMs = crashTime)
                 }
@@ -200,8 +200,8 @@ internal class CurrentSessionPartSpanImpl(
                 internal = true,
                 private = false,
                 tracer = tracerSupplier(),
-                openTelemetry = openTelemetrySupplier()
-            )
+                openTelemetry = openTelemetrySupplier(),
+            ),
         ).apply {
             start(startTimeMs = startTimeMs)
             setSystemAttribute(EmbSessionAttributes.EMB_SESSION_PART_ID, sessionPartId)
@@ -210,7 +210,7 @@ internal class CurrentSessionPartSpanImpl(
                 addSystemLink(
                     linkedSpanContext = it,
                     type = LinkType.PreviousSessionPart,
-                    attributes = previousSessionPartSpan.partLinkAttrs()
+                    attributes = previousSessionPartSpan.partLinkAttrs(),
                 )
             }
         }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceTracer.kt
@@ -21,7 +21,7 @@ class EmbraceTracer(
             name = name,
             parent = parent,
             internal = false,
-            autoTerminationMode = autoTerminationMode
+            autoTerminationMode = autoTerminationMode,
         )
 
     override fun startSpan(
@@ -35,7 +35,7 @@ class EmbraceTracer(
             parent = parent,
             startTimeMs = startTimeMs?.normalizeTimestampAsMillis(),
             internal = false,
-            autoTerminationMode = autoTerminationMode
+            autoTerminationMode = autoTerminationMode,
         )
 
     override fun <T> recordSpan(
@@ -52,7 +52,7 @@ class EmbraceTracer(
         attributes = attributes,
         events = events,
         autoTerminationMode = autoTerminationMode,
-        code = code
+        code = code,
     )
 
     override fun recordCompletedSpan(
@@ -71,7 +71,7 @@ class EmbraceTracer(
         internal = false,
         attributes = attributes,
         events = events,
-        errorCode = errorCode
+        errorCode = errorCode,
     )
 
     override fun getSpan(spanId: String): EmbraceSpan? = spanService.getSpan(spanId = spanId)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/storage/EmbraceStorageService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/storage/EmbraceStorageService.kt
@@ -68,7 +68,7 @@ class EmbraceStorageService(
             .sumOf { it.length() }
         val storageTelemetryMap = mapOf(
             EmbTelemetryAttributes.EMB_STORAGE_USED to storageUsed.toString(),
-            EmbTelemetryAttributes.EMB_STORAGE_AVAILABLE to availableStorage.toString()
+            EmbTelemetryAttributes.EMB_STORAGE_AVAILABLE to availableStorage.toString(),
         )
         telemetryService.logStorageTelemetry(storageTelemetryMap)
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeDevice.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeDevice.kt
@@ -13,6 +13,6 @@ class FakeDevice(
         deviceModel = "Galaxy S10",
         osName = "android",
         osVersion = "8.0.0",
-        androidOsApiLevel = "26"
+        androidOsApiLevel = "26",
     ),
 ) : Device

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadMessageCollator.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadMessageCollator.kt
@@ -12,7 +12,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 class FakePayloadMessageCollator(
     val currentSessionPartSpan: FakeCurrentSessionPartSpan = FakeCurrentSessionPartSpan(),
-    var userSessionId: String = ""
+    var userSessionId: String = "",
 ) : PayloadMessageCollator {
 
     val sessionCount: AtomicInteger = AtomicInteger(0)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistryTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistryTest.kt
@@ -59,8 +59,8 @@ internal class InstrumentationRegistryTest {
                 priority = 1000,
                 action = {},
                 dataSourceState = DataSourceState(
-                    factory = { dataSource }
-                )
+                    factory = { dataSource },
+                ),
             )
 
         assertEquals(0, dataSource.sessionEnds)
@@ -68,7 +68,7 @@ internal class InstrumentationRegistryTest {
 
         registry.loadInstrumentations(
             instrumentationProviders = listOf(provider),
-            args = FakeInstrumentationArgs(ApplicationProvider.getApplicationContext())
+            args = FakeInstrumentationArgs(ApplicationProvider.getApplicationContext()),
         )
         registry.onPreSessionEnd()
         registry.onPostSessionChange()
@@ -86,8 +86,8 @@ internal class InstrumentationRegistryTest {
             DataSourceState(
                 factory = {
                     BlockingTestDataSource(iterationStarted, continueIteration)
-                }
-            )
+                },
+            ),
         )
 
         val executor = Executors.newSingleThreadExecutor()

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/destination/TelemetryDestinationImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/destination/TelemetryDestinationImplTest.kt
@@ -63,20 +63,20 @@ internal class TelemetryDestinationImplTest {
         impl = createDestination()
         val expectedSchemaType = Log(
             TelemetryAttributes(
-                customAttributes = mapOf("foo" to "bar")
-            )
+                customAttributes = mapOf("foo" to "bar"),
+            ),
         )
         impl.addLog(
             schemaType = expectedSchemaType,
             severity = LogSeverity.ERROR,
-            message = "test"
+            message = "test",
         )
         eventService.eventData.single().assertFakeEvent(
             expectedTimestamp = clock.now().millisToNanos(),
             expectedMessage = "test",
             expectedSeverity = Severity.ERROR,
             expectedSchemaType = expectedSchemaType,
-            expectedIsPrivate = false
+            expectedIsPrivate = false,
         )
         verifyAndResetSessionUpdate()
     }
@@ -97,13 +97,13 @@ internal class TelemetryDestinationImplTest {
                 mapOf(PrivateSpan.asPair())
             } else {
                 emptyMap()
-            }
+            },
         )
     }
 
     private fun FakeEventService.FakeEventData.assertAttributes(
         expectedSchemaType: SchemaType,
-        expectedAdditionalAttributes: Map<String, String>
+        expectedAdditionalAttributes: Map<String, String>,
     ) {
         val attrContainer = FakeAttributesMutator()
         checkNotNull(attributes).invoke(attrContainer)
@@ -121,28 +121,28 @@ internal class TelemetryDestinationImplTest {
             schemaType = expectedSchemaType,
             severity = LogSeverity.ERROR,
             message = "test",
-            isPrivate = true
+            isPrivate = true,
         )
         eventService.eventData.single().assertFakeEvent(
             expectedTimestamp = clock.now().millisToNanos(),
             expectedMessage = "test",
             expectedSeverity = Severity.ERROR,
             expectedSchemaType = expectedSchemaType,
-            expectedIsPrivate = true
+            expectedIsPrivate = true,
         )
 
         impl.addLog(
             schemaType = expectedSchemaType,
             severity = LogSeverity.ERROR,
             message = "test",
-            isPrivate = false
+            isPrivate = false,
         )
         eventService.eventData.last().assertFakeEvent(
             expectedTimestamp = clock.now().millisToNanos(),
             expectedMessage = "test",
             expectedSeverity = Severity.ERROR,
             expectedSchemaType = expectedSchemaType,
-            expectedIsPrivate = false
+            expectedIsPrivate = false,
         )
     }
 
@@ -154,7 +154,7 @@ internal class TelemetryDestinationImplTest {
             schemaType = Log(TelemetryAttributes()),
             severity = LogSeverity.ERROR,
             message = "test",
-            timestampMs = fakeTimeMs
+            timestampMs = fakeTimeMs,
         )
 
         eventService.eventData.single().assertFakeEvent(
@@ -162,7 +162,7 @@ internal class TelemetryDestinationImplTest {
             expectedMessage = "test",
             expectedSeverity = Severity.ERROR,
             expectedSchemaType = expectedSchemaType,
-            expectedIsPrivate = false
+            expectedIsPrivate = false,
         )
     }
 
@@ -187,7 +187,7 @@ internal class TelemetryDestinationImplTest {
             startTimeMs,
             endTimeMs,
             attributes = mapOf("foo" to "bar"),
-            events = listOf(SpanEventImpl("event", clock.now().millisToNanos(), mapOf("key" to "value")))
+            events = listOf(SpanEventImpl("event", clock.now().millisToNanos(), mapOf("key" to "value"))),
         )
         val span = spanService.createdSpans.single()
         assertEquals(name, span.name)
@@ -222,7 +222,7 @@ internal class TelemetryDestinationImplTest {
             type = type,
             internal = true,
             private = false,
-            attributes = attributes
+            attributes = attributes,
         )
         val span = spanService.createdSpans.single()
         assertEquals(name, span.name)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/schema/TelemetryAttributesTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/schema/TelemetryAttributesTest.kt
@@ -36,7 +36,7 @@ internal class TelemetryAttributesTest {
     @Test
     fun `all attributes types`() {
         telemetryAttributes = TelemetryAttributes(
-            customAttributes = customAttributes
+            customAttributes = customAttributes,
         )
         val otelSessionIdKey = SessionAttributes.SESSION_ID
         telemetryAttributes.setAttribute(otelSessionIdKey, otelSessionId)
@@ -63,7 +63,7 @@ internal class TelemetryAttributesTest {
     fun `schema attribute values take priority if the same key is used`() {
         val newOtelSessionId = TestUuidSource().createUuid()
         telemetryAttributes = TelemetryAttributes(
-            customAttributes = mapOf(SessionAttributes.SESSION_ID to otelSessionId)
+            customAttributes = mapOf(SessionAttributes.SESSION_ID to otelSessionId),
         )
         telemetryAttributes.setAttribute(SessionAttributes.SESSION_ID, newOtelSessionId)
         val attributes = telemetryAttributes.snapshot()
@@ -74,7 +74,7 @@ internal class TelemetryAttributesTest {
     @Test
     fun `log properties and session properties are included in the attributes`() {
         telemetryAttributes = TelemetryAttributes(
-            customAttributes = customAttributes
+            customAttributes = customAttributes,
         )
         telemetryAttributes.setAttribute(SessionAttributes.SESSION_ID, otelSessionId)
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/InternalErrorDataSourceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/InternalErrorDataSourceImplTest.kt
@@ -25,7 +25,7 @@ internal class InternalErrorDataSourceImplTest {
     fun setUp() {
         args = FakeInstrumentationArgs(ApplicationProvider.getApplicationContext())
         dataSource = InternalErrorDataSourceImpl(
-            args
+            args,
         )
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/NetworkCallbackConnectivityServiceTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/NetworkCallbackConnectivityServiceTest.kt
@@ -346,7 +346,7 @@ internal class NetworkCallbackConnectivityServiceTest {
             disconnectedUnknown to buildCaps {
                 addCapability(NET_CAPABILITY_INTERNET)
             },
-            none to buildCaps { }
+            none to buildCaps { },
         )
 
         val connectivityStatuses = mapOf(
@@ -357,7 +357,7 @@ internal class NetworkCallbackConnectivityServiceTest {
             connectedUnknown to ConnectivityStatus.Unknown(true),
             disconnectedUnknown to ConnectivityStatus.Unknown(false),
             unverified to ConnectivityStatus.Unverified,
-            none to ConnectivityStatus.None
+            none to ConnectivityStatus.None,
         )
 
         private fun createNetworkInfo(

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/BreadcrumbDataSourceTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/crumbs/BreadcrumbDataSourceTest.kt
@@ -36,7 +36,7 @@ internal class BreadcrumbDataSourceTest {
             assertEquals(15000000000, startTimeMs)
             assertEquals(
                 mapOf(EmbBreadcrumbAttributes.MESSAGE to "Hello, world!"),
-                schemaType.attributes()
+                schemaType.attributes(),
             )
         }
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/session/EmbraceUserSessionPropertiesTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/session/EmbraceUserSessionPropertiesTest.kt
@@ -44,7 +44,7 @@ internal class EmbraceUserSessionPropertiesTest {
         store = FakeKeyValueStore()
 
         configService = FakeConfigService(
-            sessionBehavior = FakeUserSessionBehavior(MAX_SESSION_PROPERTIES_DEFAULT)
+            sessionBehavior = FakeUserSessionBehavior(MAX_SESSION_PROPERTIES_DEFAULT),
         )
         destination = FakeTelemetryDestination()
         telemetryService = FakeTelemetryService()
@@ -52,7 +52,7 @@ internal class EmbraceUserSessionPropertiesTest {
             store,
             configService,
             destination,
-            telemetryService
+            telemetryService,
         )
     }
 
@@ -242,11 +242,11 @@ internal class EmbraceUserSessionPropertiesTest {
         }
         assertFalse(
             "should not be able to add new key when limit is hit",
-            props.add("propPermNew", VALUE_VALID, PropertyScope.PERMANENT)
+            props.add("propPermNew", VALUE_VALID, PropertyScope.PERMANENT),
         )
         assertFalse(
             "should not be able to add new key when limit is hit",
-            props.add("propTempNew", VALUE_VALID, PropertyScope.USER_SESSION)
+            props.add("propTempNew", VALUE_VALID, PropertyScope.USER_SESSION),
         )
 
         // Verify telemetry tracked for dropped properties
@@ -259,17 +259,17 @@ internal class EmbraceUserSessionPropertiesTest {
         val otherValue = "other"
         assertTrue(
             "should be able to update key when properties are full",
-            props.add("prop0", otherValue, PropertyScope.PERMANENT)
+            props.add("prop0", otherValue, PropertyScope.PERMANENT),
         )
         assertEquals(
             "property was updated",
             otherValue,
-            props.get()["prop0"]
+            props.get()["prop0"],
         )
         assertTrue(props.remove("prop0"))
         assertTrue(
             "can add key once one was deleted",
-            props.add("prop11", VALUE_VALID, scope)
+            props.add("prop11", VALUE_VALID, scope),
         )
     }
 
@@ -285,26 +285,26 @@ internal class EmbraceUserSessionPropertiesTest {
         }
         assertFalse(
             "should not be able to add new key when limit is hit",
-            props.add("propPermNew", VALUE_VALID, PropertyScope.PERMANENT)
+            props.add("propPermNew", VALUE_VALID, PropertyScope.PERMANENT),
         )
         assertFalse(
             "should not be able to add new key when limit is hit",
-            props.add("propTempNew", VALUE_VALID, PropertyScope.USER_SESSION)
+            props.add("propTempNew", VALUE_VALID, PropertyScope.USER_SESSION),
         )
         val otherValue = "other"
         assertTrue(
             "should be able to update key when properties are full",
-            props.add("prop0", otherValue, PropertyScope.PERMANENT)
+            props.add("prop0", otherValue, PropertyScope.PERMANENT),
         )
         assertEquals(
             "property was updated",
             otherValue,
-            props.get()["prop0"]
+            props.get()["prop0"],
         )
         assertTrue(props.remove("prop0"))
         assertTrue(
             "can add key once one was deleted",
-            props.add("prop11", VALUE_VALID, scope)
+            props.add("prop11", VALUE_VALID, scope),
         )
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/session/UserSessionPropertiesServiceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/session/UserSessionPropertiesServiceImplTest.kt
@@ -28,7 +28,7 @@ internal class UserSessionPropertiesServiceImplTest {
             FakeConfigService(
                 sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(
                     FakeInstrumentedConfig(redaction = FakeRedactionConfig(sensitiveKeys = listOf("password"))),
-                )
+                ),
             )
         destination = FakeTelemetryDestination()
         telemetryService = FakeTelemetryService()
@@ -36,7 +36,7 @@ internal class UserSessionPropertiesServiceImplTest {
             FakeKeyValueStore(),
             fakeConfigService,
             destination,
-            telemetryService
+            telemetryService,
         )
         propState = emptyMap()
         service.addChangeListener { propState = it }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/user/EmbraceUserServiceTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/user/EmbraceUserServiceTest.kt
@@ -21,7 +21,7 @@ internal class EmbraceUserServiceTest {
 
     private val extraPersonas = setOf(
         "payer",
-        "first_day"
+        "first_day",
     )
 
     private val userPersonas = setOf(
@@ -44,7 +44,7 @@ internal class EmbraceUserServiceTest {
             email = "test@example.com",
             name = "Mr Test",
             payer = true,
-            firstDay = true
+            firstDay = true,
         )
 
         // load user info
@@ -154,7 +154,7 @@ internal class EmbraceUserServiceTest {
                 "Persona_6",
                 "Persona_7",
             ),
-            personas.toList()
+            personas.toList(),
         )
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/comms/api/EndpointTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/comms/api/EndpointTest.kt
@@ -39,10 +39,10 @@ internal class EndpointTest {
             updateRateLimitStatus()
             scheduleRetry(
                 BackgroundWorker(
-                    scheduledExecutorService
+                    scheduledExecutorService,
                 ),
                 retryAfter,
-                mockExecuteApiCalls
+                mockExecuteApiCalls,
             )
         }
 
@@ -61,10 +61,10 @@ internal class EndpointTest {
                 updateRateLimitStatus()
                 scheduleRetry(
                     BackgroundWorker(
-                        scheduledExecutorService
+                        scheduledExecutorService,
                     ),
                     null,
-                    mockExecuteApiCalls
+                    mockExecuteApiCalls,
                 )
             }
         } andThenAnswer {
@@ -72,10 +72,10 @@ internal class EndpointTest {
                 updateRateLimitStatus()
                 scheduleRetry(
                     BackgroundWorker(
-                        scheduledExecutorService
+                        scheduledExecutorService,
                     ),
                     null,
-                    mockExecuteApiCalls
+                    mockExecuteApiCalls,
                 )
             }
         } andThenAnswer {
@@ -87,10 +87,10 @@ internal class EndpointTest {
             updateRateLimitStatus()
             scheduleRetry(
                 BackgroundWorker(
-                    scheduledExecutorService
+                    scheduledExecutorService,
                 ),
                 null,
-                mockExecuteApiCalls
+                mockExecuteApiCalls,
             )
         }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingServiceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingServiceImplTest.kt
@@ -34,7 +34,7 @@ class PayloadCachingServiceImplTest {
             cacher,
             FakeClock(),
             sessionIdsProvider,
-            FakePayloadStore()
+            FakePayloadStore(),
         )
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogEnvelopeSourceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/log/LogEnvelopeSourceImplTest.kt
@@ -105,12 +105,12 @@ internal class LogEnvelopeSourceImplTest {
             userSessionId = expectedUserSessionId,
         )
         logSource.singleLogPayloadsSource = listOf(
-            LogRequest(crashPayload)
+            LogRequest(crashPayload),
         )
         cachedLogEnvelopeStore.create(
             storedTelemetryMetadata = cachedCrashEnvelopeMetadata,
             resource = fakeEnvelopeResource,
-            metadata = fakeEnvelopeMetadata
+            metadata = fakeEnvelopeMetadata,
         )
         with(logEnvelopeSource.getSingleLogEnvelopes().first().payload) {
             assertEquals(fakeEnvelopeResource, resource)
@@ -130,12 +130,12 @@ internal class LogEnvelopeSourceImplTest {
     @Test
     fun `check native crash envelope when no matching session found`() {
         logSource.singleLogPayloadsSource = listOf(
-            LogRequest(LogPayload(logs = listOf(nativeCrashWithoutSessionLog)))
+            LogRequest(LogPayload(logs = listOf(nativeCrashWithoutSessionLog))),
         )
         cachedLogEnvelopeStore.create(
             storedTelemetryMetadata = createNativeCrashEnvelopeMetadata(),
             resource = fakeEnvelopeResource,
-            metadata = fakeEnvelopeMetadata
+            metadata = fakeEnvelopeMetadata,
         )
         with(logEnvelopeSource.getSingleLogEnvelopes().first().payload) {
             assertEquals(fakeEnvelopeResource, resource)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImplTest.kt
@@ -45,7 +45,7 @@ internal class EnvelopeResourceSourceImplTest {
             FakeDevice(),
             "",
             53,
-            { "fakeReactNativeBundleId" }
+            { "fakeReactNativeBundleId" },
         )
         val envelope = source.getEnvelopeResource()
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPartPayloadSourceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPartPayloadSourceImplTest.kt
@@ -48,7 +48,7 @@ internal class SessionPartPayloadSourceImplTest {
             FakeOtelPayloadMapper(),
             FakeAppStateTracker(),
             FakeClock(),
-            InternalLoggerImpl()
+            InternalLoggerImpl(),
         )
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/injection/InitModuleImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/injection/InitModuleImplTest.kt
@@ -29,7 +29,7 @@ internal class InitModuleImplTest {
         val systemInfo = SystemInfo()
         val initModule = InitModuleImpl(
             clock = clock,
-            systemInfo = systemInfo
+            systemInfo = systemInfo,
         )
         assertSame(clock, initModule.clock)
         assertSame(systemInfo, initModule.systemInfo)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/injection/InstrumentationModuleImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/injection/InstrumentationModuleImplTest.kt
@@ -23,7 +23,7 @@ internal class InstrumentationModuleImplTest {
             openTelemetryModule = FakeOpenTelemetryModule(),
             workerThreadModule = FakeWorkerThreadModule(
                 fakeInitModule = fakeInitModule,
-                testWorkers = listOf(Worker.Background.NonIoRegWorker)
+                testWorkers = listOf(Worker.Background.NonIoRegWorker),
             ),
             configService = FakeConfigService(),
             essentialServiceModule = FakeEssentialServiceModule(),

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/logs/EmbraceLogServiceTest.kt
@@ -34,7 +34,7 @@ internal class EmbraceLogServiceTest {
         fakeConfigService = FakeConfigService(
             sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(
                 FakeInstrumentedConfig(redaction = FakeRedactionConfig(sensitiveKeys = listOf("password"))),
-            )
+            ),
         )
         fakeUserSessionPropertiesService = FakeUserSessionPropertiesService()
         destination = FakeTelemetryDestination()
@@ -74,8 +74,8 @@ internal class EmbraceLogServiceTest {
             logMessageBehavior = FakeLogMessageBehavior(
                 infoLogLimit = testLogLimit,
                 warnLogLimit = testLogLimit,
-                errorLogLimit = testLogLimit
-            )
+                errorLogLimit = testLogLimit,
+            ),
         )
         logLimitingService = LogLimitingServiceImpl(fakeConfigService)
         logService = createEmbraceLogService()
@@ -109,7 +109,7 @@ internal class EmbraceLogServiceTest {
     fun `a max length smaller than 3 does not add ellipsis`() {
         // given a config with a log message limit smaller than 3
         fakeConfigService = FakeConfigService(
-            logMessageBehavior = FakeLogMessageBehavior(logMessageMaximumAllowedLength = 2)
+            logMessageBehavior = FakeLogMessageBehavior(logMessageMaximumAllowedLength = 2),
         )
         logService = createEmbraceLogService()
 
@@ -125,7 +125,7 @@ internal class EmbraceLogServiceTest {
     fun `a log message bigger than the max length is trimmed`() {
         // given a config with message limit
         fakeConfigService = FakeConfigService(
-            logMessageBehavior = FakeLogMessageBehavior(logMessageMaximumAllowedLength = 5)
+            logMessageBehavior = FakeLogMessageBehavior(logMessageMaximumAllowedLength = 5),
         )
         logService = createEmbraceLogService()
 
@@ -146,7 +146,7 @@ internal class EmbraceLogServiceTest {
         // given a config with message limit and app framework Unity
         fakeConfigService = FakeConfigService(
             appFramework = AppFramework.UNITY,
-            logMessageBehavior = FakeLogMessageBehavior(logMessageMaximumAllowedLength = 5)
+            logMessageBehavior = FakeLogMessageBehavior(logMessageMaximumAllowedLength = 5),
         )
         logService = createEmbraceLogService()
 
@@ -163,7 +163,7 @@ internal class EmbraceLogServiceTest {
             "a".repeat(unityMaxAllowedLength + 1),
             LogSeverity.INFO,
             emptyMap(),
-            ::Log
+            ::Log,
         )
 
         // then the message is trimmed
@@ -212,7 +212,7 @@ internal class EmbraceLogServiceTest {
         assertTrue(fakeTelemetryService.appliedLimits.contains("info_log" to AppliedLimitType.TRUNCATE_ATTRIBUTES))
         assertTrue(fakeTelemetryService.appliedLimits.contains("log_attribute_key" to AppliedLimitType.TRUNCATE_STRING))
         assertTrue(
-            fakeTelemetryService.appliedLimits.contains("log_attribute_value" to AppliedLimitType.TRUNCATE_STRING)
+            fakeTelemetryService.appliedLimits.contains("log_attribute_value" to AppliedLimitType.TRUNCATE_STRING),
         )
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/logs/LogOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/logs/LogOrchestratorTest.kt
@@ -49,8 +49,8 @@ internal class LogOrchestratorTest {
             logSink,
             store,
             FakePayloadSourceModule(
-                logPayloadSource = LogPayloadSourceImpl(logSink)
-            ).logEnvelopeSource
+                logPayloadSource = LogPayloadSourceImpl(logSink),
+            ).logEnvelopeSource,
         )
         logSink.registerLogStoredCallback(logOrchestrator::onLogsAdded)
     }
@@ -171,7 +171,7 @@ internal class LogOrchestratorTest {
                     latch.countDown()
                 },
                 10L,
-                TimeUnit.MILLISECONDS
+                TimeUnit.MILLISECONDS,
             )
         }
 
@@ -181,7 +181,7 @@ internal class LogOrchestratorTest {
         assertEquals(
             "Too many logs in payload",
             50,
-            store.storedLogPayloads[0].first.data.logs?.size
+            store.storedLogPayloads[0].first.data.logs?.size,
         )
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/logs/attachments/AttachmentTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/logs/attachments/AttachmentTest.kt
@@ -47,7 +47,7 @@ internal class AttachmentTest {
         val attachment = EmbraceHosted(ByteArray(size), counter)
         attachment.assertEmbraceHostedAttributesMatch(
             size = size.toLong(),
-            errorCode = ATTACHMENT_TOO_LARGE
+            errorCode = ATTACHMENT_TOO_LARGE,
         )
     }
 
@@ -64,7 +64,7 @@ internal class AttachmentTest {
         val limitedAttachment = EmbraceHosted(bytes, smallCounter)
         limitedAttachment.assertEmbraceHostedAttributesMatch(
             size = size,
-            errorCode = OVER_MAX_ATTACHMENTS
+            errorCode = OVER_MAX_ATTACHMENTS,
         )
     }
 
@@ -98,7 +98,7 @@ internal class AttachmentTest {
         limit = false
         val limitedAttachment = UserHosted(ID, URL, smallCounter)
         limitedAttachment.assertUserHostedAttributesMatch(
-            errorCode = OVER_MAX_ATTACHMENTS
+            errorCode = OVER_MAX_ATTACHMENTS,
         )
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
@@ -155,7 +155,7 @@ class PayloadResurrectionServiceImplTest {
             expectedCustomAttributes = mapOf(
                 EmbType.Ux.Session.asPair(),
                 AppTerminationCause.Crash.asPair(),
-            )
+            ),
         )
     }
 
@@ -163,7 +163,7 @@ class PayloadResurrectionServiceImplTest {
     fun `all payloads from previous app launches are deleted after resurrection`() {
         cacheStorageService.addPayload(
             metadata = fakeCachedCrashEnvelopeMetadata,
-            data = fakeEmptyLogEnvelope()
+            data = fakeEmptyLogEnvelope(),
         )
         assertEquals(1, cacheStorageService.storedPayloadCount())
         assertEquals(0, cacheStorageService.deleteCount.get())
@@ -178,11 +178,11 @@ class PayloadResurrectionServiceImplTest {
         // simulate a race where a complete session payload _and_ cached session payload are both on disk
         payloadStorageService.addPayload(
             metadata = fakeSessionStoredTelemetryMetadata,
-            data = deadSessionEnvelope
+            data = deadSessionEnvelope,
         )
         cacheStorageService.addPayload(
             metadata = sessionMetadata,
-            data = deadSessionEnvelope
+            data = deadSessionEnvelope,
         )
         assertEquals(1, payloadStorageService.storedPayloadCount())
         assertEquals(1, cacheStorageService.storedPayloadCount())
@@ -198,11 +198,11 @@ class PayloadResurrectionServiceImplTest {
     fun `duplicate session snapshots only send the most recent one`() {
         val earlierMeta = sessionMetadata.copy(
             timestamp = sessionMetadata.timestamp - 5_000L,
-            uuid = "earlier-uuid"
+            uuid = "earlier-uuid",
         )
         val earlierEnvelope = fakeIncompleteSessionEnvelope(
             startMs = earlierMeta.timestamp,
-            lastHeartbeatTimeMs = earlierMeta.timestamp + 100L
+            lastHeartbeatTimeMs = earlierMeta.timestamp + 100L,
         )
         cacheStorageService.addPayload(metadata = earlierMeta, data = earlierEnvelope)
         cacheStorageService.addPayload(metadata = sessionMetadata, data = deadSessionEnvelope)
@@ -231,11 +231,11 @@ class PayloadResurrectionServiceImplTest {
     fun `dedupe does not affect unrelated sessions`() {
         payloadStorageService.addPayload(
             metadata = fakeSessionStoredTelemetryMetadata,
-            data = deadSessionEnvelope
+            data = deadSessionEnvelope,
         )
         cacheStorageService.addPayload(
             metadata = sessionMetadata,
-            data = deadSessionEnvelope
+            data = deadSessionEnvelope,
         )
 
         // Session B is only in the cache — should be resurrected normally.
@@ -243,7 +243,7 @@ class PayloadResurrectionServiceImplTest {
         val sessionBEnvelope = fakeIncompleteSessionEnvelope(
             userSessionId = "session-b",
             startMs = sessionBMeta.timestamp,
-            lastHeartbeatTimeMs = sessionBMeta.timestamp + 1000L
+            lastHeartbeatTimeMs = sessionBMeta.timestamp + 1000L,
         )
         cacheStorageService.addPayload(metadata = sessionBMeta, data = sessionBEnvelope)
 
@@ -257,7 +257,7 @@ class PayloadResurrectionServiceImplTest {
                 FAKE_USER_SESSION_ID to FAKE_SESSION_PART_ID,
                 FAKE_USER_SESSION_ID_2 to FAKE_SESSION_PART_ID_2,
             ),
-            storedKeys
+            storedKeys,
         )
         assertEquals(2, payloadStorageService.storedPayloadCount())
         assertEquals(0, cacheStorageService.storedPayloadCount())
@@ -275,7 +275,7 @@ class PayloadResurrectionServiceImplTest {
         val spanSnapshot =
             checkNotNull(
                 deadSessionEnvelope.data.spanSnapshots?.filterNot { it.spanId == sessionPartSpan.spanId }
-                    ?.single()
+                    ?.single(),
             )
         val resurrectedSnapshot = sentSession.findSpansByName(checkNotNull(spanSnapshot.name)).single()
 
@@ -286,8 +286,8 @@ class PayloadResurrectionServiceImplTest {
             expectedParentId = OtelIds.INVALID_SPAN_ID,
             expectedErrorCode = ErrorCode.FAILURE,
             expectedCustomAttributes = mapOf(
-                EmbType.Performance.Default.asPair()
-            )
+                EmbType.Performance.Default.asPair(),
+            ),
         )
     }
 
@@ -306,8 +306,8 @@ class PayloadResurrectionServiceImplTest {
         nativeCrashService.addNativeCrashData(
             createNativeCrashData(
                 nativeCrashId = "dead-session-native-crash",
-                sessionPartId = deadSessionEnvelope.getSessionPartId()
-            )
+                sessionPartId = deadSessionEnvelope.getSessionPartId(),
+            ),
         )
         deadSessionEnvelope.resurrectPayload()
 
@@ -319,8 +319,8 @@ class PayloadResurrectionServiceImplTest {
         nativeCrashService.addNativeCrashData(
             createNativeCrashData(
                 nativeCrashId = "dead-session-native-crash",
-                sessionPartId = "fake-id"
-            )
+                sessionPartId = "fake-id",
+            ),
         )
         deadSessionEnvelope.resurrectPayload()
 
@@ -336,7 +336,7 @@ class PayloadResurrectionServiceImplTest {
             createNativeCrashData(
                 nativeCrashId = "legacy-native-crash",
                 sessionPartId = legacySessionId,
-            )
+            ),
         )
         cacheStorageService.addPayload(
             metadata = sessionMetadata.copy(userSessionId = "", sessionPartId = ""),
@@ -348,7 +348,7 @@ class PayloadResurrectionServiceImplTest {
         val sessionPartSpan = getStoredParts().single().getSessionPartSpan()
         assertEquals(
             "legacy-native-crash",
-            sessionPartSpan?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID)
+            sessionPartSpan?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID),
         )
     }
 
@@ -360,14 +360,14 @@ class PayloadResurrectionServiceImplTest {
                 userSessionId = FAKE_USER_SESSION_ID,
                 backgroundOnly = false,
                 reason = EmbUserSessionTerminationReasonValues.INACTIVITY,
-            )
+            ),
         )
 
         val attributes = checkNotNull(getStoredParts().single().getSessionPartSpan()?.attributes)
         assertEquals("1", attributes.findAttributeValue(EmbSessionAttributes.EMB_IS_FINAL_SESSION_PART))
         assertEquals(
             EmbUserSessionTerminationReasonValues.INACTIVITY,
-            attributes.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_TERMINATION_REASON)
+            attributes.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_TERMINATION_REASON),
         )
     }
 
@@ -389,7 +389,7 @@ class PayloadResurrectionServiceImplTest {
                 userSessionId = FAKE_USER_SESSION_ID_2,
                 backgroundOnly = false,
                 reason = EmbUserSessionTerminationReasonValues.MAX_DURATION_REACHED,
-            )
+            ),
         )
 
         val attributes = checkNotNull(getStoredParts().single().getSessionPartSpan()?.attributes)
@@ -402,27 +402,27 @@ class PayloadResurrectionServiceImplTest {
         val earlierMeta = sessionMetadata.copy(
             uuid = sessionMetadata.uuid + "-earlier",
             sessionPartId = sessionMetadata.sessionPartId + "-earlier",
-            timestamp = sessionMetadata.timestamp
+            timestamp = sessionMetadata.timestamp,
         )
         val laterMeta = sessionMetadata.copy(
             uuid = sessionMetadata.uuid + "-later",
             sessionPartId = sessionMetadata.sessionPartId + "-later",
-            timestamp = sessionMetadata.timestamp + 1000L
+            timestamp = sessionMetadata.timestamp + 1000L,
         )
         cacheStorageService.addPayload(
             metadata = earlierMeta,
-            data = fakeIncompleteSessionEnvelope(userSessionId = "earlier-part")
+            data = fakeIncompleteSessionEnvelope(userSessionId = "earlier-part"),
         )
         cacheStorageService.addPayload(
             metadata = laterMeta,
-            data = fakeIncompleteSessionEnvelope(userSessionId = "later-part")
+            data = fakeIncompleteSessionEnvelope(userSessionId = "later-part"),
         )
         resurrectInBackground(
             restoreDecision = UserSessionRestoreDecision.Terminated(
                 userSessionId = FAKE_USER_SESSION_ID,
                 backgroundOnly = false,
                 reason = EmbUserSessionTerminationReasonValues.MAX_DURATION_REACHED,
-            )
+            ),
         )
 
         val parts = getStoredParts().associateBy { it.getUserSessionId() }
@@ -430,7 +430,7 @@ class PayloadResurrectionServiceImplTest {
         assertEquals("1", laterAttrs.findAttributeValue(EmbSessionAttributes.EMB_IS_FINAL_SESSION_PART))
         assertEquals(
             EmbUserSessionTerminationReasonValues.MAX_DURATION_REACHED,
-            laterAttrs.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_TERMINATION_REASON)
+            laterAttrs.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_TERMINATION_REASON),
         )
 
         val earlierAttrs = checkNotNull(parts.getValue("earlier-part").getSessionPartSpan()?.attributes)
@@ -446,7 +446,7 @@ class PayloadResurrectionServiceImplTest {
                 userSessionId = FAKE_USER_SESSION_ID,
                 backgroundOnly = true,
                 reason = EmbUserSessionTerminationReasonValues.MAX_DURATION_REACHED,
-            )
+            ),
         )
 
         val attributes = checkNotNull(getStoredParts().single().getSessionPartSpan()?.attributes)
@@ -460,7 +460,7 @@ class PayloadResurrectionServiceImplTest {
             restoreDecision = UserSessionRestoreDecision.Restored(
                 userSessionId = FAKE_USER_SESSION_ID,
                 backgroundOnly = true,
-            )
+            ),
         )
 
         val attributes = checkNotNull(getStoredParts().single().getSessionPartSpan()?.attributes)
@@ -475,7 +475,7 @@ class PayloadResurrectionServiceImplTest {
             restoreDecision = UserSessionRestoreDecision.Restored(
                 userSessionId = FAKE_USER_SESSION_ID,
                 backgroundOnly = false,
-            )
+            ),
         )
 
         val attributes = checkNotNull(getStoredParts().single().getSessionPartSpan()?.attributes)
@@ -490,7 +490,7 @@ class PayloadResurrectionServiceImplTest {
                 userSessionId = FAKE_USER_SESSION_ID_2,
                 backgroundOnly = true,
                 reason = EmbUserSessionTerminationReasonValues.MAX_DURATION_REACHED,
-            )
+            ),
         )
 
         val attributes = checkNotNull(getStoredParts().single().getSessionPartSpan()?.attributes)
@@ -507,7 +507,7 @@ class PayloadResurrectionServiceImplTest {
     fun `resurrection failure deletes cache file and logs unrecoverable error`() {
         cacheStorageService.addPayload(
             metadata = sessionMetadata,
-            data = deadSessionEnvelope
+            data = deadSessionEnvelope,
         )
         serializer.errorOnNextOperation()
         resurrectInBackground()
@@ -544,11 +544,11 @@ class PayloadResurrectionServiceImplTest {
     fun `sessionless native crash sent without envelope data when crash envelope stream returns null`() {
         val deadSessionCrashData = createNativeCrashData(
             nativeCrashId = "native-crash-1",
-            sessionPartId = "no-session-id"
+            sessionPartId = "no-session-id",
         )
         cacheStorageService.addPayload(
             metadata = fakeCachedCrashEnvelopeMetadata,
-            data = fakeEmptyLogEnvelope()
+            data = fakeEmptyLogEnvelope(),
         )
         nativeCrashService.addNativeCrashData(deadSessionCrashData)
 
@@ -567,7 +567,7 @@ class PayloadResurrectionServiceImplTest {
         assertEquals(1, logger.internalErrorMessages.size)
         assertEquals(
             InternalErrorType.NativeCrashResurrectionError.toString(),
-            logger.internalErrorMessages.single().msg
+            logger.internalErrorMessages.single().msg,
         )
     }
 
@@ -581,12 +581,12 @@ class PayloadResurrectionServiceImplTest {
     fun `multiple native crashes will be resurrected properly with the crash data sent separately`() {
         val deadSessionCrashData = createNativeCrashData(
             nativeCrashId = "native-crash-1",
-            sessionPartId = deadSessionEnvelope.getSessionPartId()
+            sessionPartId = deadSessionEnvelope.getSessionPartId(),
         )
         nativeCrashService.addNativeCrashData(deadSessionCrashData)
         cacheStorageService.addPayload(
             metadata = sessionMetadata,
-            data = deadSessionEnvelope
+            data = deadSessionEnvelope,
         )
 
         val oldResource = fakeEnvelopeResource.copy(appVersion = "1.4", sdkVersion = "6.13", osVersion = "10")
@@ -598,24 +598,24 @@ class PayloadResurrectionServiceImplTest {
             lastHeartbeatTimeMs = deadSessionEnvelope.getStartTime() - 90_000L,
             sessionProperties = mapOf("prop" to "earlier"),
             resource = oldResource,
-            metadata = oldMetadata
+            metadata = oldMetadata,
 
         )
         val earlierSessionCrashData = createNativeCrashData(
             nativeCrashId = "native-crash-2",
-            sessionPartId = earlierDeadSession.getSessionPartId()
+            sessionPartId = earlierDeadSession.getSessionPartId(),
         )
         val earlierDeadSessionMetadata = StoredTelemetryMetadata(
             timestamp = earlierDeadSession.getStartTime(),
             uuid = "fake-uuid",
             processIdentifier = "fakePid",
             envelopeType = SupportedEnvelopeType.SESSION,
-            complete = false
+            complete = false,
         )
         nativeCrashService.addNativeCrashData(earlierSessionCrashData)
         cacheStorageService.addPayload(
             metadata = earlierDeadSessionMetadata,
-            data = earlierDeadSession
+            data = earlierDeadSession,
         )
 
         resurrectInBackground()
@@ -631,11 +631,11 @@ class PayloadResurrectionServiceImplTest {
             assertEquals(deadSessionEnvelope.getUserSessionId(), getUserSessionId())
             assertEquals(
                 "native-crash-1",
-                getSessionPartSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID)
+                getSessionPartSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID),
             )
             assertEquals(
                 "foreground",
-                getSessionPartSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_STATE)
+                getSessionPartSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_STATE),
             )
         }
 
@@ -646,11 +646,11 @@ class PayloadResurrectionServiceImplTest {
             assertEquals(earlierDeadSession.getUserSessionId(), getUserSessionId())
             assertEquals(
                 "native-crash-2",
-                getSessionPartSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID)
+                getSessionPartSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID),
             )
             assertEquals(
                 "foreground",
-                getSessionPartSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_STATE)
+                getSessionPartSpan()?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_STATE),
             )
         }
 
@@ -674,7 +674,7 @@ class PayloadResurrectionServiceImplTest {
             assertEquals(earlierSessionCrashData, first)
             assertEquals(
                 "earlier",
-                second.findAttributeValue(second.keys.single { it.isEmbraceAttributeName() })
+                second.findAttributeValue(second.keys.single { it.isEmbraceAttributeName() }),
             )
         }
     }
@@ -683,14 +683,14 @@ class PayloadResurrectionServiceImplTest {
     fun `native crashes without sessions are sent properly`() {
         val deadSessionCrashData = createNativeCrashData(
             nativeCrashId = "native-crash-1",
-            sessionPartId = "no-session-id"
+            sessionPartId = "no-session-id",
         )
         cacheStorageService.addPayload(
             metadata = fakeCachedCrashEnvelopeMetadata,
             data = fakeEmptyLogEnvelope(
                 resource = fakeLaterEnvelopeResource,
-                metadata = fakeLaterEnvelopeMetadata
-            )
+                metadata = fakeLaterEnvelopeMetadata,
+            ),
         )
         nativeCrashService.addNativeCrashData(deadSessionCrashData)
         resurrectInBackground()
@@ -713,7 +713,7 @@ class PayloadResurrectionServiceImplTest {
     fun `native crashes without sessions or cached crash envelopes sent`() {
         val deadSessionCrashData = createNativeCrashData(
             nativeCrashId = "native-crash-1",
-            sessionPartId = "no-session-id"
+            sessionPartId = "no-session-id",
         )
         nativeCrashService.addNativeCrashData(deadSessionCrashData)
         resurrectInBackground()
@@ -732,7 +732,7 @@ class PayloadResurrectionServiceImplTest {
     fun `dead session is resurrected with no crashId when nativeCrashService is null`() {
         cacheStorageService.addPayload(
             metadata = sessionMetadata,
-            data = deadSessionEnvelope
+            data = deadSessionEnvelope,
         )
         resurrectInBackground({ null })
 
@@ -796,7 +796,7 @@ class PayloadResurrectionServiceImplTest {
         assertTrue(
             logger.internalErrorMessages.any {
                 it.throwable is TimeoutException
-            }
+            },
         )
     }
 
@@ -817,7 +817,7 @@ class PayloadResurrectionServiceImplTest {
     private fun Envelope<SessionPartPayload>.resurrectPayload() {
         cacheStorageService.addPayload(
             metadata = sessionMetadata,
-            data = this
+            data = this,
         )
         resurrectInBackground()
     }
@@ -826,13 +826,13 @@ class PayloadResurrectionServiceImplTest {
      * Rewrites a session payload to look like one from an SDK that predates the user session concept
      */
     private fun Envelope<SessionPartPayload>.asPreUserSessionPayload(
-        legacySessionId: String
+        legacySessionId: String,
     ): Envelope<SessionPartPayload> {
         return copy(
             data = data.copy(
                 spans = data.spans.toPreUserSessionSpan(legacySessionId),
                 spanSnapshots = data.spanSnapshots.toPreUserSessionSpan(legacySessionId),
-            )
+            ),
         )
     }
 
@@ -847,7 +847,7 @@ class PayloadResurrectionServiceImplTest {
                         } else {
                             it
                         }
-                    }
+                    },
             )
         }
 
@@ -855,7 +855,7 @@ class PayloadResurrectionServiceImplTest {
         return payloadStorageService.storedPayloads().map { bytes ->
             serializer.fromJson(
                 GZIPInputStream(ByteArrayInputStream(bytes)),
-                Envelope.sessionEnvelopeSerializer
+                Envelope.sessionEnvelopeSerializer,
             )
         }
     }
@@ -899,7 +899,7 @@ class PayloadResurrectionServiceImplTest {
         assertEquals(1, logger.internalErrorMessages.size)
         assertEquals(
             InternalErrorType.PayloadResurrectionPayloadFail.toString(),
-            logger.internalErrorMessages.single().msg
+            logger.internalErrorMessages.single().msg,
         )
     }
 
@@ -908,22 +908,22 @@ class PayloadResurrectionServiceImplTest {
         val sessionMetadata = fakeCachedSessionStoredTelemetryMetadata
         val deadSessionEnvelope = fakeIncompleteSessionEnvelope(
             startMs = sessionMetadata.timestamp,
-            lastHeartbeatTimeMs = sessionMetadata.timestamp + 1000L
+            lastHeartbeatTimeMs = sessionMetadata.timestamp + 1000L,
         )
         val messedUpSessionEnvelope = with(deadSessionEnvelope) {
             copy(
                 data = data.copy(
                     spans = listOf(
-                        startedSnapshot.copy(endTimeNanos = startedSnapshot.startTimeNanos + 10000000L).toEmbracePayload()
+                        startedSnapshot.copy(endTimeNanos = startedSnapshot.startTimeNanos + 10000000L).toEmbracePayload(),
                     ),
-                    spanSnapshots = data.spanSnapshots?.plus(listOfNotNull(startedSnapshot).map(EmbraceSpanData::toEmbracePayload))
-                )
+                    spanSnapshots = data.spanSnapshots?.plus(listOfNotNull(startedSnapshot).map(EmbraceSpanData::toEmbracePayload)),
+                ),
             )
         }
         val noSessionPartSpanEnvelope = deadSessionEnvelope.copy(
             data = deadSessionEnvelope.data.copy(
-                spanSnapshots = emptyList()
-            )
+                spanSnapshots = emptyList(),
+            ),
         )
         val multipleSessionPartSpanEnvelope = deadSessionEnvelope.copy(
             data = deadSessionEnvelope.data.copy(
@@ -933,10 +933,10 @@ class PayloadResurrectionServiceImplTest {
                             userSessionId = "fake-session-span-id",
                             startTimeMs = deadSessionEnvelope.getStartTime() + 1001L,
                             lastHeartbeatTimeMs = deadSessionEnvelope.getStartTime() + 1001L,
-                        ).snapshot()
-                    )
-                )
-            )
+                        ).snapshot(),
+                    ),
+                ),
+            ),
         )
         val fakeCachedCrashEnvelopeMetadata = StoredTelemetryMetadata(
             timestamp = 1000L,
@@ -944,7 +944,7 @@ class PayloadResurrectionServiceImplTest {
             processIdentifier = "old-process-id",
             envelopeType = CRASH,
             complete = false,
-            payloadType = PayloadType.UNKNOWN
+            payloadType = PayloadType.UNKNOWN,
         )
     }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/AppStateTrackerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/AppStateTrackerTest.kt
@@ -60,12 +60,12 @@ internal class AppStateTrackerTest {
             answers = false,
             objectMocks = false,
             constructorMocks = false,
-            staticMocks = false
+            staticMocks = false,
         )
         fakeEmbLogger = FakeInternalLogger()
         stateService = AppStateTrackerImpl(
             fakeEmbLogger,
-            TestLifecycleOwner(Lifecycle.State.INITIALIZED)
+            TestLifecycleOwner(Lifecycle.State.INITIALIZED),
         )
     }
 
@@ -155,7 +155,7 @@ internal class AppStateTrackerTest {
         stateService.onForeground()
         val foregroundExpected = listOf(
             "DecoratedSessionOrchestrator",
-            "DecoratedListener"
+            "DecoratedListener",
         )
         assertEquals(foregroundExpected, invocations)
 
@@ -211,7 +211,7 @@ internal class AppStateTrackerTest {
                 every { lifecycle } returns mockk<Lifecycle> {
                     every { currentState } returns Lifecycle.State.INITIALIZED
                 }
-            }
+            },
         )
         assertEquals(AppState.BACKGROUND, stateService.getAppState())
     }
@@ -224,7 +224,7 @@ internal class AppStateTrackerTest {
                 every { lifecycle } returns mockk<Lifecycle> {
                     every { currentState } returns Lifecycle.State.STARTED
                 }
-            }
+            },
         )
         assertEquals(AppState.FOREGROUND, stateService.getAppState())
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/PayloadFactoryBaTest.kt
@@ -60,8 +60,8 @@ internal class PayloadFactoryBaTest {
         spanService = initModule.openTelemetryModule.spanService
         configService = FakeConfigService(
             backgroundActivityBehavior = createBackgroundActivityBehavior(
-                remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 100f))
-            )
+                remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 100f)),
+            ),
         )
         blockingExecutorService = BlockingScheduledExecutorService(blockingMode = false)
     }
@@ -117,8 +117,8 @@ internal class PayloadFactoryBaTest {
                 FakeOtelPayloadMapper(),
                 FakeAppStateTracker(),
                 FakeClock(),
-                logger
-            )
+                logger,
+            ),
         )
         val collator = PayloadMessageCollatorImpl(
             payloadSourceModule.sessionPartEnvelopeSource,

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionHandlerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionHandlerTest.kt
@@ -71,7 +71,7 @@ internal class UserSessionHandlerTest {
         metadataService = FakeMetadataService()
         sessionTracker = FakeSessionPartTracker()
         configService = FakeConfigService(
-            sessionBehavior = createSessionBehavior()
+            sessionBehavior = createSessionBehavior(),
         )
         val initModule = FakeInitModule(clock = clock)
         spanSink = initModule.openTelemetryModule.spanSink
@@ -86,16 +86,16 @@ internal class UserSessionHandlerTest {
             FakeOtelPayloadMapper(),
             FakeAppStateTracker(),
             FakeClock(),
-            logger
+            logger,
         )
         val payloadSourceModule = FakePayloadSourceModule(
-            partPayloadSource = partPayloadSource
+            partPayloadSource = partPayloadSource,
         )
         val collator = PayloadMessageCollatorImpl(
             SessionPartEnvelopeSourceImpl(
                 metadataSource = FakeEnvelopeMetadataSource(),
                 resourceSource = FakeEnvelopeResourceSource(),
-                payloadSource = partPayloadSource
+                payloadSource = partPayloadSource,
             ),
             currentSessionPartSpan,
             FakeSessionIdsProvider(),
@@ -134,7 +134,7 @@ internal class UserSessionHandlerTest {
             AppState.FOREGROUND,
             clock.now(),
             initial,
-            "fakeCrashId"
+            "fakeCrashId",
         )
         assertSpanInSessionEnvelope(msg)
     }
@@ -157,8 +157,8 @@ internal class UserSessionHandlerTest {
                 payloadFactory.endPayloadWithState(
                     AppState.FOREGROUND,
                     clock.now(),
-                    initial
-                )
+                    initial,
+                ),
             )
         val spans = checkNotNull(envelope.data.spans)
         assertEquals(2, spans.size)
@@ -184,7 +184,7 @@ internal class UserSessionHandlerTest {
                 true,
                 { 1 },
                 { 1 },
-            )
+            ),
         )
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStoreTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStoreTest.kt
@@ -132,7 +132,7 @@ internal class UserSessionMetadataStoreTest {
                 "embrace.user_session",
                 getRawMap().apply {
                     remove(attribute)
-                }
+                },
             )
         }
         return metadataStore.load()

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionPartTrackerImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionPartTrackerImplTest.kt
@@ -27,7 +27,7 @@ internal class SessionPartTrackerImplTest {
         tracker.newActiveSessionPart(
             endSessionPartCallback = {},
             startSessionPartCallback = { newSession },
-            postTransitionAppState = AppState.FOREGROUND
+            postTransitionAppState = AppState.FOREGROUND,
         )
 
         assertEquals(newSession, tracker.getActiveSessionPart())
@@ -39,12 +39,12 @@ internal class SessionPartTrackerImplTest {
             startTime = 11L,
             appState = AppState.BACKGROUND,
             isColdStart = false,
-            startType = LifeEventType.MANUAL
+            startType = LifeEventType.MANUAL,
         )
         tracker.newActiveSessionPart(
             endSessionPartCallback = {},
             startSessionPartCallback = { anotherSession },
-            postTransitionAppState = AppState.BACKGROUND
+            postTransitionAppState = AppState.BACKGROUND,
         )
 
         assertEquals(anotherSession, tracker.getActiveSessionPart())
@@ -53,7 +53,7 @@ internal class SessionPartTrackerImplTest {
         tracker.newActiveSessionPart(
             endSessionPartCallback = {},
             startSessionPartCallback = { null },
-            postTransitionAppState = AppState.FOREGROUND
+            postTransitionAppState = AppState.FOREGROUND,
         )
 
         assertNull(tracker.getActiveSessionPart())
@@ -80,7 +80,7 @@ internal class SessionPartTrackerImplTest {
                     callbackInvocations.add("new-session")
                     newSessions[i]
                 },
-                postTransitionAppState = AppState.FOREGROUND
+                postTransitionAppState = AppState.FOREGROUND,
             )
         }
 
@@ -97,7 +97,7 @@ internal class SessionPartTrackerImplTest {
                 "new-session",
                 "change-listener",
             ),
-            callbackInvocations.toList()
+            callbackInvocations.toList(),
         )
     }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImplTest.kt
@@ -30,7 +30,7 @@ internal class PayloadFactoryImplTest {
         configService = FakeConfigService()
         partPayloadSource = FakeSessionPartPayloadSource()
         val payloadSourceModule = FakePayloadSourceModule(
-            partPayloadSource = partPayloadSource
+            partPayloadSource = partPayloadSource,
         )
         val collator = PayloadMessageCollatorImpl(
             sessionPartEnvelopeSource = payloadSourceModule.sessionPartEnvelopeSource,
@@ -41,7 +41,7 @@ internal class PayloadFactoryImplTest {
             payloadMessageCollator = collator,
             logEnvelopeSource = payloadSourceModule.logEnvelopeSource,
             configService = configService,
-            logger = initModule.logger
+            logger = initModule.logger,
         )
     }
 
@@ -54,7 +54,7 @@ internal class PayloadFactoryImplTest {
     @Test
     fun `verify expected payloads with ba enabled`() {
         configService.backgroundActivityBehavior = createBackgroundActivityBehavior(
-            remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 100f))
+            remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 100f)),
         )
         verifyPayloadWithState(state = FOREGROUND, zygoteCreated = true, startNewSession = true)
         verifyPayloadWithState(state = BACKGROUND, zygoteCreated = true, startNewSession = true)
@@ -64,7 +64,7 @@ internal class PayloadFactoryImplTest {
     @Test
     fun `verify expected payloads with ba disabled`() {
         configService.backgroundActivityBehavior = createBackgroundActivityBehavior(
-            remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 0f))
+            remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 0f)),
         )
         verifyPayloadWithState(state = FOREGROUND, zygoteCreated = true, startNewSession = false)
         verifyPayloadWithState(state = BACKGROUND, zygoteCreated = false, startNewSession = false)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImplTest.kt
@@ -39,7 +39,7 @@ internal class PayloadMessageCollatorImplTest {
         val sessionPartEnvelopeSource = SessionPartEnvelopeSourceImpl(
             metadataSource = FakeEnvelopeMetadataSource(),
             resourceSource = FakeEnvelopeResourceSource(),
-            payloadSource = FakeSessionPartPayloadSource()
+            payloadSource = FakeSessionPartPayloadSource(),
         )
         currentSessionPartSpan = initModule.openTelemetryModule.currentSessionPartSpan
         collator = PayloadMessageCollatorImpl(
@@ -59,7 +59,7 @@ internal class PayloadMessageCollatorImplTest {
                 AppState.BACKGROUND,
                 1,
                 1,
-            )
+            ),
         )
         msg.verifyInitialFieldsPopulated()
     }
@@ -74,7 +74,7 @@ internal class PayloadMessageCollatorImplTest {
                 AppState.FOREGROUND,
                 1,
                 1,
-            )
+            ),
         )
         msg.verifyInitialFieldsPopulated()
     }
@@ -90,7 +90,7 @@ internal class PayloadMessageCollatorImplTest {
                 AppState.BACKGROUND,
                 1,
                 1,
-            )
+            ),
         )
         startMsg.verifyInitialFieldsPopulated()
 
@@ -101,8 +101,8 @@ internal class PayloadMessageCollatorImplTest {
                 endType = SessionPartSnapshotType.NORMAL_END,
                 logger = initModule.logger,
                 continueMonitoring = true,
-                crashId = "crashId"
-            )
+                crashId = "crashId",
+            ),
         )
         payload.verifyFinalFieldsPopulated()
     }
@@ -118,7 +118,7 @@ internal class PayloadMessageCollatorImplTest {
                 AppState.FOREGROUND,
                 1,
                 1,
-            )
+            ),
         )
         startMsg.verifyInitialFieldsPopulated()
 
@@ -130,7 +130,7 @@ internal class PayloadMessageCollatorImplTest {
                 logger = initModule.logger,
                 continueMonitoring = true,
                 crashId = "crashId",
-            )
+            ),
         )
         payload.verifyFinalFieldsPopulated()
     }
@@ -149,7 +149,7 @@ internal class PayloadMessageCollatorImplTest {
                             previousState,
                             1,
                             1,
-                        )
+                        ),
                     ).verifyInitialFieldsPopulated()
                 }
             }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/OrchestratorBoundaryDelegateTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/OrchestratorBoundaryDelegateTest.kt
@@ -14,7 +14,7 @@ internal class OrchestratorBoundaryDelegateTest {
     fun setUp() {
         userSessionPropertiesService = FakeUserSessionPropertiesService()
         delegate = OrchestratorBoundaryDelegate(
-            userSessionPropertiesService
+            userSessionPropertiesService,
         )
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorListenerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorListenerTest.kt
@@ -87,8 +87,8 @@ internal class SessionOrchestratorListenerTest {
         startupClassifier = StartupClassifierImpl()
         configService = FakeConfigService(
             backgroundActivityBehavior = createBackgroundActivityBehavior(
-                remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 100f))
-            )
+                remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 100f)),
+            ),
         )
     }
 
@@ -177,7 +177,7 @@ internal class SessionOrchestratorListenerTest {
                 SessionStateEvent.UserSessionEnded::class,
                 SessionStateEvent.UserSessionActive::class,
             ),
-            events.map { it::class }
+            events.map { it::class },
         )
     }
 
@@ -252,18 +252,18 @@ internal class SessionOrchestratorListenerTest {
                 partIndex = 1,
                 lastActivityMs = clock.now(),
                 isBackgroundOnly = false,
-            )
+            ),
         )
     }
 
     private fun sessionBehaviorConfig() = FakeConfigService(
         backgroundActivityBehavior = createBackgroundActivityBehavior(
-            remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 100f))
+            remoteCfg = RemoteConfig(backgroundActivityConfig = BackgroundActivityRemoteConfig(threshold = 100f)),
         ),
         sessionBehavior = FakeUserSessionBehavior(
             maxSessionDurationMs = maxDurationMs,
             sessionInactivityTimeoutMs = inactivityMs,
-        )
+        ),
     )
 
     private fun collectEvents(vararg targetTypes: kotlin.reflect.KClass<out SessionStateEvent>): MutableList<SessionStateEvent> {
@@ -292,19 +292,19 @@ internal class SessionOrchestratorListenerTest {
             payloadMessageCollator = payloadCollator,
             logEnvelopeSource = payloadSourceModule.logEnvelopeSource,
             configService = configService,
-            logger = logger
+            logger = logger,
         )
         userSessionPropertiesService = FakeUserSessionPropertiesService()
         userService = FakeUserService()
         sessionTracker = SessionPartTrackerImpl(
             activityManager = null,
-            logger = logger
+            logger = logger,
         )
         sessionCacheExecutor = BlockingScheduledExecutorService(clock, true)
         payloadCachingService = PayloadCachingServiceImpl(
             PeriodicSessionPartCacher(
                 BackgroundWorker(sessionCacheExecutor),
-                logger
+                logger,
             ),
             clock,
             object : SessionIdsProvider {
@@ -313,17 +313,17 @@ internal class SessionOrchestratorListenerTest {
                 override fun getActiveSessionIds(): SessionIdsSnapshot =
                     SessionIdsSnapshot(userSessionId = "", sessionPartId = sessionTracker.getActiveSessionPartId() ?: "")
             },
-            store
+            store,
         )
         fakeDataSource = FakeDataSource(RuntimeEnvironment.getApplication())
         instrumentationRegistry = InstrumentationRegistryImpl(
-            logger
+            logger,
         ).apply {
             add(
                 DataSourceState(
                     factory = { fakeDataSource },
-                    configGate = { true }
-                )
+                    configGate = { true },
+                ),
             )
         }
 
@@ -334,7 +334,7 @@ internal class SessionOrchestratorListenerTest {
             configService,
             sessionTracker,
             OrchestratorBoundaryDelegate(
-                userSessionPropertiesService
+                userSessionPropertiesService,
             ),
             store,
             payloadCachingService,
@@ -344,7 +344,7 @@ internal class SessionOrchestratorListenerTest {
                 destination,
                 { 0 },
                 FakeLogLimitingService(),
-                FakeMetadataService()
+                FakeMetadataService(),
             ),
             ordinalStoreOverride ?: FakeOrdinalStore(),
             metadataStoreOverride ?: UserSessionMetadataStore(FakeKeyValueStore()),

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -140,7 +140,7 @@ internal class SessionOrchestratorTest {
         validateSession(
             sessionPartSpan = sessionPartSpan,
             endTimeMs = foregroundTime,
-            endType = LifeEventType.BKGND_STATE
+            endType = LifeEventType.BKGND_STATE,
         )
         assertTrue(store.cachedEmptyCrashPayloads.isEmpty())
         with(checkNotNull(activeUserSession())) {
@@ -159,7 +159,7 @@ internal class SessionOrchestratorTest {
         validateSession(
             sessionPartSpan = sessionPartSpan,
             endTimeMs = backgroundTime,
-            endType = LifeEventType.STATE
+            endType = LifeEventType.STATE,
         )
         assertTrue(store.cachedEmptyCrashPayloads.isEmpty())
     }
@@ -222,7 +222,7 @@ internal class SessionOrchestratorTest {
         validateSession(
             sessionPartSpan = sessionPartSpan,
             endTimeMs = endTimeMs,
-            endType = LifeEventType.MANUAL
+            endType = LifeEventType.MANUAL,
         )
         assertTrue(store.cachedEmptyCrashPayloads.isEmpty())
     }
@@ -279,7 +279,7 @@ internal class SessionOrchestratorTest {
         createOrchestrator(
             startingAppState = AppState.FOREGROUND,
             configService = FakeConfigService(
-                sessionBehavior = FakeUserSessionBehavior(sessionControlEnabled = true)
+                sessionBehavior = FakeUserSessionBehavior(sessionControlEnabled = true),
             ),
         )
 
@@ -491,7 +491,7 @@ internal class SessionOrchestratorTest {
         createOrchestrator(
             startingAppState = AppState.FOREGROUND,
             configService = FakeConfigService(
-                backgroundActivityBehavior = backgroundActivityBehavior(true)
+                backgroundActivityBehavior = backgroundActivityBehavior(true),
             ),
         )
         orchestrator.onBackground()
@@ -650,7 +650,7 @@ internal class SessionOrchestratorTest {
 
                 override fun edit(action: KeyValueStoreEditor.() -> Unit) = FakeKeyValueStore().edit(action)
                 override fun incrementAndGet(key: String): Int = 0
-            }
+            },
         )
 
         createOrchestrator(
@@ -797,7 +797,7 @@ internal class SessionOrchestratorTest {
         createOrchestrator(
             startingAppState = AppState.FOREGROUND,
             configService = sessionLimitsConfigService(
-                customInactivityTimeoutMs = TimeUnit.SECONDS.toMillis(configInactivitySecs)
+                customInactivityTimeoutMs = TimeUnit.SECONDS.toMillis(configInactivitySecs),
             ),
             metadataStoreOverride = persistedStore,
         )
@@ -991,14 +991,14 @@ internal class SessionOrchestratorTest {
         userSessionPropertiesService = FakeUserSessionPropertiesService()
         sessionTracker = SessionPartTrackerImpl(
             activityManager = null,
-            logger = logger
+            logger = logger,
         )
         sessionCacheExecutor = BlockingScheduledExecutorService(clock, true)
         inactivityWorkerExecutor = BlockingScheduledExecutorService(clock, true)
         payloadCachingService = PayloadCachingServiceImpl(
             PeriodicSessionPartCacher(
                 BackgroundWorker(sessionCacheExecutor),
-                logger
+                logger,
             ),
             clock,
             object : SessionIdsProvider {
@@ -1007,17 +1007,17 @@ internal class SessionOrchestratorTest {
                 override fun getActiveSessionIds(): SessionIdsSnapshot =
                     SessionIdsSnapshot(userSessionId = "", sessionPartId = sessionTracker.getActiveSessionPartId() ?: "")
             },
-            store
+            store,
         )
         fakeDataSource = FakeDataSource(RuntimeEnvironment.getApplication())
         instrumentationRegistry = InstrumentationRegistryImpl(
-            logger
+            logger,
         ).apply {
             add(
                 DataSourceState(
                     factory = { fakeDataSource },
-                    configGate = { true }
-                )
+                    configGate = { true },
+                ),
             )
         }
 
@@ -1028,7 +1028,7 @@ internal class SessionOrchestratorTest {
             configService,
             sessionTracker,
             OrchestratorBoundaryDelegate(
-                userSessionPropertiesService
+                userSessionPropertiesService,
             ),
             store,
             payloadCachingService,
@@ -1038,7 +1038,7 @@ internal class SessionOrchestratorTest {
                 destination,
                 { 0 },
                 FakeLogLimitingService(),
-                FakeMetadataService()
+                FakeMetadataService(),
             ),
             ordinalStoreOverride ?: FakeOrdinalStore(),
             metadataStoreOverride ?: UserSessionMetadataStore(FakeKeyValueStore()),
@@ -1376,7 +1376,7 @@ internal class SessionOrchestratorTest {
     fun `restored background user session is reused when process starts in background`() {
         val store = storeWithUserSession(
             userSessionId = "bg-session-id",
-            isBackgroundOnly = true
+            isBackgroundOnly = true,
         )
 
         // Starting with the clock beyond the inactivity time should not result in a new background only session
@@ -1401,7 +1401,7 @@ internal class SessionOrchestratorTest {
     fun `restored background user session past max duration is discarded`() {
         val store = storeWithUserSession(
             userSessionId = "bg-session-id",
-            isBackgroundOnly = true
+            isBackgroundOnly = true,
         )
 
         clock.tick(maxDurationMs + 1)
@@ -1427,7 +1427,7 @@ internal class SessionOrchestratorTest {
     fun `restored background user session is replaced when process starts in foreground`() {
         val store = storeWithUserSession(
             userSessionId = "bg-session-id",
-            isBackgroundOnly = true
+            isBackgroundOnly = true,
         )
 
         clock.tick(1000)
@@ -1458,7 +1458,7 @@ internal class SessionOrchestratorTest {
                 backgroundOnly = false,
                 reason = EmbUserSessionTerminationReasonValues.MAX_DURATION_REACHED,
             ),
-            orchestrator.userSessionRestoreDecision
+            orchestrator.userSessionRestoreDecision,
         )
     }
 
@@ -1478,7 +1478,7 @@ internal class SessionOrchestratorTest {
                 backgroundOnly = false,
                 reason = EmbUserSessionTerminationReasonValues.INACTIVITY,
             ),
-            orchestrator.userSessionRestoreDecision
+            orchestrator.userSessionRestoreDecision,
         )
     }
 
@@ -1498,7 +1498,7 @@ internal class SessionOrchestratorTest {
                 backgroundOnly = true,
                 reason = EmbUserSessionTerminationReasonValues.MAX_DURATION_REACHED,
             ),
-            orchestrator.userSessionRestoreDecision
+            orchestrator.userSessionRestoreDecision,
         )
     }
 
@@ -1514,7 +1514,7 @@ internal class SessionOrchestratorTest {
         assertEquals("live-id", activeUserSession().userSessionId)
         assertEquals(
             UserSessionRestoreDecision.Restored(userSessionId = "live-id", backgroundOnly = false),
-            orchestrator.userSessionRestoreDecision
+            orchestrator.userSessionRestoreDecision,
         )
     }
 
@@ -1530,7 +1530,7 @@ internal class SessionOrchestratorTest {
         assertEquals("bg-live", activeUserSession().userSessionId)
         assertEquals(
             UserSessionRestoreDecision.Restored(userSessionId = "bg-live", backgroundOnly = true),
-            orchestrator.userSessionRestoreDecision
+            orchestrator.userSessionRestoreDecision,
         )
     }
 
@@ -1559,7 +1559,7 @@ internal class SessionOrchestratorTest {
                 backgroundOnly = false,
                 reason = EmbUserSessionTerminationReasonValues.CLOCK_MISMATCH,
             ),
-            orchestrator.userSessionRestoreDecision
+            orchestrator.userSessionRestoreDecision,
         )
     }
 
@@ -1779,7 +1779,7 @@ internal class SessionOrchestratorTest {
         sessionBehavior = FakeUserSessionBehavior(
             maxSessionDurationMs = customMaxSessionDurationMs,
             sessionInactivityTimeoutMs = customInactivityTimeoutMs,
-        )
+        ),
     )
 
     private fun backgroundActivityBehavior(enabled: Boolean) = createBackgroundActivityBehavior(
@@ -1789,9 +1789,9 @@ internal class SessionOrchestratorTest {
                     100f
                 } else {
                     0f
-                }
-            )
-        )
+                },
+            ),
+        ),
     )
 
     private fun storeWithUserSession(
@@ -1814,7 +1814,7 @@ internal class SessionOrchestratorTest {
                 partIndex = partIndex,
                 lastActivityMs = lastActivityMs,
                 isBackgroundOnly = isBackgroundOnly,
-            )
+            ),
         )
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
@@ -40,7 +40,7 @@ internal class SessionPartSpanAttrPopulatorImplTest {
             destination,
             { 0 },
             FakeLogLimitingService(),
-            FakeMetadataService()
+            FakeMetadataService(),
         )
     }
 
@@ -109,7 +109,7 @@ internal class SessionPartSpanAttrPopulatorImplTest {
             EmbSessionAttributes.EMB_CRASH_ID to "crashId",
             EmbSessionAttributes.EMB_SESSION_END_TYPE to "state",
             EmbSessionAttributes.EMB_ERROR_LOG_COUNT to "0",
-            EmbSessionAttributes.EMB_DISK_FREE_BYTES to "500000000"
+            EmbSessionAttributes.EMB_DISK_FREE_BYTES to "500000000",
         )
         assertEquals(expected, attrs)
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStoreTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/V2PayloadStoreTest.kt
@@ -51,7 +51,7 @@ class V2PayloadStoreTest {
         verifySessionIntake(
             envelope,
             intakeService.getIntakes(),
-            "p3_1692201601000_fakeuuid_fakeProcessId_true_session_${USER_SESSION_ID}_${SESSION_PART_ID}_v2.json"
+            "p3_1692201601000_fakeuuid_fakeProcessId_true_session_${USER_SESSION_ID}_${SESSION_PART_ID}_v2.json",
         )
     }
 
@@ -62,7 +62,7 @@ class V2PayloadStoreTest {
         verifySessionIntake(
             envelope,
             intakeService.getIntakes(),
-            "p3_1692201601000_fakeuuid_fakeProcessId_true_session_${USER_SESSION_ID}_${SESSION_PART_ID}_v2.json"
+            "p3_1692201601000_fakeuuid_fakeProcessId_true_session_${USER_SESSION_ID}_${SESSION_PART_ID}_v2.json",
         )
     }
 
@@ -75,7 +75,7 @@ class V2PayloadStoreTest {
         assertSame(envelope, intake.envelope)
         assertEquals(
             "p5_1692201601000_fakeuuid_fakeProcessId_true_unknown_${USER_SESSION_ID}_${SESSION_PART_ID}_v2.json",
-            intake.metadata.filename
+            intake.metadata.filename,
         )
         assertEquals(0, intakeService.shutdownCount)
     }
@@ -93,7 +93,7 @@ class V2PayloadStoreTest {
         verifySessionIntake(
             envelope,
             intakeService.getIntakes(false),
-            "p3_1692201601000_fakeuuid_fakeProcessId_false_session_${USER_SESSION_ID}_${SESSION_PART_ID}_v2.json"
+            "p3_1692201601000_fakeuuid_fakeProcessId_false_session_${USER_SESSION_ID}_${SESSION_PART_ID}_v2.json",
         )
     }
 
@@ -114,7 +114,7 @@ class V2PayloadStoreTest {
         listOf(
             System.Exit,
             System.Exception,
-            System.Log
+            System.Log,
         ).forEach { type ->
             storeLogWithType(type)
             assertEquals(SupportedEnvelopeType.LOG, getLastLogMetadata().envelopeType)
@@ -136,7 +136,7 @@ class V2PayloadStoreTest {
         assertSame(envelope, intake.envelope)
         assertEquals(
             "p4_1692201601000_fakeuuid_fakeProcessId_true_attachment_${USER_SESSION_ID}_${SESSION_PART_ID}_v2.json",
-            intake.metadata.filename
+            intake.metadata.filename,
         )
         assertEquals(0, intakeService.shutdownCount)
     }
@@ -145,9 +145,9 @@ class V2PayloadStoreTest {
         val envelope = Envelope(
             data = LogPayload(
                 logs = listOf(
-                    Log(attributes = listOf(Attribute("emb.type", type.value)))
-                )
-            )
+                    Log(attributes = listOf(Attribute("emb.type", type.value))),
+                ),
+            ),
         )
         store.storeLogPayload(envelope, true)
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImplTests.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImplTests.kt
@@ -127,16 +127,16 @@ internal class CurrentSessionPartSpanImplTests {
             assertNotNull(
                 spanService.createSpan(
                     name = "spanzzz$it",
-                    internal = false
-                )
+                    internal = false,
+                ),
             )
         }
         assertEquals(
             NoopEmbraceSdkSpan,
             spanService.createSpan(
                 name = "failed-span",
-                internal = false
-            )
+                internal = false,
+            ),
         )
     }
 
@@ -146,16 +146,16 @@ internal class CurrentSessionPartSpanImplTests {
             assertNotNull(
                 spanService.createSpan(
                     name = "spanzzz$it",
-                    internal = false
-                )
+                    internal = false,
+                ),
             )
         }
         assertEquals(
             NoopEmbraceSdkSpan,
             spanService.createSpan(
                 name = "failed-span",
-                internal = false
-            )
+                internal = false,
+            ),
         )
 
         repeat(MAX_INTERNAL_SPANS_PER_SESSION) {
@@ -163,7 +163,7 @@ internal class CurrentSessionPartSpanImplTests {
         }
         assertEquals(
             NoopEmbraceSdkSpan,
-            spanService.createSpan(name = "failed-span")
+            spanService.createSpan(name = "failed-span"),
         )
     }
 
@@ -179,8 +179,8 @@ internal class CurrentSessionPartSpanImplTests {
                         private = false,
                         tracer = tracer,
                         openTelemetry = openTelemetry,
-                    )
-                )
+                    ),
+                ),
             )
         }
         assertEquals(
@@ -193,8 +193,8 @@ internal class CurrentSessionPartSpanImplTests {
                     private = false,
                     tracer = tracer,
                     openTelemetry = openTelemetry,
-                )
-            )
+                ),
+            ),
         )
         assertNotNull(
             spanService.createSpan(
@@ -205,8 +205,8 @@ internal class CurrentSessionPartSpanImplTests {
                     private = false,
                     tracer = tracer,
                     openTelemetry = openTelemetry,
-                )
-            )
+                ),
+            ),
         )
     }
 
@@ -218,7 +218,7 @@ internal class CurrentSessionPartSpanImplTests {
                 spanService.recordSpan(
                     name = "record$it",
                     internal = false,
-                ) { "derp" }
+                ) { "derp" },
             )
         }
         assertEquals(
@@ -226,7 +226,7 @@ internal class CurrentSessionPartSpanImplTests {
             spanService.createSpan(
                 name = "failed-span",
                 internal = false,
-            )
+            ),
         )
     }
 
@@ -239,7 +239,7 @@ internal class CurrentSessionPartSpanImplTests {
                     startTimeMs = 100L,
                     endTimeMs = 200L,
                     internal = false,
-                )
+                ),
             )
         }
         assertEquals(
@@ -247,7 +247,7 @@ internal class CurrentSessionPartSpanImplTests {
             spanService.createSpan(
                 name = "failed-span",
                 internal = false,
-            )
+            ),
         )
     }
 
@@ -257,7 +257,7 @@ internal class CurrentSessionPartSpanImplTests {
             spanService.createSpan(
                 name = "test-span",
                 internal = false,
-            )
+            ),
         )
         assertTrue(parent.start())
         repeat(MAX_NON_INTERNAL_SPANS_PER_SESSION - 1) {
@@ -266,7 +266,7 @@ internal class CurrentSessionPartSpanImplTests {
                 spanService.createSpan(
                     name = "spanzzz$it",
                     internal = false,
-                )
+                ),
             )
         }
         assertEquals(
@@ -274,7 +274,7 @@ internal class CurrentSessionPartSpanImplTests {
             spanService.createSpan(
                 name = "failed-span",
                 internal = false,
-            )
+            ),
         )
         assertEquals(
             NoopEmbraceSdkSpan,
@@ -282,18 +282,18 @@ internal class CurrentSessionPartSpanImplTests {
                 name = "child-span",
                 parent = parent,
                 internal = false,
-            )
+            ),
         )
         assertNotNull(
             spanService.createSpan(
                 name = "internal-again",
-            )
+            ),
         )
         assertNotNull(
             spanService.createSpan(
                 name = "internal-child-span",
                 parent = parent,
-            )
+            ),
         )
     }
 
@@ -315,7 +315,7 @@ internal class CurrentSessionPartSpanImplTests {
                 name = "failed-span",
                 parent = parentSpan,
                 internal = false,
-            )
+            ),
         )
         assertFalse(
             spanService.recordCompletedSpan(
@@ -324,7 +324,7 @@ internal class CurrentSessionPartSpanImplTests {
                 endTimeMs = 200L,
                 parent = parentSpan,
                 internal = false,
-            )
+            ),
         )
         spanSink.flushSpans()
         assertEquals(
@@ -333,7 +333,7 @@ internal class CurrentSessionPartSpanImplTests {
                 name = "failed-span",
                 parent = parentSpan,
                 internal = false,
-            ) { 2 }
+            ) { 2 },
         )
         assertEquals(0, spanSink.completedSpans().size)
     }
@@ -343,20 +343,20 @@ internal class CurrentSessionPartSpanImplTests {
         val parentSpan = checkNotNull(
             spanService.createSpan(
                 name = "parent-span",
-            )
+            ),
         )
         assertTrue(parentSpan.start())
         assertNotNull(
             spanService.createSpan(
                 name = "failed-span",
                 parent = parentSpan,
-            )
+            ),
         )
         assertNotNull(
             spanService.recordSpan(
                 name = "failed-span",
                 parent = parentSpan,
-            ) { }
+            ) { },
         )
         assertTrue(
             spanService.recordCompletedSpan(
@@ -364,7 +364,7 @@ internal class CurrentSessionPartSpanImplTests {
                 startTimeMs = 100L,
                 endTimeMs = 200L,
                 parent = parentSpan,
-            )
+            ),
         )
 
         repeat(MAX_NON_INTERNAL_SPANS_PER_SESSION) {
@@ -373,7 +373,7 @@ internal class CurrentSessionPartSpanImplTests {
                     name = "spanzzz$it",
                     parent = parentSpan,
                     internal = false,
-                )
+                ),
             )
         }
         assertEquals(
@@ -382,13 +382,13 @@ internal class CurrentSessionPartSpanImplTests {
                 name = "failed-span",
                 parent = parentSpan,
                 internal = false,
-            )
+            ),
         )
         assertNotNull(
             spanService.createSpan(
                 name = "internal-span",
                 parent = parentSpan,
-            )
+            ),
         )
     }
 
@@ -436,8 +436,8 @@ internal class CurrentSessionPartSpanImplTests {
             expectedErrorCode = ErrorCode.FAILURE,
             expectedCustomAttributes = mapOf(
                 AppTerminationCause.Crash.asPair(),
-                EmbType.Ux.Session.asPair()
-            )
+                EmbType.Ux.Session.asPair(),
+            ),
         )
 
         assertEmbraceSpanData(
@@ -447,8 +447,8 @@ internal class CurrentSessionPartSpanImplTests {
             expectedParentId = OtelIds.INVALID_SPAN_ID,
             expectedErrorCode = ErrorCode.FAILURE,
             expectedCustomAttributes = mapOf(
-                EmbType.Performance.Default.asPair()
-            )
+                EmbType.Performance.Default.asPair(),
+            ),
         )
 
         assertEquals(0, spanSink.completedSpans().size)
@@ -546,7 +546,7 @@ internal class CurrentSessionPartSpanImplTests {
             spanService.createSpan(
                 name = "child-span",
                 parent = parentSpan,
-            )
+            ),
         )
 
         // active span from before flush is still available and working
@@ -579,7 +579,7 @@ internal class CurrentSessionPartSpanImplTests {
         checkNotNull(spanSnapshot.links).single().validateSystemLink(
             linkedSpan = sessionPartSpanSnapshot,
             type = LinkType.EndSessionPart,
-            expectedAttributes = expectedPartLinkAttrs
+            expectedAttributes = expectedPartLinkAttrs,
         )
         checkNotNull(sessionPartSpanSnapshot.links).single().validateSystemLink(
             linkedSpan = spanSnapshot,

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/EmbraceTracerTest.kt
@@ -89,7 +89,7 @@ internal class EmbraceTracerTest {
                 name = "child-span",
                 parent = parent,
                 startTimeMs = childStartTimeMs,
-            )
+            ),
         )
         assertTrue(parent.stop())
         assertTrue(child.stop())
@@ -113,7 +113,7 @@ internal class EmbraceTracerTest {
     fun `record lambda running as span`() {
         val expectedAttributes = mapOf(
             Pair("attribute1", "value1"),
-            Pair("attribute2", "value2")
+            Pair("attribute2", "value2"),
         )
 
         val expectedEvents: List<EmbraceSpanEvent> =
@@ -130,7 +130,7 @@ internal class EmbraceTracerTest {
             name = "lambda-test-span",
             parent = parentSpan,
             attributes = expectedAttributes,
-            events = expectedEvents
+            events = expectedEvents,
         ) {
             clock.tick(10)
             returnThis
@@ -157,8 +157,8 @@ internal class EmbraceTracerTest {
             embraceTracer.recordCompletedSpan(
                 name = expectedName,
                 startTimeMs = expectedStartTimeMs,
-                endTimeMs = expectedEndTimeMs
-            )
+                endTimeMs = expectedEndTimeMs,
+            ),
         )
 
         with(verifyPublicSpan(expectedName)) {
@@ -178,8 +178,8 @@ internal class EmbraceTracerTest {
                 name = expectedName,
                 startTimeMs = expectedStartTimeMs,
                 endTimeMs = expectedEndTimeMs,
-                errorCode = ErrorCode.FAILURE
-            )
+                errorCode = ErrorCode.FAILURE,
+            ),
         )
 
         with(verifyPublicSpan(expectedName, true, ErrorCode.FAILURE)) {
@@ -202,8 +202,8 @@ internal class EmbraceTracerTest {
                 name = expectedName,
                 startTimeMs = expectedStartTimeMs,
                 endTimeMs = expectedEndTimeMs,
-                parent = parentSpan
-            )
+                parent = parentSpan,
+            ),
         )
 
         with(verifyPublicSpan(expectedName, false)) {
@@ -226,8 +226,8 @@ internal class EmbraceTracerTest {
                 startTimeMs = expectedStartTimeMs,
                 endTimeMs = expectedEndTimeMs,
                 parent = parentSpan,
-                errorCode = ErrorCode.USER_ABANDON
-            )
+                errorCode = ErrorCode.USER_ABANDON,
+            ),
         )
 
         with(verifyPublicSpan(expectedName, false, ErrorCode.USER_ABANDON)) {
@@ -244,7 +244,7 @@ internal class EmbraceTracerTest {
         val expectedEndTimeMs = expectedStartTimeMs + 100L
         val expectedAttributes = mapOf(
             Pair("attribute1", "value1"),
-            Pair("attribute2", "value2")
+            Pair("attribute2", "value2"),
         )
         val expectedEvents: List<EmbraceSpanEvent> =
             listOfNotNull(
@@ -258,8 +258,8 @@ internal class EmbraceTracerTest {
                 startTimeMs = expectedStartTimeMs,
                 endTimeMs = expectedEndTimeMs,
                 attributes = expectedAttributes,
-                events = expectedEvents
-            )
+                events = expectedEvents,
+            ),
         )
 
         with(verifyPublicSpan(expectedName)) {
@@ -292,8 +292,8 @@ internal class EmbraceTracerTest {
             span.addEvent(
                 name = "second event",
                 timestampMs = eventTimeNanos,
-                attributes = mapOf("key" to "value")
-            )
+                attributes = mapOf("key" to "value"),
+            ),
         )
         assertTrue(span.stop())
         with(verifyPublicSpan("my-span")) {
@@ -311,8 +311,8 @@ internal class EmbraceTracerTest {
             embraceTracer.startSpan(
                 name = "fallback-span",
                 parent = null,
-                startTimeMs = expectedStartTimeNanos
-            )
+                startTimeMs = expectedStartTimeNanos,
+            ),
         )
         clock.tick(10L)
         val expectedEndTimeNanos = clock.now().millisToNanos()
@@ -333,8 +333,8 @@ internal class EmbraceTracerTest {
             embraceTracer.recordCompletedSpan(
                 name = expectedName,
                 startTimeMs = expectedStartTimeNanos,
-                endTimeMs = expectedEndTimeNanos
-            )
+                endTimeMs = expectedEndTimeNanos,
+            ),
         )
 
         with(verifyPublicSpan(expectedName)) {

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/storage/EmbraceStorageServiceTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/storage/EmbraceStorageServiceTest.kt
@@ -28,7 +28,7 @@ internal class EmbraceStorageServiceTest {
         cacheDir = Files.createTempDirectory("cache_temp").toFile()
         filesDir = Files.createTempDirectory("files_temp").toFile()
         val embraceFilesPath = Files.createDirectory(
-            Paths.get(filesDir.absolutePath, "embrace")
+            Paths.get(filesDir.absolutePath, "embrace"),
         ).toFile()
         embraceFilesDir = embraceFilesPath.absolutePath
         val ctx = mockk<Context>()

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/telemetry/EmbraceTelemetryServiceTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/telemetry/EmbraceTelemetryServiceTest.kt
@@ -78,7 +78,7 @@ internal class EmbraceTelemetryServiceTest {
         // That method isn't in the map anymore
         assertEquals(
             null,
-            embraceTelemetryService.getAndClearTelemetryAttributes().getOrDefault("emb.storage.a_file", null)
+            embraceTelemetryService.getAndClearTelemetryAttributes().getOrDefault("emb.storage.a_file", null),
         )
     }
 
@@ -115,7 +115,7 @@ internal class EmbraceTelemetryServiceTest {
         // Given no limits have been logged
         assertEquals(
             null,
-            embraceTelemetryService.getAndClearTelemetryAttributes()["emb.private.applied_limit.error_log.truncate_attributes"]
+            embraceTelemetryService.getAndClearTelemetryAttributes()["emb.private.applied_limit.error_log.truncate_attributes"],
         )
 
         // When a limit is logged
@@ -124,7 +124,7 @@ internal class EmbraceTelemetryServiceTest {
         // Then the limit is in the map
         assertEquals(
             "1",
-            embraceTelemetryService.getAndClearTelemetryAttributes()["emb.private.applied_limit.error_log.truncate_attributes"]
+            embraceTelemetryService.getAndClearTelemetryAttributes()["emb.private.applied_limit.error_log.truncate_attributes"],
         )
     }
 
@@ -140,7 +140,7 @@ internal class EmbraceTelemetryServiceTest {
         // Then the counter is incremented
         assertEquals(
             "3",
-            embraceTelemetryService.getAndClearTelemetryAttributes()["emb.private.applied_limit.breadcrumb.truncate_string"]
+            embraceTelemetryService.getAndClearTelemetryAttributes()["emb.private.applied_limit.breadcrumb.truncate_string"],
         )
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/utils/ThreadExtKtTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/utils/ThreadExtKtTest.kt
@@ -22,7 +22,7 @@ class ThreadExtKtTest {
         val threadInfo = truncateStacktrace(
             thread = targetThread,
             stackTraceElements = targetThread.stackTrace,
-            maxStacktraceSize = 4
+            maxStacktraceSize = 4,
         )
         with(threadInfo) {
             assertEquals(true, name?.contains("Main"))
@@ -37,7 +37,7 @@ class ThreadExtKtTest {
     fun `verify default stacktrace size is 200`() {
         val threadInfo = truncateStacktrace(
             thread = currentThread(),
-            stackTraceElements = fakeBigStackTrace
+            stackTraceElements = fakeBigStackTrace,
         )
         assertEquals(200, threadInfo.lines?.size)
     }
@@ -47,7 +47,7 @@ class ThreadExtKtTest {
         val threadInfo = truncateStacktrace(
             thread = currentThread(),
             stackTraceElements = fakeBigStackTrace,
-            maxStacktraceSize = 600
+            maxStacktraceSize = 600,
         )
         assertEquals(500, threadInfo.lines?.size)
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/worker/BackgroundWorkerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/worker/BackgroundWorkerTest.kt
@@ -89,7 +89,7 @@ internal class BackgroundWorkerTest {
         val worker = BackgroundWorker(
             ShutdownAndWaitExecutorService(postShutdownAction = {
                 latch.countDown()
-            })
+            }),
         )
 
         var ran = false
@@ -107,7 +107,7 @@ internal class BackgroundWorkerTest {
         val worker = BackgroundWorker(
             ShutdownAndWaitExecutorService(postAwaitTerminationAction = {
                 latch.countDown()
-            })
+            }),
         )
 
         var ran = false

--- a/embrace-android-delivery-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadStorageService.kt
+++ b/embrace-android-delivery-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadStorageService.kt
@@ -127,7 +127,7 @@ class FakePayloadStorageService(
         }
         return serializer.fromJson(
             GZIPInputStream(loadPayloadAsStream(metadata)),
-            Envelope.logEnvelopeSerializer
+            Envelope.logEnvelopeSerializer,
         )
     }
 }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/debug/DeliveryTraceState.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/debug/DeliveryTraceState.kt
@@ -145,7 +145,7 @@ internal sealed class DeliveryTraceState {
      */
     class ServerCompletedRequest(
         private val endpoint: String,
-        private val metadata: String
+        private val metadata: String,
     ) : DeliveryTraceState() {
         override fun toString(): String = "[$threadName] ServerCompletedRequest, $endpoint $metadata"
     }
@@ -156,6 +156,6 @@ internal sealed class DeliveryTraceState {
 
     internal fun List<StoredTelemetryMetadata>.reportListString() = joinToString(
         "\n",
-        transform = { it.toReportString() }
+        transform = { it.toReportString() },
     )
 }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/ExecutionResult.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/ExecutionResult.kt
@@ -72,13 +72,13 @@ sealed class ExecutionResult(
             return when (responseCode) {
                 null -> Incomplete(
                     exception = executionError ?: IllegalStateException("Unknown execution error"),
-                    retry = true
+                    retry = true,
                 )
 
                 HTTP_OK -> Success
                 HTTP_TOO_MANY_REQUESTS -> TooManyRequests(
                     endpoint,
-                    headersProvider()["Retry-After"]?.toLongOrNull()?.times(1000)
+                    headersProvider()["Retry-After"]?.toLongOrNull()?.times(1000),
                 )
 
                 in HTTP_FAILURES -> Failure(responseCode)

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionService.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionService.kt
@@ -57,7 +57,7 @@ class OkHttpRequestExecutionService(
             if (throwable !is IOException) {
                 logger.trackInternalError(
                     type = InternalErrorType.PayloadDeliveryFail,
-                    throwable = throwable
+                    throwable = throwable,
                 )
             }
             executionError = throwable
@@ -85,7 +85,7 @@ class OkHttpRequestExecutionService(
                 apiRequest
                     .getHeaders()
                     .plus("X-EM-PAYLOAD-TYPES" to payloadType)
-                    .toHeaders()
+                    .toHeaders(),
             )
             .post(ApiRequestBody(payloadStream))
             .build()
@@ -124,7 +124,7 @@ class OkHttpRequestExecutionService(
             multipart -> "multipart/form-data"
             else -> "application/json"
         },
-        userAgent = "Embrace/a/$embraceVersionName"
+        userAgent = "Embrace/a/$embraceVersionName",
     )
 
     class ApiRequestBody(

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImpl.kt
@@ -91,7 +91,7 @@ class IntakeServiceImpl(
             processIntake(
                 intake = intake,
                 metadata = metadata,
-                staleEntry = staleEntry
+                staleEntry = staleEntry,
             )
         }
 

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImpl.kt
@@ -47,7 +47,7 @@ class SchedulingServiceImpl(
     private val scheduledDeliveryAttempt: ScheduledDeliveryAttempt = ScheduledDeliveryAttempt(
         clock = clock,
         scheduleAction = ::queueDeliveryAttempt,
-        worker = schedulingWorker
+        worker = schedulingWorker,
     )
 
     override fun onPayloadIntake() {
@@ -145,7 +145,7 @@ class SchedulingServiceImpl(
             .firstOrNull()
         deliveryTracer?.onFindNextPayload(
             payloadsByPriority,
-            payloadToSend
+            payloadToSend,
         )
         return payloadToSend
     }
@@ -167,7 +167,7 @@ class SchedulingServiceImpl(
                         executionService.attemptHttpRequest(
                             payloadStream = { this },
                             envelopeType = payload.envelopeType,
-                            payloadType = payload.payloadTypesHeader
+                            payloadType = payload.payloadTypesHeader,
                         )
                     } ?: ExecutionResult.NotAttempted
                 } catch (t: Throwable) {
@@ -235,7 +235,7 @@ class SchedulingServiceImpl(
 
             payloadsToRetry[payload] = RetryInstance(
                 failedAttempts = retryAttempts + 1,
-                nextRetryTimeMs = nextRetryTimeMs
+                nextRetryTimeMs = nextRetryTimeMs,
             )
         }
 
@@ -453,7 +453,7 @@ class SchedulingServiceImpl(
                         scheduleAction()
                     },
                     requestedDeliveryAttemptTimeMs - clock.now(),
-                    TimeUnit.MILLISECONDS
+                    TimeUnit.MILLISECONDS,
                 )
                 scheduledTime = requestedDeliveryAttemptTimeMs
             }
@@ -472,7 +472,7 @@ class SchedulingServiceImpl(
                 UnknownHostException::class.java,
                 ConnectException::class.java,
                 SSLException::class.java,
-                NoRouteToHostException::class.java
+                NoRouteToHostException::class.java,
             )
 
         /**

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/CachedLogEnvelopeStoreImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/CachedLogEnvelopeStoreImpl.kt
@@ -28,7 +28,7 @@ class CachedLogEnvelopeStoreImpl(
         worker,
         logger,
         clock,
-        storageLimit
+        storageLimit,
     )
 
     override fun create(
@@ -39,7 +39,7 @@ class CachedLogEnvelopeStoreImpl(
         fileStorageService.store(storedTelemetryMetadata) { stream ->
             serializer.toJson(
                 LogPayload().createLogEnvelope(resource, metadata),
-                stream
+                stream,
             )
         }
     }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImpl.kt
@@ -30,7 +30,7 @@ class PayloadStorageServiceImpl(
         worker,
         logger,
         clock,
-        storageLimit
+        storageLimit,
     )
 
     /**

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionServiceTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionServiceTest.kt
@@ -89,7 +89,7 @@ class OkHttpRequestExecutionServiceTest {
         val result = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
             envelopeType = SupportedEnvelopeType.SESSION,
-            payloadType = PayloadType.SESSION.value
+            payloadType = PayloadType.SESSION.value,
         )
 
         // then the result should be incomplete
@@ -106,7 +106,7 @@ class OkHttpRequestExecutionServiceTest {
         val result = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
             envelopeType = SupportedEnvelopeType.SESSION,
-            payloadType = PayloadType.SESSION.value
+            payloadType = PayloadType.SESSION.value,
         )
 
         // then the result should be successful
@@ -122,7 +122,7 @@ class OkHttpRequestExecutionServiceTest {
         val result = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
             envelopeType = SupportedEnvelopeType.SESSION,
-            payloadType = PayloadType.SESSION.value
+            payloadType = PayloadType.SESSION.value,
         )
 
         // then the result should be other
@@ -135,14 +135,14 @@ class OkHttpRequestExecutionServiceTest {
         server.enqueue(
             MockResponse()
                 .setResponseCode(429)
-                .setHeaders(mapOf("Retry-After" to "10").toHeaders())
+                .setHeaders(mapOf("Retry-After" to "10").toHeaders()),
         )
 
         // when attempting to make a request
         val result = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
             envelopeType = SupportedEnvelopeType.SESSION,
-            payloadType = PayloadType.SESSION.value
+            payloadType = PayloadType.SESSION.value,
         )
 
         // then the result should be too many requests
@@ -159,7 +159,7 @@ class OkHttpRequestExecutionServiceTest {
         val result = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
             envelopeType = SupportedEnvelopeType.SESSION,
-            payloadType = PayloadType.SESSION.value
+            payloadType = PayloadType.SESSION.value,
         )
 
         // then the result should be incomplete
@@ -175,14 +175,14 @@ class OkHttpRequestExecutionServiceTest {
         server.enqueue(
             MockResponse()
                 .setResponseCode(500)
-                .setHeaders(mapOf("custom-error-header" to "ouch").toHeaders())
+                .setHeaders(mapOf("custom-error-header" to "ouch").toHeaders()),
         )
 
         // when attempting to make a request
         val result = requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
             envelopeType = SupportedEnvelopeType.SESSION,
-            payloadType = PayloadType.SESSION.value
+            payloadType = PayloadType.SESSION.value,
         )
 
         // then the result should be failure
@@ -199,7 +199,7 @@ class OkHttpRequestExecutionServiceTest {
         requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
             envelopeType = SupportedEnvelopeType.SESSION,
-            payloadType = PayloadType.SESSION.value
+            payloadType = PayloadType.SESSION.value,
         )
 
         // then the request should include the expected headers
@@ -223,7 +223,7 @@ class OkHttpRequestExecutionServiceTest {
         requestExecutionService.attemptHttpRequest(
             payloadStream = { testPostBody.byteInputStream() },
             envelopeType = SupportedEnvelopeType.LOG,
-            payloadType = PayloadType.AEI.value
+            payloadType = PayloadType.AEI.value,
         )
 
         // then the request should include the expected headers

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImplTest.kt
@@ -54,13 +54,13 @@ class IntakeServiceImplTest {
 
     private val serializer = TestPlatformSerializer()
     private val sessionEnvelope = Envelope(
-        data = SessionPartPayload(spans = listOf(Span(name = "session-span")))
+        data = SessionPartPayload(spans = listOf(Span(name = "session-span"))),
     )
     private val logEnvelope = Envelope(
-        data = LogPayload(logs = listOf(Log(body = "Log data")))
+        data = LogPayload(logs = listOf(Log(body = "Log data"))),
     )
     private val attachmentEnvelope = Envelope(
-        data = Pair("my-id", ByteArray(2))
+        data = Pair("my-id", ByteArray(2)),
     )
     private val sessionDataExpected = run {
         val baos = ByteArrayOutputStream()
@@ -100,7 +100,7 @@ class IntakeServiceImplTest {
             cacheStorageService,
             logger,
             serializer,
-            PriorityWorker(executorService)
+            PriorityWorker(executorService),
         )
     }
 
@@ -237,13 +237,13 @@ class IntakeServiceImplTest {
             { _, _ -> },
             1,
             1,
-            storedTelemetryRunnableComparator
+            storedTelemetryRunnableComparator,
         )
         val latch = CountDownLatch(1)
         executor.submit(
             PriorityRunnable(sessionMetadata) {
                 latch.await(1000, TimeUnit.MILLISECONDS)
-            }
+            },
         )
         val worker = PriorityWorker<StoredTelemetryMetadata>(executor)
         intakeService = IntakeServiceImpl(
@@ -252,7 +252,7 @@ class IntakeServiceImplTest {
             cacheStorageService,
             logger,
             TestPlatformSerializer(),
-            worker
+            worker,
         )
         with(intakeService) {
             take(sessionEnvelope, sessionMetadata)
@@ -291,7 +291,7 @@ class IntakeServiceImplTest {
             uuid = UUID,
             processIdentifier = PROCESS_ID,
             envelopeType = SESSION,
-            complete = false
+            complete = false,
         ).apply {
             intakeService.take(intake = sessionEnvelope, metadata = this)
         }
@@ -304,8 +304,8 @@ class IntakeServiceImplTest {
                 uuid = UUID,
                 processIdentifier = PROCESS_ID,
                 envelopeType = LOG,
-                complete = true
-            )
+                complete = true,
+            ),
         )
         assertTrue(cacheStorageService.storedFilenames().contains(snapshot1.filename))
 
@@ -315,7 +315,7 @@ class IntakeServiceImplTest {
             uuid = UUID,
             processIdentifier = PROCESS_ID,
             envelopeType = SESSION,
-            complete = false
+            complete = false,
         ).apply {
             intakeService.take(intake = sessionEnvelope, metadata = this)
         }
@@ -328,7 +328,7 @@ class IntakeServiceImplTest {
             uuid = UUID,
             processIdentifier = PROCESS_ID,
             envelopeType = SESSION,
-            complete = true
+            complete = true,
         ).apply {
             intakeService.take(intake = sessionEnvelope, metadata = this)
         }
@@ -346,7 +346,7 @@ class IntakeServiceImplTest {
             processIdentifier = PROCESS_ID,
             envelopeType = CRASH,
             complete = false,
-            payloadType = PayloadType.UNKNOWN
+            payloadType = PayloadType.UNKNOWN,
         ).apply {
             intakeService.take(intake = logEnvelope, metadata = this)
         }
@@ -359,7 +359,7 @@ class IntakeServiceImplTest {
             processIdentifier = PROCESS_ID,
             envelopeType = CRASH,
             complete = false,
-            payloadType = PayloadType.UNKNOWN
+            payloadType = PayloadType.UNKNOWN,
         ).apply {
             intakeService.take(intake = logEnvelope, metadata = this)
         }
@@ -378,7 +378,7 @@ class IntakeServiceImplTest {
             uuid = UUID,
             processIdentifier = PROCESS_ID,
             envelopeType = SESSION,
-            complete = false
+            complete = false,
         ).apply {
             intakeService.take(intake = sessionEnvelope, metadata = this)
         }
@@ -391,7 +391,7 @@ class IntakeServiceImplTest {
             uuid = "other-uuid",
             processIdentifier = "old-pid",
             envelopeType = SESSION,
-            complete = false
+            complete = false,
         ).apply {
             cacheStorageService.store(this) {
                 it.write("old".toByteArray())
@@ -406,9 +406,9 @@ class IntakeServiceImplTest {
                 uuid = UUID,
                 processIdentifier = PROCESS_ID,
                 envelopeType = SESSION,
-                complete = true
+                complete = true,
             ),
-            staleEntry = resurrectionSource
+            staleEntry = resurrectionSource,
         )
 
         // resurrectionSource was deleted (explicit staleEntry), snapshot is still present
@@ -436,7 +436,7 @@ class IntakeServiceImplTest {
             StoredTelemetryMetadata(clock.now(), UUID, PROCESS_ID, BLOB, false, PayloadType.AEI).apply {
                 intakeService.take(
                     intake = logEnvelope,
-                    metadata = this
+                    metadata = this,
                 )
             }
 
@@ -463,7 +463,7 @@ class IntakeServiceImplTest {
             processIdentifier = PROCESS_ID,
             envelopeType = CRASH,
             complete = true,
-            payloadType = PayloadType.JVM_CRASH
+            payloadType = PayloadType.JVM_CRASH,
         )
 
         intakeService.take(logEnvelope, jvmCrashMetadata)
@@ -485,7 +485,7 @@ class IntakeServiceImplTest {
             processIdentifier = PROCESS_ID,
             envelopeType = CRASH,
             complete = false,
-            payloadType = PayloadType.JVM_CRASH
+            payloadType = PayloadType.JVM_CRASH,
         )
 
         intakeService.take(logEnvelope, incompleteCrashMetadata)
@@ -504,7 +504,7 @@ class IntakeServiceImplTest {
             processIdentifier = PROCESS_ID,
             envelopeType = CRASH,
             complete = true,
-            payloadType = PayloadType.NATIVE_CRASH
+            payloadType = PayloadType.NATIVE_CRASH,
         )
 
         intakeService.take(logEnvelope, nativeCrashMetadata)
@@ -526,7 +526,7 @@ class IntakeServiceImplTest {
             processIdentifier = PROCESS_ID,
             envelopeType = CRASH,
             complete = true,
-            payloadType = PayloadType.REACT_NATIVE_CRASH
+            payloadType = PayloadType.REACT_NATIVE_CRASH,
         )
 
         intakeService.take(logEnvelope, rnCrashMetadata)
@@ -547,7 +547,7 @@ class IntakeServiceImplTest {
             processIdentifier = PROCESS_ID,
             envelopeType = CRASH,
             complete = false,
-            payloadType = PayloadType.UNKNOWN
+            payloadType = PayloadType.UNKNOWN,
         ).apply {
             cacheStorageService.store(this) { it.write("stale".toByteArray()) }
         }
@@ -559,7 +559,7 @@ class IntakeServiceImplTest {
             processIdentifier = PROCESS_ID,
             envelopeType = CRASH,
             complete = true,
-            payloadType = PayloadType.JVM_CRASH
+            payloadType = PayloadType.JVM_CRASH,
         )
 
         intakeService.take(logEnvelope, jvmCrashMetadata, staleEntry = stale)
@@ -575,7 +575,7 @@ class IntakeServiceImplTest {
         val snapshotMetadata = sessionMetadata.copy(
             timestamp = clock.tick(),
             uuid = "snapshot-uuid",
-            complete = false
+            complete = false,
         )
         intakeService.take(sessionEnvelope, snapshotMetadata)
         executorService.runCurrentlyBlocked()
@@ -588,7 +588,7 @@ class IntakeServiceImplTest {
             processIdentifier = PROCESS_ID,
             envelopeType = CRASH,
             complete = true,
-            payloadType = PayloadType.JVM_CRASH
+            payloadType = PayloadType.JVM_CRASH,
         )
         intakeService.take(logEnvelope, jvmCrashMetadata)
 
@@ -606,8 +606,8 @@ class IntakeServiceImplTest {
             sessionMetadata.copy(
                 timestamp = clock.tick(),
                 uuid = "late-snapshot",
-                complete = false
-            )
+                complete = false,
+            ),
         )
 
         // subsequent log rejected
@@ -619,8 +619,8 @@ class IntakeServiceImplTest {
                 processIdentifier = PROCESS_ID,
                 envelopeType = LOG,
                 complete = true,
-                payloadType = PayloadType.LOG
-            )
+                payloadType = PayloadType.LOG,
+            ),
         )
 
         // subsequent crash rejected
@@ -632,8 +632,8 @@ class IntakeServiceImplTest {
                 processIdentifier = PROCESS_ID,
                 envelopeType = CRASH,
                 complete = true,
-                payloadType = PayloadType.JVM_CRASH
-            )
+                payloadType = PayloadType.JVM_CRASH,
+            ),
         )
     }
 
@@ -647,7 +647,7 @@ class IntakeServiceImplTest {
             processIdentifier = PROCESS_ID,
             envelopeType = CRASH,
             complete = true,
-            payloadType = PayloadType.JVM_CRASH
+            payloadType = PayloadType.JVM_CRASH,
         )
         intakeService.take(logEnvelope, jvmCrashMetadata)
         assertEquals(1, payloadStorageService.storedPayloadCount())
@@ -687,8 +687,8 @@ class IntakeServiceImplTest {
                 processIdentifier = PROCESS_ID,
                 envelopeType = LOG,
                 complete = true,
-                payloadType = PayloadType.LOG
-            )
+                payloadType = PayloadType.LOG,
+            ),
         )
     }
 
@@ -700,7 +700,7 @@ class IntakeServiceImplTest {
             processIdentifier = PROCESS_ID,
             envelopeType = CRASH,
             complete = true,
-            payloadType = PayloadType.JVM_CRASH
+            payloadType = PayloadType.JVM_CRASH,
         )
         intakeService.take(logEnvelope, jvmCrashMetadata)
         assertEquals(1, payloadStorageService.storedPayloadCount())
@@ -711,7 +711,7 @@ class IntakeServiceImplTest {
             processIdentifier = PROCESS_ID,
             envelopeType = LOG,
             complete = true,
-            payloadType = PayloadType.LOG
+            payloadType = PayloadType.LOG,
         )
         val attachmentInWindow = StoredTelemetryMetadata(
             timestamp = clock.tick(),
@@ -719,7 +719,7 @@ class IntakeServiceImplTest {
             processIdentifier = PROCESS_ID,
             envelopeType = ATTACHMENT,
             complete = true,
-            payloadType = PayloadType.ATTACHMENT
+            payloadType = PayloadType.ATTACHMENT,
         )
         intakeService.take(logEnvelope, logInWindow)
         intakeService.take(attachmentEnvelope, attachmentInWindow)
@@ -732,7 +732,7 @@ class IntakeServiceImplTest {
             uuid = "crash-session",
             processIdentifier = PROCESS_ID,
             envelopeType = SESSION,
-            complete = true
+            complete = true,
         )
         intakeService.take(sessionEnvelope, crashSessionMetadata)
         assertEquals(4, payloadStorageService.storedPayloadCount())

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServicePeriodicCacheTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServicePeriodicCacheTest.kt
@@ -27,7 +27,7 @@ class IntakeServicePeriodicCacheTest {
 
     private val serializer = TestPlatformSerializer()
     private val sessionEnvelope = Envelope(
-        data = SessionPartPayload(spans = listOf(Span(name = "session-span")))
+        data = SessionPartPayload(spans = listOf(Span(name = "session-span"))),
     )
     private val clock = FakeClock()
 
@@ -44,7 +44,7 @@ class IntakeServicePeriodicCacheTest {
             cacheStorageService,
             logger,
             serializer,
-            PriorityWorker(executorService)
+            PriorityWorker(executorService),
         )
     }
 

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImplTest.kt
@@ -60,7 +60,7 @@ internal class SchedulingServiceImplTest {
         networkUpdateDispatchExecutor = BlockingScheduledExecutorService(blockingMode = true)
         networkConnectivityService = FakeNetworkConnectivityService(
             initialConnectivityStatus = ConnectivityStatus.Unverified,
-            executor = networkUpdateDispatchExecutor
+            executor = networkUpdateDispatchExecutor,
         )
         storageService = FakePayloadStorageService(workerExecutor = storageExecutor).apply {
             addFakePayload(fakeLogStoredTelemetryMetadata)
@@ -129,7 +129,7 @@ internal class SchedulingServiceImplTest {
             assertEquals(
                 "Send attempt ${iteration + 1} did not result in the right number of sends after $delay ms",
                 2 * (iteration + 2),
-                executionService.sendAttempts()
+                executionService.sendAttempts(),
             )
             assertEquals("Send attempt $iteration failed", 2, storageService.storedPayloadCount())
             delay *= 2
@@ -315,7 +315,7 @@ internal class SchedulingServiceImplTest {
             assertEquals(
                 "Connection retry attempt ${iteration + 1} did not result in the right number of sends after $delay ms",
                 iteration + 2,
-                executionService.sendAttempts()
+                executionService.sendAttempts(),
             )
             delay *= 2
         }

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/CachedLogEnvelopeStoreImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/CachedLogEnvelopeStoreImplTest.kt
@@ -47,12 +47,12 @@ class CachedLogEnvelopeStoreImplTest {
         store.create(
             storedTelemetryMetadata = fakeNativeCrashEnvelope,
             resource = fakeEnvelopeResource,
-            metadata = fakeEnvelopeMetadata
+            metadata = fakeEnvelopeMetadata,
         )
 
         val anotherCrashMetadata = createNativeCrashEnvelopeMetadata(
             sessionPartId = "another-session",
-            processIdentifier = "another-process"
+            processIdentifier = "another-process",
         )
 
         assertNull(store.get(anotherCrashMetadata))
@@ -70,7 +70,7 @@ class CachedLogEnvelopeStoreImplTest {
     companion object {
         val fakeNativeCrashEnvelope = createNativeCrashEnvelopeMetadata(
             sessionPartId = "old-session-id",
-            processIdentifier = "old-process-id"
+            processIdentifier = "old-process-id",
         )
     }
 }

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
@@ -105,7 +105,7 @@ class PayloadStorageServiceImplTest {
             Pair(1000L, CRASH),
             Pair(1000L, SESSION),
             Pair(1000L, LOG),
-            Pair(1000L, BLOB)
+            Pair(1000L, BLOB),
         ).forEach {
             val metadata = StoredTelemetryMetadata(it.first, UUID, PROCESS_ID, it.second)
             service.store(metadata) { stream ->
@@ -122,7 +122,7 @@ class PayloadStorageServiceImplTest {
             Pair(0L, CRASH),
             Pair(1000L, CRASH),
             Pair(0L, SESSION),
-            Pair(1000L, SESSION)
+            Pair(1000L, SESSION),
         )
         assertEquals(expected, outputs)
     }

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/metadata/EnvelopeMetadataSourceImpl.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/metadata/EnvelopeMetadataSourceImpl.kt
@@ -18,7 +18,7 @@ class EnvelopeMetadataSourceImpl(
             username = userInfo.username,
             personas = userInfo.personas ?: emptySet(),
             timezoneDescription = TimeZone.getDefault().id,
-            locale = Locale.getDefault().language + "_" + Locale.getDefault().country
+            locale = Locale.getDefault().language + "_" + Locale.getDefault().country,
         )
     }
 }

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/metadata/ReactNativeSdkVersionInfo.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/metadata/ReactNativeSdkVersionInfo.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.envelope.metadata
 import io.embrace.android.embracesdk.internal.store.KeyValueStore
 
 class ReactNativeSdkVersionInfo(
-    private val impl: KeyValueStore
+    private val impl: KeyValueStore,
 ) : HostedSdkVersionInfo {
 
     override var hostedSdkVersion: String?

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/DeviceImpl.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/DeviceImpl.kt
@@ -30,7 +30,7 @@ class DeviceImpl(
         "/data/local/bin/",
         "/system/sd/xbin/",
         "/system/bin/failsafe/",
-        "/data/local/"
+        "/data/local/",
     )
 
     init {
@@ -65,7 +65,7 @@ class DeviceImpl(
                 Locale.US,
                 "%dx%d",
                 displayMetrics.widthPixels,
-                displayMetrics.heightPixels
+                displayMetrics.heightPixels,
             )
         } catch (ex: Exception) {
             logger.trackInternalError(InternalErrorType.ScreenResCaptureFail, ex)
@@ -119,7 +119,7 @@ class DeviceImpl(
     private var persistedJailbroken: Boolean?
         get() = store.getBoolean(
             IS_JAILBROKEN_KEY,
-            false
+            false,
         )
         set(value) = store.edit { putBoolean(IS_JAILBROKEN_KEY, value) }
 

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImpl.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImpl.kt
@@ -48,7 +48,7 @@ class EnvelopeResourceSourceImpl(
             osCode = device.systemInfo.androidOsApiLevel,
             screenResolution = device.screenResolution,
             numCores = device.numberOfCores,
-            extras = extras.toMap()
+            extras = extras.toMap(),
         )
     }
 

--- a/embrace-android-envelope/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/metadata/EnvelopeMetadataSourceImplTest.kt
+++ b/embrace-android-envelope/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/metadata/EnvelopeMetadataSourceImplTest.kt
@@ -13,7 +13,7 @@ internal class EnvelopeMetadataSourceImplTest {
             userId = "userId",
             email = "email",
             username = "username",
-            personas = setOf("persona1", "persona2")
+            personas = setOf("persona1", "persona2"),
         )
         val source = EnvelopeMetadataSourceImpl { userInfo }
         val metadata = source.getEnvelopeMetadata()

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/store/Ordinal.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/store/Ordinal.kt
@@ -43,5 +43,5 @@ enum class Ordinal(val key: String) {
      * lifetime; seeded from [USER_SESSION] the first time it is read. Surfaced as
      * `emb.session_part_number`.
      */
-    SESSION_PART("io.embrace.sessionpartnumber")
+    SESSION_PART("io.embrace.sessionpartnumber"),
 }

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/telemetry/AppliedLimitType.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/telemetry/AppliedLimitType.kt
@@ -17,5 +17,5 @@ enum class AppliedLimitType(val attributeName: String) {
     /**
      * A telemetry item was completely dropped due to rate limits or other constraints.
      */
-    DROP("drop")
+    DROP("drop"),
 }

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/NetworkUtils.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/NetworkUtils.kt
@@ -86,7 +86,7 @@ object NetworkUtils {
 
         return url.substring(
             0,
-            (if (pathPos < 0) 0 else pathPos) + suffix.length.coerceAtMost(terminalPos)
+            (if (pathPos < 0) 0 else pathPos) + suffix.length.coerceAtMost(terminalPos),
         )
     }
 

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/PriorityThreadPoolExecutor.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/PriorityThreadPoolExecutor.kt
@@ -31,7 +31,7 @@ class PriorityThreadPoolExecutor(
     TimeUnit.SECONDS,
     PriorityBlockingQueue(100, comparator),
     threadFactory,
-    handler
+    handler,
 ) {
 
     override fun <T : Any?> newTaskFor(callable: Callable<T>): RunnableFuture<T> {

--- a/embrace-android-infra/src/test/kotlin/io/embrace/android/embracesdk/internal/clock/ClockExtTest.kt
+++ b/embrace-android-infra/src/test/kotlin/io/embrace/android/embracesdk/internal/clock/ClockExtTest.kt
@@ -22,7 +22,7 @@ internal class ClockExtTest {
             validateOffset(
                 clockDrift = clockDrift,
                 driftDuringRequest = 0L,
-                expectedOffset = clockDrift
+                expectedOffset = clockDrift,
             )
         }
     }
@@ -42,7 +42,7 @@ internal class ClockExtTest {
                     } else {
                         // clock drift should tick over if the extra drift increases the absolute magnitude of an existing drift
                         clockDrift + extraDrift
-                    }
+                    },
                 )
             }
         }
@@ -57,7 +57,7 @@ internal class ClockExtTest {
                 validateOffset(
                     clockDrift = clockDrift,
                     driftDuringRequest = extraDrift,
-                    expectedOffset = 0L
+                    expectedOffset = 0L,
                 )
             }
         }
@@ -75,13 +75,13 @@ internal class ClockExtTest {
             "For clockDrift $clockDrift and driftDuringRequest $driftDuringRequest, " +
                 "expectedOffset $expectedOffset and calculatedOffset $calculatedOffset",
             0,
-            expectedOffset + calculatedOffset
+            expectedOffset + calculatedOffset,
         )
     }
 
     private class DriftClock(
         private val baseClock: Clock,
-        var action: () -> Long = { 0L }
+        var action: () -> Long = { 0L },
     ) : Clock {
         override fun now(): Long = baseClock.now() + action()
     }

--- a/embrace-android-instrumentation-androidx-navigation/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/androidx/navigation/internal/NavControllerTrackerTest.kt
+++ b/embrace-android-instrumentation-androidx-navigation/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/androidx/navigation/internal/NavControllerTrackerTest.kt
@@ -127,7 +127,7 @@ internal class NavControllerTrackerTest {
         assertTrue(
             errorLogger.internalErrorMessages.any {
                 it.msg == InternalErrorType.NavControllerTrackingFail.toString()
-            }
+            },
         )
     }
 

--- a/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/BlockedThreadDetector.kt
+++ b/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/BlockedThreadDetector.kt
@@ -38,7 +38,7 @@ class BlockedThreadDetector(
         looper = looper,
         watchdogWorker = watchdogWorker,
         clock = clock,
-        action = ::onTargetThreadProcessedMessage
+        action = ::onTargetThreadProcessedMessage,
     )
     private val started: AtomicBoolean = AtomicBoolean(false)
     private val blocked: AtomicBoolean = AtomicBoolean(false)

--- a/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadBlockageOtelMapper.kt
+++ b/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadBlockageOtelMapper.kt
@@ -25,7 +25,7 @@ internal fun mapIntervalToSpan(interval: ThreadBlockageInterval, clock: Clock, r
         endTimeNanos = (interval.endTime ?: clock.now()).millisToNanos(),
         status = Span.Status.UNSET,
         attributes = attrs,
-        events = events
+        events = events,
     )
 }
 
@@ -65,15 +65,15 @@ internal fun mapSampleToSpanEvent(sample: ThreadBlockageSample): SpanEvent {
             attrs.add(
                 Attribute(
                     ExceptionAttributes.EXCEPTION_STACKTRACE,
-                    lines.joinToString("\n")
-                )
+                    lines.joinToString("\n"),
+                ),
             )
         }
     }
     return SpanEvent(
         name = "perf.thread_blockage_sample",
         timestampNanos = sample.timestamp.millisToNanos(),
-        attributes = attrs
+        attributes = attrs,
     )
 }
 
@@ -92,5 +92,5 @@ internal fun SpanEvent.toArchSpanEvent(): io.embrace.android.embracesdk.internal
     SpanEventImpl(
         name ?: "",
         timestampNanos ?: 0,
-        attributes?.toEmbracePayload() ?: emptyMap()
+        attributes?.toEmbracePayload() ?: emptyMap(),
     )

--- a/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadBlockageSampler.kt
+++ b/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadBlockageSampler.kt
@@ -36,10 +36,10 @@ class ThreadBlockageSampler(
                             clock = clock,
                             targetThread = targetThread,
                             sampleLimit = maxSamplesPerInterval,
-                            stacktraceFrameLimit = stacktraceFrameLimit
+                            stacktraceFrameLimit = stacktraceFrameLimit,
                         ),
-                        startTime = timestamp
-                    )
+                        startTime = timestamp,
+                    ),
                 )
             }
             ThreadBlockageEvent.BLOCKED_INTERVAL -> {
@@ -54,7 +54,7 @@ class ThreadBlockageSampler(
                                 startTime = startTime,
                                 endTime = timestamp,
                                 samples = sampler.getThreadBlockageSamples(),
-                            )
+                            ),
                         )
                     }
                     currentBlockage.set(null)
@@ -77,7 +77,7 @@ class ThreadBlockageSampler(
                         startTime = blockage.startTime,
                         lastKnownTime = clock.now(),
                         samples = blockage.sampler.getThreadBlockageSamples(),
-                    )
+                    ),
                 )
             } else {
                 results = intervalSink.get().toMutableList()
@@ -120,7 +120,7 @@ class ThreadBlockageSampler(
                 code = when (current) {
                     null -> CODE_SAMPLE_LIMIT_REACHED
                     else -> CODE_DEFAULT
-                }
+                },
             )
         }
     }
@@ -152,7 +152,7 @@ class ThreadBlockageSampler(
     @CheckResult
     private fun ThreadBlockageInterval.clearSamples(): ThreadBlockageInterval = copy(
         samples = null,
-        code = CODE_SAMPLES_CLEARED
+        code = CODE_SAMPLES_CLEARED,
     )
 
     private fun ThreadBlockageInterval.hasSamples(): Boolean = code != CODE_SAMPLES_CLEARED

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/BlockedThreadDetectorTest.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/BlockedThreadDetectorTest.kt
@@ -41,9 +41,9 @@ internal class BlockedThreadDetectorTest {
         configService = FakeConfigService(
             threadBlockageBehavior = createThreadBlockageBehavior(
                 remoteCfg = RemoteConfig(
-                    threadBlockageRemoteConfig = cfg
-                )
-            )
+                    threadBlockageRemoteConfig = cfg,
+                ),
+            ),
         )
         watchdogExecutorService = BlockingScheduledExecutorService(clock)
         logger = FakeInternalLogger()

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadBlockageOtelMapperTest.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadBlockageOtelMapperTest.kt
@@ -37,9 +37,9 @@ internal class ThreadBlockageOtelMapperTest {
         priority = 5,
         lines = listOf(
             "com.example.app.MainActivity.onCreate(MainActivity.kt:10)",
-            "com.example.app.MainActivity.onCreate(MainActivity.kt:20)"
+            "com.example.app.MainActivity.onCreate(MainActivity.kt:20)",
         ),
-        frameCount = 2
+        frameCount = 2,
     )
     private val truncatedThreadSample = ThreadSample(
         threadId = 1,
@@ -48,39 +48,39 @@ internal class ThreadBlockageOtelMapperTest {
         priority = 5,
         lines = listOf(
             "com.example.app.MainActivity.onCreate(MainActivity.kt:10)",
-            "com.example.app.MainActivity.onCreate(MainActivity.kt:20)"
+            "com.example.app.MainActivity.onCreate(MainActivity.kt:20)",
         ),
-        frameCount = 10000
+        frameCount = 10000,
     )
 
     private val firstSample = ThreadBlockageSample(
         timestamp = FIRST_SAMPLE_MS,
         sampleOverheadMs = FIRST_SAMPLE_OVERHEAD_MS,
-        threadSample = threadSample
+        threadSample = threadSample,
     )
 
     private val secondSample = ThreadBlockageSample(
         timestamp = SECOND_SAMPLE_MS,
         sampleOverheadMs = SECOND_SAMPLE_OVERHEAD_MS,
-        threadSample = threadSample
+        threadSample = threadSample,
     )
 
     private val truncatedSecondSample = ThreadBlockageSample(
         timestamp = SECOND_SAMPLE_MS,
         sampleOverheadMs = SECOND_SAMPLE_OVERHEAD_MS,
-        threadSample = truncatedThreadSample
+        threadSample = truncatedThreadSample,
     )
 
     private val completedInterval = ThreadBlockageInterval(
         startTime = START_TIME_MS,
         endTime = END_TIME_MS,
-        samples = listOf(firstSample, secondSample)
+        samples = listOf(firstSample, secondSample),
     )
 
     private val completedIntervalWithTruncatedSample = ThreadBlockageInterval(
         startTime = START_TIME_MS,
         endTime = END_TIME_MS,
-        samples = listOf(firstSample, truncatedSecondSample)
+        samples = listOf(firstSample, truncatedSecondSample),
     )
 
     private val inProgressInterval =
@@ -98,7 +98,7 @@ internal class ThreadBlockageOtelMapperTest {
             } else {
                 firstSample
             }
-        }
+        },
     )
 
     @Before
@@ -170,7 +170,7 @@ internal class ThreadBlockageOtelMapperTest {
             mapIntervalToSpan(
                 it,
                 clock,
-                random
+                random,
             )
         }.single()
         val events = checkNotNull(span.events)
@@ -206,7 +206,7 @@ internal class ThreadBlockageOtelMapperTest {
         assertEquals(thread.frameCount, attrs.findAttribute(EmbAnrAttributes.FRAME_COUNT).data?.toInt())
         assertEquals(
             thread.lines?.joinToString("\n"),
-            attrs.findAttribute(ExceptionAttributes.EXCEPTION_STACKTRACE).data
+            attrs.findAttribute(ExceptionAttributes.EXCEPTION_STACKTRACE).data,
         )
     }
 

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadBlockageSamplerTest.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadBlockageSamplerTest.kt
@@ -51,13 +51,13 @@ internal class ThreadBlockageSamplerTest {
         val intervals = sampler.getThreadBlockageIntervals()
         assertEquals(
             listOf(10000L, 8000L, 6000L, 4000L, 2000L),
-            intervals.filter { it.samples != null }.map { checkNotNull(it.endTime) - it.startTime }
+            intervals.filter { it.samples != null }.map { checkNotNull(it.endTime) - it.startTime },
         )
         assertEquals(
             listOf(1500L, 1200L),
             intervals.filter {
                 it.samples == null
-            }.map { checkNotNull(it.endTime) - it.startTime }
+            }.map { checkNotNull(it.endTime) - it.startTime },
         )
     }
 
@@ -421,7 +421,7 @@ internal class ThreadBlockageSamplerTest {
         val exception = readerException.get()
         assertNull(
             "Concurrent access threw: ${exception?.javaClass?.simpleName}: ${exception?.message}",
-            exception
+            exception,
         )
     }
 

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadBlockageServiceImplTest.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadBlockageServiceImplTest.kt
@@ -32,7 +32,7 @@ internal class ThreadBlockageServiceImplTest {
         scheduledExecutorSupplier = {
             watchdogExecutorService = SingleThreadTestScheduledExecutor()
             watchdogExecutorService
-        }
+        },
     )
 
     @Before
@@ -232,13 +232,13 @@ internal class ThreadBlockageServiceImplTest {
                     extra,
                     samples.count { sample ->
                         sample.threadSample == null && sample.code == ThreadBlockageSample.CODE_SAMPLE_LIMIT_REACHED
-                    }
+                    },
                 )
                 assertEquals(
                     defaultLimit,
                     samples.count { sample ->
                         sample.code == ThreadBlockageSample.CODE_DEFAULT
-                    }
+                    },
                 )
             }
         }

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadBlockageServiceImplTimingTest.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadBlockageServiceImplTimingTest.kt
@@ -22,7 +22,7 @@ internal class ThreadBlockageServiceImplTimingTest {
     @JvmField
     val rule = ThreadBlockageServiceRule(
         clock = clock,
-        scheduledExecutorSupplier = { BlockingScheduledExecutorService(fakeClock = clock) }
+        scheduledExecutorSupplier = { BlockingScheduledExecutorService(fakeClock = clock) },
     )
 
     private lateinit var watchdogExecutorService: BlockingScheduledExecutorService

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadBlockageServiceSupplierTest.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadBlockageServiceSupplierTest.kt
@@ -20,7 +20,7 @@ internal class ThreadBlockageServiceSupplierTest {
         val service = createThreadBlockageService(
             FakeInstrumentationArgs(
                 application,
-                configService = FakeConfigService()
+                configService = FakeConfigService(),
             ),
         )
         assertNotNull(service)
@@ -33,8 +33,8 @@ internal class ThreadBlockageServiceSupplierTest {
             FakeInstrumentationArgs(
                 application,
                 configService = FakeConfigService(
-                    autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(threadBlockageServiceEnabled = false)
-                )
+                    autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(threadBlockageServiceEnabled = false),
+                ),
             ),
         )
         assertNull(service)

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/LogSeverity.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/LogSeverity.kt
@@ -18,5 +18,5 @@ enum class LogSeverity {
     /**
      * Reports log messages with error level severity.
      */
-    ERROR
+    ERROR,
 }

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/StateDataSource.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/StateDataSource.kt
@@ -26,7 +26,7 @@ abstract class StateDataSource<T : Any>(
 ) : SessionPartEndListener, SessionPartChangeListener, DataSourceImpl(
     args = args,
     limitStrategy = UpToLimitStrategy { maxTransitions },
-    instrumentationName = "${stateTypeFactory(defaultValue).stateName}_state_data_source"
+    instrumentationName = "${stateTypeFactory(defaultValue).stateName}_state_data_source",
 ) {
     val stateAttributeKey: String = "emb.state.${stateTypeFactory(defaultValue).stateName}"
 
@@ -65,7 +65,7 @@ abstract class StateDataSource<T : Any>(
                 invalidInputCallback = {
                     // Input validation failing means the transition didn't change the state value, so keep track of it as unrecorded
                     unrecordedTransitions.updateDroppedByInstrumentation(1)
-                }
+                },
             ) {
                 val droppedTransitions = unrecordedTransitions.getAndSet(noUnrecordedTransitions)
                 val transitionRecorded = currentStateToken.update(
@@ -79,7 +79,7 @@ abstract class StateDataSource<T : Any>(
                 if (!transitionRecorded) {
                     unrecordedTransitions.incrementCount(
                         notInSession = droppedTransitions.notInSession + 1,
-                        droppedByInstrumentation = droppedTransitions.droppedByInstrumentation
+                        droppedByInstrumentation = droppedTransitions.droppedByInstrumentation,
                     )
                 }
             }
@@ -129,8 +129,8 @@ abstract class StateDataSource<T : Any>(
             try {
                 partStateToken.set(
                     args.destination.startSessionPartStateCapture(
-                        state = stateTypeFactory(initialValue)
-                    )
+                        state = stateTypeFactory(initialValue),
+                    ),
                 )
             } catch (t: Throwable) {
                 logger.trackInternalError(InternalErrorType.SessionStateCreationFail, t)
@@ -152,9 +152,9 @@ abstract class StateDataSource<T : Any>(
                 get().let { oldValue ->
                     UnrecordedTransitions(
                         notInSession = oldValue.notInSession + notInSession,
-                        droppedByInstrumentation = oldValue.droppedByInstrumentation + droppedByInstrumentation
+                        droppedByInstrumentation = oldValue.droppedByInstrumentation + droppedByInstrumentation,
                     )
-                }
+                },
             )
         }
     }

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/StateInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/StateInstrumentationProvider.kt
@@ -19,7 +19,7 @@ abstract class StateInstrumentationProvider<T : StateDataSource<S>, S : Any>(
             factory = factoryProvider(args),
             configGate = {
                 args.configGate() && args.configService.autoDataCaptureBehavior.isStateCaptureEnabled()
-            }
+            },
         )
     }
 }

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/startup/StartupClassifierImpl.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/startup/StartupClassifierImpl.kt
@@ -20,7 +20,7 @@ class StartupClassifierImpl : StartupClassifier {
                 StartupType.COLD
             } else {
                 StartupType.WARM
-            }
+            },
         )
     }
 

--- a/embrace-android-instrumentation-api/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/DataSourceImplTest.kt
+++ b/embrace-android-instrumentation-api/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/DataSourceImplTest.kt
@@ -23,7 +23,7 @@ internal class DataSourceImplTest {
         var validationFailed = 0
         source.captureTelemetry(
             inputValidation = { true },
-            invalidInputCallback = { validationFailed++ }
+            invalidInputCallback = { validationFailed++ },
         ) {
             b = false
         }
@@ -63,7 +63,7 @@ internal class DataSourceImplTest {
         repeat(4) {
             source.captureTelemetry(
                 inputValidation = { false },
-                invalidInputCallback = { validationFailed++ }
+                invalidInputCallback = { validationFailed++ },
             ) {
                 count++
             }
@@ -77,11 +77,11 @@ internal class DataSourceImplTest {
         limitStrategy: LimitStrategy = NoopLimitStrategy,
         args: FakeInstrumentationArgs = FakeInstrumentationArgs(
             ApplicationProvider.getApplicationContext(),
-            logger = FakeInternalLogger(throwOnInternalError = false)
+            logger = FakeInternalLogger(throwOnInternalError = false),
         ),
     ) : DataSourceImpl(
         args,
         limitStrategy,
-        "test_data_source"
+        "test_data_source",
     )
 }

--- a/embrace-android-instrumentation-app-exit-info/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/AeiDataSourceImpl.kt
+++ b/embrace-android-instrumentation-app-exit-info/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/AeiDataSourceImpl.kt
@@ -28,7 +28,7 @@ internal class AeiDataSourceImpl(
 ) : DataSourceImpl(
     args = args,
     limitStrategy = UpToLimitStrategy { SDK_AEI_SEND_LIMIT },
-    instrumentationName = "aei_data_source"
+    instrumentationName = "aei_data_source",
 ) {
 
     private companion object {

--- a/embrace-android-instrumentation-app-exit-info/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/AeiInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-app-exit-info/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/AeiInstrumentationProvider.kt
@@ -23,10 +23,10 @@ class AeiInstrumentationProvider : InstrumentationProvider {
                     backgroundWorker = args.backgroundWorker(worker = Worker.Background.NonIoRegWorker),
                     activityManager = activityManager,
                     store = args.store,
-                    ordinalStore = args.ordinalStore
+                    ordinalStore = args.ordinalStore,
                 )
             },
-            configGate = { args.configService.appExitInfoBehavior.isAeiCaptureEnabled() }
+            configGate = { args.configService.appExitInfoBehavior.isAeiCaptureEnabled() },
         )
     }
 }

--- a/embrace-android-instrumentation-app-exit-info/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/ApplicationExitInfoExt.kt
+++ b/embrace-android-instrumentation-app-exit-info/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/ApplicationExitInfoExt.kt
@@ -43,7 +43,7 @@ internal fun ApplicationExitInfo.constructAeiObject(
         trace = result.trace,
         description = description,
         traceStatus = result.errMsg,
-        pid = pid
+        pid = pid,
     )
 }
 

--- a/embrace-android-instrumentation-app-exit-info/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/AeiDataSourceImplTest.kt
+++ b/embrace-android-instrumentation-app-exit-info/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/AeiDataSourceImplTest.kt
@@ -79,14 +79,14 @@ internal class AeiDataSourceImplTest {
             worker,
             mockActivityManager,
             store,
-            FakeOrdinalStore()
+            FakeOrdinalStore(),
         ).apply(AeiDataSourceImpl::onDataCaptureEnabled)
     }
 
     @Before
     fun setUp() {
         configService = FakeConfigService(
-            appExitInfoBehavior = FakeAppExitInfoBehavior()
+            appExitInfoBehavior = FakeAppExitInfoBehavior(),
         )
     }
 
@@ -96,7 +96,7 @@ internal class AeiDataSourceImplTest {
             mockActivityManager.getHistoricalProcessExitReasons(
                 any(),
                 any(),
-                any()
+                any(),
             )
         } returns listOf(mockAppExitInfo)
 
@@ -129,7 +129,7 @@ internal class AeiDataSourceImplTest {
             mockActivityManager.getHistoricalProcessExitReasons(
                 any(),
                 any(),
-                any()
+                any(),
             )
         } returns emptyList()
         startApplicationExitInfoService()
@@ -149,7 +149,7 @@ internal class AeiDataSourceImplTest {
             mockActivityManager.getHistoricalProcessExitReasons(
                 any(),
                 any(),
-                any()
+                any(),
             )
         } returns entries
 
@@ -203,7 +203,7 @@ internal class AeiDataSourceImplTest {
             mockActivityManager.getHistoricalProcessExitReasons(
                 any(),
                 any(),
-                any()
+                any(),
             )
         } returns listOf(mockAppExitInfo)
         startApplicationExitInfoService()
@@ -256,7 +256,7 @@ internal class AeiDataSourceImplTest {
             mockActivityManager.getHistoricalProcessExitReasons(
                 any(),
                 any(),
-                any()
+                any(),
             )
         } returns listOf(mockAppExitInfo)
 
@@ -275,7 +275,7 @@ internal class AeiDataSourceImplTest {
             mockActivityManager.getHistoricalProcessExitReasons(
                 any(),
                 any(),
-                any()
+                any(),
             )
         } returns listOf(mockAppExitInfo)
 
@@ -296,7 +296,7 @@ internal class AeiDataSourceImplTest {
             mockActivityManager.getHistoricalProcessExitReasons(
                 any(),
                 any(),
-                any()
+                any(),
             )
         } returns listOf(mockAppExitInfo)
 
@@ -318,7 +318,7 @@ internal class AeiDataSourceImplTest {
             mockActivityManager.getHistoricalProcessExitReasons(
                 any(),
                 any(),
-                any()
+                any(),
             )
         } returns listOf(mockAppExitInfo)
 
@@ -341,7 +341,7 @@ internal class AeiDataSourceImplTest {
             mockActivityManager.getHistoricalProcessExitReasons(
                 any(),
                 any(),
-                any()
+                any(),
             )
         } returns listOf(mockAppExitInfo)
 
@@ -359,7 +359,7 @@ internal class AeiDataSourceImplTest {
             mockActivityManager.getHistoricalProcessExitReasons(
                 any(),
                 any(),
-                any()
+                any(),
             )
         } throws NullPointerException()
 
@@ -377,7 +377,7 @@ internal class AeiDataSourceImplTest {
             mockActivityManager.getHistoricalProcessExitReasons(
                 any(),
                 any(),
-                any()
+                any(),
             )
         } returns entries
 

--- a/embrace-android-instrumentation-app-exit-info/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/AeiNdkCrashProtobufSendTest.kt
+++ b/embrace-android-instrumentation-app-exit-info/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/AeiNdkCrashProtobufSendTest.kt
@@ -130,7 +130,7 @@ internal class AeiNdkCrashProtobufSendTest {
         val stream = ResourceReader.readResource(resName)
         val activityManager = createMockActivityManager(
             stream,
-            reason
+            reason,
         )
         val args = FakeInstrumentationArgs(
             mockk(),
@@ -152,13 +152,13 @@ internal class AeiNdkCrashProtobufSendTest {
                 getHistoricalProcessExitReasons(
                     any(),
                     any(),
-                    any()
+                    any(),
                 )
             } returns listOf(
                 mockk(relaxed = true) {
                     every { traceInputStream } returns stream
                     every { reason } returns code
-                }
+                },
             )
         }
     }

--- a/embrace-android-instrumentation-compose-tap/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/ComposeTapDataSource.kt
+++ b/embrace-android-instrumentation-compose-tap/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/ComposeTapDataSource.kt
@@ -15,7 +15,7 @@ internal class ComposeTapDataSource(
 ) : DataSourceImpl(
     args = args,
     limitStrategy = UpToLimitStrategy(args.configService.breadcrumbBehavior::getTapBreadcrumbLimit),
-    instrumentationName = "compose_tap_data_source"
+    instrumentationName = "compose_tap_data_source",
 ) {
 
     @Volatile

--- a/embrace-android-instrumentation-compose-tap/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/ComposeTapInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-compose-tap/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/ComposeTapInstrumentationProvider.kt
@@ -14,7 +14,7 @@ class ComposeTapInstrumentationProvider : InstrumentationProvider {
                     tapDataSourceProvider = { tapDataSource },
                 )
             },
-            configGate = args.configService.autoDataCaptureBehavior::isComposeClickCaptureEnabled
+            configGate = args.configService.autoDataCaptureBehavior::isComposeClickCaptureEnabled,
         )
     }
 }

--- a/embrace-android-instrumentation-compose-tap/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/EmbraceNodeIterator.kt
+++ b/embrace-android-instrumentation-compose-tap/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/EmbraceNodeIterator.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.semantics.getOrNull
 private const val UNKNOWN_ELEMENT_NAME = "Unlabeled Compose element"
 
 internal class EmbraceNodeIterator(
-    private val dataSource: ComposeTapDataSource
+    private val dataSource: ComposeTapDataSource,
 ) {
 
     /**
@@ -29,7 +29,7 @@ internal class EmbraceNodeIterator(
             val clickedView = ClickedView(it, x, y)
             dataSource.logComposeTap(
                 Pair(clickedView.x, clickedView.y),
-                clickedView.tag
+                clickedView.tag,
             )
         }
     }

--- a/embrace-android-instrumentation-crash-jvm/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/JvmCrashDataSourceImpl.kt
+++ b/embrace-android-instrumentation-crash-jvm/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/JvmCrashDataSourceImpl.kt
@@ -29,7 +29,7 @@ class JvmCrashDataSourceImpl(
     DataSourceImpl(
         args = args,
         limitStrategy = NoopLimitStrategy,
-        instrumentationName = "jvm_crash_data_source"
+        instrumentationName = "jvm_crash_data_source",
     ) {
 
     private val serializer: PlatformSerializer = args.serializer
@@ -59,12 +59,12 @@ class JvmCrashDataSourceImpl(
                     val crashException = LegacyExceptionInfo.ofThrowable(exception)
                     setAttribute(
                         ExceptionAttributes.EXCEPTION_TYPE,
-                        crashException.name
+                        crashException.name,
                     )
                     setAttribute(
                         ExceptionAttributes.EXCEPTION_MESSAGE,
                         crashException.message
-                            ?: ""
+                            ?: "",
                     )
                     setAttribute(
                         ExceptionAttributes.EXCEPTION_STACKTRACE,
@@ -78,7 +78,7 @@ class JvmCrashDataSourceImpl(
                         EmbType.System.Crash.embAndroidCrashExceptionCause,
                         encodeToUTF8String(
                             getExceptionCause(exception),
-                        )
+                        ),
                     )
                     setAttribute(
                         EmbAndroidAttributes.EMB_ANDROID_THREADS,

--- a/embrace-android-instrumentation-crash-jvm/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/JvmCrashInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-crash-jvm/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/JvmCrashInstrumentationProvider.kt
@@ -9,7 +9,7 @@ class JvmCrashInstrumentationProvider : InstrumentationProvider {
         return DataSourceState(
             factory = {
                 JvmCrashDataSourceImpl(args)
-            }
+            },
         )
     }
 

--- a/embrace-android-instrumentation-crash-jvm/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/JvmCrashDataSourceImplTest.kt
+++ b/embrace-android-instrumentation-crash-jvm/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/JvmCrashDataSourceImplTest.kt
@@ -40,9 +40,9 @@ internal class JvmCrashDataSourceImplTest {
             ctx,
             configService = FakeConfigService(
                 autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(
-                    uncaughtExceptionHandlerEnabled = crashHandlerEnabled
-                )
-            )
+                    uncaughtExceptionHandlerEnabled = crashHandlerEnabled,
+                ),
+            ),
         )
         crashDataSource = JvmCrashDataSourceImpl(args).apply {
             telemetryModifier = modifier
@@ -73,7 +73,7 @@ internal class JvmCrashDataSourceImplTest {
         val embraceDefaultHandler = EmbraceUncaughtExceptionHandler(
             defaultHandler = null,
             dataSource = FakeJvmCrashDataSource(),
-            logger = FakeInternalLogger()
+            logger = FakeInternalLogger(),
         )
         Thread.setDefaultUncaughtExceptionHandler(embraceDefaultHandler)
         setupForHandleCrash(true)

--- a/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashDataSourceImpl.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashDataSourceImpl.kt
@@ -20,7 +20,7 @@ internal class NativeCrashDataSourceImpl(
 ) : NativeCrashDataSource, DataSourceImpl(
     args = args,
     limitStrategy = NoopLimitStrategy,
-    instrumentationName = "native_crash_data_source"
+    instrumentationName = "native_crash_data_source",
 ) {
     override fun getAndSendNativeCrash(): NativeCrashData? {
         return nativeCrashProcessor.getLatestNativeCrash()?.apply {
@@ -89,7 +89,7 @@ internal class NativeCrashDataSourceImpl(
                 severity = LogSeverity.ERROR,
                 message = "",
                 addCurrentSessionInfo = false,
-                timestampMs = nativeCrash.timestamp
+                timestampMs = nativeCrash.timestamp,
             )
         }
     }

--- a/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImpl.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImpl.kt
@@ -52,7 +52,7 @@ internal class NativeCrashHandlerInstallerImpl(
                 mainThreadHandler.postAtFrontOfQueue { installSignals() }
                 mainThreadHandler.postDelayed(
                     Runnable(::checkSignalHandlersOverwritten),
-                    HANDLER_CHECK_DELAY_MS
+                    HANDLER_CHECK_DELAY_MS,
                 )
                 args.registerSessionPartChangeListener { updateSessionIds() }
             }
@@ -68,7 +68,7 @@ internal class NativeCrashHandlerInstallerImpl(
         delegate.onSessionChange(
             sessionPartId,
             userSessionId,
-            createNativeReportPath(sessionPartId, userSessionId)
+            createNativeReportPath(sessionPartId, userSessionId),
         )
     }
 
@@ -108,7 +108,7 @@ internal class NativeCrashHandlerInstallerImpl(
             delegate.installSignalHandlers(
                 markerFilePath,
                 reportId,
-                devLogging
+                devLogging,
             )
         }
     }

--- a/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashProcessorImpl.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashProcessorImpl.kt
@@ -59,7 +59,7 @@ internal class NativeCrashProcessorImpl(
                 } else {
                     logger.trackInternalError(
                         type = InternalErrorType.NativeCrashLoadFail,
-                        throwable = FileNotFoundException("Failed to load crash report at ${crashFile.path}")
+                        throwable = FileNotFoundException("Failed to load crash report at ${crashFile.path}"),
                     )
                     null
                 }
@@ -69,8 +69,8 @@ internal class NativeCrashProcessorImpl(
                     type = InternalErrorType.NativeCrashLoadFail,
                     throwable = RuntimeException(
                         "Failed to read native crash file {crashFilePath=" + crashFile.absolutePath + "}.",
-                        t
-                    )
+                        t,
+                    ),
                 )
                 null
             }

--- a/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NdkCrashInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NdkCrashInstrumentationProvider.kt
@@ -27,7 +27,7 @@ class NdkCrashInstrumentationProvider : InstrumentationProvider {
                 val nativeOutputDir = StorageLocation.NATIVE.asFile(
                     logger = args.logger,
                     rootDirSupplier = { args.context.filesDir },
-                    fallbackDirSupplier = { args.context.cacheDir }
+                    fallbackDirSupplier = { args.context.cacheDir },
                 )
 
                 val processor = NativeCrashProcessorImpl(
@@ -36,7 +36,7 @@ class NdkCrashInstrumentationProvider : InstrumentationProvider {
                     delegate,
                     args.configService.nativeSymbolMap,
                     nativeOutputDir,
-                    args.priorityWorker(Worker.Priority.DataPersistenceWorker)
+                    args.priorityWorker(Worker.Priority.DataPersistenceWorker),
                 )
 
                 val nativeCrashHandlerInstaller = NativeCrashHandlerInstallerImpl(

--- a/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/SharedObjectLoaderImpl.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/SharedObjectLoaderImpl.kt
@@ -29,7 +29,7 @@ internal class SharedObjectLoaderImpl(
                     if (!loggedFailure.getAndSet(true)) {
                         logger.trackInternalError(
                             type = InternalErrorType.NativeReadFail,
-                            throwable = exc
+                            throwable = exc,
                         )
                     }
                     return false

--- a/embrace-android-instrumentation-crash-ndk/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeMainThreadHandler.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeMainThreadHandler.kt
@@ -8,7 +8,7 @@ import java.util.LinkedList
 import java.util.Queue
 
 class FakeMainThreadHandler(
-    private val handlerProvider: () -> Handler = ::defaultHandlerProvider
+    private val handlerProvider: () -> Handler = ::defaultHandlerProvider,
 ) : MainThreadHandler {
 
     override val wrappedHandler: Handler

--- a/embrace-android-instrumentation-crash-ndk/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashDataSourceImplTest.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashDataSourceImplTest.kt
@@ -51,7 +51,7 @@ internal class NativeCrashDataSourceImplTest {
         nativeCrashDataSource.sendNativeCrash(
             nativeCrash = testNativeCrashData,
             userSessionProperties = mapOf(sessionPropertyName to "value"),
-            metadata = mapOf(EmbSessionAttributes.EMB_STATE to "background")
+            metadata = mapOf(EmbSessionAttributes.EMB_STATE to "background"),
         )
 
         with(args.destination.logEvents.single()) {
@@ -61,22 +61,22 @@ internal class NativeCrashDataSourceImplTest {
             assertEquals("background", attributes[EmbSessionAttributes.EMB_STATE])
             assertEquals(
                 testNativeCrashData.sessionPartId,
-                attributes[EmbSessionAttributes.EMB_SESSION_PART_ID]
+                attributes[EmbSessionAttributes.EMB_SESSION_PART_ID],
             )
             assertEquals(
                 testNativeCrashData.userSessionId,
-                attributes[SessionAttributes.SESSION_ID]
+                attributes[SessionAttributes.SESSION_ID],
             )
             assertEquals(
                 testNativeCrashData.userSessionId,
-                attributes[EmbSessionAttributes.EMB_USER_SESSION_ID]
+                attributes[EmbSessionAttributes.EMB_USER_SESSION_ID],
             )
             assertEquals("1", attributes[EmbAndroidAttributes.EMB_ANDROID_CRASH_NUMBER])
             assertEquals(testNativeCrashData.crash, attributes[embNativeCrashException])
             val json = args.serializer.toJson(testNativeCrashData.symbols)
             assertEquals(
                 json.toByteArray().toUTF8String(),
-                attributes[embNativeCrashSymbols]
+                attributes[embNativeCrashSymbols],
             )
         }
     }

--- a/embrace-android-instrumentation-crash-ndk/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImplTest.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImplTest.kt
@@ -39,8 +39,8 @@ class NativeCrashHandlerInstallerImplTest {
         val fakeConfigService =
             FakeConfigService(
                 autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(
-                    sigHandlerDetectionEnabled = true
-                )
+                    sigHandlerDetectionEnabled = true,
+                ),
             )
         fakeSharedObjectLoader = FakeSharedObjectLoader()
         fakeDelegate = FakeJniDelegate()
@@ -60,10 +60,10 @@ class NativeCrashHandlerInstallerImplTest {
             activeSessionIdsSupplier = {
                 SessionIdsSnapshot(
                     userSessionId = userSessionId.orEmpty(),
-                    sessionPartId = sessionPartId.orEmpty()
+                    sessionPartId = sessionPartId.orEmpty(),
                 )
             },
-            processIdentifier = "pid"
+            processIdentifier = "pid",
         )
         nativeCrashHandlerInstaller = NativeCrashHandlerInstallerImpl(
             args = args,

--- a/embrace-android-instrumentation-fcm/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/fcm/PushNotificationBreadcrumb.kt
+++ b/embrace-android-instrumentation-fcm/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/fcm/PushNotificationBreadcrumb.kt
@@ -8,7 +8,8 @@ class PushNotificationBreadcrumb {
 
         // this is a notification + data
         NOTIFICATION_AND_DATA("notif-data"),
-        UNKNOWN("unknown");
+        UNKNOWN("unknown"),
+        ;
 
         companion object Builder {
             fun notificationTypeFor(hasData: Boolean, hasNotification: Boolean): NotificationType {

--- a/embrace-android-instrumentation-fcm/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/fcm/PushNotificationDataSource.kt
+++ b/embrace-android-instrumentation-fcm/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/fcm/PushNotificationDataSource.kt
@@ -16,7 +16,7 @@ class PushNotificationDataSource(
 ) : DataSourceImpl(
     args = args,
     limitStrategy = UpToLimitStrategy(args.configService.breadcrumbBehavior::getCustomBreadcrumbLimit),
-    instrumentationName = "push_notification_data_source"
+    instrumentationName = "push_notification_data_source",
 ) {
 
     fun logPushNotification(
@@ -58,7 +58,7 @@ class PushNotificationDataSource(
                     from = if (captureFcmPiiData) from else null,
                     priority = notificationPriority ?: 0,
                 ),
-                clock.now()
+                clock.now(),
             )
         }
     }

--- a/embrace-android-instrumentation-fcm/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/fcm/PushNotificationInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-fcm/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/fcm/PushNotificationInstrumentationProvider.kt
@@ -13,7 +13,7 @@ class PushNotificationInstrumentationProvider : InstrumentationProvider {
             factory = {
                 fcmDataSource = PushNotificationDataSource(args)
                 fcmDataSource
-            }
+            },
         )
     }
 }

--- a/embrace-android-instrumentation-huc-lite/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/huclite/DelegatingInstrumentedUrlStreamHandler.kt
+++ b/embrace-android-instrumentation-huc-lite/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/huclite/DelegatingInstrumentedUrlStreamHandler.kt
@@ -25,7 +25,7 @@ internal class DelegatingInstrumentedUrlStreamHandler(
                     delegateHandler.javaClass,
                     "openConnection",
                     URL::class.java,
-                    Proxy::class.java
+                    Proxy::class.java,
                 )
             method.isAccessible = true
             return wrapInstrumentedConnection(method.invoke(delegateHandler, url, proxy) as URLConnection?)
@@ -41,7 +41,7 @@ internal class DelegatingInstrumentedUrlStreamHandler(
                     delegateHandler,
                     delegateHandler.javaClass,
                     "openConnection",
-                    URL::class.java
+                    URL::class.java,
                 )
             method.isAccessible = true
             return wrapInstrumentedConnection(method.invoke(delegateHandler, url) as URLConnection?)

--- a/embrace-android-instrumentation-huc-lite/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/huclite/InstrumentedHttpsURLConnection.kt
+++ b/embrace-android-instrumentation-huc-lite/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/huclite/InstrumentedHttpsURLConnection.kt
@@ -30,7 +30,7 @@ internal class InstrumentedHttpsURLConnection(
     private val requestData: RequestData? =
         hucLiteDataSource.createRequestData(
             wrappedConnection = wrappedConnection,
-            clock = clock
+            clock = clock,
         )
 
     // Overridden methods that will return when a TCP connection has been established without sending the request

--- a/embrace-android-instrumentation-huc-lite/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/huclite/InstrumentedHttpsURLStreamHandler.kt
+++ b/embrace-android-instrumentation-huc-lite/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/huclite/InstrumentedHttpsURLStreamHandler.kt
@@ -29,7 +29,7 @@ internal class InstrumentedHttpsURLStreamHandler(
                     delegatedHandler.javaClass,
                     "openConnection",
                     URL::class.java,
-                    Proxy::class.java
+                    Proxy::class.java,
                 )
             method.isAccessible = true
             val httpsConnection = method.invoke(delegatedHandler, url, proxy) as HttpsURLConnection
@@ -46,7 +46,7 @@ internal class InstrumentedHttpsURLStreamHandler(
                     delegatedHandler,
                     delegatedHandler.javaClass,
                     "openConnection",
-                    URL::class.java
+                    URL::class.java,
                 )
             method.isAccessible = true
             val httpsConnection = method.invoke(delegatedHandler, url) as HttpsURLConnection
@@ -67,6 +67,6 @@ internal class InstrumentedHttpsURLStreamHandler(
 
     private class InstrumentedConnectionException(
         override val message: String?,
-        override val cause: Throwable?
+        override val cause: Throwable?,
     ) : IOException(message, cause)
 }

--- a/embrace-android-instrumentation-huc-lite/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/HucLiteDataSource.kt
+++ b/embrace-android-instrumentation-huc-lite/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/HucLiteDataSource.kt
@@ -40,7 +40,7 @@ class HucLiteDataSource(
 ) : DataSourceImpl(
     args = args,
     limitStrategy = NoopLimitStrategy,
-    instrumentationName = "huc_lite_data_source"
+    instrumentationName = "huc_lite_data_source",
 ) {
     private val telemetryDestination = args.destination
     private val domainCountLimiter = args.configService.networkBehavior.domainCountLimiter
@@ -77,7 +77,7 @@ class HucLiteDataSource(
                     },
                     clock = clock,
                     telemetryDestination = telemetryDestination,
-                    errorHandler = ::errorHandler
+                    errorHandler = ::errorHandler,
                 )
             }.onFailure {
                 errorHandler(it)
@@ -141,8 +141,8 @@ class HucLiteDataSource(
             getOverriddenURLString(
                 request = HucLitePathOverrideRequest(
                     requestHeaderProvider = connection::getRequestProperty,
-                    originalUrl = connection.url
-                )
+                    originalUrl = connection.url,
+                ),
             )
         }
 
@@ -172,7 +172,7 @@ class HucLiteDataSource(
                         url = telemetryUrlProvider(),
                         httpMethod = method,
                         responseCode = responseCode,
-                    )
+                    ),
                 )
                 telemetryDestination.recordCompletedSpan(
                     name = "$method ${pathProvider()}",
@@ -180,7 +180,7 @@ class HucLiteDataSource(
                     endTimeMs = endTimeMs,
                     errorCode = errorCode,
                     type = EmbType.Performance.Network,
-                    attributes = networkRequestSchemaType.attributes()
+                    attributes = networkRequestSchemaType.attributes(),
                 )
             }
         }
@@ -194,8 +194,8 @@ class HucLiteDataSource(
                         url = telemetryUrlProvider(),
                         httpMethod = method,
                         errorType = t::class.java.canonicalName ?: t::class.java.simpleName,
-                        errorMessage = t.message ?: "Unexpected error"
-                    )
+                        errorMessage = t.message ?: "Unexpected error",
+                    ),
                 )
                 telemetryDestination.recordCompletedSpan(
                     name = "$method ${pathProvider()}",
@@ -203,7 +203,7 @@ class HucLiteDataSource(
                     endTimeMs = errorTimeMs,
                     errorCode = ErrorCodeAttribute.Failure,
                     type = EmbType.Performance.Network,
-                    attributes = networkRequestSchemaType.attributes()
+                    attributes = networkRequestSchemaType.attributes(),
                 )
             }
         }
@@ -243,7 +243,7 @@ class HucLiteDataSource(
 
         private fun recordRequest(
             urlProvider: () -> String,
-            recordingFunction: () -> Unit
+            recordingFunction: () -> Unit,
         ) {
             runCatching {
                 if (requestRecorded.compareAndSet(false, true)) {

--- a/embrace-android-instrumentation-huc-lite/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/HucLiteInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-huc-lite/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/HucLiteInstrumentationProvider.kt
@@ -9,10 +9,10 @@ class HucLiteInstrumentationProvider : InstrumentationProvider {
         return DataSourceState(
             factory = {
                 HucLiteDataSource(
-                    args = args
+                    args = args,
                 )
             },
-            configGate = args.configService.networkBehavior::isHucLiteInstrumentationEnabled
+            configGate = args.configService.networkBehavior::isHucLiteInstrumentationEnabled,
         )
     }
 }

--- a/embrace-android-instrumentation-huc-lite/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huclite/HucTestHarness.kt
+++ b/embrace-android-instrumentation-huc-lite/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huclite/HucTestHarness.kt
@@ -32,7 +32,7 @@ internal class HucTestHarness {
             destination = fakeTelemetryDestination,
             logger = fakeEmbLogger,
             clock = fakeClock,
-        )
+        ),
     )
 
     var mockWrappedConnection: HttpsURLConnection =

--- a/embrace-android-instrumentation-huc-lite/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huclite/InstrumentedHttpsURLConnectionTest.kt
+++ b/embrace-android-instrumentation-huc-lite/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huclite/InstrumentedHttpsURLConnectionTest.kt
@@ -74,7 +74,7 @@ internal class InstrumentedHttpsURLConnectionTest {
 
         assertSingleClientError(
             expectedStartTime = startTime,
-            expectedEndTime = getCurrentTimeMs()
+            expectedEndTime = getCurrentTimeMs(),
         )
     }
 
@@ -106,7 +106,7 @@ internal class InstrumentedHttpsURLConnectionTest {
         assertSingleSuccessfulRequest(
             expectedMethod = "POST",
             expectedStartTime = startTime,
-            expectedEndTime = endTime
+            expectedEndTime = endTime,
         )
     }
 
@@ -193,7 +193,7 @@ internal class InstrumentedHttpsURLConnectionTest {
         assertSingleSuccessfulRequest(
             expectedStartTime = startTime,
             expectedEndTime = getCurrentTimeMs(),
-            expectedUrl = "https://fakeurl.pizza/override/path?doStuff=true"
+            expectedUrl = "https://fakeurl.pizza/override/path?doStuff=true",
         )
     }
 
@@ -205,7 +205,7 @@ internal class InstrumentedHttpsURLConnectionTest {
 
         assertSingleSuccessfulRequest(
             expectedStartTime = startTime,
-            expectedEndTime = getCurrentTimeMs()
+            expectedEndTime = getCurrentTimeMs(),
         )
     }
 
@@ -219,7 +219,7 @@ internal class InstrumentedHttpsURLConnectionTest {
             expectedStartTime = FAKE_TIME_MS,
             expectedEndTime = FAKE_TIME_MS,
             expectedResponseCode = 503,
-            expectedMethod = "POST"
+            expectedMethod = "POST",
         )
     }
 

--- a/embrace-android-instrumentation-huc-lite/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/HucLiteDataSourceTest.kt
+++ b/embrace-android-instrumentation-huc-lite/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/HucLiteDataSourceTest.kt
@@ -50,7 +50,7 @@ class HucLiteDataSourceTest {
             defaultLimitSupplier = { 2 },
             domainLimitsSupplier = {
                 mapOf(testUrl.host to 4)
-            }
+            },
         )
         fakeTelemetryDestination = FakeTelemetryDestination()
         fakeTelemetryService = FakeTelemetryService()
@@ -81,7 +81,7 @@ class HucLiteDataSourceTest {
         factoryInstaller = {
             factoryField = it
             attemptToSetURLStreamHandlerFactory(it)
-        }
+        },
     )
 
     @Test
@@ -137,7 +137,7 @@ class HucLiteDataSourceTest {
             networkBehavior = FakeNetworkBehavior(
                 urlEnabled = false,
                 domainCountLimiter = domainCountLimiter,
-            )
+            ),
         )
 
         ds.createRequestData(

--- a/embrace-android-instrumentation-huc/src/main/java/io/embrace/android/embracesdk/instrumentation/huc/HttpUrlConnectionTracker.kt
+++ b/embrace-android-instrumentation-huc/src/main/java/io/embrace/android/embracesdk/instrumentation/huc/HttpUrlConnectionTracker.kt
@@ -145,7 +145,7 @@ internal object HttpUrlConnectionTracker {
                                 parentHandler.javaClass,
                                 EmbraceUrlStreamHandler.METHOD_NAME_OPEN_CONNECTION,
                                 URL::class.java,
-                                Proxy::class.java
+                                Proxy::class.java,
                             )
                         method.isAccessible = true
                         val parentConnection = method.invoke(parentHandler, url, proxy) as URLConnection?
@@ -163,7 +163,7 @@ internal object HttpUrlConnectionTracker {
                                 parentHandler,
                                 parentHandler.javaClass,
                                 EmbraceUrlStreamHandler.METHOD_NAME_OPEN_CONNECTION,
-                                URL::class.java
+                                URL::class.java,
                             )
                         method.isAccessible = true
                         val parentConnection = method.invoke(parentHandler, url) as URLConnection?

--- a/embrace-android-instrumentation-huc/src/main/java/io/embrace/android/embracesdk/instrumentation/huc/InternalNetworkApiImpl.kt
+++ b/embrace-android-instrumentation-huc/src/main/java/io/embrace/android/embracesdk/instrumentation/huc/InternalNetworkApiImpl.kt
@@ -40,15 +40,15 @@ internal class InternalNetworkApiImpl(
                     responseHeaders = body?.responseHeaders,
                     capturedResponseBody = body?.capturedResponseBody,
                     dataCaptureErrorMessage = body?.dataCaptureErrorMessage,
-                )
-            )
+                ),
+            ),
         )
     }
 
     override fun shouldCaptureNetworkBody(url: String, method: String): Boolean {
         return networkCaptureDataSource?.shouldCaptureNetworkBody(
             url = url,
-            method = method
+            method = method,
         ) ?: false
     }
 

--- a/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationApi.kt
+++ b/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationApi.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 
 class FakeInstrumentationApi(
-    var sdkTimeMs: Long = 1000
+    var sdkTimeMs: Long = 1000,
 ) : InstrumentationApi {
     override fun appReady() {
     }

--- a/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/EmbraceUrlConnectionDelegateDelegationTest.kt
+++ b/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/EmbraceUrlConnectionDelegateDelegationTest.kt
@@ -24,7 +24,7 @@ internal class EmbraceUrlConnectionDelegateDelegationTest {
         connectionDelegate = EmbraceUrlConnectionDelegate<HttpsURLConnection>(
             mockConnection,
             true,
-            FakeInternalNetworkApi()
+            FakeInternalNetworkApi(),
         )
     }
 

--- a/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/EmbraceUrlConnectionDelegateTest.kt
+++ b/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/EmbraceUrlConnectionDelegateTest.kt
@@ -39,7 +39,7 @@ internal class EmbraceUrlConnectionDelegateTest {
     fun `completed successful requests with compressed responses from a wrapped stream are recorded properly`() {
         executeRequest(
             connection = createMockGzipConnection(),
-            wrappedIoStream = true
+            wrappedIoStream = true,
         )
         validateWholeRequest(
             url = url.toString(),
@@ -50,7 +50,7 @@ internal class EmbraceUrlConnectionDelegateTest {
             responseBodySize = gzippedResponseBodySize,
             requestSize = requestBodySize,
             networkDataCaptured = true,
-            responseBody = responseBodyText
+            responseBody = responseBodyText,
         )
     }
 
@@ -58,7 +58,7 @@ internal class EmbraceUrlConnectionDelegateTest {
     fun `completed successful requests with uncompressed responses from a wrapped stream are recorded properly`() {
         executeRequest(
             connection = createMockUncompressedConnection(),
-            wrappedIoStream = true
+            wrappedIoStream = true,
         )
         validateWholeRequest(
             url = url.toString(),
@@ -69,7 +69,7 @@ internal class EmbraceUrlConnectionDelegateTest {
             responseBodySize = responseBodySize,
             requestSize = requestBodySize,
             networkDataCaptured = true,
-            responseBody = responseBodyText
+            responseBody = responseBodyText,
         )
     }
 
@@ -77,7 +77,7 @@ internal class EmbraceUrlConnectionDelegateTest {
     fun `completed successful requests with compressed responses from an unwrapped output streams are recorded properly`() {
         executeRequest(
             connection = createMockGzipConnection(),
-            wrappedIoStream = false
+            wrappedIoStream = false,
         )
         validateWholeRequest(
             url = url.toString(),
@@ -86,7 +86,7 @@ internal class EmbraceUrlConnectionDelegateTest {
             httpMethod = HttpMethod.POST.name,
             httpStatus = HTTP_OK,
             responseBodySize = gzippedResponseBodySize,
-            requestSize = 0
+            requestSize = 0,
         )
     }
 
@@ -94,7 +94,7 @@ internal class EmbraceUrlConnectionDelegateTest {
     fun `completed successful requests with uncompressed responses from an unwrapped output streams are recorded properly`() {
         executeRequest(
             connection = createMockUncompressedConnection(),
-            wrappedIoStream = false
+            wrappedIoStream = false,
         )
         validateWholeRequest(
             url = url.toString(),
@@ -103,7 +103,7 @@ internal class EmbraceUrlConnectionDelegateTest {
             httpMethod = HttpMethod.POST.name,
             httpStatus = HTTP_OK,
             responseBodySize = responseBodySize,
-            requestSize = 0
+            requestSize = 0,
         )
     }
 
@@ -112,7 +112,7 @@ internal class EmbraceUrlConnectionDelegateTest {
         executeRequest(
             connection = createMockUncompressedConnection(),
             wrappedIoStream = true,
-            exceptionOnInputStream = true
+            exceptionOnInputStream = true,
         )
         validateWholeRequest(
             url = url.toString(),
@@ -123,7 +123,7 @@ internal class EmbraceUrlConnectionDelegateTest {
             responseBodySize = 0,
             requestSize = 0,
             errorType = IO_ERROR,
-            errorMessage = "nope"
+            errorMessage = "nope",
         )
     }
 
@@ -132,7 +132,7 @@ internal class EmbraceUrlConnectionDelegateTest {
         executeRequest(
             connection = createMockGzipConnection(),
             wrappedIoStream = true,
-            exceptionOnInputStream = true
+            exceptionOnInputStream = true,
         )
         validateWholeRequest(
             url = url.toString(),
@@ -143,7 +143,7 @@ internal class EmbraceUrlConnectionDelegateTest {
             responseBodySize = 0,
             requestSize = 0,
             errorType = IO_ERROR,
-            errorMessage = "nope"
+            errorMessage = "nope",
         )
     }
 
@@ -152,7 +152,7 @@ internal class EmbraceUrlConnectionDelegateTest {
         executeRequest(
             connection = createMockUncompressedConnection(),
             wrappedIoStream = false,
-            exceptionOnInputStream = true
+            exceptionOnInputStream = true,
         )
         validateWholeRequest(
             url = url.toString(),
@@ -163,7 +163,7 @@ internal class EmbraceUrlConnectionDelegateTest {
             responseBodySize = 0,
             requestSize = 0,
             errorType = IO_ERROR,
-            errorMessage = "nope"
+            errorMessage = "nope",
         )
     }
 
@@ -172,7 +172,7 @@ internal class EmbraceUrlConnectionDelegateTest {
         executeRequest(
             connection = createMockGzipConnection(),
             wrappedIoStream = false,
-            exceptionOnInputStream = true
+            exceptionOnInputStream = true,
         )
         validateWholeRequest(
             url = url.toString(),
@@ -183,7 +183,7 @@ internal class EmbraceUrlConnectionDelegateTest {
             responseBodySize = 0,
             requestSize = 0,
             errorType = IO_ERROR,
-            errorMessage = "nope"
+            errorMessage = "nope",
         )
     }
 
@@ -191,7 +191,7 @@ internal class EmbraceUrlConnectionDelegateTest {
     fun `completed unsuccessful requests are recorded properly`() {
         executeRequest(
             connection = createMockGzipConnection(expectedResponseCode = 500),
-            wrappedIoStream = true
+            wrappedIoStream = true,
         )
         validateWholeRequest(
             url = url.toString(),
@@ -202,7 +202,7 @@ internal class EmbraceUrlConnectionDelegateTest {
             responseBodySize = gzippedResponseBodySize,
             requestSize = requestBodySize,
             networkDataCaptured = true,
-            responseBody = responseBodyText
+            responseBody = responseBodyText,
         )
     }
 
@@ -210,7 +210,7 @@ internal class EmbraceUrlConnectionDelegateTest {
     fun `completed requests with custom paths are recorded properly`() {
         executeRequest(
             connection = createMockConnectionWithPathOverride(),
-            wrappedIoStream = true
+            wrappedIoStream = true,
         )
         validateWholeRequest(
             url = customUrl.toString(),
@@ -221,7 +221,7 @@ internal class EmbraceUrlConnectionDelegateTest {
             responseBodySize = gzippedResponseBodySize,
             requestSize = requestBodySize,
             networkDataCaptured = true,
-            responseBody = responseBodyText
+            responseBody = responseBodyText,
         )
     }
 
@@ -230,7 +230,7 @@ internal class EmbraceUrlConnectionDelegateTest {
         executeRequest(
             connection = createMockConnectionWithPathOverride(),
             wrappedIoStream = true,
-            exceptionOnInputStream = true
+            exceptionOnInputStream = true,
         )
         validateWholeRequest(
             url = customUrl.toString(),
@@ -241,7 +241,7 @@ internal class EmbraceUrlConnectionDelegateTest {
             responseBodySize = 0,
             requestSize = 0,
             errorType = IO_ERROR,
-            errorMessage = "nope"
+            errorMessage = "nope",
         )
     }
 
@@ -249,7 +249,7 @@ internal class EmbraceUrlConnectionDelegateTest {
     fun `completed network call logged once with a wrapped output stream`() {
         executeRequest(
             connection = createMockUncompressedConnection(),
-            wrappedIoStream = true
+            wrappedIoStream = true,
         )
         assertEquals(1, internalApi.networkRequests.size)
     }
@@ -258,7 +258,7 @@ internal class EmbraceUrlConnectionDelegateTest {
     fun `completed network call logged exactly once with unwrapped output stream`() {
         executeRequest(
             connection = createMockUncompressedConnection(),
-            wrappedIoStream = false
+            wrappedIoStream = false,
         )
         assertEquals(1, internalApi.networkRequests.size)
     }
@@ -268,7 +268,7 @@ internal class EmbraceUrlConnectionDelegateTest {
         executeRequest(
             connection = createMockUncompressedConnection(),
             wrappedIoStream = true,
-            exceptionOnInputStream = true
+            exceptionOnInputStream = true,
         )
         assertEquals(1, internalApi.networkRequests.size)
     }
@@ -290,7 +290,7 @@ internal class EmbraceUrlConnectionDelegateTest {
         verifyIncompleteRequestLogged(
             mockConnection = mockConnection,
             errorType = TIMEOUT_ERROR,
-            noResponseAccess = false
+            noResponseAccess = false,
         )
         assertEquals(1, internalApi.networkRequests.size)
     }
@@ -304,7 +304,7 @@ internal class EmbraceUrlConnectionDelegateTest {
         verifyIncompleteRequestLogged(
             mockConnection = mockConnection,
             errorType = TIMEOUT_ERROR,
-            noResponseAccess = false
+            noResponseAccess = false,
         )
         assertEquals(1, internalApi.networkRequests.size)
     }
@@ -318,7 +318,7 @@ internal class EmbraceUrlConnectionDelegateTest {
         verifyIncompleteRequestLogged(
             mockConnection = mockConnection,
             errorType = TIMEOUT_ERROR,
-            noResponseAccess = false
+            noResponseAccess = false,
         )
         assertEquals(1, internalApi.networkRequests.size)
     }
@@ -340,7 +340,7 @@ internal class EmbraceUrlConnectionDelegateTest {
     fun `check traceparents are not forwarded by default`() {
         executeRequest(
             connection = createMockConnectionWithTraceparent(),
-            wrappedIoStream = true
+            wrappedIoStream = true,
         )
         val request = retrieveNetworkRequest()
         assertNull(request.w3cTraceparent)
@@ -352,7 +352,7 @@ internal class EmbraceUrlConnectionDelegateTest {
         executeRequest(
             connection = createMockConnectionWithTraceparent(),
             wrappedIoStream = true,
-            exceptionOnInputStream = true
+            exceptionOnInputStream = true,
         )
         val request = retrieveNetworkRequest()
         assertNull(request.responseCode)
@@ -365,7 +365,7 @@ internal class EmbraceUrlConnectionDelegateTest {
         internalApi.networkSpanForwardingEnabled = true
         executeRequest(
             connection = createMockConnectionWithTraceparent(),
-            wrappedIoStream = true
+            wrappedIoStream = true,
         )
         val request = retrieveNetworkRequest()
         assertEquals(HTTP_OK, request.responseCode)
@@ -378,7 +378,7 @@ internal class EmbraceUrlConnectionDelegateTest {
         executeRequest(
             connection = createMockConnectionWithTraceparent(),
             wrappedIoStream = true,
-            exceptionOnInputStream = true
+            exceptionOnInputStream = true,
         )
         val request = retrieveNetworkRequest()
         assertNull(request.responseCode)
@@ -390,9 +390,9 @@ internal class EmbraceUrlConnectionDelegateTest {
     fun `check traceIds are logged if a custom header name is specified`() {
         executeRequest(
             connection = createMockGzipConnection(
-                extraRequestHeaders = mapOf(Pair(traceIdHeaderName, listOf(customTraceId)))
+                extraRequestHeaders = mapOf(Pair(traceIdHeaderName, listOf(customTraceId))),
             ),
-            wrappedIoStream = true
+            wrappedIoStream = true,
         )
         val request = retrieveNetworkRequest()
         assertEquals(HTTP_OK, request.responseCode)
@@ -400,18 +400,18 @@ internal class EmbraceUrlConnectionDelegateTest {
     }
 
     private fun createMockConnectionWithPathOverride() = createMockGzipConnection(
-        extraRequestHeaders = mapOf(Pair(PATH_OVERRIDE, listOf(customPath)))
+        extraRequestHeaders = mapOf(Pair(PATH_OVERRIDE, listOf(customPath))),
     )
 
     private fun createMockConnectionWithTraceparent() = createMockGzipConnection(
-        extraRequestHeaders = mapOf(Pair(TRACEPARENT_HEADER_NAME, listOf(TRACEPARENT)))
+        extraRequestHeaders = mapOf(Pair(TRACEPARENT_HEADER_NAME, listOf(TRACEPARENT))),
     )
 
     private fun createMockUncompressedConnection(): HttpsURLConnection {
         return createMockConnection(
             inputStream = ByteArrayInputStream(responseBodyBytes),
             expectedResponseSize = responseBodySize,
-            expectedResponseCode = HTTP_OK
+            expectedResponseCode = HTTP_OK,
         )
     }
 
@@ -425,8 +425,8 @@ internal class EmbraceUrlConnectionDelegateTest {
             expectedResponseSize = gzippedResponseBodySize,
             expectedResponseCode = expectedResponseCode,
             extraResponseHeaders = mapOf(
-                Pair(CONTENT_ENCODING, listOf("gzip"))
-            )
+                Pair(CONTENT_ENCODING, listOf("gzip")),
+            ),
         )
     }
 
@@ -447,7 +447,7 @@ internal class EmbraceUrlConnectionDelegateTest {
 
         val requestHeaders = mutableMapOf(
             Pair(requestHeaderName, listOf(requestHeaderValue)),
-            Pair(traceIdHeaderName, listOf(defaultTraceId))
+            Pair(traceIdHeaderName, listOf(defaultTraceId)),
         )
 
         if (extraRequestHeaders.isNotEmpty()) {
@@ -456,7 +456,7 @@ internal class EmbraceUrlConnectionDelegateTest {
 
         val responseHeaders = mutableMapOf(
             Pair(CONTENT_LENGTH, listOf(expectedResponseSize.toString())),
-            Pair(responseHeaderName, listOf(responseHeaderValue))
+            Pair(responseHeaderName, listOf(responseHeaderValue)),
         )
 
         if (extraResponseHeaders.isNotEmpty()) {

--- a/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/EmbraceUrlStreamHandlerTest.kt
+++ b/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/EmbraceUrlStreamHandlerTest.kt
@@ -33,7 +33,7 @@ internal class EmbraceUrlStreamHandlerTest {
             EmbraceHttpUrlStreamHandler(
                 httpUrlStreamHandler,
                 internalApi,
-            )
+            ),
         )
         val connection = checkNotNull(url.openConnection())
         assertNull(connection.getRequestProperty(TRACEPARENT_HEADER_NAME))
@@ -48,8 +48,8 @@ internal class EmbraceUrlStreamHandlerTest {
             "secure.txt",
             EmbraceHttpsUrlStreamHandler(
                 httpsUrlStreamHandler,
-                internalApi
-            )
+                internalApi,
+            ),
         )
         val connection = checkNotNull(url.openConnection())
         assertNull(connection.getRequestProperty(TRACEPARENT_HEADER_NAME))
@@ -65,8 +65,8 @@ internal class EmbraceUrlStreamHandlerTest {
             "insecure.txt",
             EmbraceHttpUrlStreamHandler(
                 httpUrlStreamHandler,
-                internalApi
-            )
+                internalApi,
+            ),
         )
         val connection = checkNotNull(url.openConnection())
         assertNotNull(connection.getRequestProperty(TRACEPARENT_HEADER_NAME))
@@ -82,8 +82,8 @@ internal class EmbraceUrlStreamHandlerTest {
             "secure.txt",
             EmbraceHttpsUrlStreamHandler(
                 httpsUrlStreamHandler,
-                internalApi
-            )
+                internalApi,
+            ),
         )
         val connection = checkNotNull(url.openConnection())
         assertNotNull(connection.getRequestProperty(TRACEPARENT_HEADER_NAME))
@@ -98,8 +98,8 @@ internal class EmbraceUrlStreamHandlerTest {
             "insecure.txt",
             EmbraceHttpUrlStreamHandler(
                 httpUrlStreamHandler,
-                internalApi
-            )
+                internalApi,
+            ),
         )
         val connection = checkNotNull(url.openConnection())
         assertTrue(connection is EmbraceHttpUrlConnectionImpl<*>)
@@ -114,8 +114,8 @@ internal class EmbraceUrlStreamHandlerTest {
             "insecure.txt",
             EmbraceHttpsUrlStreamHandler(
                 httpsUrlStreamHandler,
-                internalApi
-            )
+                internalApi,
+            ),
         )
         val connection = checkNotNull(url.openConnection())
         assertTrue(connection is EmbraceHttpsUrlConnectionImpl<*>)

--- a/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/HttpUrlConnectionUtilsTest.kt
+++ b/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/HttpUrlConnectionUtilsTest.kt
@@ -14,13 +14,13 @@ internal class HttpUrlConnectionUtilsTest {
             FakeURLStreamHandler(),
             WrapperURLStreamHandler(),
             NoOpenConnectionURLStreamHandler(),
-            WrapperNoOpenConnectionURLStreamHandler()
+            WrapperNoOpenConnectionURLStreamHandler(),
         ).forEach { urlStreamHandler ->
             val method = findDeclaredMethod(
                 obj = urlStreamHandler,
                 objClz = urlStreamHandler.javaClass,
                 methodName = EmbraceUrlStreamHandler.METHOD_NAME_OPEN_CONNECTION,
-                url.javaClass
+                url.javaClass,
             )
             assertNotNull(method)
         }
@@ -33,7 +33,7 @@ internal class HttpUrlConnectionUtilsTest {
             obj = urlStreamHandler,
             objClz = urlStreamHandler.javaClass,
             methodName = "nahhhh",
-            url.javaClass
+            url.javaClass,
         )
     }
 
@@ -45,7 +45,7 @@ internal class HttpUrlConnectionUtilsTest {
             objClz = urlStreamHandler.javaClass,
             methodName = EmbraceUrlStreamHandler.METHOD_NAME_OPEN_CONNECTION,
             url.javaClass,
-            url.javaClass
+            url.javaClass,
         )
     }
 

--- a/embrace-android-instrumentation-navigation/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/NavigationEventBroker.kt
+++ b/embrace-android-instrumentation-navigation/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/NavigationEventBroker.kt
@@ -35,7 +35,7 @@ internal class NavigationEventBroker(
                         calculateStateAndNotifyLoad(
                             activityStartTime = startTime,
                             eventTime = event.timestampMs,
-                            event = event
+                            event = event,
                         )
                     } else if (!visibleScreens.contains(event.componentId)) {
                         // If the activity has a NavController but there isn't a screen visible, the app is emerging from the background.
@@ -45,7 +45,7 @@ internal class NavigationEventBroker(
                             notifyLoad(
                                 event = event,
                                 loadTime = startTime,
-                                stateValue = lastDest
+                                stateValue = lastDest,
                             )
                         }
                     }
@@ -62,7 +62,7 @@ internal class NavigationEventBroker(
                 visibleScreens[event.componentId] = event.name
                 calculateStateAndNotifyLoad(
                     eventTime = event.timestampMs,
-                    event = event
+                    event = event,
                 )
             }
             is NavigationEvent.Backgrounded -> {

--- a/embrace-android-instrumentation-navigation/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/NavigationStateDataSource.kt
+++ b/embrace-android-instrumentation-navigation/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/NavigationStateDataSource.kt
@@ -20,7 +20,7 @@ class NavigationStateDataSource(
 ),
     NavigationControllerEventListener {
     private val broker = NavigationEventBroker(
-        onScreenLoad = ::onScreenLoad
+        onScreenLoad = ::onScreenLoad,
     )
 
     private val activityNavigationTracker = ActivityNavigationTracker(

--- a/embrace-android-instrumentation-navigation/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/ActivityNavigationTrackerTest.kt
+++ b/embrace-android-instrumentation-navigation/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/ActivityNavigationTrackerTest.kt
@@ -93,7 +93,7 @@ internal class ActivityNavigationTrackerTest {
         second: ActivityController<out Activity>,
     ): List<Long> {
         return invokeCallbacks(
-            listOf(first::start, first::resume, first::pause, second::start, second::resume, second::pause, ::onBackground)
+            listOf(first::start, first::resume, first::pause, second::start, second::resume, second::pause, ::onBackground),
         )
     }
 
@@ -102,7 +102,7 @@ internal class ActivityNavigationTrackerTest {
         second: ActivityController<out Activity>,
     ): List<Long> {
         return invokeCallbacks(
-            listOf(first::start, first::resume, second::start, second::resume, first::pause, second::pause, ::onBackground)
+            listOf(first::start, first::resume, second::start, second::resume, first::pause, second::pause, ::onBackground),
         )
     }
 

--- a/embrace-android-instrumentation-navigation/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/NavigationEventBrokerTest.kt
+++ b/embrace-android-instrumentation-navigation/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/navigation/NavigationEventBrokerTest.kt
@@ -54,8 +54,8 @@ internal class NavigationEventBrokerTest {
                 homeActivity.localClassName,
                 settingsActivity.localClassName,
                 "Backgrounded",
-                profileActivity.localClassName
-            )
+                profileActivity.localClassName,
+            ),
         )
     }
 
@@ -73,7 +73,7 @@ internal class NavigationEventBrokerTest {
             listOf(
                 homeActivity.localClassName,
                 "Backgrounded",
-            )
+            ),
         )
     }
 
@@ -101,7 +101,7 @@ internal class NavigationEventBrokerTest {
         broker.submitAndTick(ActivityResumed(settingsActivity, clock.now()))
         loadTimes.add(broker.submitAndTick(ActivityResumed(homeActivity, clock.now())))
         assertStateTransitions(
-            listOf(settingsActivity.localClassName, homeActivity.localClassName)
+            listOf(settingsActivity.localClassName, homeActivity.localClassName),
         )
     }
 

--- a/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/EmbraceHttpPathOverride.kt
+++ b/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/EmbraceHttpPathOverride.kt
@@ -23,7 +23,7 @@ private val RELATIVE_PATH_PATTERN: Pattern = Pattern.compile("[A-Za-z0-9-._~:/\\
 @JvmOverloads
 fun getOverriddenURLString(
     request: HttpPathOverrideRequest,
-    pathOverride: String? = request.getHeaderByName(PATH_OVERRIDE)
+    pathOverride: String? = request.getHeaderByName(PATH_OVERRIDE),
 ): String {
     val url = try {
         if (pathOverride != null && validatePathOverride(pathOverride)) {

--- a/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkCaptureDataSourceImpl.kt
+++ b/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkCaptureDataSourceImpl.kt
@@ -18,7 +18,7 @@ class NetworkCaptureDataSourceImpl(
 ) : NetworkCaptureDataSource, DataSourceImpl(
     args = args,
     limitStrategy = NoopLimitStrategy,
-    instrumentationName = "network_capture_data_source"
+    instrumentationName = "network_capture_data_source",
 ) {
 
     private val keyValueStore: KeyValueStore = args.store
@@ -43,7 +43,7 @@ class NetworkCaptureDataSourceImpl(
             request.startTime,
             request.endTime,
             body,
-            request.errorMessage
+            request.errorMessage,
         )
     }
 
@@ -71,7 +71,7 @@ class NetworkCaptureDataSourceImpl(
                 val responseBody =
                     requestBody.dataCaptureErrorMessage ?: parseBody(
                         requestBody.capturedResponseBody,
-                        rule.maxSize
+                        rule.maxSize,
                     )
                 decreaseNetworkCaptureRuleRemainingCount(rule.id, rule.maxCount)
 
@@ -94,7 +94,7 @@ class NetworkCaptureDataSourceImpl(
                     sessionPartId = args.sessionPartId(),
                     startTime = startTime,
                     url = url,
-                    errorMessage = errorMessage
+                    errorMessage = errorMessage,
                 )
 
                 val networkLog = getNetworkPayload(capturedNetworkCall)
@@ -131,10 +131,10 @@ class NetworkCaptureDataSourceImpl(
                     startTime = call.startTime,
                     url = call.url,
                     errorMessage = call.errorMessage,
-                    encryptedPayload = call.encryptedPayload
+                    encryptedPayload = call.encryptedPayload,
                 ),
                 LogSeverity.INFO,
-                call.networkId
+                call.networkId,
             )
         }
     }
@@ -199,7 +199,7 @@ class NetworkCaptureDataSourceImpl(
         val capturePublicKey = configService.networkBehavior.getNetworkBodyCapturePublicKey() ?: return null
         return networkCaptureEncryptionManager.encrypt(
             serializer.toJson(capturedNetworkCall),
-            capturePublicKey
+            capturePublicKey,
         )
     }
 

--- a/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkCaptureInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkCaptureInstrumentationProvider.kt
@@ -17,7 +17,7 @@ class NetworkCaptureInstrumentationProvider : InstrumentationProvider {
             factory = {
                 networkCaptureDataSource = NetworkCaptureDataSourceImpl(args)
                 networkCaptureDataSource
-            }
+            },
         )
     }
 

--- a/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceImpl.kt
+++ b/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceImpl.kt
@@ -34,7 +34,7 @@ class NetworkRequestDataSourceImpl(
 ) : NetworkRequestDataSource, DataSourceImpl(
     args,
     NoopLimitStrategy,
-    "network_request_data_source"
+    "network_request_data_source",
 ) {
     private val activeRequests: MutableMap<String, SpanToken> = ConcurrentHashMap()
     private val domainCountLimiter: DomainCountLimiter = args.configService.networkBehavior.domainCountLimiter
@@ -46,7 +46,7 @@ class NetworkRequestDataSourceImpl(
 
         // Get the domain, if it can be successfully parsed. If not, don't log this call.
         val domain = getDomain(
-            stripUrl(request.url)
+            stripUrl(request.url),
         ) ?: return
 
         captureTelemetry(
@@ -55,7 +55,7 @@ class NetworkRequestDataSourceImpl(
             },
             invalidInputCallback = {
                 telemetryService.trackAppliedLimit("network_request", AppliedLimitType.DROP)
-            }
+            },
         ) {
             val networkRequestSchemaType = SchemaType.NetworkRequest(generateSchemaAttributes(request))
             val statusCode = request.statusCode
@@ -70,7 +70,7 @@ class NetworkRequestDataSourceImpl(
                 endTimeMs = request.endTime,
                 type = EmbType.Performance.Network,
                 attributes = networkRequestSchemaType.attributes(),
-                errorCode = errorCode
+                errorCode = errorCode,
             )
         }
     }
@@ -82,19 +82,19 @@ class NetworkRequestDataSourceImpl(
 
         // Get the domain, if it can be successfully parsed. If not, don't log this call.
         val domain = getDomain(
-            stripUrl(startData.url)
+            stripUrl(startData.url),
         ) ?: return null
 
         return captureTelemetry(
             inputValidation = { domainCountLimiter.canLogNetworkRequest(domain) },
             invalidInputCallback = {
                 telemetryService.trackAppliedLimit("network_request", AppliedLimitType.DROP)
-            }
+            },
         ) {
             val spanToken = destination.startSpanCapture(
                 schemaType = SchemaType.NetworkRequest(requestStartAttributes(startData)),
                 startTimeMs = startData.sdkClockStartTime,
-                name = getNetworkSpanName(startData.httpMethod, startData.url)
+                name = getNetworkSpanName(startData.httpMethod, startData.url),
             )
 
             spanToken.asW3cTraceparent()?.also { traceparent ->

--- a/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestInstrumentationProvider.kt
@@ -17,7 +17,7 @@ class NetworkRequestInstrumentationProvider : InstrumentationProvider {
             factory = {
                 networkRequestDataSource = NetworkRequestDataSourceImpl(args)
                 networkRequestDataSource
-            }
+            },
         )
     }
 

--- a/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/EmbraceHttpPathOverrideTest.kt
+++ b/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/EmbraceHttpPathOverrideTest.kt
@@ -9,7 +9,7 @@ internal class EmbraceHttpPathOverrideTest {
     fun `check override path validity`() {
         val request: HttpPathOverrideRequest = FakeHttpOverrideRequest(
             urlString = DEFAULT_URL,
-            overriddenUrlStringProvider = ::customUrlProvider
+            overriddenUrlStringProvider = ::customUrlProvider,
         )
 
         assertEquals(DEFAULT_URL, getOverriddenURLString(request, null))

--- a/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/FakeNetworkCapturedCall.kt
+++ b/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/FakeNetworkCapturedCall.kt
@@ -24,6 +24,6 @@ fun fakeNetworkCapturedCall(): NetworkCapturedCall {
         startTime = 1713452000,
         url = "https://httpbin.org/get",
         errorMessage = "",
-        encryptedPayload = "encrypted-payload"
+        encryptedPayload = "encrypted-payload",
     )
 }

--- a/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkCaptureDataSourceTest.kt
+++ b/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkCaptureDataSourceTest.kt
@@ -34,7 +34,7 @@ internal class NetworkCaptureDataSourceTest {
     fun setUp() {
         cfg = RemoteConfig()
         configService = FakeConfigService(
-            networkBehavior = createNetworkBehavior(remoteCfg = cfg)
+            networkBehavior = createNetworkBehavior(remoteCfg = cfg),
         )
     }
 
@@ -136,7 +136,7 @@ internal class NetworkCaptureDataSourceTest {
                 startTime = 0,
                 endTime = 2000,
                 body = networkCaptureData,
-            )
+            ),
         )
         assertEquals(0, destination.logEvents.size)
 
@@ -148,8 +148,8 @@ internal class NetworkCaptureDataSourceTest {
                 statusCode = 200,
                 startTime = 0,
                 endTime = 6000,
-                body = networkCaptureData
-            )
+                body = networkCaptureData,
+            ),
         )
         assertEquals(1, destination.logEvents.size)
     }
@@ -168,8 +168,8 @@ internal class NetworkCaptureDataSourceTest {
                 statusCode = 200,
                 startTime = 0,
                 endTime = 2000,
-                body = networkCaptureData
-            )
+                body = networkCaptureData,
+            ),
         )
         assertEquals(1, destination.logEvents.size)
 
@@ -180,8 +180,8 @@ internal class NetworkCaptureDataSourceTest {
                 statusCode = 404,
                 startTime = 0,
                 endTime = 2000,
-                body = networkCaptureData
-            )
+                body = networkCaptureData,
+            ),
         )
         assertEquals(2, destination.logEvents.size)
 
@@ -192,8 +192,8 @@ internal class NetworkCaptureDataSourceTest {
                 statusCode = 500,
                 startTime = 0,
                 endTime = 2000,
-                body = networkCaptureData
-            )
+                body = networkCaptureData,
+            ),
         )
         assertEquals(2, destination.logEvents.size)
     }
@@ -237,7 +237,7 @@ internal class NetworkCaptureDataSourceTest {
                 rules = setOf(getDefaultRule()),
                 captureBodyEncryptionEnabled = true,
                 publicKey = fakeNetworkBodyPublicKey,
-            )
+            ),
         )
         args = FakeInstrumentationArgs(
             application = ApplicationProvider.getApplicationContext(),
@@ -260,7 +260,7 @@ internal class NetworkCaptureDataSourceTest {
                     capturedResponseBody = "response-body-plaintext".toByteArray(),
                     dataCaptureErrorMessage = null,
                 ),
-            )
+            ),
         )
 
         assertEquals(1, destination.logEvents.size)
@@ -280,7 +280,7 @@ internal class NetworkCaptureDataSourceTest {
         args = FakeInstrumentationArgs(
             application = ApplicationProvider.getApplicationContext(),
             configService = configService,
-            telemetryService = telemetryService
+            telemetryService = telemetryService,
         )
 
         val largeBody = ByteArray(3) { 'a'.code.toByte() }
@@ -291,8 +291,8 @@ internal class NetworkCaptureDataSourceTest {
                 statusCode = 200,
                 startTime = 0,
                 endTime = 1000,
-                body = HttpNetworkRequest.HttpRequestBody(null, null, largeBody, null, largeBody, null)
-            )
+                body = HttpNetworkRequest.HttpRequestBody(null, null, largeBody, null, largeBody, null),
+            ),
         )
 
         assertEquals(2, telemetryService.appliedLimits.size)
@@ -304,11 +304,11 @@ internal class NetworkCaptureDataSourceTest {
 
     private fun getService(): NetworkCaptureDataSourceImpl {
         configService = FakeConfigService(
-            networkBehavior = createNetworkBehavior(remoteCfg = cfg)
+            networkBehavior = createNetworkBehavior(remoteCfg = cfg),
         )
         args = FakeInstrumentationArgs(
             application = ApplicationProvider.getApplicationContext(),
-            configService = configService
+            configService = configService,
         )
         destination = args.destination
         return NetworkCaptureDataSourceImpl(args)
@@ -332,7 +332,7 @@ internal class NetworkCaptureDataSourceTest {
             expiresIn = expiresIn,
             maxSize = maxSize,
             maxCount = maxCount,
-            statusCodes = statusCodes
+            statusCodes = statusCodes,
         )
 
     private val fakeNetworkBodyPublicKey: String =

--- a/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceStatefulApiTest.kt
+++ b/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceStatefulApiTest.kt
@@ -37,7 +37,7 @@ internal class NetworkRequestDataSourceStatefulApiTest {
             url = "www.example2.com",
             startTime = 200,
             endTime = 300,
-            statusCode = 404
+            statusCode = 404,
         )
         runRequest(
             url = "www.example3.com",
@@ -58,7 +58,7 @@ internal class NetworkRequestDataSourceStatefulApiTest {
             startTime = 600L,
             endTime = 650L,
             errorType = "RuntimeException",
-            errorMessage = "err"
+            errorMessage = "err",
         )
 
         val spans = harness.getNetworkSpans()
@@ -80,7 +80,7 @@ internal class NetworkRequestDataSourceStatefulApiTest {
                 HttpAttributes.HTTP_RESPONSE_BODY_SIZE to "1000",
                 EmbNetworkRequestAttributes.EMB_W3C_TRACEPARENT to firstRequestSpan.asW3cTraceparent(),
                 EmbNetworkRequestAttributes.EMB_TRACE_ID to "fake-trace-id",
-            )
+            ),
         )
 
         harness.assertNetworkRequest(
@@ -88,14 +88,14 @@ internal class NetworkRequestDataSourceStatefulApiTest {
             expectedName = "GET ",
             expectedStartTimeMs = 200L,
             expectedEndTimeMs = 300L,
-            expectedErrorCode = ErrorCodeAttribute.Failure
+            expectedErrorCode = ErrorCodeAttribute.Failure,
         )
         harness.assertNetworkRequest(
             spanToken = requestSpans["www.example3.com"],
             expectedName = "GET ",
             expectedStartTimeMs = 300L,
             expectedEndTimeMs = 400L,
-            expectedErrorCode = ErrorCodeAttribute.Failure
+            expectedErrorCode = ErrorCodeAttribute.Failure,
         )
         harness.assertNetworkRequest(
             spanToken = requestSpans["www.example4.com"],
@@ -112,7 +112,7 @@ internal class NetworkRequestDataSourceStatefulApiTest {
             expectedAttributes = mapOf(
                 ErrorAttributes.ERROR_TYPE to "RuntimeException",
                 ExceptionAttributes.EXCEPTION_MESSAGE to "err",
-            )
+            ),
         )
     }
 
@@ -156,7 +156,7 @@ internal class NetworkRequestDataSourceStatefulApiTest {
         with(checkNotNull(harness.getNetworkSpans().single())) {
             assertEquals(
                 NetworkUtils.stripUrl(url),
-                attributes["url.full"]
+                attributes["url.full"],
             )
         }
     }
@@ -167,7 +167,7 @@ internal class NetworkRequestDataSourceStatefulApiTest {
         val endUrl = "https://www.example1.com"
         runRequest(
             url = url,
-            endUrl = endUrl
+            endUrl = endUrl,
         )
         assertNotNull(harness.getNetworkSpans().single { it.attributes["url.full"] == endUrl })
     }
@@ -179,29 +179,29 @@ internal class NetworkRequestDataSourceStatefulApiTest {
 
         val request1 = startRequest(
             url = url,
-            startTime = 10L
+            startTime = 10L,
         )
 
         val request2 = startRequest(
             url = url,
-            startTime = 11L
+            startTime = 11L,
         )
 
         val request3 = startRequest(
             url = url,
-            startTime = 15L
+            startTime = 15L,
         )
 
         endRequest(
             callId = request2,
             url = url,
-            endTime = 1050L
+            endTime = 1050L,
         )
 
         endRequest(
             callId = request3,
             url = url,
-            endTime = 1100L
+            endTime = 1100L,
         )
 
         endRequest(
@@ -260,7 +260,7 @@ internal class NetworkRequestDataSourceStatefulApiTest {
                 endTime = endTime,
                 statusCode = statusCode,
                 errorType = errorType,
-                errorMessage = errorMessage
+                errorMessage = errorMessage,
             )
         }
     }
@@ -274,8 +274,8 @@ internal class NetworkRequestDataSourceStatefulApiTest {
             startData = RequestStartData(
                 url = url,
                 httpMethod = httpMethod,
-                sdkClockStartTime = startTime
-            )
+                sdkClockStartTime = startTime,
+            ),
         )
 
     private fun endRequest(
@@ -306,7 +306,7 @@ internal class NetworkRequestDataSourceStatefulApiTest {
                 traceId = traceId,
                 userAgentName = userAgentName,
                 userAgentVersion = userAgentVersion,
-            )
+            ),
         )
     }
 }

--- a/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceTest.kt
+++ b/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceTest.kt
@@ -50,7 +50,7 @@ internal class NetworkRequestDataSourceTest {
                 endTime = 650L,
                 errorType = "RuntimeException",
                 errorMessage = "",
-            )
+            ),
         )
 
         harness.args.destination.createdSpans
@@ -72,14 +72,14 @@ internal class NetworkRequestDataSourceTest {
             expectedName = expectedSpanName,
             expectedStartTimeMs = 200L,
             expectedEndTimeMs = 300L,
-            expectedErrorCode = ErrorCodeAttribute.Failure
+            expectedErrorCode = ErrorCodeAttribute.Failure,
         )
         harness.assertNetworkRequest(
             spanToken = requestSpans["www.example3.com"],
             expectedName = expectedSpanName,
             expectedStartTimeMs = 300L,
             expectedEndTimeMs = 400L,
-            expectedErrorCode = ErrorCodeAttribute.Failure
+            expectedErrorCode = ErrorCodeAttribute.Failure,
         )
         harness.assertNetworkRequest(
             spanToken = requestSpans["www.example4.com"],
@@ -136,7 +136,7 @@ internal class NetworkRequestDataSourceTest {
         with(checkNotNull(harness.getNetworkSpans().single())) {
             assertEquals(
                 NetworkUtils.stripUrl(url),
-                attributes["url.full"]
+                attributes["url.full"],
             )
         }
     }
@@ -157,8 +157,8 @@ internal class NetworkRequestDataSourceTest {
                 bytesSent = 100L,
                 bytesReceived = 1000L,
                 statusCode = statusCode,
-                body = body
-            )
+                body = body,
+            ),
         )
     }
 }

--- a/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceTestHarness.kt
+++ b/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceTestHarness.kt
@@ -20,9 +20,9 @@ internal class NetworkRequestDataSourceTestHarness {
         application = ApplicationProvider.getApplicationContext(),
         configService = FakeConfigService(
             networkBehavior = FakeNetworkBehavior(domainCountLimiter = domainCountLimiter),
-            networkSpanForwardingBehavior = networkSpanForwardingBehavior
+            networkSpanForwardingBehavior = networkSpanForwardingBehavior,
         ),
-        telemetryService = telemetryService
+        telemetryService = telemetryService,
     )
     val dataSource: NetworkRequestDataSource = NetworkRequestDataSourceImpl(args)
 
@@ -36,7 +36,7 @@ internal class NetworkRequestDataSourceTestHarness {
         expectedStartTimeMs: Long,
         expectedEndTimeMs: Long,
         expectedErrorCode: ErrorCodeAttribute? = null,
-        expectedAttributes: Map<String, String> = emptyMap()
+        expectedAttributes: Map<String, String> = emptyMap(),
     ) {
         with(checkNotNull(spanToken)) {
             assertEquals(expectedName, name)

--- a/embrace-android-instrumentation-network-status/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkStateInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-network-status/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkStateInstrumentationProvider.kt
@@ -8,7 +8,7 @@ class NetworkStateInstrumentationProvider :
     StateInstrumentationProvider<NetworkStateDataSource, SchemaType.NetworkState.Status>(
         configGate = {
             configService.autoDataCaptureBehavior.isNetworkConnectivityCaptureEnabled()
-        }
+        },
     ) {
     override fun factoryProvider(args: InstrumentationArgs): () -> NetworkStateDataSource {
         return { NetworkStateDataSource(args) }

--- a/embrace-android-instrumentation-network-status/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkStatusDataSource.kt
+++ b/embrace-android-instrumentation-network-status/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkStatusDataSource.kt
@@ -15,7 +15,7 @@ class NetworkStatusDataSource(
 ) : NetworkConnectivityListener, DataSourceImpl(
     args = args,
     limitStrategy = UpToLimitStrategy { MAX_CAPTURED_NETWORK_STATE_TRANSITIONS },
-    instrumentationName = "network_status_data_source"
+    instrumentationName = "network_status_data_source",
 ) {
     private val currentConnectionType: AtomicReference<ConnectionType> = AtomicReference(null)
     private var span: SpanToken? = null

--- a/embrace-android-instrumentation-network-status/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkStatusInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-network-status/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkStatusInstrumentationProvider.kt
@@ -12,7 +12,7 @@ class NetworkStatusInstrumentationProvider : InstrumentationProvider {
             },
             configGate = {
                 args.configService.autoDataCaptureBehavior.isNetworkConnectivityCaptureEnabled()
-            }
+            },
         )
     }
 }

--- a/embrace-android-instrumentation-network-status/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkStateDataSourceTest.kt
+++ b/embrace-android-instrumentation-network-status/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkStateDataSourceTest.kt
@@ -38,7 +38,7 @@ internal class NetworkStateDataSourceTest {
             assertEquals(
                 "Expected $expectedState for $connectivityStatus",
                 expectedState,
-                dataSource.getCurrentStateValue()
+                dataSource.getCurrentStateValue(),
             )
         }
     }

--- a/embrace-android-instrumentation-okhttp/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/bytecode/OkHttpBytecodeEntrypoint.kt
+++ b/embrace-android-instrumentation-okhttp/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/bytecode/OkHttpBytecodeEntrypoint.kt
@@ -39,11 +39,11 @@ object OkHttpBytecodeEntrypoint {
         try {
             addInterceptor(
                 thiz.interceptors(),
-                EmbraceOkHttpInterceptor(InterceptorType.APPLICATION, provider)
+                EmbraceOkHttpInterceptor(InterceptorType.APPLICATION, provider),
             )
             addInterceptor(
                 thiz.networkInterceptors(),
-                EmbraceOkHttpInterceptor(InterceptorType.NETWORK, provider)
+                EmbraceOkHttpInterceptor(InterceptorType.NETWORK, provider),
             )
         } catch (ignored: Throwable) {
         }

--- a/embrace-android-instrumentation-okhttp/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpDataSource.kt
+++ b/embrace-android-instrumentation-okhttp/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpDataSource.kt
@@ -40,7 +40,7 @@ internal class OkHttpDataSource(
 ) : DataSourceImpl(
     args = args,
     limitStrategy = NoopLimitStrategy, // always allow the OkHttp request chain to proceed
-    instrumentationName = "okhttp_data_source"
+    instrumentationName = "okhttp_data_source",
 ) {
     /**
      * A map that stashes instrumentation information for a request so that different interceptors can reference the same instance.
@@ -72,13 +72,13 @@ internal class OkHttpDataSource(
                 url = getOverriddenURLString(EmbraceOkHttpPathOverrideRequest(request)),
                 httpMethod = request.method,
                 sdkClockStartTime = sdkClockStartTime,
-            )
+            ),
         ) ?: return null
 
         return CallData(
             id = callId,
             clockOffset = clockOffset,
-            sdkClockStartTime = sdkClockStartTime
+            sdkClockStartTime = sdkClockStartTime,
         ).also {
             activeCalls[call] = it
         }
@@ -120,7 +120,7 @@ internal class OkHttpDataSource(
                     traceId = request.header(CUSTOM_TRACE_ID_HEADER_NAME),
                     userAgentName = OKHTTP_USER_AGENT_NAME,
                     userAgentVersion = OkHttp.VERSION,
-                )
+                ),
             )
         } finally {
             activeCalls.remove(call)
@@ -154,7 +154,7 @@ internal class OkHttpDataSource(
         val contentLength: Long = getContentLengthFromHeader(networkResponse)
             ?: getContentLengthFromBody(
                 networkResponse = networkResponse,
-                contentType = networkResponse.header(CONTENT_TYPE_HEADER_NAME, null)
+                contentType = networkResponse.header(CONTENT_TYPE_HEADER_NAME, null),
             ) ?: 0L
 
         var response: Response = networkResponse
@@ -167,13 +167,13 @@ internal class OkHttpDataSource(
 
         val shouldCaptureNetworkData = networkCaptureDataSourceProvider()?.shouldCaptureNetworkBody(
             request.url.toString(),
-            request.method
+            request.method,
         ) ?: false
         if (shouldCaptureNetworkData && networkCaptureDataSource != null) {
             // Decompress any response body that is gzipped so it can be captured in plain text
             if (ENCODING_GZIP.equals(
                     networkResponse.header(CONTENT_ENCODING_HEADER_NAME, null),
-                    ignoreCase = true
+                    ignoreCase = true,
                 ) && networkResponse.promisesBody()
             ) {
                 networkResponse.body?.also {
@@ -190,8 +190,8 @@ internal class OkHttpDataSource(
                     } else {
                         null
                     },
-                    networkCaptureData = networkCaptureData
-                )
+                    networkCaptureData = networkCaptureData,
+                ),
             )
         }
 
@@ -212,7 +212,7 @@ internal class OkHttpDataSource(
         statusCode = statusCode,
         traceId = traceId,
         w3cTraceparent = w3cTraceparent,
-        body = networkCaptureData
+        body = networkCaptureData,
     )
 
     private fun createRequestEndData(
@@ -244,7 +244,7 @@ internal class OkHttpDataSource(
         val realResponseBody = RealResponseBody(
             networkResponse.header(CONTENT_TYPE_HEADER_NAME, null),
             -1L,
-            GzipSource(source()).buffer()
+            GzipSource(source()).buffer(),
         )
         val responseBuilder = networkResponse.newBuilder().request(request)
         responseBuilder.headers(strippedHeaders)
@@ -331,8 +331,8 @@ internal class OkHttpDataSource(
                 InternalErrorType.DataSourceDataCaptureFail,
                 RuntimeException(
                     "Failure during the building of NetworkCaptureData. $dataCaptureErrorMessage",
-                    e
-                )
+                    e,
+                ),
             )
         }
         return HttpNetworkRequest.HttpRequestBody(
@@ -341,7 +341,7 @@ internal class OkHttpDataSource(
             capturedRequestBody = requestBodyBytes,
             responseHeaders = responseHeaders,
             capturedResponseBody = responseBodyBytes,
-            dataCaptureErrorMessage = dataCaptureErrorMessage
+            dataCaptureErrorMessage = dataCaptureErrorMessage,
         )
     }
 
@@ -369,7 +369,7 @@ internal class OkHttpDataSource(
         } catch (e: IOException) {
             logger.trackInternalError(
                 InternalErrorType.DataSourceDataCaptureFail,
-                e
+                e,
             )
         }
         return null
@@ -400,7 +400,7 @@ internal class OkHttpDataSource(
             "Request Headers",
             "Query Parameters",
             "Request Body",
-            "Response Body"
+            "Response Body",
         )
     }
 }

--- a/embrace-android-instrumentation-okhttp/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-okhttp/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpInstrumentationProvider.kt
@@ -16,7 +16,7 @@ class OkHttpInstrumentationProvider : InstrumentationProvider {
                 okhttpDataSource = OkHttpDataSource(
                     args,
                     ::retrieveNetworkRequestDataSource,
-                    ::retrieveNetworkCaptureDataSource
+                    ::retrieveNetworkCaptureDataSource,
                 )
                 okhttpDataSource
             },

--- a/embrace-android-instrumentation-okhttp/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpDataSourceTest.kt
+++ b/embrace-android-instrumentation-okhttp/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpDataSourceTest.kt
@@ -103,7 +103,7 @@ internal class OkHttpDataSourceTest {
         args = FakeInstrumentationArgs(
             application = ApplicationProvider.getApplicationContext(),
             configService = configService,
-            clock = sdkClock
+            clock = sdkClock,
         )
         val networkRequestDataSource = NetworkRequestDataSourceImpl(args)
         val networkCaptureDataSource = NetworkCaptureDataSourceImpl(args)
@@ -117,9 +117,9 @@ internal class OkHttpDataSourceTest {
                         duration = 0,
                         urlRegex = "^.*$",
                         expiresIn = 60000,
-                        statusCodes = setOf(200, 500)
+                        statusCodes = setOf(200, 500),
                     ),
-                )
+                ),
             )
             networkSpanForwardingBehavior = FakeNetworkSpanForwardingBehavior()
         }
@@ -133,27 +133,27 @@ internal class OkHttpDataSourceTest {
         val preNetworkInterceptorTestInterceptor = TestInspectionInterceptor(
             beforeRequestSent = { request ->
                 preNetworkInterceptorBeforeRequestSupplier.invoke(
-                    request
+                    request,
                 )
             },
             afterResponseReceived = { response ->
                 preNetworkInterceptorAfterResponseSupplier.invoke(
-                    response
+                    response,
                 )
-            }
+            },
         )
         val networkInterceptor = EmbraceOkHttpInterceptor(InterceptorType.NETWORK) { dataSource }
         val postNetworkInterceptorTestInterceptor = TestInspectionInterceptor(
             beforeRequestSent = { request ->
                 postNetworkInterceptorBeforeRequestSupplier.invoke(
-                    request
+                    request,
                 )
             },
             afterResponseReceived = { response ->
                 postNetworkInterceptorAfterResponseSupplier.invoke(
-                    response
+                    response,
                 )
-            }
+            },
         )
         okHttpClient = OkHttpClient.Builder()
             .addInterceptor(applicationInterceptor)
@@ -202,7 +202,7 @@ internal class OkHttpDataSourceTest {
         server.enqueue(createBaseMockResponse(500).setGzipBody(RESPONSE_BODY))
         runAndValidatePostRequest(
             expectedResponseBodySize = RESPONSE_BODY_GZIPPED_SIZE,
-            expectedHttpStatus = 500
+            expectedHttpStatus = 500,
         )
     }
 
@@ -212,7 +212,7 @@ internal class OkHttpDataSourceTest {
         postRequestBuilder.header("x-emb-path", CUSTOM_PATH)
         runAndValidatePostRequest(
             expectedResponseBodySize = RESPONSE_BODY_GZIPPED_SIZE,
-            expectedPath = CUSTOM_PATH
+            expectedPath = CUSTOM_PATH,
         )
     }
 
@@ -222,7 +222,7 @@ internal class OkHttpDataSourceTest {
         postRequestBuilder.header("x-emb-path", CUSTOM_PATH)
         runAndValidatePostRequest(
             expectedResponseBodySize = RESPONSE_BODY_GZIPPED_SIZE,
-            expectedPath = CUSTOM_PATH
+            expectedPath = CUSTOM_PATH,
         )
     }
 
@@ -301,7 +301,7 @@ internal class OkHttpDataSourceTest {
         postNetworkInterceptorAfterResponseSupplier = ::removeContentLengthFromResponse
         server.enqueue(
             createBaseMockResponse().addHeader(CONTENT_TYPE_HEADER_NAME, CONTENT_TYPE_EVENT_STREAM)
-                .setBody(RESPONSE_BODY)
+                .setBody(RESPONSE_BODY),
         )
         runAndValidatePostRequest(0)
     }
@@ -477,8 +477,8 @@ internal class OkHttpDataSourceTest {
                         gzipStream.finish()
                     }
                     byteArrayStream.toByteArray()
-                }
-            )
+                },
+            ),
         ).addHeader(CONTENT_ENCODING_HEADER_NAME, ENCODING_GZIP)
 
     private fun runAndValidatePostRequest(
@@ -494,7 +494,7 @@ internal class OkHttpDataSourceTest {
             httpMethod = "POST",
             requestSize = REQUEST_BODY_SIZE,
             responseBody = RESPONSE_BODY,
-            systemClockTimes = runAndGetResponseTimes(::runPostRequest)
+            systemClockTimes = runAndGetResponseTimes(::runPostRequest),
         )
     }
 
@@ -509,7 +509,7 @@ internal class OkHttpDataSourceTest {
             requestSize = 0,
             responseBodySize = expectedResponseBodySize,
             responseBody = null,
-            systemClockTimes = runAndGetResponseTimes(::runGetRequest)
+            systemClockTimes = runAndGetResponseTimes(::runGetRequest),
         )
     }
 
@@ -523,7 +523,7 @@ internal class OkHttpDataSourceTest {
             timeBeforeRequest = beforeSystemTime,
             timeAfterRequest = afterSystemTime,
             minClockDrift = minClockDrift,
-            maxClockDrift = maxClockDrift
+            maxClockDrift = maxClockDrift,
         )
     }
 
@@ -551,13 +551,13 @@ internal class OkHttpDataSourceTest {
             assertTrue(
                 "SystemClock before: ${systemClockTimes.timeBeforeRequest}, " +
                     "max drift: ${systemClockTimes.maxClockDrift}, span start time: ${span.startTimeMs}",
-                systemClockTimes.timeBeforeRequest - systemClockTimes.maxClockDrift <= span.startTimeMs
+                systemClockTimes.timeBeforeRequest - systemClockTimes.maxClockDrift <= span.startTimeMs,
             )
             val endTime = checkNotNull(span.endTimeMs)
             assertTrue(
                 "SystemClock after: ${systemClockTimes.timeAfterRequest}, " +
                     "min drift: ${systemClockTimes.minClockDrift}, span end time: $endTime",
-                systemClockTimes.timeAfterRequest - systemClockTimes.minClockDrift >= endTime
+                systemClockTimes.timeAfterRequest - systemClockTimes.minClockDrift >= endTime,
             )
             val attrs = span.attributes
             assertEquals(server.url(path).toString(), attrs[UrlAttributes.URL_FULL])

--- a/embrace-android-instrumentation-power-save/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/powersave/LowPowerDataSource.kt
+++ b/embrace-android-instrumentation-power-save/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/powersave/LowPowerDataSource.kt
@@ -16,7 +16,7 @@ class LowPowerDataSource(
 ) : DataSourceImpl(
     args = args,
     limitStrategy = UpToLimitStrategy { MAX_CAPTURED_POWER_MODE_INTERVALS },
-    instrumentationName = "low_power_data_source"
+    instrumentationName = "low_power_data_source",
 ) {
 
     private companion object {

--- a/embrace-android-instrumentation-power-save/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/powersave/PowerSaveInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-power-save/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/powersave/PowerSaveInstrumentationProvider.kt
@@ -16,7 +16,7 @@ class PowerSaveInstrumentationProvider : InstrumentationProvider {
                     provider = { args.systemService(Context.POWER_SERVICE) },
                 )
             },
-            configGate = { args.configService.autoDataCaptureBehavior.isPowerSaveModeCaptureEnabled() }
+            configGate = { args.configService.autoDataCaptureBehavior.isPowerSaveModeCaptureEnabled() },
         )
     }
 }

--- a/embrace-android-instrumentation-power-save/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/powersave/PowerStateDataSource.kt
+++ b/embrace-android-instrumentation-power-save/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/powersave/PowerStateDataSource.kt
@@ -44,7 +44,7 @@ class PowerStateDataSource(
                 } else {
                     PowerMode.NORMAL
                 },
-                transitionTimeMs = timestamp
+                transitionTimeMs = timestamp,
             )
         }
     }

--- a/embrace-android-instrumentation-power-save/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/powersave/PowerStateInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-power-save/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/powersave/PowerStateInstrumentationProvider.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 
 class PowerStateInstrumentationProvider :
     StateInstrumentationProvider<PowerStateDataSource, SchemaType.PowerState.PowerMode>(
-        configGate = { configService.autoDataCaptureBehavior.isPowerSaveModeCaptureEnabled() }
+        configGate = { configService.autoDataCaptureBehavior.isPowerSaveModeCaptureEnabled() },
     ) {
     override fun factoryProvider(args: InstrumentationArgs): () -> PowerStateDataSource {
         return { PowerStateDataSource(args) }

--- a/embrace-android-instrumentation-power-save/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/powersave/LowPowerDataSourceTest.kt
+++ b/embrace-android-instrumentation-power-save/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/powersave/LowPowerDataSourceTest.kt
@@ -25,7 +25,7 @@ internal class LowPowerDataSourceTest {
     @Before
     fun setUp() {
         args = FakeInstrumentationArgs(
-            application = ApplicationProvider.getApplicationContext()
+            application = ApplicationProvider.getApplicationContext(),
         )
         dataSource = LowPowerDataSource(
             args,
@@ -78,7 +78,7 @@ internal class LowPowerDataSourceTest {
         assertEquals("device-low-power", span.name)
         assertEquals(
             mapOf(EmbType.System.LowPower.asPair()),
-            span.attributes
+            span.attributes,
         )
     }
 }

--- a/embrace-android-instrumentation-profiler/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadStacktraceSampler.kt
+++ b/embrace-android-instrumentation-profiler/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadStacktraceSampler.kt
@@ -21,7 +21,7 @@ class ThreadStacktraceSampler(
                 truncateStacktrace(
                     targetThread,
                     targetThread.stackTrace,
-                    stacktraceFrameLimit
+                    stacktraceFrameLimit,
                 )
             } else {
                 null
@@ -31,7 +31,7 @@ class ThreadStacktraceSampler(
                     sample = trace,
                     sampleTimeMs = sampleTimeMs,
                     sampleOverheadMs = sampleTimeMs - clock.now(),
-                )
+                ),
             )
         }
     }

--- a/embrace-android-instrumentation-profiler/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadStacktraceSamplerTest.kt
+++ b/embrace-android-instrumentation-profiler/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadStacktraceSamplerTest.kt
@@ -22,7 +22,7 @@ class ThreadStacktraceSamplerTest {
             clock,
             Thread.currentThread(),
             sampleLimit,
-            200
+            200,
         )
     }
 

--- a/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/attrs/UserSessionPropertiesExt.kt
+++ b/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/attrs/UserSessionPropertiesExt.kt
@@ -8,5 +8,5 @@ private const val EMBRACE_SESSION_PROPERTY_NAME_PREFIX = "emb.properties."
 fun String.toEmbraceAttributeName(): String = EMBRACE_SESSION_PROPERTY_NAME_PREFIX + this
 
 fun String.isEmbraceAttributeName(): Boolean = startsWith(
-    EMBRACE_SESSION_PROPERTY_NAME_PREFIX
+    EMBRACE_SESSION_PROPERTY_NAME_PREFIX,
 )

--- a/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/ErrorCodeAttribute.kt
+++ b/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/ErrorCodeAttribute.kt
@@ -7,7 +7,7 @@ import io.embrace.android.embracesdk.semconv.EmbSpanAttributes
  * Attribute that stores the errorCode in an OpenTelemetry span
  */
 sealed class ErrorCodeAttribute(
-    override val value: String
+    override val value: String,
 ) : EmbraceAttribute {
     override val key: String = EmbSpanAttributes.EMB_ERROR_CODE
 

--- a/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
+++ b/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
@@ -45,14 +45,14 @@ sealed class SchemaType(
 
     class Breadcrumb(message: String) : SchemaType(
         telemetryType = EmbType.System.Breadcrumb,
-        fixedObjectName = "breadcrumb"
+        fixedObjectName = "breadcrumb",
     ) {
         override val schemaAttributes: Map<String, String> = mapOf(EmbBreadcrumbAttributes.MESSAGE to message)
     }
 
     class View(viewName: String) : SchemaType(
         telemetryType = EmbType.Ux.View,
-        fixedObjectName = "screen-view"
+        fixedObjectName = "screen-view",
     ) {
         override val schemaAttributes: Map<String, String> = mapOf(EmbViewAttributes.VIEW_NAME to viewName)
     }
@@ -70,7 +70,7 @@ sealed class SchemaType(
         priority: Int,
     ) : SchemaType(
         telemetryType = EmbType.System.PushNotification,
-        fixedObjectName = "push-notification"
+        fixedObjectName = "push-notification",
     ) {
         override val schemaAttributes: Map<String, String> = mapOf(
             EmbPushNotificationAttributes.NOTIFICATION_TITLE to title,
@@ -78,7 +78,7 @@ sealed class SchemaType(
             EmbPushNotificationAttributes.NOTIFICATION_BODY to body,
             EmbPushNotificationAttributes.NOTIFICATION_ID to id,
             EmbPushNotificationAttributes.NOTIFICATION_FROM to from,
-            EmbPushNotificationAttributes.NOTIFICATION_PRIORITY to priority.toString()
+            EmbPushNotificationAttributes.NOTIFICATION_PRIORITY to priority.toString(),
         ).toNonNullMap()
     }
 
@@ -94,12 +94,12 @@ sealed class SchemaType(
         coords: String,
     ) : SchemaType(
         telemetryType = EmbType.Ux.Tap,
-        fixedObjectName = "ui-tap"
+        fixedObjectName = "ui-tap",
     ) {
         override val schemaAttributes: Map<String, String> = mapOf(
             EmbViewAttributes.VIEW_NAME to viewName,
             EmbTapAttributes.TAP_TYPE to type,
-            EmbTapAttributes.TAP_COORDS to coords
+            EmbTapAttributes.TAP_COORDS to coords,
         ).toNonNullMap()
     }
 
@@ -107,10 +107,10 @@ sealed class SchemaType(
         url: String,
     ) : SchemaType(
         telemetryType = EmbType.Ux.WebView,
-        fixedObjectName = "web-view"
+        fixedObjectName = "web-view",
     ) {
         override val schemaAttributes: Map<String, String> = mapOf(
-            UrlAttributes.URL_FULL to url
+            UrlAttributes.URL_FULL to url,
         ).toNonNullMap()
     }
 
@@ -145,7 +145,7 @@ sealed class SchemaType(
             EmbAeiAttributes.DESCRIPTION to description,
             EmbAeiAttributes.TRACE_STATUS to traceStatus,
             EmbAndroidAttributes.EMB_ANDROID_CRASH_NUMBER to crashNumber.toString(),
-            EmbAndroidAttributes.EMB_ANDROID_AEI_CRASH_NUMBER to aeiNumber.toString()
+            EmbAndroidAttributes.EMB_ANDROID_AEI_CRASH_NUMBER to aeiNumber.toString(),
         ).toNonNullMap()
     }
 
@@ -178,7 +178,7 @@ sealed class SchemaType(
 
     object LowPower : SchemaType(
         telemetryType = EmbType.System.LowPower,
-        fixedObjectName = "device-low-power"
+        fixedObjectName = "device-low-power",
     ) {
         override val schemaAttributes: Map<String, String> = emptyMap()
     }
@@ -204,7 +204,7 @@ sealed class SchemaType(
         errorMessage: String?,
         encryptedPayload: String?,
     ) : SchemaType(
-        telemetryType = EmbType.System.NetworkCapturedRequest
+        telemetryType = EmbType.System.NetworkCapturedRequest,
     ) {
         override val schemaAttributes: Map<String, String> = mapOf(
             EmbNetworkCapturedRequestAttributes.DURATION to duration.toString(),
@@ -225,7 +225,7 @@ sealed class SchemaType(
             EmbNetworkCapturedRequestAttributes.START_TIME to startTime.toString(),
             EmbNetworkCapturedRequestAttributes.URL to url,
             ExceptionAttributes.EXCEPTION_MESSAGE to errorMessage,
-            EmbNetworkCapturedRequestAttributes.ENCRYPTED_PAYLOAD to encryptedPayload
+            EmbNetworkCapturedRequestAttributes.ENCRYPTED_PAYLOAD to encryptedPayload,
         ).toNonNullMap()
     }
 
@@ -233,10 +233,10 @@ sealed class SchemaType(
         networkStatus: String,
     ) : SchemaType(
         telemetryType = EmbType.System.NetworkStatus,
-        fixedObjectName = "network-status"
+        fixedObjectName = "network-status",
     ) {
         override val schemaAttributes: Map<String, String> = mapOf(
-            EmbNetworkStatusAttributes.NETWORK to networkStatus
+            EmbNetworkStatusAttributes.NETWORK to networkStatus,
         ).toNonNullMap()
     }
 
@@ -244,24 +244,24 @@ sealed class SchemaType(
         status: Int,
     ) : SchemaType(
         telemetryType = EmbType.Performance.ThermalState,
-        fixedObjectName = "thermal-state"
+        fixedObjectName = "thermal-state",
     ) {
         override val schemaAttributes: Map<String, String> = mapOf(
-            EmbThermalStateAttributes.STATUS to status.toString()
+            EmbThermalStateAttributes.STATUS to status.toString(),
         )
     }
 
     class InternalError(throwable: Throwable) : SchemaType(
         telemetryType = EmbType.System.InternalError,
-        fixedObjectName = "internal-error"
+        fixedObjectName = "internal-error",
     ) {
         override val schemaAttributes: Map<String, String> = mapOf(
             ExceptionAttributes.EXCEPTION_TYPE to throwable.javaClass.name,
             ExceptionAttributes.EXCEPTION_STACKTRACE to throwable.stackTrace.joinToString(
                 "\n",
-                transform = StackTraceElement::toString
+                transform = StackTraceElement::toString,
             ),
-            ExceptionAttributes.EXCEPTION_MESSAGE to (throwable.message ?: "")
+            ExceptionAttributes.EXCEPTION_MESSAGE to (throwable.message ?: ""),
         )
     }
 
@@ -274,10 +274,10 @@ sealed class SchemaType(
         val stateName: String,
     ) : SchemaType(
         telemetryType = EmbType.State,
-        fixedObjectName = "state-$stateName"
+        fixedObjectName = "state-$stateName",
     ) {
         override val schemaAttributes: Map<String, String> = mapOf(
-            EmbStateTransitionAttributes.EMB_STATE_INITIAL_VALUE to initialValue.toString()
+            EmbStateTransitionAttributes.EMB_STATE_INITIAL_VALUE to initialValue.toString(),
         )
     }
 
@@ -292,7 +292,8 @@ sealed class SchemaType(
             WAN(EmbNetworkStateAttributes.NetworkStatusValues.WAN),
             WAN_CONNECTING(EmbNetworkStateAttributes.NetworkStatusValues.WAN_CONNECTING),
             UNKNOWN(EmbNetworkStateAttributes.NetworkStatusValues.UNKNOWN),
-            UNKNOWN_CONNECTING(EmbNetworkStateAttributes.NetworkStatusValues.UNKNOWN_CONNECTING);
+            UNKNOWN_CONNECTING(EmbNetworkStateAttributes.NetworkStatusValues.UNKNOWN_CONNECTING),
+            ;
 
             override fun toString(): String = value
         }
@@ -303,7 +304,8 @@ sealed class SchemaType(
         enum class PowerMode(private val value: String) {
             NORMAL(EmbPowerStateAttributes.PowerModeValues.NORMAL),
             LOW(EmbPowerStateAttributes.PowerModeValues.LOW),
-            UNKNOWN(EmbPowerStateAttributes.PowerModeValues.UNKNOWN);
+            UNKNOWN(EmbPowerStateAttributes.PowerModeValues.UNKNOWN),
+            ;
 
             override fun toString(): String = value
         }
@@ -326,7 +328,7 @@ sealed class SchemaType(
         attributes: TelemetryAttributes,
         sendMode: SendMode,
     ) : SchemaType(
-        telemetryType = EmbType.Custom(type, subType, sendMode)
+        telemetryType = EmbType.Custom(type, subType, sendMode),
     ) {
         override val schemaAttributes: Map<String, String> = attributes.snapshot()
     }

--- a/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SendMode.kt
+++ b/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SendMode.kt
@@ -17,7 +17,9 @@ enum class SendMode {
     /**
      * Queue for delivery at the next convenient time. Used when the delivery environment is unstable, e.g. when an app is about to crash.
      */
-    DEFER;
+    DEFER,
+
+    ;
 
     companion object {
         fun fromString(value: String?): SendMode {

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/AppStartupTraceEmitter.kt
@@ -128,7 +128,7 @@ internal class AppStartupTraceEmitter(
                 startTrace(
                     isColdStart = recordColdStart,
                     sdkInitStartMs = sdkInitStartMs,
-                    activityInitTimeMs = activityInitTimeMs
+                    activityInitTimeMs = activityInitTimeMs,
                 )
             }
         }
@@ -195,8 +195,8 @@ internal class AppStartupTraceEmitter(
                 endTimeMs = endTimeMs,
                 attributes = attributes,
                 events = events,
-                errorCode = errorCode
-            )
+                errorCode = errorCode,
+            ),
         )
     }
 
@@ -250,7 +250,7 @@ internal class AppStartupTraceEmitter(
         } else {
             logger.trackInternalError(
                 type = InternalErrorType.AppLaunchTraceFail,
-                throwable = IllegalStateException("App startup trace could not be started")
+                throwable = IllegalStateException("App startup trace could not be started"),
             )
         }
     }
@@ -268,11 +268,11 @@ internal class AppStartupTraceEmitter(
                 }
                 val activityInitStartMs = cappedBy(
                     value = startupActivityPreCreatedMs ?: startupActivityInitStartMs,
-                    ceiling = uiLoadedMs
+                    ceiling = uiLoadedMs,
                 )
                 val activityInitEndMs = cappedBy(
                     value = startupActivityInitEndMs,
-                    ceiling = uiLoadedMs
+                    ceiling = uiLoadedMs,
                 )
 
                 recordTrace(
@@ -313,7 +313,7 @@ internal class AppStartupTraceEmitter(
                     internal = false,
                     attributes = trackedInterval.attributes,
                     events = trackedInterval.events,
-                    errorCode = trackedInterval.errorCode
+                    errorCode = trackedInterval.errorCode,
                 )
             }
         } while (additionalTrackedIntervals.isNotEmpty())
@@ -336,7 +336,7 @@ internal class AppStartupTraceEmitter(
 
             stop(
                 errorCode = if (!completed) ErrorCodeAttribute.UserAbandon else null,
-                endTimeMs = traceEndTimeMs
+                endTimeMs = traceEndTimeMs,
             )
 
             getStartTimeMs()?.let { traceStartTimeMs ->
@@ -435,7 +435,7 @@ internal class AppStartupTraceEmitter(
     private enum class TraceEnd {
         RESUMED,
         RENDERED,
-        READY
+        READY,
     }
 
     companion object {

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleImpl.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleImpl.kt
@@ -49,7 +49,7 @@ class DataCaptureServiceModuleImpl(
         StartupTracker(
             appStartupDataCollector = appStartupDataCollector,
             activityLoadEventEmitter = activityLoadEventEmitter,
-            drawEventEmitter = createDrawEventEmitter(versionChecker, logger)
+            drawEventEmitter = createDrawEventEmitter(versionChecker, logger),
         )
     }
 
@@ -72,7 +72,7 @@ class DataCaptureServiceModuleImpl(
                 firstDrawDetector = createDrawEventEmitter(versionChecker, logger),
                 autoTraceEnabled = configService.autoDataCaptureBehavior.isUiLoadTracingTraceAll(),
                 clock = clock,
-                versionChecker = versionChecker
+                versionChecker = versionChecker,
             )
         } else {
             null

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/StartupTracker.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/StartupTracker.kt
@@ -51,7 +51,7 @@ class StartupTracker(
             val activityName = activity.localClassName
             val callback = {
                 appStartupDataCollector.firstFrameRendered(
-                    activityName = activityName
+                    activityName = activityName,
                 )
             }
             drawEventEmitter?.registerFirstDrawCallback(activity, {}, callback)
@@ -73,7 +73,7 @@ class StartupTracker(
     override fun onActivityResumed(activity: Activity) {
         if (activity.observeForStartup()) {
             appStartupDataCollector.startupActivityResumed(
-                activityName = activity.localClassName
+                activityName = activity.localClassName,
             )
         }
     }

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/activity/LifecycleStage.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/activity/LifecycleStage.kt
@@ -8,7 +8,8 @@ enum class LifecycleStage(private val typeName: String) {
     START("start"),
     RESUME("resume"),
     RENDER("render"),
-    READY("ready");
+    READY("ready"),
+    ;
 
     fun spanName(componentName: String): String = "$componentName-$typeName"
 }

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/activity/UiLoadExt.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/activity/UiLoadExt.kt
@@ -159,7 +159,7 @@ private class LifecycleEventEmitter(
         if (activity.traceLoad()) {
             uiLoadEventListener.createEnd(
                 instanceId = traceInstanceId(activity),
-                timestampMs = nowMs()
+                timestampMs = nowMs(),
             )
         }
     }
@@ -171,7 +171,7 @@ private class LifecycleEventEmitter(
                 val renderStartCallback = {
                     uiLoadEventListener.render(
                         instanceId = instanceId,
-                        timestampMs = nowMs()
+                        timestampMs = nowMs(),
                     )
                 }
 
@@ -179,7 +179,7 @@ private class LifecycleEventEmitter(
                 val renderEndCallback = {
                     uiLoadEventListener.renderEnd(
                         instanceId = instanceId,
-                        timestampMs = nowMs()
+                        timestampMs = nowMs(),
                     )
                 }
                 drawEventEmitter.registerFirstDrawCallback(activity, renderStartCallback, renderEndCallback)
@@ -199,7 +199,7 @@ private class LifecycleEventEmitter(
             )
             uiLoadEventListener.startEnd(
                 instanceId = instanceId,
-                timestampMs = nowMs()
+                timestampMs = nowMs(),
             )
         }
     }
@@ -208,7 +208,7 @@ private class LifecycleEventEmitter(
         if (activity.traceLoad()) {
             uiLoadEventListener.resume(
                 instanceId = traceInstanceId(activity),
-                timestampMs = nowMs()
+                timestampMs = nowMs(),
             )
         }
     }
@@ -218,7 +218,7 @@ private class LifecycleEventEmitter(
             val now = nowMs()
             uiLoadEventListener.resumeEnd(
                 instanceId = traceInstanceId(activity),
-                timestampMs = now
+                timestampMs = now,
             )
         }
     }
@@ -229,7 +229,7 @@ private class LifecycleEventEmitter(
             instanceStartTime.remove(instanceId)
             uiLoadEventListener.discard(
                 instanceId = instanceId,
-                timestampMs = nowMs()
+                timestampMs = nowMs(),
             )
             drawEventEmitter?.unregisterFirstDrawCallback(activity)
         }

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/activity/UiLoadTraceEmitter.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/activity/UiLoadTraceEmitter.kt
@@ -60,12 +60,12 @@ internal class UiLoadTraceEmitter(
             instanceId = instanceId,
             activityName = activityName,
             timestampMs = timestampMs,
-            manualEnd = manualEnd
+            manualEnd = manualEnd,
         )
         startChildSpan(
             instanceId = instanceId,
             timestampMs = timestampMs,
-            lifecycleStage = LifecycleStage.CREATE
+            lifecycleStage = LifecycleStage.CREATE,
         )
     }
 
@@ -73,7 +73,7 @@ internal class UiLoadTraceEmitter(
         endChildSpan(
             instanceId = instanceId,
             timestampMs = timestampMs,
-            lifecycleStage = LifecycleStage.CREATE
+            lifecycleStage = LifecycleStage.CREATE,
         )
     }
 
@@ -83,12 +83,12 @@ internal class UiLoadTraceEmitter(
             instanceId = instanceId,
             activityName = activityName,
             timestampMs = timestampMs,
-            manualEnd = manualEnd
+            manualEnd = manualEnd,
         )
         startChildSpan(
             instanceId = instanceId,
             timestampMs = timestampMs,
-            lifecycleStage = LifecycleStage.START
+            lifecycleStage = LifecycleStage.START,
         )
     }
 
@@ -96,7 +96,7 @@ internal class UiLoadTraceEmitter(
         endChildSpan(
             instanceId = instanceId,
             timestampMs = timestampMs,
-            lifecycleStage = LifecycleStage.START
+            lifecycleStage = LifecycleStage.START,
         )
     }
 
@@ -105,7 +105,7 @@ internal class UiLoadTraceEmitter(
             startChildSpan(
                 instanceId = instanceId,
                 timestampMs = timestampMs,
-                lifecycleStage = LifecycleStage.RESUME
+                lifecycleStage = LifecycleStage.RESUME,
             )
         } else {
             if (traceCompleteTrigger(instanceId) == TraceCompleteTrigger.RESUME) {
@@ -117,7 +117,7 @@ internal class UiLoadTraceEmitter(
                 startChildSpan(
                     instanceId = instanceId,
                     timestampMs = timestampMs,
-                    lifecycleStage = LifecycleStage.READY
+                    lifecycleStage = LifecycleStage.READY,
                 )
             }
         }
@@ -127,7 +127,7 @@ internal class UiLoadTraceEmitter(
         endChildSpan(
             instanceId = instanceId,
             timestampMs = timestampMs,
-            lifecycleStage = LifecycleStage.RESUME
+            lifecycleStage = LifecycleStage.RESUME,
         )
 
         val endType = traceCompleteTrigger(instanceId)
@@ -140,7 +140,7 @@ internal class UiLoadTraceEmitter(
             startChildSpan(
                 instanceId = instanceId,
                 timestampMs = timestampMs,
-                lifecycleStage = LifecycleStage.READY
+                lifecycleStage = LifecycleStage.READY,
             )
         }
     }
@@ -150,7 +150,7 @@ internal class UiLoadTraceEmitter(
             startChildSpan(
                 instanceId = instanceId,
                 timestampMs = timestampMs,
-                lifecycleStage = LifecycleStage.RENDER
+                lifecycleStage = LifecycleStage.RENDER,
             )
         }
     }
@@ -160,7 +160,7 @@ internal class UiLoadTraceEmitter(
             endChildSpan(
                 instanceId = instanceId,
                 timestampMs = timestampMs,
-                lifecycleStage = LifecycleStage.RENDER
+                lifecycleStage = LifecycleStage.RENDER,
             )
 
             val endType = traceCompleteTrigger(instanceId)
@@ -176,7 +176,7 @@ internal class UiLoadTraceEmitter(
                     startChildSpan(
                         instanceId = instanceId,
                         timestampMs = timestampMs,
-                        lifecycleStage = LifecycleStage.READY
+                        lifecycleStage = LifecycleStage.READY,
                     )
                 }
 
@@ -190,7 +190,7 @@ internal class UiLoadTraceEmitter(
             endChildSpan(
                 instanceId = instanceId,
                 timestampMs = timestampMs,
-                lifecycleStage = LifecycleStage.READY
+                lifecycleStage = LifecycleStage.READY,
             )
             endTrace(
                 instanceId = instanceId,
@@ -204,7 +204,7 @@ internal class UiLoadTraceEmitter(
         endTrace(
             instanceId = instanceId,
             timestampMs = timestampMs,
-            errorCode = ErrorCodeAttribute.UserAbandon
+            errorCode = ErrorCodeAttribute.UserAbandon,
         )
     }
 
@@ -232,7 +232,7 @@ internal class UiLoadTraceEmitter(
                 internal = false,
                 attributes = attributes,
                 events = events,
-                errorCode = errorCode
+                errorCode = errorCode,
             )
         }
     }
@@ -258,7 +258,7 @@ internal class UiLoadTraceEmitter(
                 activeTraces[instanceId] = UiLoadTrace(
                     root = root,
                     traceCompleteTrigger = determineEndEvent(manualEnd),
-                    activityName = activityName
+                    activityName = activityName,
                 )
             }
         }
@@ -296,7 +296,7 @@ internal class UiLoadTraceEmitter(
             )?.let { newSpan ->
                 val newChildren = trace.children.plus(lifecycleStage to newSpan)
                 activeTraces[instanceId] = trace.copy(
-                    children = newChildren
+                    children = newChildren,
                 )
             }
         }

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/activity/UiLoadType.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/activity/UiLoadType.kt
@@ -12,5 +12,5 @@ internal enum class UiLoadType(val typeName: String) {
     /**
      * Load where the instance has already been created and just needs to be started and resumed (e.g. foregrounding)
      */
-    HOT("hot")
+    HOT("hot"),
 }

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/ui/DrawEventEmitter.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/ui/DrawEventEmitter.kt
@@ -18,7 +18,7 @@ interface DrawEventEmitter {
     fun registerFirstDrawCallback(
         activity: Activity,
         drawBeginCallback: () -> Unit,
-        drawCompleteCallback: () -> Unit
+        drawCompleteCallback: () -> Unit,
     )
 
     /**

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/ui/FirstDrawDetector.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/ui/FirstDrawDetector.kt
@@ -30,7 +30,7 @@ internal class FirstDrawDetector(
     override fun registerFirstDrawCallback(
         activity: Activity,
         drawBeginCallback: () -> Unit,
-        drawCompleteCallback: () -> Unit
+        drawCompleteCallback: () -> Unit,
     ) {
         val instanceId = traceInstanceId(activity)
         if (!trackingLoad(instanceId)) {
@@ -50,8 +50,8 @@ internal class FirstDrawDetector(
                 logger.trackInternalError(
                     type = InternalErrorType.UiCallbackFail,
                     throwable = IllegalStateException(
-                        "Fail to attach frame rendering callback because the callback on Window was null"
-                    )
+                        "Fail to attach frame rendering callback because the callback on Window was null",
+                    ),
                 )
 
                 // Adding an empty function indicates that the registration has failed and no subsequent attempts should
@@ -70,7 +70,7 @@ internal class FirstDrawDetector(
             }.exceptionOrNull()?.let { exception ->
                 logger.trackInternalError(
                     type = InternalErrorType.UiCallbackFail,
-                    throwable = IllegalStateException("Failed to unregister first draw callback", exception)
+                    throwable = IllegalStateException("Failed to unregister first draw callback", exception),
                 )
             }
             loadingActivities.remove(instanceId)
@@ -81,7 +81,7 @@ internal class FirstDrawDetector(
 
     private fun View.onNextDraw(onDrawCallback: () -> Unit) {
         viewTreeObserver.addOnDrawListener(
-            PyNextDrawListener(this, onDrawCallback)
+            PyNextDrawListener(this, onDrawCallback),
         )
     }
 

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/ui/HandlerMessageDrawDetector.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/ui/HandlerMessageDrawDetector.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.internal.handler.MainThreadHandler
 
 @RequiresApi(M)
 internal class HandlerMessageDrawDetector(
-    private val handler: MainThreadHandler
+    private val handler: MainThreadHandler,
 ) : DrawEventEmitter {
 
     override fun registerFirstDrawCallback(
@@ -20,7 +20,7 @@ internal class HandlerMessageDrawDetector(
         handler.sendMessageAtFrontOfQueue(
             Message.obtain(handler.wrappedHandler, drawCompleteCallback).apply {
                 isAsynchronous = true
-            }
+            },
         )
     }
 

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeDrawEventEmitter.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeDrawEventEmitter.kt
@@ -15,7 +15,7 @@ class FakeDrawEventEmitter : DrawEventEmitter {
     override fun registerFirstDrawCallback(
         activity: Activity,
         drawBeginCallback: () -> Unit,
-        drawCompleteCallback: () -> Unit
+        drawCompleteCallback: () -> Unit,
     ) {
         registeredActivities[traceInstanceId(activity)] = drawBeginCallback to drawCompleteCallback
         lastRegisteredActivity = activity

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeMainThreadHandler.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeMainThreadHandler.kt
@@ -8,7 +8,7 @@ import java.util.LinkedList
 import java.util.Queue
 
 class FakeMainThreadHandler(
-    private val handlerProvider: () -> Handler = ::defaultHandlerProvider
+    private val handlerProvider: () -> Handler = ::defaultHandlerProvider,
 ) : MainThreadHandler {
 
     override val wrappedHandler: Handler

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeUiLoadEventListener.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeUiLoadEventListener.kt
@@ -11,8 +11,8 @@ class FakeUiLoadEventListener : UiLoadEventListener {
                 stage = "create",
                 instanceId = instanceId,
                 activityName = activityName,
-                timestampMs = timestampMs
-            )
+                timestampMs = timestampMs,
+            ),
         )
     }
 
@@ -21,8 +21,8 @@ class FakeUiLoadEventListener : UiLoadEventListener {
             EventData(
                 stage = "createEnd",
                 instanceId = instanceId,
-                timestampMs = timestampMs
-            )
+                timestampMs = timestampMs,
+            ),
         )
     }
 
@@ -32,8 +32,8 @@ class FakeUiLoadEventListener : UiLoadEventListener {
                 stage = "start",
                 instanceId = instanceId,
                 activityName = activityName,
-                timestampMs = timestampMs
-            )
+                timestampMs = timestampMs,
+            ),
         )
     }
 
@@ -42,8 +42,8 @@ class FakeUiLoadEventListener : UiLoadEventListener {
             EventData(
                 stage = "startEnd",
                 instanceId = instanceId,
-                timestampMs = timestampMs
-            )
+                timestampMs = timestampMs,
+            ),
         )
     }
 
@@ -52,8 +52,8 @@ class FakeUiLoadEventListener : UiLoadEventListener {
             EventData(
                 stage = "resume",
                 instanceId = instanceId,
-                timestampMs = timestampMs
-            )
+                timestampMs = timestampMs,
+            ),
         )
     }
 
@@ -62,8 +62,8 @@ class FakeUiLoadEventListener : UiLoadEventListener {
             EventData(
                 stage = "resumeEnd",
                 instanceId = instanceId,
-                timestampMs = timestampMs
-            )
+                timestampMs = timestampMs,
+            ),
         )
     }
 
@@ -72,8 +72,8 @@ class FakeUiLoadEventListener : UiLoadEventListener {
             EventData(
                 stage = "render",
                 instanceId = instanceId,
-                timestampMs = timestampMs
-            )
+                timestampMs = timestampMs,
+            ),
         )
     }
 
@@ -82,8 +82,8 @@ class FakeUiLoadEventListener : UiLoadEventListener {
             EventData(
                 stage = "renderEnd",
                 instanceId = instanceId,
-                timestampMs = timestampMs
-            )
+                timestampMs = timestampMs,
+            ),
         )
     }
 
@@ -92,8 +92,8 @@ class FakeUiLoadEventListener : UiLoadEventListener {
             EventData(
                 stage = "complete",
                 instanceId = instanceId,
-                timestampMs = timestampMs
-            )
+                timestampMs = timestampMs,
+            ),
         )
     }
 
@@ -102,8 +102,8 @@ class FakeUiLoadEventListener : UiLoadEventListener {
             EventData(
                 stage = "discard",
                 instanceId = instanceId,
-                timestampMs = timestampMs
-            )
+                timestampMs = timestampMs,
+            ),
         )
     }
 

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/ClockTickingActivityLifecycleCallbacks.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/ClockTickingActivityLifecycleCallbacks.kt
@@ -6,7 +6,7 @@ import android.os.Bundle
 import io.embrace.android.embracesdk.fakes.FakeClock
 
 class ClockTickingActivityLifecycleCallbacks(
-    private val clock: FakeClock
+    private val clock: FakeClock,
 ) : Application.ActivityLifecycleCallbacks {
 
     override fun onActivityPreCreated(activity: Activity, savedInstanceState: Bundle?) {

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleImplTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleImplTest.kt
@@ -35,7 +35,7 @@ internal class DataCaptureServiceModuleImplTest {
             logger = FakeInternalLogger(),
             destination = FakeTelemetryDestination(),
             configService = FakeConfigService(
-                autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(uiLoadTracingEnabled = false)
+                autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(uiLoadTracingEnabled = false),
             ),
             startupClassifier = StartupClassifierImpl(),
         )
@@ -51,7 +51,7 @@ internal class DataCaptureServiceModuleImplTest {
             logger = FakeInternalLogger(),
             destination = FakeTelemetryDestination(),
             configService = FakeConfigService(
-                autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(uiLoadTracingTraceAll = false)
+                autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(uiLoadTracingTraceAll = false),
             ),
             startupClassifier = StartupClassifierImpl(),
         )

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/activity/UiLoadExtTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/activity/UiLoadExtTest.kt
@@ -45,7 +45,7 @@ internal class UiLoadExtTest {
         uiLoadEventListener = FakeUiLoadEventListener()
         drawEventEmitter = FakeDrawEventEmitter()
         RuntimeEnvironment.getApplication().registerActivityLifecycleCallbacks(
-            ClockTickingActivityLifecycleCallbacks(clock)
+            ClockTickingActivityLifecycleCallbacks(clock),
         )
     }
 
@@ -159,7 +159,7 @@ internal class UiLoadExtTest {
             firstDrawDetector = drawEventEmitter,
             autoTraceEnabled = autoTraceEnabled,
             clock = clock,
-            versionChecker = BuildVersionChecker
+            versionChecker = BuildVersionChecker,
         ).apply {
             RuntimeEnvironment.getApplication().registerActivityLifecycleCallbacks(this)
             activityController = Robolectric.buildActivity(activityClass.java)
@@ -201,120 +201,120 @@ internal class UiLoadExtTest {
         private val expectedColdOpenEvents = listOf(
             createEvent(
                 stage = "create",
-                timestampMs = START_TIME_MS + PRE_DURATION
+                timestampMs = START_TIME_MS + PRE_DURATION,
             ),
             createEvent(
                 stage = "createEnd",
-                timestampMs = START_TIME_MS + POST_DURATION + STATE_DURATION + PRE_DURATION
+                timestampMs = START_TIME_MS + POST_DURATION + STATE_DURATION + PRE_DURATION,
             ),
             createEvent(
                 stage = "start",
-                timestampMs = START_TIME_MS + POST_DURATION + STATE_DURATION + PRE_DURATION * 2
+                timestampMs = START_TIME_MS + POST_DURATION + STATE_DURATION + PRE_DURATION * 2,
             ),
             createEvent(
                 stage = "startEnd",
-                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2
+                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2,
             ),
             createEvent(
                 stage = "resume",
-                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2 + PRE_DURATION
+                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2 + PRE_DURATION,
             ),
             createEvent(
                 stage = "resumeEnd",
-                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 3
+                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 3,
             ),
             createEvent(
                 stage = "render",
-                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 3
+                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 3,
             ),
             createEvent(
                 stage = "renderEnd",
-                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 3 + RENDER_DURATION
+                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 3 + RENDER_DURATION,
             ),
             createEvent(
                 stage = "discard",
-                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 3 + RENDER_DURATION + PRE_DURATION
+                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 3 + RENDER_DURATION + PRE_DURATION,
             ),
         )
 
         val expectedHotOpenEvents = listOf(
             createEvent(
                 stage = "start",
-                timestampMs = START_TIME_MS + PRE_DURATION
+                timestampMs = START_TIME_MS + PRE_DURATION,
             ),
             createEvent(
                 stage = "startEnd",
-                timestampMs = START_TIME_MS + POST_DURATION + STATE_DURATION + PRE_DURATION
+                timestampMs = START_TIME_MS + POST_DURATION + STATE_DURATION + PRE_DURATION,
             ),
             createEvent(
                 stage = "resume",
-                timestampMs = START_TIME_MS + POST_DURATION + STATE_DURATION + PRE_DURATION * 2
+                timestampMs = START_TIME_MS + POST_DURATION + STATE_DURATION + PRE_DURATION * 2,
             ),
             createEvent(
                 stage = "resumeEnd",
-                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2
+                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2,
             ),
             createEvent(
                 stage = "render",
-                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2
+                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2,
             ),
             createEvent(
                 stage = "renderEnd",
-                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2 + RENDER_DURATION
+                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2 + RENDER_DURATION,
             ),
             createEvent(
                 stage = "discard",
-                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2 + RENDER_DURATION + PRE_DURATION
+                timestampMs = START_TIME_MS + (POST_DURATION + STATE_DURATION + PRE_DURATION) * 2 + RENDER_DURATION + PRE_DURATION,
             ),
         )
 
         val legacyColdOpenEvents = listOf(
             createEvent(
                 stage = "create",
-                timestampMs = START_TIME_MS + STATE_DURATION
+                timestampMs = START_TIME_MS + STATE_DURATION,
             ),
             createEvent(
                 stage = "createEnd",
-                timestampMs = START_TIME_MS + STATE_DURATION * 2
+                timestampMs = START_TIME_MS + STATE_DURATION * 2,
             ),
             createEvent(
                 stage = "start",
-                timestampMs = START_TIME_MS + STATE_DURATION * 2
+                timestampMs = START_TIME_MS + STATE_DURATION * 2,
             ),
             createEvent(
                 stage = "startEnd",
-                timestampMs = START_TIME_MS + STATE_DURATION * 3
+                timestampMs = START_TIME_MS + STATE_DURATION * 3,
             ),
             createEvent(
                 stage = "resume",
-                timestampMs = START_TIME_MS + STATE_DURATION * 3
+                timestampMs = START_TIME_MS + STATE_DURATION * 3,
             ),
             createEvent(
                 stage = "discard",
-                timestampMs = START_TIME_MS + STATE_DURATION * 4
+                timestampMs = START_TIME_MS + STATE_DURATION * 4,
             ),
         )
 
         val legacyHotOpenEvents = listOf(
             createEvent(
                 stage = "createEnd",
-                timestampMs = START_TIME_MS + STATE_DURATION
+                timestampMs = START_TIME_MS + STATE_DURATION,
             ),
             createEvent(
                 stage = "start",
-                timestampMs = START_TIME_MS + STATE_DURATION
+                timestampMs = START_TIME_MS + STATE_DURATION,
             ),
             createEvent(
                 stage = "startEnd",
-                timestampMs = START_TIME_MS + STATE_DURATION * 2
+                timestampMs = START_TIME_MS + STATE_DURATION * 2,
             ),
             createEvent(
                 stage = "resume",
-                timestampMs = START_TIME_MS + STATE_DURATION * 2
+                timestampMs = START_TIME_MS + STATE_DURATION * 2,
             ),
             createEvent(
                 stage = "discard",
-                timestampMs = START_TIME_MS + STATE_DURATION * 3
+                timestampMs = START_TIME_MS + STATE_DURATION * 3,
             ),
         )
 
@@ -322,7 +322,7 @@ internal class UiLoadExtTest {
             EventData(
                 stage = stage,
                 instanceId = 0,
-                timestampMs = timestampMs
+                timestampMs = timestampMs,
             )
     }
 }

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/activity/UiLoadTraceEmitterTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/activity/UiLoadTraceEmitterTest.kt
@@ -209,8 +209,8 @@ internal class UiLoadTraceEmitterTest {
                 SpanEventImpl(
                     name = "custom-event",
                     timestampNanos = timestamps.first.millisToNanos(),
-                    attributes = customAttributes
-                )
+                    attributes = customAttributes,
+                ),
             )
 
             assertEmbraceSpanData(
@@ -227,7 +227,7 @@ internal class UiLoadTraceEmitterTest {
                 expectedParent = trace,
                 expectedCustomAttributes = customAttributes,
                 expectedEvents = listOf(expectedEvent),
-                expectedErrorCode = ErrorCodeAttribute.Failure
+                expectedErrorCode = ErrorCodeAttribute.Failure,
             )
 
             assertTrue(trace.attributes.keys.none { it == "before-start" || it == "after-end" })
@@ -239,7 +239,7 @@ internal class UiLoadTraceEmitterTest {
                         span = checkNotNull(spanMap["$activityName-create"]),
                         expectedStartTimeMs = startMs(),
                         expectedEndTimeMs = endMs(),
-                        expectedParent = trace
+                        expectedParent = trace,
                     )
                 }
             } else {
@@ -251,7 +251,7 @@ internal class UiLoadTraceEmitterTest {
                     span = checkNotNull(spanMap["$activityName-start"]),
                     expectedStartTimeMs = startMs(),
                     expectedEndTimeMs = endMs(),
-                    expectedParent = trace
+                    expectedParent = trace,
                 )
             }
 
@@ -261,7 +261,7 @@ internal class UiLoadTraceEmitterTest {
                         span = checkNotNull(spanMap["$activityName-resume"]),
                         expectedStartTimeMs = startMs(),
                         expectedEndTimeMs = endMs(),
-                        expectedParent = trace
+                        expectedParent = trace,
                     )
                 }
             } else {
@@ -274,7 +274,7 @@ internal class UiLoadTraceEmitterTest {
                         span = checkNotNull(spanMap["$activityName-render"]),
                         expectedStartTimeMs = startMs(),
                         expectedEndTimeMs = endMs(),
-                        expectedParent = trace
+                        expectedParent = trace,
                     )
                 }
             } else {
@@ -297,7 +297,7 @@ internal class UiLoadTraceEmitterTest {
                     span = checkNotNull(spanMap["$activityName-ready"]),
                     expectedStartTimeMs = lastEventEndTimeMs,
                     expectedEndTimeMs = traceEndTime,
-                    expectedParent = trace
+                    expectedParent = trace,
                 )
                 assertNotEquals(traceEndTime, lastEventEndTimeMs)
             } else {
@@ -325,7 +325,7 @@ internal class UiLoadTraceEmitterTest {
             PreviousState.FROM_ACTIVITY -> {
                 traceEmitter.discard(
                     instanceId = lastInstanceId,
-                    timestampMs = lastActivityExitMs
+                    timestampMs = lastActivityExitMs,
                 )
             }
 
@@ -401,11 +401,11 @@ internal class UiLoadTraceEmitterTest {
                     SpanEventImpl(
                         name = "custom-event",
                         timestampNanos = traceStartMs.millisToNanos(),
-                        attributes = customAttributes
-                    )
-                )
+                        attributes = customAttributes,
+                    ),
+                ),
             ),
-            errorCode = ErrorCodeAttribute.Failure
+            errorCode = ErrorCodeAttribute.Failure,
         )
 
         val resumeEvents = activityResume(instanceId).apply {
@@ -558,7 +558,7 @@ internal class UiLoadTraceEmitterTest {
     private enum class PreviousState {
         FROM_ACTIVITY,
         FROM_BACKGROUND,
-        FROM_INTERRUPTED_LOAD
+        FROM_INTERRUPTED_LOAD,
     }
 
     companion object {

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/AppStartupTraceEmitterTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/AppStartupTraceEmitterTest.kt
@@ -162,7 +162,7 @@ internal class AppStartupTraceEmitterTest {
         val emitter = createTraceEmitter().apply {
             initApp(
                 hasAppInitEvents = true,
-                isColdStart = true
+                isColdStart = true,
             )
             preActivityInit(false)
         }
@@ -186,7 +186,7 @@ internal class AppStartupTraceEmitterTest {
         val emitter = createTraceEmitter().apply {
             initApp(
                 hasAppInitEvents = true,
-                isColdStart = true
+                isColdStart = true,
             )
             preActivityInit(false)
             createActivity()
@@ -215,7 +215,7 @@ internal class AppStartupTraceEmitterTest {
         val emitter = createTraceEmitter(manualEnd = true).apply {
             initApp(
                 hasAppInitEvents = true,
-                isColdStart = true
+                isColdStart = true,
             )
             initActivity(
                 loadSplashScreen = false,
@@ -245,7 +245,7 @@ internal class AppStartupTraceEmitterTest {
         val emitter = createTraceEmitter().apply {
             initApp(
                 hasAppInitEvents = true,
-                isColdStart = false
+                isColdStart = false,
             )
             preActivityInit(false)
         }
@@ -264,12 +264,12 @@ internal class AppStartupTraceEmitterTest {
         val emitter = createTraceEmitter(manualEnd = true).apply {
             initApp(
                 hasAppInitEvents = true,
-                isColdStart = false
+                isColdStart = false,
             )
             initActivity(
                 loadSplashScreen = false,
                 abortFirstLoad = false,
-                activityInitOptions = ActivityInitOptions.NORMAL
+                activityInitOptions = ActivityInitOptions.NORMAL,
             )
         }
         val abandonTime = clock.tick()
@@ -352,7 +352,7 @@ internal class AppStartupTraceEmitterTest {
         createTraceEmitter()
             .simulateAppStartup(
                 isColdStart = false,
-                hasAppInitEvents = false
+                hasAppInitEvents = false,
             )
     }
 
@@ -363,7 +363,7 @@ internal class AppStartupTraceEmitterTest {
             .simulateAppStartup(
                 isColdStart = false,
                 hasAppInitEvents = false,
-                abortFirstActivityLoad = true
+                abortFirstActivityLoad = true,
             )
     }
 
@@ -378,7 +378,7 @@ internal class AppStartupTraceEmitterTest {
     fun `no crashes if startup service not available in P`() {
         startupService = null
         createTraceEmitter().simulateAppStartup(
-            verifyTrace = false
+            verifyTrace = false,
         )
     }
 
@@ -394,7 +394,7 @@ internal class AppStartupTraceEmitterTest {
     fun `verify cold start trace without application init start and end triggered in P`() {
         createTraceEmitter()
             .simulateAppStartup(
-                hasAppInitEvents = false
+                hasAppInitEvents = false,
             )
     }
 
@@ -403,7 +403,7 @@ internal class AppStartupTraceEmitterTest {
     fun `verify cold start trace aborted activity creation in P`() {
         createTraceEmitter()
             .simulateAppStartup(
-                abortFirstActivityLoad = true
+                abortFirstActivityLoad = true,
             )
     }
 
@@ -412,7 +412,7 @@ internal class AppStartupTraceEmitterTest {
     fun `verify cold start trace with splash screen in P`() {
         createTraceEmitter()
             .simulateAppStartup(
-                loadSplashScreen = true
+                loadSplashScreen = true,
             )
     }
 
@@ -421,7 +421,7 @@ internal class AppStartupTraceEmitterTest {
     fun `verify cold start trace with manual end in P`() {
         createTraceEmitter(manualEnd = true)
             .simulateAppStartup(
-                manualEnd = true
+                manualEnd = true,
             )
     }
 
@@ -431,7 +431,7 @@ internal class AppStartupTraceEmitterTest {
         createTraceEmitter()
             .simulateAppStartup(
                 isColdStart = false,
-                hasAppInitEvents = false
+                hasAppInitEvents = false,
             )
     }
 
@@ -441,7 +441,7 @@ internal class AppStartupTraceEmitterTest {
         createTraceEmitter(manualEnd = true)
             .simulateAppStartup(
                 isColdStart = false,
-                manualEnd = true
+                manualEnd = true,
             )
     }
 
@@ -450,7 +450,7 @@ internal class AppStartupTraceEmitterTest {
     fun `no crashes if startup service not available in M`() {
         startupService = null
         createTraceEmitter().simulateAppStartup(
-            verifyTrace = false
+            verifyTrace = false,
         )
     }
 
@@ -466,7 +466,7 @@ internal class AppStartupTraceEmitterTest {
     fun `verify cold start trace without application init start and end triggered in M`() {
         createTraceEmitter()
             .simulateAppStartup(
-                hasAppInitEvents = false
+                hasAppInitEvents = false,
             )
     }
 
@@ -475,7 +475,7 @@ internal class AppStartupTraceEmitterTest {
     fun `verify cold start trace aborted activity creation in M`() {
         createTraceEmitter()
             .simulateAppStartup(
-                abortFirstActivityLoad = true
+                abortFirstActivityLoad = true,
             )
     }
 
@@ -484,7 +484,7 @@ internal class AppStartupTraceEmitterTest {
     fun `verify cold start trace with splash screen in M`() {
         createTraceEmitter()
             .simulateAppStartup(
-                loadSplashScreen = true
+                loadSplashScreen = true,
             )
     }
 
@@ -493,7 +493,7 @@ internal class AppStartupTraceEmitterTest {
     fun `verify cold start trace with manual end in M`() {
         createTraceEmitter(manualEnd = true)
             .simulateAppStartup(
-                manualEnd = true
+                manualEnd = true,
             )
     }
 
@@ -527,7 +527,7 @@ internal class AppStartupTraceEmitterTest {
         createTraceEmitter()
             .simulateAppStartup(
                 isColdStart = false,
-                hasAppInitEvents = false
+                hasAppInitEvents = false,
             )
     }
 
@@ -537,7 +537,7 @@ internal class AppStartupTraceEmitterTest {
         createTraceEmitter(manualEnd = true)
             .simulateAppStartup(
                 isColdStart = false,
-                manualEnd = true
+                manualEnd = true,
             )
     }
 
@@ -546,7 +546,7 @@ internal class AppStartupTraceEmitterTest {
     fun `no crashes if startup service not available in L`() {
         startupService = null
         createTraceEmitter().simulateAppStartup(
-            verifyTrace = false
+            verifyTrace = false,
         )
     }
 
@@ -562,7 +562,7 @@ internal class AppStartupTraceEmitterTest {
     fun `verify cold start trace without application init start and end triggered in L`() {
         createTraceEmitter()
             .simulateAppStartup(
-                hasAppInitEvents = false
+                hasAppInitEvents = false,
             )
     }
 
@@ -571,7 +571,7 @@ internal class AppStartupTraceEmitterTest {
     fun `verify cold start trace aborted activity creation in L`() {
         createTraceEmitter()
             .simulateAppStartup(
-                abortFirstActivityLoad = true
+                abortFirstActivityLoad = true,
             )
     }
 
@@ -580,7 +580,7 @@ internal class AppStartupTraceEmitterTest {
     fun `verify cold start trace with splash screen in L`() {
         createTraceEmitter()
             .simulateAppStartup(
-                loadSplashScreen = true
+                loadSplashScreen = true,
             )
     }
 
@@ -589,7 +589,7 @@ internal class AppStartupTraceEmitterTest {
     fun `verify cold start trace with manual end in L`() {
         createTraceEmitter(manualEnd = true)
             .simulateAppStartup(
-                manualEnd = true
+                manualEnd = true,
             )
     }
 
@@ -599,7 +599,7 @@ internal class AppStartupTraceEmitterTest {
         createTraceEmitter()
             .simulateAppStartup(
                 isColdStart = false,
-                hasAppInitEvents = false
+                hasAppInitEvents = false,
             )
     }
 
@@ -609,7 +609,7 @@ internal class AppStartupTraceEmitterTest {
         createTraceEmitter(manualEnd = true)
             .simulateAppStartup(
                 isColdStart = false,
-                manualEnd = true
+                manualEnd = true,
             )
     }
 
@@ -630,7 +630,7 @@ internal class AppStartupTraceEmitterTest {
                     DEFAULT_FAKE_CURRENT_TIME
                 } else {
                     null
-                }
+                },
             ),
         )
 
@@ -645,7 +645,7 @@ internal class AppStartupTraceEmitterTest {
     ) {
         val appInitTimestamps = initApp(
             hasAppInitEvents = hasAppInitEvents,
-            isColdStart = isColdStart
+            isColdStart = isColdStart,
         )
 
         val customSpanStartMs = clock.now()
@@ -656,7 +656,7 @@ internal class AppStartupTraceEmitterTest {
         val activityInitTimestamps = initActivity(
             loadSplashScreen = loadSplashScreen,
             abortFirstLoad = abortFirstActivityLoad,
-            activityInitOptions = activityInitOptions
+            activityInitOptions = activityInitOptions,
         )
 
         val traceStart = if (isColdStart) {
@@ -681,11 +681,11 @@ internal class AppStartupTraceEmitterTest {
                 appInitTimestamps = appInitTimestamps,
                 customSpanTimeStamps = customSpanStartMs to customSpanEndMs,
                 activityInitTimestamps = activityInitTimestamps,
-                traceEnd = checkNotNull(traceEnd)
+                traceEnd = checkNotNull(traceEnd),
             ).verifyTrace(
                 isColdStart = isColdStart,
                 hasAppInitEvents = hasAppInitEvents,
-                manualEnd = manualEnd
+                manualEnd = manualEnd,
             )
         }
     }
@@ -717,7 +717,7 @@ internal class AppStartupTraceEmitterTest {
             input = trace,
             expectedStartTimeMs = traceStart,
             expectedEndTimeMs = traceEnd,
-            expectedCustomAttributes = mapOf("custom-attribute" to "true")
+            expectedCustomAttributes = mapOf("custom-attribute" to "true"),
         )
 
         if (!isColdStart) {
@@ -769,7 +769,7 @@ internal class AppStartupTraceEmitterTest {
             startTimeMs = start,
             endTimeMs = end,
             endState = AppState.BACKGROUND,
-            threadName = "main"
+            threadName = "main",
         )
 
         val applicationInitEnd = if (hasAppInitEvents) {
@@ -792,7 +792,7 @@ internal class AppStartupTraceEmitterTest {
             applicationInitStart = applicationInitStart,
             applicationInitEnd = applicationInitEnd,
             sdkInitStart = sdkInitStart,
-            sdkInitEnd = sdkInitEnd
+            sdkInitEnd = sdkInitEnd,
         )
     }
 
@@ -962,13 +962,13 @@ internal class AppStartupTraceEmitterTest {
         OMIT(startTime = TimestampOption.MISSING, endTime = TimestampOption.MISSING),
         OMIT_END(endTime = TimestampOption.MISSING),
         DELAY(startTime = TimestampOption.DELAY, endTime = TimestampOption.DELAY),
-        DELAY_END(endTime = TimestampOption.DELAY)
+        DELAY_END(endTime = TimestampOption.DELAY),
     }
 
     private enum class TimestampOption {
         NORMAL,
         DELAY,
-        MISSING
+        MISSING,
     }
 
     companion object {

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/StartupServiceImplTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/StartupServiceImplTest.kt
@@ -37,7 +37,7 @@ internal class StartupServiceImplTest {
             startTimeMs = startTimeMillis,
             endTimeMs = endTimeMillis,
             endState = AppState.BACKGROUND,
-            threadName = "main"
+            threadName = "main",
         )
         val currentSpans = destination.completedSpans()
         assertEquals(1, currentSpans.size)
@@ -59,7 +59,7 @@ internal class StartupServiceImplTest {
                 startTimeMs = 10,
                 endTimeMs = 20,
                 endState = AppState.BACKGROUND,
-                threadName = "main"
+                threadName = "main",
             )
         }
         assertEquals(1, destination.completedSpans().size)
@@ -68,7 +68,7 @@ internal class StartupServiceImplTest {
                 startTimeMs = 10,
                 endTimeMs = 20,
                 endState = AppState.BACKGROUND,
-                threadName = "main"
+                threadName = "main",
             )
         }
         assertEquals(1, destination.completedSpans().size)

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/StartupTrackerTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/StartupTrackerTest.kt
@@ -110,7 +110,7 @@ internal class StartupTrackerTest {
                 firstActivityInitTime = createTime,
                 createTime = createTime,
                 startTime = startTime,
-                resumeTime = resumeTime
+                resumeTime = resumeTime,
             )
         }
     }
@@ -163,7 +163,7 @@ internal class StartupTrackerTest {
         val secondLaunchTimes = launchActivity()
         assertNotEquals(
             secondLaunchTimes.createTime,
-            dataCollector.startupActivityInitStartMs
+            dataCollector.startupActivityInitStartMs,
         )
     }
 
@@ -245,7 +245,7 @@ internal class StartupTrackerTest {
         postCreateTime: Long? = null,
         startTime: Long,
         resumeTime: Long,
-        renderTime: Long? = null
+        renderTime: Long? = null,
     ) {
         assertEquals(firstActivityInitTime, dataCollector.firstActivityInitMs)
         assertEquals(preCreateTime, dataCollector.startupActivityPreCreatedMs)

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/ui/HandlerMessageDrawDetectorTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/ui/HandlerMessageDrawDetectorTest.kt
@@ -30,7 +30,7 @@ internal class HandlerMessageDrawDetectorTest {
         detector.registerFirstDrawCallback(
             activity = Robolectric.buildActivity(Activity::class.java).get(),
             drawBeginCallback = { beginCallbackInvoked = true },
-            drawCompleteCallback = { endCallbackInvoked = true }
+            drawCompleteCallback = { endCallbackInvoked = true },
         )
         assertTrue(beginCallbackInvoked)
         with(handler.messageQueue.single()) {

--- a/embrace-android-instrumentation-taps/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/view/taps/TapBreadcrumbType.kt
+++ b/embrace-android-instrumentation-taps/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/view/taps/TapBreadcrumbType.kt
@@ -5,5 +5,5 @@ package io.embrace.android.embracesdk.internal.instrumentation.view.taps
  */
 enum class TapBreadcrumbType(val value: String) {
     TAP("tap"),
-    LONG_PRESS("long_press")
+    LONG_PRESS("long_press"),
 }

--- a/embrace-android-instrumentation-taps/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/view/taps/TapDataSource.kt
+++ b/embrace-android-instrumentation-taps/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/view/taps/TapDataSource.kt
@@ -11,11 +11,11 @@ import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
  * Captures custom breadcrumbs.
  */
 class TapDataSource(
-    args: InstrumentationArgs
+    args: InstrumentationArgs,
 ) : DataSourceImpl(
     args = args,
     limitStrategy = UpToLimitStrategy(args.configService.breadcrumbBehavior::getTapBreadcrumbLimit),
-    instrumentationName = "tap_data_source"
+    instrumentationName = "tap_data_source",
 ) {
 
     companion object {

--- a/embrace-android-instrumentation-taps/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/view/taps/TapInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-taps/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/view/taps/TapInstrumentationProvider.kt
@@ -13,7 +13,7 @@ class TapInstrumentationProvider : InstrumentationProvider {
             factory = {
                 tapDataSource = TapDataSource(args)
                 tapDataSource
-            }
+            },
         )
     }
 }

--- a/embrace-android-instrumentation-taps/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/view/taps/TapBreadcrumbDataSourceTest.kt
+++ b/embrace-android-instrumentation-taps/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/view/taps/TapBreadcrumbDataSourceTest.kt
@@ -37,9 +37,9 @@ internal class TapBreadcrumbDataSourceTest {
                 mapOf(
                     EmbViewAttributes.VIEW_NAME to "my-button-id",
                     EmbTapAttributes.TAP_TYPE to "tap",
-                    EmbTapAttributes.TAP_COORDS to "126,309"
+                    EmbTapAttributes.TAP_COORDS to "126,309",
                 ),
-                schemaType.attributes()
+                schemaType.attributes(),
             )
         }
     }

--- a/embrace-android-instrumentation-thermal-state/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thermalstate/ThermalStateDataSource.kt
+++ b/embrace-android-instrumentation-thermal-state/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thermalstate/ThermalStateDataSource.kt
@@ -19,7 +19,7 @@ class ThermalStateDataSource(
 ) : DataSourceImpl(
     args,
     limitStrategy = UpToLimitStrategy { MAX_CAPTURED_THERMAL_STATES },
-    instrumentationName = "thermal_state_data_source"
+    instrumentationName = "thermal_state_data_source",
 ) {
     private companion object {
         private const val MAX_CAPTURED_THERMAL_STATES = 100

--- a/embrace-android-instrumentation-thermal-state/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thermalstate/ThermalStateInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-thermal-state/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thermalstate/ThermalStateInstrumentationProvider.kt
@@ -17,7 +17,7 @@ class ThermalStateInstrumentationProvider : InstrumentationProvider {
             },
             configGate = {
                 args.configService.autoDataCaptureBehavior.isThermalStatusCaptureEnabled()
-            }
+            },
         )
     }
 }

--- a/embrace-android-instrumentation-thermal-state/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thermalstate/ThermalStateDataSourceTest.kt
+++ b/embrace-android-instrumentation-thermal-state/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thermalstate/ThermalStateDataSourceTest.kt
@@ -38,7 +38,7 @@ internal class ThermalStateDataSourceTest {
         assertEquals(PowerManager.THERMAL_STATUS_SEVERE, destination.createdSpans[1].attributes[EmbThermalStateAttributes.STATUS]?.toInt())
         assertEquals(
             PowerManager.THERMAL_STATUS_CRITICAL,
-            destination.createdSpans[2].attributes[EmbThermalStateAttributes.STATUS]?.toInt()
+            destination.createdSpans[2].attributes[EmbThermalStateAttributes.STATUS]?.toInt(),
         )
     }
 

--- a/embrace-android-instrumentation-view/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/view/ViewDataSource.kt
+++ b/embrace-android-instrumentation-view/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/view/ViewDataSource.kt
@@ -17,7 +17,7 @@ class ViewDataSource(
 ) : DataSourceImpl(
     args,
     UpToLimitStrategy { args.configService.breadcrumbBehavior.getFragmentBreadcrumbLimit() },
-    "view_data_source"
+    "view_data_source",
 ),
     Application.ActivityLifecycleCallbacks {
 

--- a/embrace-android-instrumentation-view/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/view/ViewInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-view/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/view/ViewInstrumentationProvider.kt
@@ -10,7 +10,7 @@ class ViewInstrumentationProvider : InstrumentationProvider {
             factory = {
                 ViewDataSource(args)
             },
-            configGate = { args.configService.breadcrumbBehavior.isActivityBreadcrumbCaptureEnabled() }
+            configGate = { args.configService.breadcrumbBehavior.isActivityBreadcrumbCaptureEnabled() },
         )
     }
 }

--- a/embrace-android-instrumentation-view/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/view/ViewDataSourceTest.kt
+++ b/embrace-android-instrumentation-view/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/view/ViewDataSourceTest.kt
@@ -40,7 +40,7 @@ internal class ViewDataSourceTest {
                 EmbViewAttributes.VIEW_NAME to "my_fragment",
                 EmbType.Ux.View.asPair(),
             ),
-            span.attributes
+            span.attributes,
         )
     }
 
@@ -57,7 +57,7 @@ internal class ViewDataSourceTest {
                 it.type == EmbType.Ux.View &&
                     it.attributes[EmbViewAttributes.VIEW_NAME] == "my_fragment" &&
                     it.attributes["emb.type"] == "ux.view"
-            }
+            },
         )
 
         val firstSpan = spans.first()
@@ -80,7 +80,7 @@ internal class ViewDataSourceTest {
                 it.type == EmbType.Ux.View &&
                     it.attributes["emb.type"] == "ux.view" &&
                     it.isRecording()
-            }
+            },
         )
 
         val firstSpan = spans.first()
@@ -101,9 +101,9 @@ internal class ViewDataSourceTest {
         assertEquals(
             mapOf(
                 EmbViewAttributes.VIEW_NAME to "my_fragment",
-                EmbType.Ux.View.asPair()
+                EmbType.Ux.View.asPair(),
             ),
-            span.attributes
+            span.attributes,
         )
     }
 
@@ -125,7 +125,7 @@ internal class ViewDataSourceTest {
                 EmbViewAttributes.VIEW_NAME to "some_view",
                 EmbType.Ux.View.asPair(),
             ),
-            span.attributes
+            span.attributes,
         )
     }
 
@@ -141,7 +141,7 @@ internal class ViewDataSourceTest {
             spans.all {
                 it.type == EmbType.Ux.View &&
                     it.attributes["emb.type"] == "ux.view"
-            }
+            },
         )
 
         val firstSpan = spans.first()

--- a/embrace-android-instrumentation-webview/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/webview/WebViewUrlDataSource.kt
+++ b/embrace-android-instrumentation-webview/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/webview/WebViewUrlDataSource.kt
@@ -14,7 +14,7 @@ class WebViewUrlDataSource(
 ) : DataSourceImpl(
     args = args,
     limitStrategy = UpToLimitStrategy(args.configService.breadcrumbBehavior::getWebViewBreadcrumbLimit),
-    instrumentationName = "webview_url_data_source"
+    instrumentationName = "webview_url_data_source",
 ) {
 
     private val breadcrumbBehavior: BreadcrumbBehavior = args.configService.breadcrumbBehavior

--- a/embrace-android-instrumentation-webview/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/webview/WebviewInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-webview/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/webview/WebviewInstrumentationProvider.kt
@@ -14,7 +14,7 @@ class WebviewInstrumentationProvider : InstrumentationProvider {
                 webViewUrlDataSource = WebViewUrlDataSource(args)
                 webViewUrlDataSource
             },
-            configGate = { args.configService.breadcrumbBehavior.isWebViewBreadcrumbCaptureEnabled() }
+            configGate = { args.configService.breadcrumbBehavior.isWebViewBreadcrumbCaptureEnabled() },
         )
     }
 }

--- a/embrace-android-instrumentation-webview/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/webview/WebViewUrlDataSourceTest.kt
+++ b/embrace-android-instrumentation-webview/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/webview/WebViewUrlDataSourceTest.kt
@@ -33,9 +33,9 @@ internal class WebViewUrlDataSourceTest {
             assertEquals(args.clock.now(), startTimeMs)
             assertEquals(
                 mapOf(
-                    UrlAttributes.URL_FULL to "http://www.google.com?query=123"
+                    UrlAttributes.URL_FULL to "http://www.google.com?query=123",
                 ),
-                schemaType.attributes()
+                schemaType.attributes(),
             )
         }
     }
@@ -47,9 +47,9 @@ internal class WebViewUrlDataSourceTest {
             configService = FakeConfigService(
                 breadcrumbBehavior = FakeBreadcrumbBehavior(
                     queryParamCaptureEnabled = false,
-                    webViewBreadcrumbCaptureEnabled = true
-                )
-            )
+                    webViewBreadcrumbCaptureEnabled = true,
+                ),
+            ),
         )
 
         val clock = FakeClock()
@@ -60,9 +60,9 @@ internal class WebViewUrlDataSourceTest {
             assertEquals(clock.now(), startTimeMs)
             assertEquals(
                 mapOf(
-                    UrlAttributes.URL_FULL to "http://www.google.com"
+                    UrlAttributes.URL_FULL to "http://www.google.com",
                 ),
-                schemaType.attributes()
+                schemaType.attributes(),
             )
         }
     }
@@ -74,9 +74,9 @@ internal class WebViewUrlDataSourceTest {
             configService = FakeConfigService(
                 breadcrumbBehavior = FakeBreadcrumbBehavior(
                     queryParamCaptureEnabled = false,
-                    webViewBreadcrumbCaptureEnabled = true
-                )
-            )
+                    webViewBreadcrumbCaptureEnabled = true,
+                ),
+            ),
         )
 
         source = WebViewUrlDataSource(args)

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
@@ -88,7 +88,7 @@ class OtelSdkConfig(
         EmbraceSpanProcessor(
             sessionIdsProvider,
             processIdentifier,
-            spanExporter
+            spanExporter,
         )
     }
 

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbLogger.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbLogger.kt
@@ -37,7 +37,7 @@ class EmbLogger(
             severityNumber = severityNumber,
             severityText = severityText,
             addCurrentMetadata = true,
-            eventAttributes = attributes
+            eventAttributes = attributes,
         )
     }
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbLoggerProvider.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbLoggerProvider.kt
@@ -24,7 +24,7 @@ class EmbLoggerProvider(
         val key = ApiKey(
             instrumentationScopeName = name,
             instrumentationScopeVersion = version,
-            schemaUrl = schemaUrl
+            schemaUrl = schemaUrl,
         )
 
         val logger = (
@@ -40,7 +40,7 @@ class EmbLoggerProvider(
         val loggerImpl = otelImpl.loggerProvider.getLogger(
             name = key.instrumentationScopeName,
             version = key.instrumentationScopeVersion,
-            schemaUrl = key.schemaUrl
+            schemaUrl = key.schemaUrl,
         )
         val logger = EmbLogger(loggerImpl, eventService)
         loggers[key] = logger

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpan.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpan.kt
@@ -119,7 +119,7 @@ class EmbSpan(
             EmbSpanEvent(
                 it.name ?: "",
                 it.timestampNanos ?: 0,
-                it.attributes.toEmbAttributesMutator()
+                it.attributes.toEmbAttributesMutator(),
             )
         }
 

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracer.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracer.kt
@@ -21,7 +21,7 @@ class EmbTracer(
     private val openTelemetry: OpenTelemetry,
     private val spanService: SpanService,
     private val clock: Clock,
-    private val useKotlinSdk: Boolean
+    private val useKotlinSdk: Boolean,
 ) : Tracer {
 
     override fun startSpan(
@@ -40,7 +40,7 @@ class EmbTracer(
             parentCtx = parentContext ?: openTelemetry.getDefaultContext(useKotlinSdk),
             openTelemetry = openTelemetry,
             spanKind = spanKind,
-            startTimeMs = startTimestamp?.nanosToMillis()
+            startTimeMs = startTimestamp?.nanosToMillis(),
         )
         var span: Span? = null
         spanService.createSpan(spanCreator).let { embraceSpan ->

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerProvider.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerProvider.kt
@@ -16,7 +16,7 @@ class EmbTracerProvider(
     private val impl: OpenTelemetry,
     private val spanService: SpanService,
     private val clock: Clock,
-    private val useKotlinSdk: Boolean
+    private val useKotlinSdk: Boolean,
 ) : TracerProvider {
 
     private val tracers = ConcurrentHashMap<ApiKey, Tracer>()
@@ -30,7 +30,7 @@ class EmbTracerProvider(
         val key = ApiKey(
             instrumentationScopeName = name,
             instrumentationScopeVersion = version,
-            schemaUrl = schemaUrl
+            schemaUrl = schemaUrl,
         )
 
         val tracer = (
@@ -46,14 +46,14 @@ class EmbTracerProvider(
         val tracerImpl = impl.tracerProvider.getTracer(
             name = key.instrumentationScopeName,
             version = key.instrumentationScopeVersion,
-            schemaUrl = key.schemaUrl
+            schemaUrl = key.schemaUrl,
         )
         val tracer = EmbTracer(
             impl = tracerImpl,
             spanService = spanService,
             clock = clock,
             openTelemetry = impl,
-            useKotlinSdk = useKotlinSdk
+            useKotlinSdk = useKotlinSdk,
         )
         tracers[key] = tracer
         return tracer

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/DefaultLogRecordExporter.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/DefaultLogRecordExporter.kt
@@ -30,7 +30,7 @@ internal class DefaultLogRecordExporter(
                         exporter.export(
                             telemetry.filterNot {
                                 it.attributes.containsKey(PrivateSpan.key)
-                            }
+                            },
                         )
                     } catch (ignored: Throwable) {
                         result = StoreDataResult.FAILURE

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EventServiceImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EventServiceImpl.kt
@@ -57,7 +57,7 @@ class EventServiceImpl(
             severityText = severityText,
             attributes = {
                 container.attributes.forEach { (k, v) -> setStringAttribute(k, v.toString()) }
-            }
+            },
         )
     }
 

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/LogSinkImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/LogSinkImpl.kt
@@ -23,8 +23,8 @@ class LogSinkImpl : LogSink {
                     logRequests.add(
                         LogRequest(
                             payload = log,
-                            defer = sendMode == SendMode.DEFER
-                        )
+                            defer = sendMode == SendMode.DEFER,
+                        ),
                     )
                 } else {
                     storedLogs.add(log)

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/payload/LogMapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/payload/LogMapper.kt
@@ -13,6 +13,6 @@ fun ReadableLogRecord.toEmbracePayload(): Log {
         severityNumber = severityNumber?.ordinal,
         severityText = severityText,
         body = body?.toString(),
-        attributes = attributes.map { (key, value) -> Attribute(key, value.toString()) }
+        attributes = attributes.map { (key, value) -> Attribute(key, value.toString()) },
     )
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/payload/SpanMapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/payload/SpanMapper.kt
@@ -29,13 +29,13 @@ fun EmbraceSpanData.toEmbracePayload(): Span = Span(
 fun SpanEvent.toEmbracePayload(): EmbraceSpanEvent? = EmbraceSpanEvent.create(
     name = name ?: "",
     timestampMs = (timestampNanos ?: 0).nanosToMillis(),
-    attributes = attributes?.toEmbracePayload() ?: emptyMap()
+    attributes = attributes?.toEmbracePayload() ?: emptyMap(),
 )
 
 fun EmbraceSpanEvent.toEmbracePayload(): SpanEvent = SpanEvent(
     name = name,
     timestampNanos = timestampNanos,
-    attributes = attributes.toEmbracePayload()
+    attributes = attributes.toEmbracePayload(),
 )
 
 fun Map<String, String>.toEmbracePayload(): List<Attribute> =
@@ -48,7 +48,7 @@ fun EmbraceLinkData.toEmbracePayload() = Link(
     spanId = spanContext.spanId,
     traceId = spanContext.traceId,
     attributes = attributes.toEmbracePayload(),
-    isRemote = spanContext.isRemote
+    isRemote = spanContext.isRemote,
 )
 
 fun Span.toEmbracePayload(): EmbraceSpanData {
@@ -67,6 +67,6 @@ fun Span.toEmbracePayload(): EmbraceSpanData {
         },
         events = events?.mapNotNull { it.toEmbracePayload() } ?: emptyList(),
         attributes = attributes?.toEmbracePayload() ?: emptyMap(),
-        links = links ?: emptyList()
+        links = links ?: emptyList(),
     )
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/DataValidator.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/DataValidator.kt
@@ -63,7 +63,7 @@ class DataValidator(
             attributes.truncate(
                 maxCount = maxAttributeCount,
                 maxKeyLength = maxKeyLength,
-                maxValueLength = maxValueLength
+                maxValueLength = maxValueLength,
             )
         } else {
             attributes
@@ -111,8 +111,8 @@ class DataValidator(
             attributes = truncateAttributes(
                 attributes = attributes,
                 internal = internal,
-                countOverride = otelLimitsConfig.getMaxEventAttributeCount()
-            )
+                countOverride = otelLimitsConfig.getMaxEventAttributeCount(),
+            ),
         )
     }
 
@@ -129,7 +129,7 @@ class DataValidator(
         return truncatedEntries.associate {
             val truncatedKey = PropertyUtils.truncate(
                 value = it.key,
-                maxLength = maxKeyLength
+                maxLength = maxKeyLength,
             )
             if (truncatedKey != it.key) {
                 telemetryService.trackAppliedLimit("span_attribute_key", AppliedLimitType.TRUNCATE_STRING)
@@ -138,7 +138,7 @@ class DataValidator(
             val truncatedValue = truncateAttributeValue(
                 key = it.key,
                 value = it.value,
-                maxLength = maxValueLength
+                maxLength = maxValueLength,
             )
             if (truncatedValue != it.value) {
                 telemetryService.trackAppliedLimit("span_attribute_value", AppliedLimitType.TRUNCATE_STRING)

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OtelExt.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OtelExt.kt
@@ -31,7 +31,7 @@ fun SpanLinkData.toEmbracePayload(): Link = Link(
     spanId = spanContext.spanId,
     traceId = spanContext.traceId,
     attributes = attributes.map { Attribute(it.key, it.value.toString()) },
-    isRemote = spanContext.isRemote
+    isRemote = spanContext.isRemote,
 )
 
 fun SpanEventData.toEmbracePayload(): EmbraceSpanEvent? {

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OtelSdkWrapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OtelSdkWrapper.kt
@@ -45,7 +45,7 @@ class OtelSdkWrapper(
         EmbTrace.trace("otel-tracer-init") {
             kotlinApi.tracerProvider.getTracer(
                 name = configuration.sdkName,
-                version = configuration.sdkVersion
+                version = configuration.sdkVersion,
             )
         }
     }
@@ -93,7 +93,7 @@ class OtelSdkWrapper(
         EmbOpenTelemetry(
             impl = kotlinApi,
             traceProviderSupplier = { EmbTracerProvider(kotlinApi, spanService, otelClock, useKotlinSdk) },
-            loggerProviderSupplier = { EmbLoggerProvider(kotlinApi, eventService) }
+            loggerProviderSupplier = { EmbLoggerProvider(kotlinApi, eventService) },
         )
     }
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/StoreDataResult.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/StoreDataResult.kt
@@ -5,5 +5,5 @@ package io.embrace.android.embracesdk.internal.otel.sdk
  */
 enum class StoreDataResult {
     SUCCESS,
-    FAILURE
+    FAILURE,
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/DefaultSpanExporter.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/DefaultSpanExporter.kt
@@ -29,7 +29,7 @@ internal class DefaultSpanExporter(
                         exporter.export(
                             telemetry.filterNot {
                                 it.attributes.containsKey(PrivateSpan.key)
-                            }
+                            },
                         )
                     } catch (ignored: Throwable) {
                         result = StoreDataResult.FAILURE

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImpl.kt
@@ -282,7 +282,7 @@ private class EmbraceSpanImpl(
                     val attribute = dataValidator.truncateAttribute(
                         key = key,
                         value = value,
-                        internal = otelSpanStartArgs.internal
+                        internal = otelSpanStartArgs.internal,
                     )
                     customAttributes[attribute.first] = attribute.second
                     spanRepository.notifySpanUpdate()
@@ -339,7 +339,7 @@ private class EmbraceSpanImpl(
                 status = status.toEmbracePayload(),
                 events = events(),
                 attributes = getAttributesPayload(),
-                links = links()
+                links = links(),
             )
         } else {
             null
@@ -383,7 +383,7 @@ private class EmbraceSpanImpl(
             EmbraceSpanEvent.create(
                 name = it.name,
                 timestampMs = it.timestampNanos.nanosToMillis(),
-                attributes = it.attributes.redactIfSensitive()
+                attributes = it.attributes.redactIfSensitive(),
             )
         }
         return systemEvents.map(EmbraceSpanEvent::toEmbracePayload) +
@@ -446,7 +446,7 @@ private class EmbraceSpanImpl(
             EmbraceSpanEvent.create(
                 name = it.name,
                 timestampMs = it.timestampNanos.nanosToMillis(),
-                attributes = it.attributes.redactIfSensitive()
+                attributes = it.attributes.redactIfSensitive(),
             )
         }
         (systemEvents + redactedCustomEvents).forEach { event ->
@@ -475,6 +475,6 @@ private class EmbraceSpanImpl(
     private fun validateName(name: String) =
         dataValidator.truncateName(
             name = name,
-            internal = internal
+            internal = internal,
         )
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanService.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanService.kt
@@ -40,7 +40,7 @@ class EmbraceSpanService(
                         canStartNewSpan = canStartNewSpan,
                         initCallback = initCallback,
                         tracer = tracerSupplier(),
-                        openTelemetry = openTelemetrySupplier()
+                        openTelemetry = openTelemetrySupplier(),
                     )
                     realSpansService.initializeService(sdkInitStartTimeMs)
                     if (realSpansService.initialized()) {
@@ -68,7 +68,7 @@ class EmbraceSpanService(
             type = type,
             internal = internal,
             private = private,
-            autoTerminationMode = autoTerminationMode
+            autoTerminationMode = autoTerminationMode,
         )
 
     override fun createSpan(otelSpanStartArgs: OtelSpanStartArgs): EmbraceSdkSpan = currentDelegate.createSpan(otelSpanStartArgs)
@@ -92,7 +92,7 @@ class EmbraceSpanService(
         attributes = attributes,
         events = events,
         autoTerminationMode = autoTerminationMode,
-        code = code
+        code = code,
     )
 
     override fun recordCompletedSpan(
@@ -116,7 +116,7 @@ class EmbraceSpanService(
         private = private,
         attributes = attributes,
         events = events,
-        errorCode = errorCode
+        errorCode = errorCode,
     )
 
     override fun getSpan(spanId: String): EmbraceSpan? = currentDelegate.getSpan(spanId = spanId)

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanExt.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanExt.kt
@@ -31,6 +31,6 @@ fun Span.toFailedSpan(endTimeMs: Long): Span {
         endTimeNanos = endTimeMs.millisToNanos(),
         parentSpanId = parentSpanId ?: OtelIds.INVALID_SPAN_ID,
         status = Span.Status.ERROR,
-        attributes = newAttributes.map { Attribute(it.key, it.value) }.plus(attributes ?: emptyList())
+        attributes = newAttributes.map { Attribute(it.key, it.value) }.plus(attributes ?: emptyList()),
     )
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImpl.kt
@@ -55,7 +55,7 @@ class SpanServiceImpl(
                         autoTerminationMode = autoTerminationMode,
                         parentCtx = (parent as? EmbraceSdkSpan)?.createContext(openTelemetry),
                         openTelemetry = openTelemetry,
-                    )
+                    ),
                 )
             } else {
                 NoopEmbraceSdkSpan
@@ -69,7 +69,7 @@ class SpanServiceImpl(
                 otelSpanStartArgs.initialSpanName.isNotBlank() &&
                 canStartNewSpan(
                     otelSpanStartArgs.parentContext.getEmbraceSpan(openTelemetry),
-                    otelSpanStartArgs.internal
+                    otelSpanStartArgs.internal,
                 )
             ) {
                 embraceSpanFactory.create(otelSpanStartArgs)
@@ -97,7 +97,7 @@ class SpanServiceImpl(
             type = type,
             internal = internal,
             private = private,
-            autoTerminationMode = autoTerminationMode
+            autoTerminationMode = autoTerminationMode,
         )
         try {
             val started = span?.start() ?: false
@@ -109,7 +109,7 @@ class SpanServiceImpl(
                     span?.addEvent(
                         event.name,
                         event.timestampNanos.nanosToMillis(),
-                        event.attributes
+                        event.attributes,
                     )
                 }
             }
@@ -154,7 +154,7 @@ class SpanServiceImpl(
                         tracer = tracer,
                         parentCtx = (parent as? EmbraceSdkSpan)?.createContext(openTelemetry),
                         openTelemetry = openTelemetry,
-                    )
+                    ),
                 )
                 if (newSpan.start(startTimeMs)) {
                     validAttributes.forEach {

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/UninitializedSdkSpanService.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/UninitializedSdkSpanService.kt
@@ -67,7 +67,7 @@ class UninitializedSdkSpanService : SpanService {
                 private = private,
                 attributes = attributes,
                 events = events,
-                errorCode = errorCode
+                errorCode = errorCode,
             ) ?: if (bufferedCallsCount.getAndIncrement() < MAX_BUFFERED_CALLS) {
                 bufferedCalls.add(
                     BufferedRecordCompletedSpan(
@@ -81,7 +81,7 @@ class UninitializedSdkSpanService : SpanService {
                         attributes = attributes,
                         events = events,
                         errorCode = errorCode,
-                    )
+                    ),
                 )
                 true
             } else {
@@ -110,7 +110,7 @@ class UninitializedSdkSpanService : SpanService {
                         private = it.private,
                         attributes = it.attributes,
                         events = it.events,
-                        errorCode = it.errorCode
+                        errorCode = it.errorCode,
                     )
                 }
             } while (bufferedCalls.isNotEmpty())

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfigTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfigTest.kt
@@ -23,7 +23,7 @@ internal class OtelSdkConfigTest {
             osVersion = "testOsVersionName",
             androidOsApiLevel = "99",
             deviceManufacturer = "testManufacturer",
-            deviceModel = "testModel"
+            deviceModel = "testModel",
         )
 
         val configuration = OtelSdkConfig(
@@ -33,7 +33,7 @@ internal class OtelSdkConfigTest {
             sdkVersion = "1.0",
             appVersion = "2.5.1",
             packageName = "com.test.app",
-            systemInfo = systemInfo
+            systemInfo = systemInfo,
         )
 
         val attrs = FakeAttributesMutator().apply(configuration.resourceAction).attributes
@@ -49,7 +49,7 @@ internal class OtelSdkConfigTest {
             AndroidAttributes.ANDROID_OS_API_LEVEL to systemInfo.androidOsApiLevel,
             DeviceAttributes.DEVICE_MANUFACTURER to systemInfo.deviceManufacturer,
             DeviceAttributes.DEVICE_MODEL_IDENTIFIER to systemInfo.deviceModel,
-            DeviceAttributes.DEVICE_MODEL_NAME to systemInfo.deviceModel
+            DeviceAttributes.DEVICE_MODEL_NAME to systemInfo.deviceModel,
         ).mapKeys { it.key }
         assertEquals(expected, attrs)
     }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbLoggerProviderTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbLoggerProviderTest.kt
@@ -21,7 +21,7 @@ internal class EmbLoggerProviderTest {
         val otel = EmbOpenTelemetry(
             NoopOpenTelemetry,
             { FakeTracerProvider() },
-            ::sdkLoggerProvider
+            ::sdkLoggerProvider,
         )
         embLoggerProvider = EmbLoggerProvider(
             otelImpl = otel,

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbLoggerTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbLoggerTest.kt
@@ -25,7 +25,7 @@ internal class EmbLoggerTest {
         eventService = FakeEventService()
         logger = EmbLogger(
             impl = sdkLogger,
-            eventService = eventService
+            eventService = eventService,
         )
     }
 

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpanTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbSpanTest.kt
@@ -33,7 +33,7 @@ internal class EmbSpanTest {
         embSpan = EmbSpan(
             impl = fakeEmbraceSpan,
             clock = openTelemetryClock,
-            openTelemetry = fakeOpenTelemetry()
+            openTelemetry = fakeOpenTelemetry(),
         )
     }
 

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerProviderTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerProviderTest.kt
@@ -31,7 +31,7 @@ internal class EmbTracerProviderTest {
             impl = otel,
             spanService = spanService,
             clock = openTelemetryClock,
-            useKotlinSdk = TESTS_DEFAULT_USE_KOTLIN_SDK
+            useKotlinSdk = TESTS_DEFAULT_USE_KOTLIN_SDK,
         )
     }
 

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerTest.kt
@@ -32,7 +32,7 @@ internal class EmbTracerTest {
             spanService = spanService,
             clock = openTelemetryClock,
             openTelemetry = fakeOpenTelemetry(),
-            useKotlinSdk = TESTS_DEFAULT_USE_KOTLIN_SDK
+            useKotlinSdk = TESTS_DEFAULT_USE_KOTLIN_SDK,
         )
     }
 
@@ -54,7 +54,7 @@ internal class EmbTracerTest {
             "foo",
             parentContext = parentCtx,
             spanKind = SpanKind.CLIENT,
-            startTimestamp = 500L.nanosToMillis()
+            startTimestamp = 500L.nanosToMillis(),
         ) {
             setStringAttribute("foo", "bar")
         }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/logs/DefaultLogRecordExporterTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/logs/DefaultLogRecordExporterTest.kt
@@ -35,7 +35,7 @@ internal class DefaultLogRecordExporterTest {
         val privateData = FakeReadWriteLogRecord(
             attributeContainer = FakeAttributesMutator().apply {
                 setStringAttribute(PrivateSpan.key, PrivateSpan.value)
-            }
+            },
         )
 
         runBlocking { exporter.export(listOf(data, privateData)) }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OpenTelemetrySdkTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OpenTelemetrySdkTest.kt
@@ -47,7 +47,7 @@ internal class OpenTelemetrySdkTest {
             expectedServiceVersion = configuration.appVersion,
             systemInfo = systemInfo,
             expectedDistroName = configuration.sdkName,
-            expectedDistroVersion = configuration.sdkVersion
+            expectedDistroVersion = configuration.sdkVersion,
         )
     }
 
@@ -59,7 +59,7 @@ internal class OpenTelemetrySdkTest {
             expectedServiceVersion = configuration.appVersion,
             systemInfo = systemInfo,
             expectedDistroName = configuration.sdkName,
-            expectedDistroVersion = configuration.sdkVersion
+            expectedDistroVersion = configuration.sdkVersion,
         )
     }
 
@@ -80,7 +80,7 @@ internal class OpenTelemetrySdkTest {
         val tracer = sdk.openTelemetryKotlin.tracerProvider.getTracer(
             name = "testScope",
             version = "v1",
-            schemaUrl = "url"
+            schemaUrl = "url",
         )
         tracer.startSpan("test").end()
         with(spanExporter.exportedSpans.single().instrumentationScopeInfo) {
@@ -106,7 +106,7 @@ internal class OpenTelemetrySdkTest {
         val logger = loggerProvider.getLogger(
             name = "testScope",
             version = "v1",
-            schemaUrl = "url"
+            schemaUrl = "url",
         )
         logger.emit()
         with(logExporter.exportedLogs.single().instrumentationScopeInfo) {

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImplTest.kt
@@ -39,7 +39,7 @@ internal class EmbraceSpanFactoryImplTest {
             openTelemetryClock = openTelemetryClock,
             spanRepository = spanRepository,
             dataValidator = DataValidator(telemetryService = FakeTelemetryService()),
-            telemetryService = FakeTelemetryService()
+            telemetryService = FakeTelemetryService(),
         )
     }
 
@@ -53,7 +53,7 @@ internal class EmbraceSpanFactoryImplTest {
                 private = false,
                 tracer = tracer,
                 openTelemetry = fakeOpenTelemetry(),
-            )
+            ),
         )
         assertTrue(span.start(clock.now()))
         with(span) {
@@ -76,7 +76,7 @@ internal class EmbraceSpanFactoryImplTest {
                 private = true,
                 tracer = tracer,
                 openTelemetry = fakeOpenTelemetry(),
-            )
+            ),
         )
         assertTrue(span.start(clock.now()))
         with(span) {
@@ -97,7 +97,7 @@ internal class EmbraceSpanFactoryImplTest {
                 private = false,
                 tracer = tracer,
                 openTelemetry = fakeOpenTelemetry(),
-            )
+            ),
         )
         assertTrue(span.start(clock.now()))
         with(span) {
@@ -118,7 +118,7 @@ internal class EmbraceSpanFactoryImplTest {
                 private = false,
                 tracer = tracer,
                 openTelemetry = fakeOpenTelemetry(),
-            )
+            ),
         )
         val spanBuilder = OtelSpanStartArgs(
             name = "from-span-builder",

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanImplTest.kt
@@ -81,7 +81,7 @@ internal class EmbraceSpanImplTest {
             dataValidator = dataValidator,
             stopCallback = ::stopCallback,
             redactionFunction = ::redactionFunction,
-            telemetryService = FakeTelemetryService()
+            telemetryService = FakeTelemetryService(),
         )
         embraceSpan = embraceSpanFactory.create(
             otelSpanStartArgs = OtelSpanStartArgs(
@@ -91,7 +91,7 @@ internal class EmbraceSpanImplTest {
                 private = false,
                 tracer = tracer,
                 openTelemetry = fakeOpenTelemetry(),
-            )
+            ),
         )
         fakeClock.tick(100)
     }
@@ -134,7 +134,7 @@ internal class EmbraceSpanImplTest {
                 expectedStartTimeMs = expectedStartTimeMs,
                 expectedEndTimeMs = null,
                 eventCount = 1,
-                expectedCustomAttributeCount = 1
+                expectedCustomAttributeCount = 1,
             )
             assertEquals("00-$traceId-$spanId-01", embraceSpan.asW3cTraceParent())
             assertEquals(1, spanRepository.getActiveSpans().size)
@@ -170,7 +170,7 @@ internal class EmbraceSpanImplTest {
             assertSnapshot(
                 expectedStartTimeMs = expectedStartTimeMs,
                 expectedEndTimeMs = expectedEndTimeMs,
-                expectedStatus = Span.Status.ERROR
+                expectedStatus = Span.Status.ERROR,
             )
             validateStoppedSpan()
         }
@@ -186,7 +186,7 @@ internal class EmbraceSpanImplTest {
             assertSnapshot(
                 expectedStartTimeMs = expectedStartTimeMs,
                 expectedEndTimeMs = expectedEndTimeMs,
-                expectedStatus = Span.Status.ERROR
+                expectedStatus = Span.Status.ERROR,
             )
             validateStoppedSpan()
         }
@@ -202,16 +202,16 @@ internal class EmbraceSpanImplTest {
                 addEvent(
                     name = "second current event",
                     timestampMs = null,
-                    attributes = mapOf(Pair("key", "value"), Pair("key2", "value1"))
-                )
+                    attributes = mapOf(Pair("key", "value"), Pair("key2", "value1")),
+                ),
             )
             assertTrue(addEvent(name = "past event", timestampMs = fakeClock.now() - 1L, attributes = emptyMap()))
             assertTrue(
                 addEvent(
                     name = "future event",
                     timestampMs = fakeClock.now() + 2L,
-                    mapOf(Pair("key", "value"), Pair("key2", "value1"))
-                )
+                    mapOf(Pair("key", "value"), Pair("key2", "value1")),
+                ),
             )
             assertTrue(updateNotified)
         }
@@ -290,12 +290,12 @@ internal class EmbraceSpanImplTest {
                 assertEquals(timestampNanos, timestampNanos)
                 assertEquals(
                     IllegalStateException::class.java.canonicalName,
-                    attrs.single { it.key == ExceptionAttributes.EXCEPTION_TYPE }.data
+                    attrs.single { it.key == ExceptionAttributes.EXCEPTION_TYPE }.data,
                 )
                 assertEquals("oops", attrs.single { it.key == ExceptionAttributes.EXCEPTION_MESSAGE }.data)
                 assertEquals(
                     firstExceptionStackTrace,
-                    attrs.single { it.key == ExceptionAttributes.EXCEPTION_STACKTRACE }.data
+                    attrs.single { it.key == ExceptionAttributes.EXCEPTION_STACKTRACE }.data,
                 )
             }
             with(sanitizedEvents[1]) {
@@ -304,13 +304,13 @@ internal class EmbraceSpanImplTest {
                 assertEquals(timestampNanos, timestampNanos)
                 assertEquals(
                     RuntimeException::class.java.canonicalName,
-                    attrs.single { it.key == ExceptionAttributes.EXCEPTION_TYPE }.data
+                    attrs.single { it.key == ExceptionAttributes.EXCEPTION_TYPE }.data,
                 )
                 assertEquals("haha", attrs.single { it.key == ExceptionAttributes.EXCEPTION_MESSAGE }.data)
                 assertEquals("myValue", attrs.single { it.key == "myKey" }.data)
                 assertEquals(
                     secondExceptionStackTrace,
-                    attrs.single { it.key == ExceptionAttributes.EXCEPTION_STACKTRACE }.data
+                    attrs.single { it.key == ExceptionAttributes.EXCEPTION_STACKTRACE }.data,
                 )
             }
         }
@@ -353,8 +353,8 @@ internal class EmbraceSpanImplTest {
                 addEvent(
                     name = "yo",
                     timestampMs = null,
-                    attributes = eventAttributesAMap
-                )
+                    attributes = eventAttributesAMap,
+                ),
             )
             assertFalse(addEvent("failed event"))
             assertFalse(recordException(exception = RuntimeException()))
@@ -434,8 +434,8 @@ internal class EmbraceSpanImplTest {
         assertFalse(
             embraceSpan.addSystemLink(
                 checkNotNull(FakeEmbraceSdkSpan.stopped().spanContext),
-                LinkType.PreviousSessionPart
-            )
+                LinkType.PreviousSessionPart,
+            ),
         )
     }
 
@@ -462,8 +462,8 @@ internal class EmbraceSpanImplTest {
                 addEvent(
                     name = EXPECTED_EVENT_NAME,
                     timestampMs = null,
-                    attributes = mapOf(Pair(EXPECTED_ATTRIBUTE_NAME, EXPECTED_ATTRIBUTE_VALUE))
-                )
+                    attributes = mapOf(Pair(EXPECTED_ATTRIBUTE_NAME, EXPECTED_ATTRIBUTE_VALUE)),
+                ),
             )
             assertTrue(addAttribute(key = EXPECTED_ATTRIBUTE_NAME, value = EXPECTED_ATTRIBUTE_VALUE))
 

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanServiceTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanServiceTest.kt
@@ -50,7 +50,7 @@ internal class EmbraceSpanServiceTest {
             packageName = "com.test.app",
             systemInfo = SystemInfo(),
             sessionIdsProvider = { FakeSessionIdsProvider(userSessionId = "fake-session-id") },
-            processIdentifierProvider = { "fake-pid" }
+            processIdentifierProvider = { "fake-pid" },
         )
         val otelSdkWrapper = OtelSdkWrapper(
             otelClock = fakeClock,
@@ -76,12 +76,12 @@ internal class EmbraceSpanServiceTest {
                     openTelemetryClock = clock,
                     spanRepository = SpanRepository(),
                     dataValidator = dataValidator,
-                    telemetryService = FakeTelemetryService()
+                    telemetryService = FakeTelemetryService(),
                 )
             },
             dataValidator = dataValidator,
             tracerSupplier = { tracer },
-            openTelemetrySupplier = { fakeOpenTelemetry() }
+            openTelemetrySupplier = { fakeOpenTelemetry() },
         )
     }
 
@@ -94,7 +94,7 @@ internal class EmbraceSpanServiceTest {
             initCallback = ::initCallback,
             embraceSpanFactorySupplier = { FakeEmbraceSpanFactory() },
             tracerSupplier = { tracer },
-            openTelemetrySupplier = { fakeOpenTelemetry() }
+            openTelemetrySupplier = { fakeOpenTelemetry() },
         )
         assertFalse(uninitializedService.initialized())
         assertEquals(NoopEmbraceSdkSpan, uninitializedService.createSpan("test-span"))
@@ -126,7 +126,7 @@ internal class EmbraceSpanServiceTest {
         val expectedType = EmbType.Performance.Default
         val expectedAttributes = mapOf(
             Pair("attribute1", "value1"),
-            Pair("attribute2", "value2")
+            Pair("attribute2", "value2"),
         )
         val expectedEvents = listOfNotNull(
             EmbraceSpanEvent.create(name = "event1", timestampMs = 1_000_000L.nanosToMillis(), expectedAttributes),

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/OtelSpanStartArgsTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/OtelSpanStartArgsTest.kt
@@ -44,7 +44,7 @@ internal class OtelSpanStartArgsTest {
             private = true,
             tracer = tracer,
             startTimeMs = originalStartTime,
-            openTelemetry = fakeOpenTelemetry()
+            openTelemetry = fakeOpenTelemetry(),
         )
         val startTime = clock.tick()
         with(args.embraceAttributes.toSet()) {
@@ -57,7 +57,7 @@ internal class OtelSpanStartArgsTest {
 
         args.startSpan(startTime).assertSpan(
             expectedName = "emb-test",
-            expectedStartTimeMs = startTime
+            expectedStartTimeMs = startTime,
         )
         assertEquals(originalStartTime, args.startTimeMs)
     }
@@ -74,7 +74,7 @@ internal class OtelSpanStartArgsTest {
             private = false,
             tracer = tracer,
             parentCtx = ctx,
-            openTelemetry = otel
+            openTelemetry = otel,
         )
         val spanContext = args.parentContext.extractSpan().spanContext
         assertEquals(parent.spanContext.traceId, spanContext.traceId)
@@ -95,13 +95,13 @@ internal class OtelSpanStartArgsTest {
             private = false,
             tracer = tracer,
             spanKind = SpanKind.CLIENT,
-            openTelemetry = fakeOpenTelemetry()
+            openTelemetry = fakeOpenTelemetry(),
         )
         val startTime = otelClock.now()
         args.startSpan(startTime).assertSpan(
             expectedName = "test",
             expectedStartTimeMs = startTime,
-            expectedSpanKind = SpanKind.CLIENT
+            expectedSpanKind = SpanKind.CLIENT,
         )
     }
 
@@ -113,7 +113,7 @@ internal class OtelSpanStartArgsTest {
             internal = false,
             private = false,
             tracer = tracer,
-            openTelemetry = fakeOpenTelemetry()
+            openTelemetry = fakeOpenTelemetry(),
         )
         args.customAttributes["test-key"] = "test-value"
         assertEquals("test-value", args.customAttributes["test-key"])
@@ -129,12 +129,12 @@ internal class OtelSpanStartArgsTest {
             internal = false,
             private = false,
             tracer = tracer,
-            openTelemetry = fakeOpenTelemetry()
+            openTelemetry = fakeOpenTelemetry(),
         )
 
         creator.startSpan(startTime).assertSpan(
             expectedName = TOO_LONG_SPAN_NAME,
-            expectedStartTimeMs = startTime
+            expectedStartTimeMs = startTime,
         )
 
         val internalSpanCreator = OtelSpanStartArgs(
@@ -143,12 +143,12 @@ internal class OtelSpanStartArgsTest {
             internal = true,
             private = false,
             tracer = tracer,
-            openTelemetry = fakeOpenTelemetry()
+            openTelemetry = fakeOpenTelemetry(),
         )
 
         internalSpanCreator.startSpan(startTime).assertSpan(
             expectedName = "emb-$TOO_LONG_INTERNAL_SPAN_NAME",
-            expectedStartTimeMs = startTime
+            expectedStartTimeMs = startTime,
         )
     }
 

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
@@ -80,7 +80,7 @@ internal class SpanServiceImplTest {
     @Test
     fun `create trace that is internally logged but public`() {
         val embraceSpan = checkNotNull(
-            spansService.createSpan(name = "test-span", internal = true, private = false)
+            spansService.createSpan(name = "test-span", internal = true, private = false),
         )
         assertNull(embraceSpan.parent)
         assertTrue(embraceSpan.start())
@@ -93,7 +93,7 @@ internal class SpanServiceImplTest {
     @Test
     fun `create trace that is private but not considered internally logged`() {
         val embraceSpan = checkNotNull(
-            spansService.createSpan(name = "test-span", internal = false, private = true)
+            spansService.createSpan(name = "test-span", internal = false, private = true),
         )
         assertNull(embraceSpan.parent)
         assertTrue(embraceSpan.start())
@@ -118,7 +118,7 @@ internal class SpanServiceImplTest {
             spansService.createSpan(
                 name = "test-span",
                 type = EmbType.Performance.Default,
-            )
+            ),
         )
         assertTrue(embraceSpan.start())
         assertTrue(embraceSpan.stop())
@@ -183,7 +183,7 @@ internal class SpanServiceImplTest {
                 parent = parent,
                 startTimeMs = childStartTimeMs,
                 type = EmbType.Ux.View,
-            )
+            ),
         )
         clock.tick(40L)
         val childSpanEndTimeMs = clock.now()
@@ -214,7 +214,7 @@ internal class SpanServiceImplTest {
         val expectedType = EmbType.Performance.Default
         val expectedAttributes = mapOf(
             Pair("attribute1", "value1"),
-            Pair("attribute2", "value2")
+            Pair("attribute2", "value2"),
         )
         val expectedEvents = listOfNotNull(
             EmbraceSpanEvent.create(name = "event1", timestampMs = 1_000_000L.nanosToMillis(), expectedAttributes),
@@ -257,7 +257,7 @@ internal class SpanServiceImplTest {
                 startTimeMs = expectedStartTimeMs,
                 endTimeMs = expectedEndTimeMs,
                 parent = parentSpan,
-            )
+            ),
         )
 
         with(verifyAndReturnSoleCompletedSpan("emb-$expectedName")) {
@@ -282,7 +282,7 @@ internal class SpanServiceImplTest {
                     startTimeMs = 0,
                     endTimeMs = 1,
                     errorCode = errorCode,
-                )
+                ),
             )
             with(verifyAndReturnSoleCompletedSpan("emb-test${errorCode.name}")) {
                 assertError(errorCode)
@@ -298,7 +298,7 @@ internal class SpanServiceImplTest {
                 name = "test-pan",
                 startTimeMs = 500,
                 endTimeMs = 499,
-            )
+            ),
         )
     }
 
@@ -372,7 +372,7 @@ internal class SpanServiceImplTest {
                 startTimeMs = 100L,
                 endTimeMs = 200L,
                 internal = false,
-            )
+            ),
         )
         assertNotNull(spansService.recordSpan(name = TOO_LONG_SPAN_NAME, internal = false) { 1 })
         assertEquals(2, spanSink.completedSpans().size)
@@ -384,7 +384,7 @@ internal class SpanServiceImplTest {
                 startTimeMs = 100L,
                 endTimeMs = 200L,
                 internal = false,
-            )
+            ),
         )
         assertEquals(4, spanSink.completedSpans().size)
     }
@@ -398,7 +398,7 @@ internal class SpanServiceImplTest {
                 startTimeMs = 100L,
                 endTimeMs = 200L,
                 internal = true,
-            )
+            ),
         )
         assertTrue(
             spansService.recordCompletedSpan(
@@ -406,8 +406,8 @@ internal class SpanServiceImplTest {
                 startTimeMs = 100L,
                 endTimeMs = 200L,
                 internal = true,
-                attributes = tooBigSystemAttributes
-            )
+                attributes = tooBigSystemAttributes,
+            ),
         )
         assertTrue(
             spansService.recordCompletedSpan(
@@ -415,19 +415,19 @@ internal class SpanServiceImplTest {
                 startTimeMs = 100L,
                 endTimeMs = 200L,
                 internal = true,
-                events = tooBigSystemEvents
-            )
+                events = tooBigSystemEvents,
+            ),
         )
         assertNotNull(
             spansService.recordSpan(name = TOO_LONG_INTERNAL_SPAN_NAME, internal = true) {
                 1
-            }
+            },
         )
         assertNotNull(spansService.createSpan(name = MAX_LENGTH_INTERNAL_SPAN_NAME, internal = true))
         assertNotNull(
             spansService.recordSpan(name = MAX_LENGTH_INTERNAL_SPAN_NAME, internal = true) {
                 2
-            }
+            },
         )
         assertTrue(
             spansService.recordCompletedSpan(
@@ -436,8 +436,8 @@ internal class SpanServiceImplTest {
                 endTimeMs = 200L,
                 internal = true,
                 attributes = maxSizeSystemAttributes,
-                events = maxSizeSystemEvents
-            )
+                events = maxSizeSystemEvents,
+            ),
         )
         val completedSpans = spanSink.completedSpans()
         assertEquals(6, completedSpans.size)
@@ -454,7 +454,7 @@ internal class SpanServiceImplTest {
                 endTimeMs = 200L,
                 internal = false,
                 events = tooBigCustomEvents,
-            )
+            ),
         )
         assertTrue(
             spansService.recordCompletedSpan(
@@ -463,7 +463,7 @@ internal class SpanServiceImplTest {
                 endTimeMs = 200L,
                 internal = false,
                 events = maxSizeCustomEvents,
-            )
+            ),
         )
 
         assertEquals(maxEventAttrCount, spanSink.flushSpans().single { it.name == "too many events" }.events.size)
@@ -487,7 +487,7 @@ internal class SpanServiceImplTest {
                 endTimeMs = 200L,
                 internal = false,
                 events = events,
-            )
+            ),
         )
 
         val completedSpans = spanSink.completedSpans()
@@ -505,7 +505,7 @@ internal class SpanServiceImplTest {
                 endTimeMs = 200L,
                 internal = false,
                 attributes = tooBigCustomAttributes,
-            )
+            ),
         )
         assertTrue(
             spansService.recordCompletedSpan(
@@ -514,7 +514,7 @@ internal class SpanServiceImplTest {
                 endTimeMs = 200L,
                 internal = false,
                 attributes = maxSizeCustomAttributes,
-            )
+            ),
         )
 
         spanSink.flushSpans()
@@ -535,7 +535,7 @@ internal class SpanServiceImplTest {
                 endTimeMs = 200L,
                 internal = false,
                 attributes = attributesMap,
-            )
+            ),
         )
 
         val truncatedAttributesSpan = spanSink.completedSpans().single { it.name == MAX_LENGTH_SPAN_NAME }
@@ -556,7 +556,7 @@ internal class SpanServiceImplTest {
                 startTimeMs = 100L,
                 endTimeMs = 200L,
                 internal = false,
-            )
+            ),
         )
         assertTrue(
             spansService.recordCompletedSpan(
@@ -565,7 +565,7 @@ internal class SpanServiceImplTest {
                 endTimeMs = 200L,
                 internal = false,
                 events = tooBigCustomEvents,
-            )
+            ),
         )
         assertTrue(
             spansService.recordCompletedSpan(
@@ -574,7 +574,7 @@ internal class SpanServiceImplTest {
                 endTimeMs = 200L,
                 internal = false,
                 attributes = tooBigCustomAttributes,
-            )
+            ),
         )
     }
 
@@ -589,7 +589,7 @@ internal class SpanServiceImplTest {
                 startTimeMs = 100L,
                 endTimeMs = 200L,
                 internal = true,
-            )
+            ),
         )
         assertTrue(
             spansService.recordCompletedSpan(
@@ -598,7 +598,7 @@ internal class SpanServiceImplTest {
                 endTimeMs = 200L,
                 internal = true,
                 events = tooBigSystemEvents,
-            )
+            ),
         )
         assertTrue(
             spansService.recordCompletedSpan(
@@ -607,7 +607,7 @@ internal class SpanServiceImplTest {
                 endTimeMs = 200L,
                 internal = true,
                 attributes = tooBigSystemAttributes,
-            )
+            ),
         )
 
         assertEquals(3, spanSink.completedSpans().size)
@@ -624,7 +624,7 @@ internal class SpanServiceImplTest {
             packageName = "com.test.app",
             systemInfo = SystemInfo(),
             sessionIdsProvider = { FakeSessionIdsProvider(userSessionId = "fake-session-id") },
-            processIdentifierProvider = { "fake-pid" }
+            processIdentifierProvider = { "fake-pid" },
         )
         val otelSdkWrapper = OtelSdkWrapper(
             otelClock = fakeClock,
@@ -641,12 +641,12 @@ internal class SpanServiceImplTest {
                 openTelemetryClock = fakeClock,
                 spanRepository = SpanRepository(),
                 dataValidator = dataValidator,
-                telemetryService = FakeTelemetryService()
+                telemetryService = FakeTelemetryService(),
             ),
             dataValidator = dataValidator,
             canStartNewSpan = ::canStartNewSpan,
             initCallback = ::initCallback,
-            openTelemetry = otelSdkWrapper.openTelemetryKotlin
+            openTelemetry = otelSdkWrapper.openTelemetryKotlin,
         ).apply {
             initializeService(fakeClock.now().nanosToMillis())
         }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSinkImplTests.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSinkImplTests.kt
@@ -49,8 +49,8 @@ internal class SpanSinkImplTests {
         spanSink.storeCompletedSpans(
             listOf(
                 FakeSpanData(name = "fake1"),
-                FakeSpanData(name = "fake2")
-            ).map(FakeSpanData::toEmbraceSpanData)
+                FakeSpanData(name = "fake2"),
+            ).map(FakeSpanData::toEmbraceSpanData),
         )
         val unblockCompletedSpansLatch = CountDownLatch(1)
         val unblockFlushLatch = CountDownLatch(1)

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/AppEnvironment.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/AppEnvironment.kt
@@ -16,6 +16,6 @@ class AppEnvironment(val isDebug: Boolean) {
         PROD("prod"),
 
         @SerialName("UNKNOWN")
-        UNKNOWN("UNKNOWN")
+        UNKNOWN("UNKNOWN"),
     }
 }

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/ApiRequestV2.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/ApiRequestV2.kt
@@ -16,7 +16,7 @@ data class ApiRequestV2(
         val headers = mutableMapOf(
             "Accept" to accept,
             "User-Agent" to userAgent,
-            "Content-Type" to contentType
+            "Content-Type" to contentType,
         )
         contentEncoding?.let { headers["Content-Encoding"] = it }
         appId?.let { headers["X-EM-AID"] = it }

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/HttpMethod.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/comms/api/HttpMethod.kt
@@ -10,5 +10,5 @@ enum class HttpMethod {
     CONNECT,
     OPTIONS,
     TRACE,
-    PATCH
+    PATCH,
 }

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/AppFramework.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/AppFramework.kt
@@ -9,7 +9,8 @@ enum class AppFramework(val value: Int) {
     NATIVE(1),
     REACT_NATIVE(2),
     UNITY(3),
-    FLUTTER(4);
+    FLUTTER(4),
+    ;
 
     companion object {
 

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/Envelope.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/Envelope.kt
@@ -43,7 +43,7 @@ data class Envelope<T>(
                 metadata = metadata,
                 version = "0.1.0",
                 type = "logs",
-                data = this
+                data = this,
             )
     }
 }

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeResource.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeResource.kt
@@ -23,7 +23,7 @@
     "ArrayInDataClass",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "UnusedImport"
+    "UnusedImport",
 )
 
 package io.embrace.android.embracesdk.internal.payload

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/Span.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/Span.kt
@@ -72,6 +72,6 @@ data class Span(
         ERROR("Error"),
 
         @SerialName("Ok")
-        OK("Ok")
+        OK("Ok"),
     }
 }

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/ThreadState.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/ThreadState.kt
@@ -10,5 +10,5 @@ enum class ThreadState(val code: Int) {
     BLOCKED(2),
     WAITING(3),
     TIMED_WAITING(4),
-    TERMINATED(5)
+    TERMINATED(5),
 }

--- a/embrace-android-payload/src/test/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeResourceAdapterTest.kt
+++ b/embrace-android-payload/src/test/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeResourceAdapterTest.kt
@@ -42,8 +42,8 @@ internal class EnvelopeResourceAdapterTest {
         screenResolution = "1080x2400",
         numCores = 8,
         extras = mapOf(
-            "foo" to "bar"
-        )
+            "foo" to "bar",
+        ),
     )
     private val emptyResource = EnvelopeResource()
 
@@ -89,7 +89,7 @@ internal class EnvelopeResourceAdapterTest {
 
     private fun loadGoldenFile(filename: String): String {
         return checkNotNull(
-            javaClass.classLoader?.getResourceAsStream(filename)
+            javaClass.classLoader?.getResourceAsStream(filename),
         ).bufferedReader().readText()
     }
 

--- a/embrace-android-payload/src/test/kotlin/io/embrace/android/embracesdk/internal/payload/LegacyExceptionInfoTest.kt
+++ b/embrace-android-payload/src/test/kotlin/io/embrace/android/embracesdk/internal/payload/LegacyExceptionInfoTest.kt
@@ -15,11 +15,11 @@ internal class LegacyExceptionInfoTest {
         assertEquals("UhOh.", info.message)
         assertEquals(
             "io.embrace.android.embracesdk.internal.payload.LegacyExceptionInfoTest\$testOfThrowable\$throwable\$1",
-            info.name
+            info.name,
         )
         assertEquals(
             "io.embrace.android.embracesdk.internal.payload.LegacyExceptionInfoTest.testOfThrowable(LegacyExceptionInfoTest.kt:12)",
-            info.lines.first()
+            info.lines.first(),
         )
         assertNull(info.originalLength)
     }
@@ -31,7 +31,7 @@ internal class LegacyExceptionInfoTest {
         val obj = LegacyExceptionInfo(
             "java.lang.IllegalStateException",
             "Whoops!",
-            (0 until len).map { "line $it" }
+            (0 until len).map { "line $it" },
         )
         assertEquals(limit, obj.lines.size)
         val expected = (0 until limit).map { "line $it" }

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/Embrace.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/Embrace.kt
@@ -22,7 +22,7 @@ public object Embrace : SdkApi by delegate {
     @Deprecated(
         "Calling Embrace.getInstance() is deprecated. Use the Embrace object directly instead. " +
             "For example, Embrace.getInstance().start() is now Embrace.start()",
-        replaceWith = ReplaceWith("Embrace")
+        replaceWith = ReplaceWith("Embrace"),
     )
     @JvmStatic
     public fun getInstance(): Embrace = this

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -114,7 +114,7 @@ internal class EmbraceImpl(
                 bootstrapper.configService,
                 bootstrapper.payloadSourceModule,
                 this,
-                bootstrapper
+                bootstrapper,
             )
 
             // not fully initialized, but the SDK shouldn't catastrophically throw after this point,
@@ -179,7 +179,7 @@ internal class EmbraceImpl(
                         it.asFile(
                             logger = null,
                             rootDirSupplier = { rootDir },
-                            fallbackDirSupplier = { fallbackDir }
+                            fallbackDirSupplier = { fallbackDir },
                         ).value
                     }.forEach {
                         it.deleteRecursively()

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExceptionData.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExceptionData.kt
@@ -6,5 +6,5 @@ internal class ExceptionData(
     val name: String?,
     val message: String?,
     val stacktrace: String?,
-    val logExceptionType: LogExceptionType? = null
+    val logExceptionType: LogExceptionType? = null,
 )

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/InstrumentationApiDelegate.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/InstrumentationApiDelegate.kt
@@ -63,7 +63,7 @@ internal class InstrumentationApiDelegate(
                 endTimeMs = endTimeMs,
                 attributes = attributes,
                 events = events.map(::toSpanEvent),
-                errorCode = errorCode.toErrorCodeAttribute()
+                errorCode = errorCode.toErrorCodeAttribute(),
             )
         }
     }
@@ -89,7 +89,7 @@ internal class InstrumentationApiDelegate(
                 endTimeMs = endTimeMs,
                 attributes = attributes,
                 events = events.map(::toSpanEvent),
-                errorCode = errorCode?.toErrorCodeAttribute()
+                errorCode = errorCode?.toErrorCodeAttribute(),
             )
         }
     }
@@ -97,7 +97,7 @@ internal class InstrumentationApiDelegate(
     private fun toSpanEvent(event: EmbraceSpanEvent): SpanEvent = SpanEventImpl(
         name = event.name,
         timestampNanos = event.timestampNanos,
-        attributes = event.attributes
+        attributes = event.attributes,
     )
 
     private fun ErrorCode?.toErrorCodeAttribute(): ErrorCodeAttribute? {

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/LogsApiDelegate.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/LogsApiDelegate.kt
@@ -125,7 +125,7 @@ internal class LogsApiDelegate(
                 message = exceptionMessage,
                 stacktrace = throwable.getSafeStackTrace()?.let(::serializeStacktrace),
                 logExceptionType = LogExceptionType.HANDLED,
-            )
+            ),
         )
     }
 
@@ -144,7 +144,7 @@ internal class LogsApiDelegate(
                 message = message,
                 stacktrace = serializeStacktrace(stacktraceElements),
                 logExceptionType = LogExceptionType.HANDLED,
-            )
+            ),
         )
     }
 
@@ -200,7 +200,7 @@ internal class LogsApiDelegate(
             message = message,
             severity = logSeverity,
             attributes = attrs,
-            schemaProvider = createSchemaProvider(attrs)
+            schemaProvider = createSchemaProvider(attrs),
         )
 
         // store attachment

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/NetworkRequestApiDelegate.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/NetworkRequestApiDelegate.kt
@@ -60,9 +60,9 @@ internal class NetworkRequestApiDelegate(
                     capturedRequestBody = data.capturedRequestBody,
                     responseHeaders = data.responseHeaders,
                     capturedResponseBody = data.capturedResponseBody,
-                    dataCaptureErrorMessage = data.dataCaptureErrorMessage
+                    dataCaptureErrorMessage = data.dataCaptureErrorMessage,
                 )
-            }
+            },
         )
     }
 }

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/UnityInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/UnityInternalInterfaceImpl.kt
@@ -29,7 +29,7 @@ internal class UnityInternalInterfaceImpl(
                 logger.logError(
                     "Unity metadata is corrupted or malformed. Unity version is " +
                         unityVersion + ", Unity build id is " + buildGuid +
-                        " and Unity SDK version is " + sdkVersionMessage
+                        " and Unity SDK version is " + sdkVersionMessage,
                 )
                 return
             }

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
@@ -132,7 +132,7 @@ internal class InitializedModuleGraph(
                 null,
                 null,
                 null,
-                null
+                null,
             )
         }
     }
@@ -150,7 +150,7 @@ internal class InitializedModuleGraph(
             configService,
             openTelemetryModule,
             threadBlockageService,
-            deliveryModule
+            deliveryModule,
         )
     }
 

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InternalInterfaceModuleImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InternalInterfaceModuleImpl.kt
@@ -22,7 +22,7 @@ internal class InternalInterfaceModuleImpl(
     override val embraceInternalInterface: EmbraceInternalInterface by singleton {
         EmbraceInternalInterfaceImpl(
             configService,
-            payloadSourceModule.resourceSource
+            payloadSourceModule.resourceSource,
         )
     }
 
@@ -33,7 +33,7 @@ internal class InternalInterfaceModuleImpl(
             bootstrapper,
             payloadSourceModule.rnBundleIdTracker,
             payloadSourceModule.hostedSdkVersionInfo,
-            initModule.logger
+            initModule.logger,
         )
     }
 
@@ -42,7 +42,7 @@ internal class InternalInterfaceModuleImpl(
             embrace,
             embraceInternalInterface,
             payloadSourceModule.hostedSdkVersionInfo,
-            initModule.logger
+            initModule.logger,
         )
     }
 
@@ -51,7 +51,7 @@ internal class InternalInterfaceModuleImpl(
             embrace,
             embraceInternalInterface,
             payloadSourceModule.hostedSdkVersionInfo,
-            initModule.logger
+            initModule.logger,
         )
     }
 }

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -46,7 +46,7 @@ internal class ModuleInitBootstrapper(
         ->
         CoreModuleImpl(
             context,
-            initModule
+            initModule,
         )
     },
     private val configServiceSupplier: ConfigServiceSupplier = {
@@ -81,7 +81,7 @@ internal class ModuleInitBootstrapper(
         val storageService = EmbraceStorageService(
             coreModule.context,
             initModule.telemetryService,
-            StatFsAvailabilityChecker(coreModule.context)
+            StatFsAvailabilityChecker(coreModule.context),
         )
         workerThreadModule
             .backgroundWorker(Worker.Background.IoRegWorker)
@@ -182,7 +182,7 @@ internal class ModuleInitBootstrapper(
             requestExecutionServiceProvider,
             payloadStorageServiceProvider,
             cacheStorageServiceProvider,
-            deliveryTracer
+            deliveryTracer,
         )
     },
     private val threadBlockageServiceSupplier: ThreadBlockageServiceSupplier = { args: InstrumentationArgs ->
@@ -306,7 +306,7 @@ internal class ModuleInitBootstrapper(
                     threadBlockageServiceSupplier,
                     logModuleSupplier,
                     userSessionOrchestrationModuleSupplier,
-                    payloadSourceModuleSupplier
+                    payloadSourceModuleSupplier,
                 )
                 return isInitialized()
             }

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
@@ -27,7 +27,7 @@ internal fun ModuleGraph.postInit() {
     openTelemetryModule.applyConfiguration(
         sensitiveKeysBehavior = configService.sensitiveKeysBehavior,
         bypassValidation = configService.isOnlyUsingOtelExporters(),
-        otelBehavior = configService.otelBehavior
+        otelBehavior = configService.otelBehavior,
     )
 
     initModule.logger.errorHandlerProvider = { featureModule.internalErrorDataSource.dataSource }
@@ -97,7 +97,7 @@ internal fun ModuleGraph.loadInstrumentation() {
     threadBlockageService?.startCapture()
 
     featureModule.lastRunCrashVerifier.readAndCleanMarkerAsync(
-        workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker)
+        workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker),
     )
 }
 
@@ -140,7 +140,7 @@ internal fun ModuleGraph.triggerPayloadSend() {
                 },
                 userSessionRestoreDecisionProvider = {
                     userSessionOrchestrationModule.sessionOrchestrator.userSessionRestoreDecision
-                }
+                },
             )
             resurrectionAttempted = true
         } else {
@@ -148,8 +148,8 @@ internal fun ModuleGraph.triggerPayloadSend() {
             initModule.logger.trackInternalError(
                 type = InternalErrorType.PayloadResurrectionFail,
                 throwable = IllegalStateException(
-                    "Resurrection service not found. Undelivered payloads not processed: $payloadCount"
-                )
+                    "Resurrection service not found. Undelivered payloads not processed: $payloadCount",
+                ),
             )
         }
 
@@ -160,7 +160,7 @@ internal fun ModuleGraph.triggerPayloadSend() {
     }
     worker.submit { // potentially trigger first delivery attempt by firing network status callback
         deliveryModule?.schedulingService?.let(
-            essentialServiceModule.networkConnectivityService::addNetworkConnectivityListener
+            essentialServiceModule.networkConnectivityService::addNetworkConnectivityListener,
         )
         deliveryModule?.schedulingService?.onPayloadIntake()
     }
@@ -175,7 +175,7 @@ internal fun ModuleGraph.markSdkInitComplete() {
         coreModule.sdkStartTime,
         initModule.clock.now(),
         essentialServiceModule.appStateTracker.getAppState(),
-        Thread.currentThread().name
+        Thread.currentThread().name,
     )
     end()
     val appId = configService.appId
@@ -200,7 +200,7 @@ private fun ModuleGraph.eventMetadataSupplierProvider(): Provider<Map<String, St
                     .getProperties()
                     .mapKeys { property ->
                         property.key.toEmbraceAttributeName()
-                    }
+                    },
             )
             instrumentationModule.instrumentationRegistry.getCurrentStates().forEach {
                 put(it.key, it.value.toString())

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogExceptionType.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogExceptionType.kt
@@ -8,5 +8,5 @@ package io.embrace.android.embracesdk.internal.logs
 internal enum class LogExceptionType(val value: String) {
     NONE("none"),
     HANDLED("handled"),
-    UNHANDLED("unhandled")
+    UNHANDLED("unhandled"),
 }

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/concurrency/BlockingScheduledExecutorServiceTests.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/concurrency/BlockingScheduledExecutorServiceTests.kt
@@ -40,7 +40,7 @@ internal class BlockingScheduledExecutorServiceTests {
         executorService.schedule(
             { executorRunThread = Thread.currentThread() },
             10L,
-            TimeUnit.MILLISECONDS
+            TimeUnit.MILLISECONDS,
         )
         executorService.moveForwardAndRunBlocked(10L)
 
@@ -66,7 +66,7 @@ internal class BlockingScheduledExecutorServiceTests {
             executorService.schedule(
                 { tasksExecuted++ },
                 100L + it,
-                TimeUnit.MILLISECONDS
+                TimeUnit.MILLISECONDS,
             )
         }
 
@@ -128,7 +128,7 @@ internal class BlockingScheduledExecutorServiceTests {
         val taskStatus = executorService.schedule(
             command = { tasksExecuted++ },
             delay = 10L,
-            unit = TimeUnit.SECONDS
+            unit = TimeUnit.SECONDS,
         )
         assertFalse(taskStatus.isDone)
         assertEquals(1, executorService.scheduledTasksCount())
@@ -143,7 +143,7 @@ internal class BlockingScheduledExecutorServiceTests {
         val taskStatus = executorService.schedule(
             callable = { tasksExecuted++ },
             delay = 10L,
-            unit = TimeUnit.SECONDS
+            unit = TimeUnit.SECONDS,
         )
         assertFalse(taskStatus.isDone)
         assertEquals(1, executorService.scheduledTasksCount())
@@ -160,7 +160,7 @@ internal class BlockingScheduledExecutorServiceTests {
         val taskStatus = executorService.schedule(
             command = { tasksExecuted++ },
             delay = 10L,
-            unit = TimeUnit.SECONDS
+            unit = TimeUnit.SECONDS,
         )
         assertFalse(taskStatus.isDone)
         assertFalse(taskStatus.isCancelled)
@@ -179,7 +179,7 @@ internal class BlockingScheduledExecutorServiceTests {
             command = { tasksExecuted++ },
             initialDelay = 500L,
             period = 10L,
-            unit = TimeUnit.MILLISECONDS
+            unit = TimeUnit.MILLISECONDS,
         )
         assertFalse(taskStatus.isDone)
         executorService.runCurrentlyBlocked()
@@ -209,7 +209,7 @@ internal class BlockingScheduledExecutorServiceTests {
             command = { tasksExecuted++ },
             initialDelay = 0L,
             period = 10L,
-            unit = TimeUnit.MILLISECONDS
+            unit = TimeUnit.MILLISECONDS,
         )
         executorService.runCurrentlyBlocked()
         assertEquals(1, tasksExecuted)
@@ -226,7 +226,7 @@ internal class BlockingScheduledExecutorServiceTests {
             },
             initialDelay = 500L,
             delay = 10L,
-            unit = TimeUnit.MILLISECONDS
+            unit = TimeUnit.MILLISECONDS,
         )
         assertFalse(taskStatus.isDone)
         executorService.runCurrentlyBlocked()
@@ -259,7 +259,7 @@ internal class BlockingScheduledExecutorServiceTests {
             },
             initialDelay = 0L,
             delay = 10L,
-            unit = TimeUnit.MILLISECONDS
+            unit = TimeUnit.MILLISECONDS,
         )
         executorService.runCurrentlyBlocked()
         assertEquals(1, tasksExecuted)
@@ -350,7 +350,7 @@ internal class BlockingScheduledExecutorServiceTests {
             executorService.schedule(
                 { tasksExecuted++ },
                 100L + it,
-                TimeUnit.MILLISECONDS
+                TimeUnit.MILLISECONDS,
             )
         }
 
@@ -382,7 +382,7 @@ internal class BlockingScheduledExecutorServiceTests {
             executorService.schedule(
                 { tasksExecuted++ },
                 100L + it,
-                TimeUnit.MILLISECONDS
+                TimeUnit.MILLISECONDS,
             )
         }
 

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationModule.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationModule.kt
@@ -9,9 +9,9 @@ import io.embrace.android.embracesdk.internal.injection.InstrumentationModule
 class FakeInstrumentationModule(
     application: Application,
     private val logger: FakeInternalLogger = FakeInternalLogger(),
-    override val instrumentationArgs: InstrumentationArgs = FakeInstrumentationArgs(application, logger = logger)
+    override val instrumentationArgs: InstrumentationArgs = FakeInstrumentationArgs(application, logger = logger),
 ) : InstrumentationModule {
     override val instrumentationRegistry: InstrumentationRegistry = InstrumentationRegistryImpl(
-        logger
+        logger,
     )
 }

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
@@ -54,7 +54,7 @@ internal class ModuleInitBootstrapperTest {
                 FakeInstrumentationModule(application, logger = logger).apply {
                     registry = instrumentationRegistry
                 }
-            }
+            },
         )
     }
 
@@ -64,7 +64,7 @@ internal class ModuleInitBootstrapperTest {
             assertTrue(
                 moduleInitBootstrapper.init(
                     context = context,
-                )
+                ),
             )
             assertNotNull(initModule)
             assertNotNull(openTelemetryModule)
@@ -82,12 +82,12 @@ internal class ModuleInitBootstrapperTest {
         assertTrue(
             moduleInitBootstrapper.init(
                 context = context,
-            )
+            ),
         )
         assertFalse(
             moduleInitBootstrapper.init(
                 context = context,
-            )
+            ),
         )
     }
 
@@ -96,7 +96,7 @@ internal class ModuleInitBootstrapperTest {
         assertTrue(
             moduleInitBootstrapper.init(
                 context = context,
-            )
+            ),
         )
     }
 
@@ -119,7 +119,7 @@ internal class ModuleInitBootstrapperTest {
             eventAttributes = null,
         )
         assertFalse(
-            preLogger.logs.single().attributes.containsKey(EmbSessionAttributes.EMB_STATE)
+            preLogger.logs.single().attributes.containsKey(EmbSessionAttributes.EMB_STATE),
         )
 
         moduleInitBootstrapper.postInit()
@@ -138,7 +138,7 @@ internal class ModuleInitBootstrapperTest {
             eventAttributes = null,
         )
         assertTrue(
-            postLogger.logs.single().attributes.containsKey(EmbSessionAttributes.EMB_STATE)
+            postLogger.logs.single().attributes.containsKey(EmbSessionAttributes.EMB_STATE),
         )
     }
 
@@ -157,7 +157,7 @@ internal class ModuleInitBootstrapperTest {
             moduleInitBootstrapper.logModule.logOrchestrator,
             moduleInitBootstrapper.userSessionOrchestrationModule.sessionOrchestrator,
             moduleInitBootstrapper.featureModule.crashMarker,
-            moduleInitBootstrapper.deliveryModule?.payloadStore
+            moduleInitBootstrapper.deliveryModule?.payloadStore,
         )
         assertEquals(expected, handlers)
     }

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/InternalInterfaceModuleImplTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/InternalInterfaceModuleImplTest.kt
@@ -23,7 +23,7 @@ internal class InternalInterfaceModuleImplTest {
             FakeConfigService(),
             FakePayloadSourceModule(),
             EmbraceImpl(),
-            ModuleInitBootstrapper(FakeInitModule())
+            ModuleInitBootstrapper(FakeInitModule()),
         )
 
         assertNotNull(module.flutterInternalInterface)

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/ReactNativeInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/ReactNativeInternalInterfaceImplTest.kt
@@ -51,7 +51,7 @@ internal class ReactNativeInternalInterfaceImplTest {
             FakeInitModule(),
             instrumentationModuleSupplier = { _, _, _, _, _, _, _, _, _ ->
                 FakeInstrumentationModule(ApplicationProvider.getApplicationContext())
-            }
+            },
         )
         impl = ReactNativeInternalInterfaceImpl(
             embrace,
@@ -59,7 +59,7 @@ internal class ReactNativeInternalInterfaceImplTest {
             bootstrapper,
             rnBundleIdTracker,
             hostedSdkVersionInfo,
-            logger
+            logger,
         )
     }
 
@@ -131,7 +131,7 @@ internal class ReactNativeInternalInterfaceImplTest {
             bootstrapper,
             rnBundleIdTracker,
             hostedSdkVersionInfo,
-            logger
+            logger,
         )
 
         every { embrace.isStarted } returns true
@@ -167,7 +167,7 @@ internal class ReactNativeInternalInterfaceImplTest {
                 "t\":\"type\",\"" +
                 "st\":\"" +
                 "stack\"}",
-            lastSentCrashAttributes[embAndroidReactNativeCrashJsException]
+            lastSentCrashAttributes[embAndroidReactNativeCrashJsException],
         )
     }
 

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/UserApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/UserApiDelegateTest.kt
@@ -31,7 +31,7 @@ internal class UserApiDelegateTest {
                 FakeEssentialServiceModule().apply {
                     fakeUserService = userService as FakeUserService
                 }
-            }
+            },
         )
         moduleInitBootstrapper.init(ApplicationProvider.getApplicationContext())
         val sdkCallChecker = SdkCallChecker(FakeInternalLogger(), FakeTelemetryService())

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/UserSessionApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/UserSessionApiDelegateTest.kt
@@ -38,7 +38,7 @@ internal class UserSessionApiDelegateTest {
             },
             userSessionOrchestrationModuleSupplier = { _, _, _, _, _, _, _, _, _, _, _ ->
                 fakeModule
-            }
+            },
         )
         moduleInitBootstrapper.init(ApplicationProvider.getApplicationContext())
         userSessionPropertiesService =

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/network/EmbraceNetworkRequestTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/network/EmbraceNetworkRequestTest.kt
@@ -30,7 +30,7 @@ internal class EmbraceNetworkRequestTest {
             END_TIME,
             BYTES_SENT,
             BYTES_RECEIVED,
-            RESPONSE_CODE
+            RESPONSE_CODE,
         )
         verifyDefaultCompletedRequest(request)
     }
@@ -45,7 +45,7 @@ internal class EmbraceNetworkRequestTest {
             BYTES_SENT,
             BYTES_RECEIVED,
             RESPONSE_CODE,
-            TRACE_ID
+            TRACE_ID,
         )
         verifyDefaultCompletedRequest(request)
         assertEquals(TRACE_ID, request.traceId)
@@ -64,7 +64,7 @@ internal class EmbraceNetworkRequestTest {
             RESPONSE_CODE,
             TRACE_ID,
             null,
-            captureData
+            captureData,
         )
         verifyDefaultCompletedRequest(request)
         assertEquals(TRACE_ID, request.traceId)
@@ -84,7 +84,7 @@ internal class EmbraceNetworkRequestTest {
             RESPONSE_CODE,
             TRACE_ID,
             traceParent,
-            captureData
+            captureData,
         )
         verifyDefaultCompletedRequest(request)
         assertEquals(TRACE_ID, request.traceId)
@@ -100,7 +100,7 @@ internal class EmbraceNetworkRequestTest {
             START_TIME,
             END_TIME,
             ERR_TYPE,
-            ERR_MSG
+            ERR_MSG,
         )
         verifyDefaultIncompleteRequest(request)
     }
@@ -114,7 +114,7 @@ internal class EmbraceNetworkRequestTest {
             END_TIME,
             ERR_TYPE,
             ERR_MSG,
-            TRACE_ID
+            TRACE_ID,
         )
         verifyDefaultIncompleteRequest(request)
         assertEquals(TRACE_ID, request.traceId)
@@ -132,7 +132,7 @@ internal class EmbraceNetworkRequestTest {
             ERR_MSG,
             TRACE_ID,
             null,
-            captureData
+            captureData,
         )
         verifyDefaultIncompleteRequest(request)
         assertEquals(TRACE_ID, request.traceId)
@@ -151,7 +151,7 @@ internal class EmbraceNetworkRequestTest {
             ERR_MSG,
             TRACE_ID,
             traceParent,
-            captureData
+            captureData,
         )
         verifyDefaultIncompleteRequest(request)
         assertEquals(TRACE_ID, request.traceId)

--- a/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/PayloadType.kt
+++ b/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/PayloadType.kt
@@ -15,7 +15,8 @@ enum class PayloadType(
     NETWORK_CAPTURE("sys.network_capture", "network"),
     INTERNAL_ERROR("sys.internal", "internal"),
     ATTACHMENT("attachment", "attachment"),
-    UNKNOWN("unknown", "unknown");
+    UNKNOWN("unknown", "unknown"),
+    ;
 
     companion object {
 

--- a/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadata.kt
+++ b/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadata.kt
@@ -54,15 +54,15 @@ data class StoredTelemetryMetadata(
 
         private fun parseV1(filename: String, parts: List<String>): Result<StoredTelemetryMetadata> {
             val envelopeType = SupportedEnvelopeType.fromPriority(parts[0]) ?: return failure(
-                IllegalArgumentException("Invalid priority: $filename")
+                IllegalArgumentException("Invalid priority: $filename"),
             )
             val timestamp = parts[1].toLongOrNull() ?: return failure(
-                IllegalArgumentException("Invalid timestamp: $filename")
+                IllegalArgumentException("Invalid timestamp: $filename"),
             )
             val uuid = parts[2]
             val processId = parts[3]
             val complete = parts[4].toBooleanStrictOrNull() ?: return failure(
-                IllegalArgumentException("Invalid completeness state: $filename")
+                IllegalArgumentException("Invalid completeness state: $filename"),
             )
             val payloadType = PayloadType.fromFilenameComponent(parts[5])
             return success(
@@ -73,21 +73,21 @@ data class StoredTelemetryMetadata(
                     envelopeType = envelopeType,
                     complete = complete,
                     payloadType = payloadType,
-                )
+                ),
             )
         }
 
         private fun parseV2(filename: String, parts: List<String>): Result<StoredTelemetryMetadata> {
             val envelopeType = SupportedEnvelopeType.fromPriority(parts[0]) ?: return failure(
-                IllegalArgumentException("Invalid priority: $filename")
+                IllegalArgumentException("Invalid priority: $filename"),
             )
             val timestamp = parts[1].toLongOrNull() ?: return failure(
-                IllegalArgumentException("Invalid timestamp: $filename")
+                IllegalArgumentException("Invalid timestamp: $filename"),
             )
             val uuid = parts[2]
             val processId = parts[3]
             val complete = parts[4].toBooleanStrictOrNull() ?: return failure(
-                IllegalArgumentException("Invalid completeness state: $filename")
+                IllegalArgumentException("Invalid completeness state: $filename"),
             )
             val payloadType = PayloadType.fromFilenameComponent(parts[5])
             val userSessionId = decodeId(parts[6])
@@ -102,7 +102,7 @@ data class StoredTelemetryMetadata(
                     payloadType = payloadType,
                     userSessionId = userSessionId,
                     sessionPartId = sessionPartId,
-                )
+                ),
             )
         }
     }

--- a/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/SupportedEnvelopeType.kt
+++ b/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/SupportedEnvelopeType.kt
@@ -18,7 +18,8 @@ enum class SupportedEnvelopeType(
     SESSION(Envelope.sessionEnvelopeSerializer as KSerializer<Envelope<*>>, "p3", Endpoint.SESSIONS),
     ATTACHMENT(null, "p4", Endpoint.ATTACHMENTS),
     LOG(Envelope.logEnvelopeSerializer as KSerializer<Envelope<*>>, "p5", Endpoint.LOGS),
-    BLOB(Envelope.logEnvelopeSerializer as KSerializer<Envelope<*>>, "p7", Endpoint.LOGS);
+    BLOB(Envelope.logEnvelopeSerializer as KSerializer<Envelope<*>>, "p7", Endpoint.LOGS),
+    ;
 
     companion object {
         private val valueMap =

--- a/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImpl.kt
+++ b/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImpl.kt
@@ -55,7 +55,7 @@ class FileStorageServiceImpl(
     ) {
         if (pruneStorage(
                 newPayload = metadata,
-                cutoffMs = clock.now() - maxAgeMs
+                cutoffMs = clock.now() - maxAgeMs,
             )
         ) {
             return
@@ -141,7 +141,7 @@ class FileStorageServiceImpl(
         }
         val removals = input.sortedWith(
             compareByDescending(StoredTelemetryMetadata::envelopeType)
-                .thenBy(StoredTelemetryMetadata::timestamp)
+                .thenBy(StoredTelemetryMetadata::timestamp),
         )
             .take(removalCount)
         removals.forEach(::processDelete)

--- a/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/StorageLocation.kt
+++ b/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/StorageLocation.kt
@@ -20,5 +20,5 @@ enum class StorageLocation(val dir: String) {
     /**
      * Cached envelopes
      */
-    ENVELOPE("embrace_envelopes")
+    ENVELOPE("embrace_envelopes"),
 }

--- a/embrace-android-telemetry-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadataTest.kt
+++ b/embrace-android-telemetry-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/StoredTelemetryMetadataTest.kt
@@ -18,7 +18,7 @@ class StoredTelemetryMetadataTest {
         SupportedEnvelopeType.CRASH to "p1",
         SupportedEnvelopeType.SESSION to "p3",
         SupportedEnvelopeType.LOG to "p5",
-        SupportedEnvelopeType.BLOB to "p7"
+        SupportedEnvelopeType.BLOB to "p7",
     )
 
     @Test
@@ -36,7 +36,7 @@ class StoredTelemetryMetadataTest {
                         payloadType = PayloadType.AEI,
                         userSessionId = USER_SESSION_ID,
                         sessionPartId = SESSION_PART_ID,
-                    ).filename
+                    ).filename,
                 )
             }
         }
@@ -55,7 +55,7 @@ class StoredTelemetryMetadataTest {
                         envelopeType = type,
                         complete = payloadComplete,
                         payloadType = PayloadType.AEI,
-                    ).filename
+                    ).filename,
                 )
             }
         }
@@ -74,7 +74,7 @@ class StoredTelemetryMetadataTest {
         ).filename
         assertEquals(
             "p3_${TIMESTAMP}_${UUID}_${PROCESS_ID}_true_session_${USER_SESSION_ID}_none_v2.json",
-            filename
+            filename,
         )
     }
 

--- a/embrace-android-utils/src/main/kotlin/io/embrace/android/embracesdk/internal/clock/NormalizedIntervalClock.kt
+++ b/embrace-android-utils/src/main/kotlin/io/embrace/android/embracesdk/internal/clock/NormalizedIntervalClock.kt
@@ -35,8 +35,8 @@ class NormalizedIntervalClock(
                 logger?.trackInternalError(
                     InternalErrorType.InternalInterfaceFail,
                     IllegalStateException(
-                        "NormalizedIntervalClock drifted back in time by more than threshold. Delivery is likely out-of-order."
-                    )
+                        "NormalizedIntervalClock drifted back in time by more than threshold. Delivery is likely out-of-order.",
+                    ),
                 )
             }
         }

--- a/embrace-gradle-plugin-integration-tests/src/main/kotlin/io/embrace/android/gradle/integration/framework/IntegrationTestExtension.kt
+++ b/embrace-gradle-plugin-integration-tests/src/main/kotlin/io/embrace/android/gradle/integration/framework/IntegrationTestExtension.kt
@@ -51,8 +51,8 @@ abstract class IntegrationTestExtension(objectFactory: ObjectFactory) {
                 endpoint = endpoint,
                 fileName = filename,
                 failBuildOnUploadErrors = true,
-                baseUrl = checkNotNull(project.findProperty("embrace.baseUrl")?.toString())
-            )
+                baseUrl = checkNotNull(project.findProperty("embrace.baseUrl")?.toString()),
+            ),
         )
     }
 
@@ -67,8 +67,8 @@ abstract class IntegrationTestExtension(objectFactory: ObjectFactory) {
                 apiToken = apiToken.get(),
                 endpoint = EmbraceEndpoint.NDK,
                 failBuildOnUploadErrors = true,
-                baseUrl = checkNotNull(project.findProperty("embrace.baseUrl")?.toString())
-            )
+                baseUrl = checkNotNull(project.findProperty("embrace.baseUrl")?.toString()),
+            ),
         )
     }
 
@@ -105,7 +105,7 @@ abstract class IntegrationTestExtension(objectFactory: ObjectFactory) {
                     isMinifyEnabled = true
                     proguardFiles(
                         getDefaultProguardFile("proguard-android-optimize.txt"),
-                        "proguard-rules.pro"
+                        "proguard-rules.pro",
                     )
                 }
             }
@@ -140,7 +140,7 @@ abstract class IntegrationTestExtension(objectFactory: ObjectFactory) {
 
         dependencies.add(
             "coreLibraryDesugaring",
-            "com.android.tools:desugar_jdk_libs:2.1.5"
+            "com.android.tools:desugar_jdk_libs:2.1.5",
         )
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/main/kotlin/io/embrace/android/gradle/integration/framework/IntegrationTestPlugin.kt
+++ b/embrace-gradle-plugin-integration-tests/src/main/kotlin/io/embrace/android/gradle/integration/framework/IntegrationTestPlugin.kt
@@ -19,7 +19,7 @@ class IntegrationTestPlugin : Plugin<Project> {
         extension = project.extensions.create(
             "integrationTest",
             IntegrationTestExtension::class.java,
-            project.objects
+            project.objects,
         )
         extension.variantData.set(
             AndroidCompactedVariantData(
@@ -28,8 +28,8 @@ class IntegrationTestPlugin : Plugin<Project> {
                 "release",
                 false,
                 listOf("development"),
-                ""
-            )
+                "",
+            ),
         )
         project.extensions.configure(JavaPluginExtension::class.java) { java ->
             java.sourceCompatibility = JavaVersion.VERSION_11

--- a/embrace-gradle-plugin-integration-tests/src/main/kotlin/io/embrace/android/gradle/integration/framework/ProjectType.kt
+++ b/embrace-gradle-plugin-integration-tests/src/main/kotlin/io/embrace/android/gradle/integration/framework/ProjectType.kt
@@ -2,5 +2,5 @@ package io.embrace.android.gradle.integration.framework
 
 enum class ProjectType {
     ANDROID,
-    JVM
+    JVM,
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/config/JdkEnv.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/config/JdkEnv.kt
@@ -2,7 +2,7 @@ package io.embrace.android.gradle.config
 
 enum class JdkEnv(val path: String) {
     JAVA_17(resolveJdkPath(17)),
-    JAVA_21(resolveJdkPath(21))
+    JAVA_21(resolveJdkPath(21)),
 }
 
 private fun resolveJdkPath(version: Int): String {
@@ -10,6 +10,6 @@ private fun resolveJdkPath(version: Int): String {
         ?: System.getenv("LOCAL_JAVA_${version}_PATH")
         ?: error(
             "No JDK path supplied for Java $version. Please check the " +
-                "LOCAL_JAVA_${version}_PATH or JAVA_HOME_${version}_X64 envars are set."
+                "LOCAL_JAVA_${version}_PATH or JAVA_HOME_${version}_X64 envars are set.",
         )
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/config/TestMatrix.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/config/TestMatrix.kt
@@ -17,7 +17,7 @@ sealed class TestMatrix(
     val gradle: String,
     val kotlin: String,
     val jdk: JdkEnv,
-    val compileAndTargetSdk: String
+    val compileAndTargetSdk: String,
 ) {
 
     object UnsupportedOldGradleVersion : TestMatrix("8.0.0", "8.0", "2.0.0", JdkEnv.JAVA_17, "34")

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/framework/AssertionInterface.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/framework/AssertionInterface.kt
@@ -20,7 +20,7 @@ import org.junit.Assert.assertTrue
 import java.io.File
 
 class AssertionInterface(
-    private val apiServer: FakeApiServer
+    private val apiServer: FakeApiServer,
 ) {
 
     private val multipartFormReader: MultipartFormReader = MultipartFormReader()
@@ -62,7 +62,7 @@ class AssertionInterface(
      */
     inline fun <reified T> deserializeExpectedRequestBody(
         projectDir: File,
-        expectedPath: String
+        expectedPath: String,
     ): T {
         val json = projectDir.file(expectedPath).readText()
         return MoshiSerializer().fromJson(json, T::class.java)
@@ -74,7 +74,7 @@ class AssertionInterface(
     inline fun <reified T> compareRequestBodyAgainstExpected(
         request: RecordedRequest,
         projectDir: File,
-        expectedPath: String
+        expectedPath: String,
     ) {
         val observed = deserializeRequestBody<T>(request)
         val expected = deserializeExpectedRequestBody<T>(projectDir, expectedPath)
@@ -185,7 +185,7 @@ class AssertionInterface(
     fun AssertionInterface.verifyHandshakes(
         expectedLibs: List<String>,
         expectedArchs: List<String>,
-        expectedVariants: List<String>
+        expectedVariants: List<String>,
     ) {
         val handshakes = fetchRequests(EmbraceEndpoint.NDK_HANDSHAKE).map {
             deserializeRequestBody<NdkUploadHandshakeRequest>(it)
@@ -197,7 +197,7 @@ class AssertionInterface(
                 handshake ?: error("Handshake not found for variant: $variant"),
                 variant,
                 expectedLibs,
-                expectedArchs
+                expectedArchs,
             )
         }
     }
@@ -206,7 +206,7 @@ class AssertionInterface(
         handshake: NdkUploadHandshakeRequest,
         expectedVariantName: String,
         expectedLibs: List<String>,
-        expectedArchs: List<String>
+        expectedArchs: List<String>,
     ) {
         assertEquals(expectedVariantName, handshake.variant)
         assertEquals(IntegrationTestDefaults.APP_ID, handshake.appId)
@@ -232,7 +232,7 @@ class AssertionInterface(
     fun AssertionInterface.verifyUploads(
         expectedLibs: List<String>,
         expectedArchs: List<String>,
-        expectedVariants: List<String>
+        expectedVariants: List<String>,
     ) {
         val uploads = fetchRequests(EmbraceEndpoint.NDK).map(::readMultipartRequest)
         val expectedLibsSize = expectedLibs.size
@@ -247,7 +247,7 @@ class AssertionInterface(
                 uploads,
                 fieldIndex = 6,
                 expectedData = it,
-                count = expectedArchsSize * expectedVariantsSize
+                count = expectedArchsSize * expectedVariantsSize,
             )
             validateUploadedFile(uploads, it)
         }
@@ -258,7 +258,7 @@ class AssertionInterface(
                 uploads,
                 fieldIndex = 3,
                 expectedData = it,
-                count = expectedLibsSize * expectedArchsSize
+                count = expectedLibsSize * expectedArchsSize,
             )
         }
 
@@ -268,7 +268,7 @@ class AssertionInterface(
                 uploads,
                 fieldIndex = 4,
                 expectedData = arch,
-                count = expectedLibsSize * expectedVariantsSize
+                count = expectedLibsSize * expectedVariantsSize,
             )
         }
 
@@ -284,13 +284,13 @@ class AssertionInterface(
         uploads: List<List<FormPart>>,
         fieldIndex: Int,
         expectedData: String,
-        count: Int
+        count: Int,
     ) {
         val filteredUploads = uploads.filter { it[fieldIndex].data == expectedData }
         assertEquals(
             "Expected $count uploads with $expectedData in field $fieldIndex",
             count,
-            filteredUploads.size
+            filteredUploads.size,
         )
     }
 

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/framework/PluginIntegrationTestRule.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/framework/PluginIntegrationTestRule.kt
@@ -124,7 +124,7 @@ class PluginIntegrationTestRule : ExternalResource() {
             baseUrl,
             additionalArgs,
             attachDebugger,
-            testMatrix
+            testMatrix,
         )
 
         // run any preconditions before the build
@@ -235,7 +235,7 @@ class PluginIntegrationTestRule : ExternalResource() {
                 "-Pkotlin_version=${testMatrix.kotlin}",
                 "-Pplugin_snapshot_version=${loadSnapshotVersion()}",
                 "-PcompileAndTargetSdk=${testMatrix.compileAndTargetSdk}",
-            )
+            ),
         )
         // Android projects currently require this flag to compile
         if (projectType == ProjectType.ANDROID) {
@@ -245,12 +245,12 @@ class PluginIntegrationTestRule : ExternalResource() {
             println(
                 "Waiting for debugger to attach. You need to run the remote debugging " +
                     "configuration from Android Studio for this test case to continue. Please " +
-                    "see this module's README.md for further details."
+                    "see this module's README.md for further details.",
             )
             args.addAll(
                 listOf(
                     "-Dorg.gradle.debug=true",
-                )
+                ),
             )
         }
         return args

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/AgpSupportTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/AgpSupportTest.kt
@@ -45,7 +45,7 @@ class AgpSupportTest {
             expectedExceptionMessage = errorMessage,
             assertions = {
                 verifyNoUploads()
-            }
+            },
         )
     }
 
@@ -71,10 +71,10 @@ class AgpSupportTest {
                             assertEquals(testMatrix.kotlin, kotlinVersion)
                         }
                         assertEquals(testMatrix.jdk.name.removePrefix("JAVA_"), sourceCompatibility)
-                    }
+                    },
                 )
                 verifyJvmMappingRequestsSent(1)
-            }
+            },
         )
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/AndroidBuildTypeProductFlavorTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/AndroidBuildTypeProductFlavorTest.kt
@@ -24,7 +24,7 @@ class AndroidBuildTypeProductFlavorTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(expectedVariants = variants, expectedAppIds = appIds)
                 verifyJvmMappingRequestsSent(obfuscatedAppIds)
-            }
+            },
         )
     }
 
@@ -37,7 +37,7 @@ class AndroidBuildTypeProductFlavorTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(expectedVariants = variants, expectedAppIds = appIds)
                 verifyJvmMappingRequestsSent(listOf("democ", "demor"))
-            }
+            },
         )
     }
 
@@ -63,7 +63,7 @@ class AndroidBuildTypeProductFlavorTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(expectedVariants = variants, expectedAppIds = appIds)
                 verifyJvmMappingRequestsSent(listOf("fullc"))
-            }
+            },
         )
     }
 
@@ -76,7 +76,7 @@ class AndroidBuildTypeProductFlavorTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(expectedVariants = variants, expectedAppIds = appIds)
                 verifyJvmMappingRequestsSent(obfuscatedAppIds)
-            }
+            },
         )
     }
 
@@ -89,7 +89,7 @@ class AndroidBuildTypeProductFlavorTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(expectedVariants = variants, expectedAppIds = appIds)
                 verifyJvmMappingRequestsSent(listOf("democ", "demor"))
-            }
+            },
         )
     }
 
@@ -102,7 +102,7 @@ class AndroidBuildTypeProductFlavorTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(expectedVariants = variants, expectedAppIds = appIds)
                 verifyJvmMappingRequestsSent(listOf("demor", "fullr"))
-            }
+            },
         )
     }
 
@@ -115,7 +115,7 @@ class AndroidBuildTypeProductFlavorTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(expectedVariants = variants, expectedAppIds = appIds)
                 verifyJvmMappingRequestsSent(listOf("fullc"))
-            }
+            },
         )
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/AndroidBuildTypeTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/AndroidBuildTypeTest.kt
@@ -24,7 +24,7 @@ class AndroidBuildTypeTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(expectedVariants = variants, expectedAppIds = appIds)
                 verifyJvmMappingRequestsSent(obfuscatedAppIds)
-            }
+            },
         )
     }
 
@@ -37,7 +37,7 @@ class AndroidBuildTypeTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(expectedVariants = variants, expectedAppIds = appIds)
                 verifyJvmMappingRequestsSent(listOf("custo"))
-            }
+            },
         )
     }
 
@@ -50,7 +50,7 @@ class AndroidBuildTypeTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(expectedVariants = variants, expectedAppIds = appIds)
                 verifyJvmMappingRequestsSent(obfuscatedAppIds)
-            }
+            },
         )
     }
 
@@ -63,7 +63,7 @@ class AndroidBuildTypeTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(expectedVariants = variants, expectedAppIds = appIds)
                 verifyJvmMappingRequestsSent(listOf("custo"))
-            }
+            },
         )
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/AndroidFlavorDimensionsTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/AndroidFlavorDimensionsTest.kt
@@ -24,7 +24,7 @@ class AndroidFlavorDimensionsTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(expectedVariants = variants, expectedAppIds = appIds)
                 verifyJvmMappingRequestsSent(obfuscatedAppIds)
-            }
+            },
         )
     }
 
@@ -37,7 +37,7 @@ class AndroidFlavorDimensionsTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(expectedVariants = variants, expectedAppIds = appIds)
                 verifyJvmMappingRequestsSent(listOf("democ", "demor"))
-            }
+            },
         )
     }
 
@@ -50,7 +50,7 @@ class AndroidFlavorDimensionsTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(expectedVariants = variants, expectedAppIds = appIds)
                 verifyJvmMappingRequestsSent(listOf("demor", "fullr"))
-            }
+            },
         )
     }
 
@@ -63,7 +63,7 @@ class AndroidFlavorDimensionsTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(expectedVariants = variants, expectedAppIds = appIds)
                 verifyJvmMappingRequestsSent(listOf("fullc"))
-            }
+            },
         )
     }
 
@@ -76,7 +76,7 @@ class AndroidFlavorDimensionsTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(expectedVariants = variants, expectedAppIds = appIds)
                 verifyJvmMappingRequestsSent(obfuscatedAppIds)
-            }
+            },
         )
     }
 
@@ -89,7 +89,7 @@ class AndroidFlavorDimensionsTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(expectedVariants = variants, expectedAppIds = appIds)
                 verifyJvmMappingRequestsSent(listOf("democ", "demor"))
-            }
+            },
         )
     }
 
@@ -102,7 +102,7 @@ class AndroidFlavorDimensionsTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(expectedVariants = variants, expectedAppIds = appIds)
                 verifyJvmMappingRequestsSent(listOf("demor", "fullr"))
-            }
+            },
         )
     }
 
@@ -115,7 +115,7 @@ class AndroidFlavorDimensionsTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(expectedVariants = variants, expectedAppIds = appIds)
                 verifyJvmMappingRequestsSent(listOf("fullc"))
-            }
+            },
         )
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/AndroidNdkTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/AndroidNdkTest.kt
@@ -32,14 +32,14 @@ class AndroidNdkTest {
                 setupMockResponses(
                     defaultExpectedLibs,
                     defaultExpectedArchs,
-                    defaultExpectedVariants
+                    defaultExpectedVariants,
                 )
             },
             assertions = {
                 verifyBuildTelemetryRequestSent(variantsSentInBuildTelemetry)
                 verifyHandshakes(defaultExpectedLibs, defaultExpectedArchs, defaultExpectedVariants)
                 verifyUploads(defaultExpectedLibs, defaultExpectedArchs, defaultExpectedVariants)
-            }
+            },
         )
     }
 
@@ -53,14 +53,14 @@ class AndroidNdkTest {
                 setupMockResponses(
                     defaultExpectedLibs,
                     defaultExpectedArchs,
-                    defaultExpectedVariants
+                    defaultExpectedVariants,
                 )
             },
             assertions = {
                 verifyBuildTelemetryRequestSent(variantsSentInBuildTelemetry)
                 verifyHandshakes(defaultExpectedLibs, defaultExpectedArchs, defaultExpectedVariants)
                 verifyUploads(defaultExpectedLibs, defaultExpectedArchs, defaultExpectedVariants)
-            }
+            },
         )
     }
 
@@ -77,13 +77,13 @@ class AndroidNdkTest {
                 // Read and parse the smali file containing the injected symbols
                 val smaliFile = SmaliConfigReader().readSmaliFiles(
                     projectDir,
-                    listOf("/io/embrace/android/embracesdk/internal/config/instrumented/Base64SharedObjectFilesMapImpl")
+                    listOf("/io/embrace/android/embracesdk/internal/config/instrumented/Base64SharedObjectFilesMapImpl"),
                 ).first()
 
                 // Get the return value of the getBase64SharedObjectFilesMap method
                 val method = SmaliParser().parse(
                     smaliFile,
-                    listOf(SmaliMethod("getBase64SharedObjectFilesMap()Ljava/lang/String;"))
+                    listOf(SmaliMethod("getBase64SharedObjectFilesMap()Ljava/lang/String;")),
                 ).methods.first()
 
                 // Decode the base64 string into a map
@@ -97,7 +97,7 @@ class AndroidNdkTest {
                         assertTrue(symbols[arch]?.containsKey(lib) ?: false)
                     }
                 }
-            }
+            },
         )
     }
 
@@ -111,14 +111,14 @@ class AndroidNdkTest {
                 setupMockResponses(
                     defaultExpectedLibs,
                     defaultExpectedArchs,
-                    defaultExpectedVariants
+                    defaultExpectedVariants,
                 )
             },
             assertions = {
                 verifyBuildTelemetryRequestSent(variantsSentInBuildTelemetry)
                 verifyHandshakes(defaultExpectedLibs, defaultExpectedArchs, defaultExpectedVariants)
                 verifyUploads(defaultExpectedLibs, defaultExpectedArchs, defaultExpectedVariants)
-            }
+            },
         )
     }
 
@@ -137,7 +137,7 @@ class AndroidNdkTest {
                 verifyBuildTelemetryRequestSent(variantsSentInBuildTelemetry)
                 verifyHandshakes(expectedLibs, defaultExpectedArchs, defaultExpectedVariants)
                 verifyUploads(expectedLibs, defaultExpectedArchs, defaultExpectedVariants)
-            }
+            },
         )
     }
 
@@ -151,14 +151,14 @@ class AndroidNdkTest {
                 setupMockResponses(
                     expectedLibs = emptyList(),
                     expectedArchs = emptyList(),
-                    expectedVariants = defaultExpectedVariants
+                    expectedVariants = defaultExpectedVariants,
                 )
             },
             assertions = {
                 verifyBuildTelemetryRequestSent(variantsSentInBuildTelemetry)
                 verifyHandshakes(defaultExpectedLibs, defaultExpectedArchs, defaultExpectedVariants)
                 verifyNoUploads()
-            }
+            },
         )
     }
 
@@ -174,14 +174,14 @@ class AndroidNdkTest {
                 setupMockResponses(
                     expectedLibs = expectedLibs,
                     expectedArchs = expectedArchs,
-                    expectedVariants = defaultExpectedVariants
+                    expectedVariants = defaultExpectedVariants,
                 )
             },
             assertions = {
                 verifyBuildTelemetryRequestSent(variantsSentInBuildTelemetry)
                 verifyHandshakes(defaultExpectedLibs, defaultExpectedArchs, defaultExpectedVariants)
                 verifyUploads(expectedLibs, expectedArchs, defaultExpectedVariants)
-            }
+            },
         )
     }
 
@@ -196,7 +196,7 @@ class AndroidNdkTest {
                 verifyNoHandshakes()
                 verifyNoUploads()
                 verifyJvmMappingRequestsSent(1)
-            }
+            },
         )
     }
 
@@ -211,7 +211,7 @@ class AndroidNdkTest {
                 verifyNoHandshakes()
                 verifyNoUploads()
                 verifyJvmMappingRequestsSent(0)
-            }
+            },
         )
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/AndroidNestedTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/AndroidNestedTest.kt
@@ -22,7 +22,7 @@ class AndroidNestedTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(variants)
                 verifyJvmMappingRequestsSent(1)
-            }
+            },
         )
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/AndroidProductFlavorTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/AndroidProductFlavorTest.kt
@@ -24,7 +24,7 @@ class AndroidProductFlavorTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(expectedVariants = variants, expectedAppIds = appIds)
                 verifyJvmMappingRequestsSent(obfuscatedAppIds)
-            }
+            },
         )
     }
 
@@ -37,7 +37,7 @@ class AndroidProductFlavorTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(expectedVariants = variants, expectedAppIds = appIds)
                 verifyJvmMappingRequestsSent(listOf("demor"))
-            }
+            },
         )
     }
 
@@ -50,7 +50,7 @@ class AndroidProductFlavorTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(expectedVariants = variants, expectedAppIds = appIds)
                 verifyJvmMappingRequestsSent(obfuscatedAppIds)
-            }
+            },
         )
     }
 
@@ -63,7 +63,7 @@ class AndroidProductFlavorTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(expectedVariants = variants, expectedAppIds = appIds)
                 verifyJvmMappingRequestsSent(listOf("fullr"))
-            }
+            },
         )
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/AndroidSimpleTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/AndroidSimpleTest.kt
@@ -23,7 +23,7 @@ class AndroidSimpleTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(variants)
                 verifyJvmMappingRequestsSent(1)
-            }
+            },
         )
     }
 
@@ -37,7 +37,7 @@ class AndroidSimpleTest {
                 verifyNoHandshakes()
                 verifyNoUploads()
                 verifyJvmMappingRequestsSent(0)
-            }
+            },
         )
     }
 
@@ -50,7 +50,7 @@ class AndroidSimpleTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(variants)
                 verifyJvmMappingRequestsSent(1)
-            }
+            },
         )
     }
 
@@ -63,7 +63,7 @@ class AndroidSimpleTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(variants)
                 verifyNoRequestsSent(EmbraceEndpoint.PROGUARD)
-            }
+            },
         )
     }
 
@@ -76,7 +76,7 @@ class AndroidSimpleTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(variants)
                 verifyJvmMappingRequestsSent(1)
-            }
+            },
         )
     }
 
@@ -89,7 +89,7 @@ class AndroidSimpleTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(variants)
                 verifyJvmMappingRequestsSent(1)
-            }
+            },
         )
     }
 
@@ -102,7 +102,7 @@ class AndroidSimpleTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(variants)
                 verifyNoRequestsSent(EmbraceEndpoint.PROGUARD)
-            }
+            },
         )
     }
 
@@ -115,7 +115,7 @@ class AndroidSimpleTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(variants)
                 verifyJvmMappingRequestsSent(1)
-            }
+            },
         )
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/BytecodeInstrumentationTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/BytecodeInstrumentationTest.kt
@@ -38,7 +38,7 @@ class BytecodeInstrumentationTest {
             setup = ndkSetup,
             assertions = { projectDir ->
                 verifyBytecodeInstrumented(projectDir, "bytecode-instrumentation-enabled.json")
-            }
+            },
         )
     }
 
@@ -52,7 +52,7 @@ class BytecodeInstrumentationTest {
             setup = ndkSetup,
             assertions = { projectDir ->
                 verifyBytecodeInstrumented(projectDir, "bytecode-instrumentation-disabled.json")
-            }
+            },
         )
     }
 
@@ -66,7 +66,7 @@ class BytecodeInstrumentationTest {
             setup = ndkSetup,
             assertions = { projectDir ->
                 verifyBytecodeInstrumented(projectDir, "bytecode-instrumentation-disabled.json")
-            }
+            },
         )
     }
 
@@ -80,7 +80,7 @@ class BytecodeInstrumentationTest {
             setup = ndkSetup,
             assertions = { projectDir ->
                 verifyBytecodeInstrumented(projectDir, "bytecode-instrumentation-disabled.json")
-            }
+            },
         )
     }
 

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/CompressSharedObjectFilesTaskTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/CompressSharedObjectFilesTaskTest.kt
@@ -56,7 +56,7 @@ class CompressSharedObjectFilesTaskTest {
                     .sumOf { it.length() } // returns size in bytes
 
                 assertTrue(compressedSize < originalSize)
-            }
+            },
         )
     }
 
@@ -72,7 +72,7 @@ class CompressSharedObjectFilesTaskTest {
                         assertTrue(compressedFile.exists())
                     }
                 }
-            }
+            },
         )
     }
 
@@ -87,7 +87,7 @@ class CompressSharedObjectFilesTaskTest {
             expectedOutcome = TaskOutcome.NO_SOURCE,
             assertions = {
                 verifyNoUploads()
-            }
+            },
         )
     }
 
@@ -103,7 +103,7 @@ class CompressSharedObjectFilesTaskTest {
             expectedOutcome = TaskOutcome.NO_SOURCE,
             assertions = {
                 verifyNoUploads()
-            }
+            },
         )
     }
 
@@ -122,7 +122,7 @@ class CompressSharedObjectFilesTaskTest {
             expectedOutcome = TaskOutcome.NO_SOURCE,
             assertions = {
                 verifyNoUploads()
-            }
+            },
         )
     }
 
@@ -140,7 +140,7 @@ class CompressSharedObjectFilesTaskTest {
             expectedExceptionMessage = "Expected an input to be a directory but it was a file.",
             assertions = {
                 verifyNoUploads()
-            }
+            },
         )
     }
 
@@ -158,7 +158,7 @@ class CompressSharedObjectFilesTaskTest {
             expectedExceptionMessage = "Specified architectures directory does not contain any architecture directories",
             assertions = {
                 verifyNoUploads()
-            }
+            },
         )
     }
 
@@ -177,7 +177,7 @@ class CompressSharedObjectFilesTaskTest {
             expectedExceptionMessage = "No shared object files found in architecture directory someArch",
             assertions = {
                 verifyNoUploads()
-            }
+            },
         )
     }
 
@@ -199,7 +199,7 @@ class CompressSharedObjectFilesTaskTest {
             expectedExceptionMessage = "No shared object files found in architecture directory someArch",
             assertions = {
                 verifyNoUploads()
-            }
+            },
         )
     }
 
@@ -219,9 +219,9 @@ class CompressSharedObjectFilesTaskTest {
                     projectDir.file("build/compressedSharedObjectFiles/arm64-v8a/")
                         .listFiles { file -> file.name == "nestedDirectory" || file.name == "libexample.so" }
                         .orEmpty()
-                        .isEmpty()
+                        .isEmpty(),
                 )
-            }
+            },
         )
     }
 
@@ -239,7 +239,7 @@ class CompressSharedObjectFilesTaskTest {
             },
             assertions = {
                 verifyNoUploads()
-            }
+            },
         )
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/CompressedFileUploadTaskIntegrationTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/CompressedFileUploadTaskIntegrationTest.kt
@@ -33,7 +33,7 @@ class CompressedFileUploadTaskIntegrationTest {
             },
             assertions = {
                 assertFileUploaded(expectedFileContents, EmbraceEndpoint.PROGUARD)
-            }
+            },
         )
     }
 
@@ -44,7 +44,7 @@ class CompressedFileUploadTaskIntegrationTest {
             expectedOutcome = TaskOutcome.NO_SOURCE,
             assertions = {
                 verifyNoRequestsSent(EmbraceEndpoint.PROGUARD)
-            }
+            },
         )
     }
 
@@ -59,7 +59,7 @@ class CompressedFileUploadTaskIntegrationTest {
             },
             assertions = {
                 assertFileUploaded(expectedFileContents, EmbraceEndpoint.NDK)
-            }
+            },
         )
     }
 

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/ConfigCacheTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/ConfigCacheTest.kt
@@ -31,12 +31,12 @@ class ConfigCacheTest {
                 setupMockResponses(
                     defaultExpectedLibs,
                     defaultExpectedArchs,
-                    defaultExpectedVariants
+                    defaultExpectedVariants,
                 )
             },
             projectType = ProjectType.ANDROID,
             assertions = {
-            }
+            },
         )
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/ConfigInstrumentationTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/ConfigInstrumentationTest.kt
@@ -42,7 +42,7 @@ class ConfigInstrumentationTest {
             },
             assertions = { projectDir ->
                 verifyInstrumentedConfig(projectDir, "instrumented-config-default.json")
-            }
+            },
         )
     }
 
@@ -61,7 +61,7 @@ class ConfigInstrumentationTest {
             },
             assertions = { projectDir ->
                 verifyInstrumentedConfig(projectDir, "instrumented-config-overrides.json")
-            }
+            },
         )
     }
 

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/DesugaringTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/DesugaringTest.kt
@@ -21,7 +21,7 @@ class DesugaringTest {
             expectedExceptionMessage = "Desugaring must be enabled when minSdk is < 26",
             assertions = {
                 verifyNoUploads()
-            }
+            },
         )
     }
 
@@ -38,7 +38,7 @@ class DesugaringTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(listOf("debug", "release"))
                 verifyJvmMappingRequestsSent(1)
-            }
+            },
         )
     }
 
@@ -55,7 +55,7 @@ class DesugaringTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(listOf("debug", "release"))
                 verifyJvmMappingRequestsSent(1)
-            }
+            },
         )
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/DexguardTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/DexguardTest.kt
@@ -22,7 +22,7 @@ class DexguardTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(variants)
                 verifyJvmMappingRequestsSent(1)
-            }
+            },
         )
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/DisablePluginTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/DisablePluginTest.kt
@@ -22,7 +22,7 @@ class DisablePluginTest {
             assertions = {
                 verifyBuildTelemetryRequestSent(variants)
                 verifyJvmMappingRequestsSent(1)
-            }
+            },
         )
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/EncodeFileToBase64TaskIntegrationTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/EncodeFileToBase64TaskIntegrationTest.kt
@@ -27,7 +27,7 @@ class EncodeFileToBase64TaskIntegrationTest {
             assertions = { projectDir ->
                 val encodedMap = projectDir.buildFile("encoded_map.txt").bufferedReader().use { it.readText() }
                 assertEquals(expectedBase64Encoding, encodedMap)
-            }
+            },
         )
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/FileCompressionTaskIntegrationTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/FileCompressionTaskIntegrationTest.kt
@@ -36,7 +36,7 @@ class FileCompressionTaskIntegrationTest {
                 assertEquals("Hello, world!", output)
                 val input = projectDir.file("input.txt").readText()
                 assertEquals(input, output)
-            }
+            },
         )
     }
 
@@ -48,7 +48,7 @@ class FileCompressionTaskIntegrationTest {
             assertions = { projectDir ->
                 assertFalse(projectDir.file("mapping.txt").exists())
                 assertFalse(projectDir.buildFile("mapping.txt").exists())
-            }
+            },
         )
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/GenerateRnSourcemapTaskIntegrationTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/GenerateRnSourcemapTaskIntegrationTest.kt
@@ -44,7 +44,7 @@ class GenerateRnSourcemapTaskIntegrationTest {
                 parts[1].validateBodyApiToken(IntegrationTestDefaults.API_TOKEN)
                 parts[2].validateBodyBuildId()
                 parts[3].validateMappingFile("sourcemap.json")
-            }
+            },
         )
     }
 

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/HashSharedObjectFilesTaskTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/HashSharedObjectFilesTaskTest.kt
@@ -51,9 +51,9 @@ class HashSharedObjectFilesTaskTest {
             assertions = { projectDir ->
                 assertEquals(
                     projectDir.file("expectedOutput.json").bufferedReader().use { it.readText() },
-                    projectDir.file("build/output.json").bufferedReader().use { it.readText() }
+                    projectDir.file("build/output.json").bufferedReader().use { it.readText() },
                 )
-            }
+            },
         )
     }
 
@@ -77,7 +77,7 @@ class HashSharedObjectFilesTaskTest {
             expectedExceptionMessage = "Shared object files not found",
             assertions = {
                 verifyNoUploads()
-            }
+            },
         )
     }
 
@@ -95,7 +95,7 @@ class HashSharedObjectFilesTaskTest {
             expectedExceptionMessage = "Compressed shared object files directory does not contain any architecture directories",
             assertions = {
                 verifyNoUploads()
-            }
+            },
         )
     }
 
@@ -113,7 +113,7 @@ class HashSharedObjectFilesTaskTest {
             },
             assertions = {
                 verifyNoUploads()
-            }
+            },
         )
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/IsolatedProjectsTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/IsolatedProjectsTest.kt
@@ -29,9 +29,9 @@ class IsolatedProjectsTest {
                     listOf("debug", "release"),
                     additionalAssertions = {
                         assertTrue(checkNotNull(isIsolatedProjectsEnabled))
-                    }
+                    },
                 )
-            }
+            },
         )
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/MissingConfigFileTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/MissingConfigFileTest.kt
@@ -27,7 +27,7 @@ class MissingConfigFileTest {
                 endpoints.forEach {
                     verifyNoRequestsSent(it)
                 }
-            }
+            },
         )
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/PluginTelemetryTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/PluginTelemetryTest.kt
@@ -20,7 +20,7 @@ class PluginTelemetryTest {
             projectType = ProjectType.ANDROID,
             assertions = {
                 verifyBuildTelemetryRequestSent(listOf("debug", "release"))
-            }
+            },
         )
     }
 
@@ -33,7 +33,7 @@ class PluginTelemetryTest {
             additionalArgs = listOf("-Pembrace.disableCollectBuildData=true"),
             assertions = {
                 verifyNoRequestsSent(EmbraceEndpoint.BUILD_DATA)
-            }
+            },
         )
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/ReactNativeAndroidTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/ReactNativeAndroidTest.kt
@@ -29,7 +29,7 @@ class ReactNativeAndroidTest {
         "libjsi.so",
         "libnative-filters.so",
         "libnative-imagetranscoder.so",
-        "libreactnative.so"
+        "libreactnative.so",
     )
 
     private val defaultExpectedArchs = listOf("x86_64", "x86", "armeabi-v7a", "arm64-v8a")
@@ -55,7 +55,7 @@ class ReactNativeAndroidTest {
                 verifyBuildTelemetryRequestSent(variantsSentInBuildTelemetry, testMatrix = TestMatrix.MiddleVersion)
                 verifyHandshakes(defaultExpectedLibs, defaultExpectedArchs, defaultExpectedVariants)
                 verifyUploads(handshakeLibs, handshakeArchs, defaultExpectedVariants)
-            }
+            },
         )
     }
 
@@ -72,7 +72,7 @@ class ReactNativeAndroidTest {
             },
             assertions = { projectDir ->
                 verifyAsmInjection(File(projectDir, "app"), "27D4D89A18B0426A47151D4888D4E40A")
-            }
+            },
         )
     }
 
@@ -89,7 +89,7 @@ class ReactNativeAndroidTest {
             assertions = { projectDir ->
                 verifyNoUploads()
                 verifyAsmInjection(projectDir, null)
-            }
+            },
         )
     }
 
@@ -115,7 +115,7 @@ class ReactNativeAndroidTest {
                 verifyNoHandshakes()
                 verifyNoUploads()
                 verifyJvmMappingRequestsSent(0)
-            }
+            },
         )
     }
 
@@ -137,13 +137,13 @@ class ReactNativeAndroidTest {
         // Read and parse the smali file containing the injected symbols
         val smaliFile = SmaliConfigReader().readSmaliFiles(
             buildDir,
-            listOf("/io/embrace/android/embracesdk/internal/config/instrumented/ProjectConfigImpl")
+            listOf("/io/embrace/android/embracesdk/internal/config/instrumented/ProjectConfigImpl"),
         ).first()
 
         // Get the return value of the getBase64SharedObjectFilesMap method
         val method = SmaliParser().parse(
             smaliFile,
-            listOf(SmaliMethod("getReactNativeBundleId()Ljava/lang/String;"))
+            listOf(SmaliMethod("getReactNativeBundleId()Ljava/lang/String;")),
         ).methods.first()
 
         assertEquals(expectedBundleId, method.returnValue)

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/UnityTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/UnityTest.kt
@@ -41,7 +41,7 @@ class UnityTest {
             assertions = {
                 verifyLineMapRequestSent()
                 verifyMethodMapRequestSent()
-            }
+            },
         )
     }
 
@@ -58,7 +58,7 @@ class UnityTest {
                 verifyNoHandshakes()
                 verifyNoUploads()
                 verifyJvmMappingRequestsSent(0)
-            }
+            },
         )
     }
 

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/UnsuccessfulHttpCallTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/UnsuccessfulHttpCallTest.kt
@@ -28,7 +28,7 @@ class UnsuccessfulHttpCallTest {
                 verifyBuildTelemetryRequestSent(variants)
                 verifyJvmMappingRequestsSent(1)
             },
-            expectedExceptionMessage = "Embrace HTTP request failed: ${EmbraceEndpoint.PROGUARD.url}, status=400"
+            expectedExceptionMessage = "Embrace HTTP request failed: ${EmbraceEndpoint.PROGUARD.url}, status=400",
         )
     }
 
@@ -45,7 +45,7 @@ class UnsuccessfulHttpCallTest {
                 verifyBuildTelemetryRequestSent(variants)
                 verifyJvmMappingRequestsSent(1)
             },
-            expectedExceptionMessage = "Embrace HTTP request failed: ${EmbraceEndpoint.PROGUARD.url}"
+            expectedExceptionMessage = "Embrace HTTP request failed: ${EmbraceEndpoint.PROGUARD.url}",
         )
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/UploadSharedObjectFilesTaskTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/UploadSharedObjectFilesTaskTest.kt
@@ -26,9 +26,9 @@ class UploadSharedObjectFilesTaskTest {
                 compareRequestBodyAgainstExpected<NdkHandshakeRequestBody>(
                     request,
                     projectDir,
-                    "expected/handshake.json"
+                    "expected/handshake.json",
                 )
-            }
+            },
         )
     }
 
@@ -41,7 +41,7 @@ class UploadSharedObjectFilesTaskTest {
             },
             assertions = { _ ->
                 verifyUploads(listOf("libemb-crisps.so"), listOf("arm64-v8a"), listOf("demoDevelopmentRelease"))
-            }
+            },
         )
     }
 
@@ -55,7 +55,7 @@ class UploadSharedObjectFilesTaskTest {
             expectedExceptionMessage = "Failed to read the architectures to hashed shared object files map: Failed to deserialize object",
             assertions = {
                 verifyNoUploads()
-            }
+            },
         )
     }
 
@@ -69,7 +69,7 @@ class UploadSharedObjectFilesTaskTest {
             expectedExceptionMessage = "Compressed file not found for requested",
             assertions = { _ ->
                 verifyNoUploads()
-            }
+            },
         )
     }
 
@@ -83,7 +83,7 @@ class UploadSharedObjectFilesTaskTest {
             expectedExceptionMessage = "Requested architecture was not found",
             assertions = { _ ->
                 verifyNoUploads()
-            }
+            },
         )
     }
 
@@ -97,7 +97,7 @@ class UploadSharedObjectFilesTaskTest {
             expectedExceptionMessage = "Exception occurred while making network request",
             assertions = {
                 verifyNoUploads()
-            }
+            },
         )
     }
 
@@ -111,7 +111,7 @@ class UploadSharedObjectFilesTaskTest {
             expectedExceptionMessage = "An arch with no symbols was requested",
             assertions = {
                 verifyNoUploads()
-            }
+            },
         )
     }
 
@@ -125,7 +125,7 @@ class UploadSharedObjectFilesTaskTest {
             },
             assertions = {
                 verifyNoUploads()
-            }
+            },
         )
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/utils/NdkSymbols.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/utils/NdkSymbols.kt
@@ -4,5 +4,5 @@ import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class NdkSymbols(
-    val symbols: Map<String, Map<String, String>>? = null
+    val symbols: Map<String, Map<String, String>>? = null,
 )

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/network/NdkHandshakeRequestBody.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/network/NdkHandshakeRequestBody.kt
@@ -7,5 +7,5 @@ data class NdkHandshakeRequestBody(
     val app: String,
     val token: String,
     val variant: String,
-    val archs: Map<String, Map<String, String>>
+    val archs: Map<String, Map<String, String>>,
 )

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePlugin.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePlugin.kt
@@ -25,7 +25,7 @@ class EmbraceGradlePlugin : Plugin<Project> {
         val embrace = project.extensions.create(
             "embrace",
             EmbraceExtension::class.java,
-            project.objects
+            project.objects,
         )
 
         // this property will hold configuration for each variant. It will be updated each time a new variant

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePluginDelegate.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/EmbraceGradlePluginDelegate.kt
@@ -33,7 +33,7 @@ class EmbraceGradlePluginDelegate {
         val embraceVariantConfigurationBuilder =
             EmbraceVariantConfigurationBuilder(
                 project.layout.projectDirectory,
-                project.providers
+                project.providers,
             )
 
         val taskRegistrar = TaskRegistrar(
@@ -41,7 +41,7 @@ class EmbraceGradlePluginDelegate {
             behavior,
             embraceVariantConfigurationBuilder,
             variantConfigurationsListProperty,
-            agpWrapper
+            agpWrapper,
         )
 
         taskRegistrar.registerTasks()
@@ -77,7 +77,7 @@ class EmbraceGradlePluginDelegate {
         } catch (e: Throwable) {
             logger.info(
                 "There was an exception while checking if desugaring is required. " +
-                    "We will consider desugaring is not required. Build will continue normally."
+                    "We will consider desugaring is not required. Build will continue normally.",
             )
         }
 
@@ -95,7 +95,7 @@ class EmbraceGradlePluginDelegate {
                     "}\n" +
                     "in your app\'s module build.gradle file. Use a newer version of the desugaring library if required.\n" +
                     "You can find more info at: \n" +
-                    "https://developer.android.com/studio/write/java8-support#library-desugaring"
+                    "https://developer.android.com/studio/write/java8-support#library-desugaring",
             )
         }
     }
@@ -113,7 +113,7 @@ class EmbraceGradlePluginDelegate {
                         "gradle.properties.\nAlternatively you can set your minSdk to 26 or higher.\n" +
                         "This avoids a desugaring bug in old AGP versions that will lead to runtime crashes on old devices.\n" +
                         "For the full context for this workaround, please see the following issue:" +
-                        " https://issuetracker.google.com/issues/230454566#comment18"
+                        " https://issuetracker.google.com/issues/230454566#comment18",
                 )
             }
         }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/agp/AgpWrapperImpl.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/agp/AgpWrapperImpl.kt
@@ -7,11 +7,11 @@ import org.gradle.api.Project
 class AgpWrapperImpl(project: Project) : AgpWrapper {
 
     private val extension: CommonExtension<*, *, *, *> = checkNotNull(
-        project.extensions.findByType(CommonExtension::class.java)
+        project.extensions.findByType(CommonExtension::class.java),
     )
 
     private val componentsExtension: AndroidComponentsExtension<*, *, *> = checkNotNull(
-        project.extensions.findByType(AndroidComponentsExtension::class.java)
+        project.extensions.findByType(AndroidComponentsExtension::class.java),
     )
 
     override val version by lazy {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryService.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/buildreporter/BuildTelemetryService.kt
@@ -54,7 +54,7 @@ abstract class BuildTelemetryService :
                 project.gradle.sharedServices
                     .registerIfAbsent(
                         BuildTelemetryService::class.java.name,
-                        BuildTelemetryService::class.java
+                        BuildTelemetryService::class.java,
                     ) { serviceSpec: BuildServiceSpec<Params> ->
                         serviceSpec.parameters { params: Params ->
                             val telemetryProvider = BuildTelemetryCollector().collect(
@@ -62,7 +62,7 @@ abstract class BuildTelemetryService :
                                 behavior,
                                 project.providers,
                                 variantConfigurations,
-                                agpWrapper
+                                agpWrapper,
                             )
                             params.request.set(telemetryProvider)
                             params.baseUrl.set(behavior.baseUrl)
@@ -72,7 +72,7 @@ abstract class BuildTelemetryService :
 
             // subscribe for tasks events
             project.objects.newInstance(
-                BuildEventsListenerRegistryProvider::class.java
+                BuildEventsListenerRegistryProvider::class.java,
             ).getBuildEventsListenerRegistry().onTaskCompletion(serviceProvider)
             return serviceProvider
         }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/PluginBehaviorImpl.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/PluginBehaviorImpl.kt
@@ -51,7 +51,7 @@ class PluginBehaviorImpl(
 
     @Deprecated(
         "This will be removed in a future release." +
-            " Add embrace dependencies to the classpath manually instead."
+            " Add embrace dependencies to the classpath manually instead.",
     )
     override val autoAddEmbraceDependencies: Boolean by lazy {
         val userValue = embrace.autoAddEmbraceDependencies.orNull ?: true

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/variant/BuildVariantConfigFromFile.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/variant/BuildVariantConfigFromFile.kt
@@ -27,7 +27,7 @@ fun buildVariantConfig(
         variantFlavorConfigurationFileFinder(variantInfo, projectDirectory),
         variantProductFlavorsConfigurationFileFinder(variantInfo, projectDirectory),
         variantBuildTypeConfigurationFileFinder(variantInfo, projectDirectory),
-        defaultConfigurationFileFinder(projectDirectory)
+        defaultConfigurationFileFinder(projectDirectory),
     ),
     systemWrapper: SystemWrapper = JavaSystemWrapper(),
 ): EmbraceVariantConfig? {
@@ -67,11 +67,11 @@ private fun buildVariantConfiguration(configFile: File, systemWrapper: SystemWra
             "Embrace config file ${configFile.absoluteFile} contains an unrecognized key.\n" +
                 "Please check your embrace-config.json for typos or unsupported options.\n" +
                 "Available options are documented here: https://embrace.io/docs/android/configuration/configuration-file/\n" +
-                "Error: ${ex.localizedMessage}"
+                "Error: ${ex.localizedMessage}",
         )
     } catch (ex: Throwable) {
         throw IllegalArgumentException(
-            "Problem parsing field in Embrace config file ${configFile.absoluteFile}.\nError=${ex.localizedMessage}"
+            "Problem parsing field in Embrace config file ${configFile.absoluteFile}.\nError=${ex.localizedMessage}",
         )
     }
 }
@@ -85,7 +85,7 @@ private fun getApiTokenFromEnv(config: EmbraceVariantConfig, systemWrapper: Syst
 
     if (!config.apiToken.isNullOrEmpty() && !apiTokenFromEnv.isNullOrEmpty()) {
         logger.warn(
-            "API tokens were found in both an environment variable and the configuration file. The latter will be used."
+            "API tokens were found in both an environment variable and the configuration file. The latter will be used.",
         )
     }
 
@@ -101,7 +101,7 @@ private fun getAppIdFromEnv(config: EmbraceVariantConfig, systemWrapper: SystemW
 
     if (!config.appId.isNullOrEmpty() && !appIdFromEnv.isNullOrEmpty()) {
         logger.warn(
-            "App IDs were found in both an environment variable and the configuration file. The latter will be used."
+            "App IDs were found in both an environment variable and the configuration file. The latter will be used.",
         )
     }
 

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/variant/EmbraceVariantConfigurationBuilder.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/variant/EmbraceVariantConfigurationBuilder.kt
@@ -58,7 +58,7 @@ class EmbraceVariantConfigurationBuilder(
         override fun obtain(): EmbraceVariantConfig? =
             buildVariantConfig(
                 variantInfo = parameters.getVariantInfo().get(),
-                projectDirectory = parameters.getProjectDirectory().get()
+                projectDirectory = parameters.getProjectDirectory().get(),
             )
     }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/variant/VariantConfigurationFileFinder.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/variant/VariantConfigurationFileFinder.kt
@@ -11,7 +11,7 @@ const val VARIANT_CONFIG_FILE_NAME = "embrace-config.json"
  */
 class VariantConfigurationFileFinder(
     private val projectDirectory: Directory,
-    private val fileLocations: List<String>
+    private val fileLocations: List<String>,
 ) {
     /**
      * It tries to fetch the file.
@@ -36,22 +36,22 @@ fun defaultConfigurationFileFinder(projectDirectory: Directory): VariantConfigur
 
 fun variantBuildTypeConfigurationFileFinder(
     variantInfo: AndroidCompactedVariantData,
-    projectDirectory: Directory
+    projectDirectory: Directory,
 ): VariantConfigurationFileFinder = singleLocationFileFinder(projectDirectory, variantInfo.buildTypeName)
 
 fun variantFlavorConfigurationFileFinder(
     variantInfo: AndroidCompactedVariantData,
-    projectDirectory: Directory
+    projectDirectory: Directory,
 ): VariantConfigurationFileFinder = singleLocationFileFinder(projectDirectory, variantInfo.flavorName)
 
 fun variantNameConfigurationFileFinder(
     variantInfo: AndroidCompactedVariantData,
-    projectDirectory: Directory
+    projectDirectory: Directory,
 ): VariantConfigurationFileFinder = singleLocationFileFinder(projectDirectory, variantInfo.name)
 
 fun variantProductFlavorsConfigurationFileFinder(
     variantInfo: AndroidCompactedVariantData,
-    projectDirectory: Directory
+    projectDirectory: Directory,
 ): VariantConfigurationFileFinder =
     VariantConfigurationFileFinder(
         projectDirectory,
@@ -59,7 +59,7 @@ fun variantProductFlavorsConfigurationFileFinder(
             it.isNotEmpty()
         }.map {
             "src/$it"
-        }.toList()
+        }.toList(),
     )
 
 private fun singleLocationFileFinder(projectDirectory: Directory, path: String): VariantConfigurationFileFinder =

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/dependency/DependenciesInstaller.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/dependency/DependenciesInstaller.kt
@@ -37,7 +37,7 @@ fun Project.installDependenciesForVariant(
 
     val targetConfigurations = listOf(
         fetchConfiguration("${variantName}CompileClasspath", this),
-        fetchConfiguration("${variantName}RuntimeClasspath", this)
+        fetchConfiguration("${variantName}RuntimeClasspath", this),
     )
 
     targetConfigurations.forEach { targetConfiguration ->
@@ -52,7 +52,7 @@ fun Project.installDependenciesForVariant(
                         provider {
                             val embraceCoreSdkMetadata = EmbraceDependencyMetadata.Core(BuildConfig.VERSION)
                             project.dependencies.create(embraceCoreSdkMetadata.gradleShortNomenclature())
-                        }
+                        },
                     )
 
                     // true so to tell Gradle to install Embrace dependencies through ComponentMetadataRule
@@ -64,9 +64,9 @@ fun Project.installDependenciesForVariant(
                     it.attribute(
                         Attribute.of(
                             INSTALL_EMBRACE_DEPENDENCIES_ATTRIBUTE,
-                            String::class.java
+                            String::class.java,
                         ),
-                        installEmbraceDependenciesAttributeValue
+                        installEmbraceDependenciesAttributeValue,
                     )
                 }
             } catch (e: InvalidUserDataException) {
@@ -74,7 +74,7 @@ fun Project.installDependenciesForVariant(
                     "This happens because someone that gets executed before the embrace gradle plugin is resolving " +
                         "dependencies (either explicit or implicitly) at configuration time. We recommend to find who's " +
                         "doing that, and fix it. Gradle does not recommend resolving dependencies during configuration " +
-                        "phase."
+                        "phase.",
                 )
                 throw e
             }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/dependency/EmbraceDependencyMetadata.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/dependency/EmbraceDependencyMetadata.kt
@@ -15,6 +15,6 @@ internal sealed class EmbraceDependencyMetadata(
     class Core(version: String = BuildConfig.VERSION) : EmbraceDependencyMetadata(
         EMBRACE_SDK_GROUP,
         EMBRACE_CORE_SDK_NAME,
-        version
+        version,
     )
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/gradle/NullSafeMap.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/gradle/NullSafeMap.kt
@@ -16,7 +16,7 @@ inline fun <O : Any, I : Any> Provider<I>.safeMap(
             override fun transform(input: I): O? {
                 return transform(input)
             }
-        }
+        },
     )
 }
 

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/AsmTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/AsmTaskRegistration.kt
@@ -26,20 +26,20 @@ class AsmTaskRegistration : EmbraceTaskRegistration {
             variant.instrumentation.setAsmFramesComputationMode(FramesComputationMode.COMPUTE_FRAMES_FOR_INSTRUMENTED_METHODS)
             variant.instrumentation.transformClassesWith(
                 EmbraceClassVisitorFactory::class.java,
-                InstrumentationScope.ALL
+                InstrumentationScope.ALL,
             ) { params: BytecodeInstrumentationParams ->
                 params.config.set(
                     variantConfigurationsListProperty.map { variantConfigs ->
                         variantConfigs.first { it.variantName == variant.name }
-                    }
+                    },
                 )
                 params.disabled.set(
                     project.provider {
                         behavior.isPluginDisabledForVariant(variant.name) || behavior.isInstrumentationDisabledForVariant(variant.name)
-                    }
+                    },
                 )
                 params.classInstrumentationFilter.set(
-                    ClassInstrumentationFilter(behavior.instrumentation.ignoredClasses)
+                    ClassInstrumentationFilter(behavior.instrumentation.ignoredClasses),
                 )
                 params.shouldInstrumentFirebaseMessaging.set(behavior.instrumentation.fcmPushNotificationsEnabled)
                 params.shouldInstrumentWebview.set(behavior.instrumentation.webviewEnabled)
@@ -51,23 +51,23 @@ class AsmTaskRegistration : EmbraceTaskRegistration {
                 params.variantOutputInfo.set(variant.toVariantOutputInfoProvider(project))
 
                 val encodeFileToBase64Task = project.lazyTaskLookup<EncodeFileToBase64Task>(
-                    "${EncodeFileToBase64Task.NAME}${data.name.capitalizedString()}"
+                    "${EncodeFileToBase64Task.NAME}${data.name.capitalizedString()}",
                 )
 
                 params.encodedSharedObjectFilesMap.set(
                     encodeFileToBase64Task.safeFlatMap {
                         it.outputFile
-                    }
+                    },
                 )
 
                 val reactNativeTask = project.lazyTaskLookup<GenerateRnSourcemapTask>(
-                    "${GenerateRnSourcemapTask.NAME}${data.name.capitalizedString()}"
+                    "${GenerateRnSourcemapTask.NAME}${data.name.capitalizedString()}",
                 )
 
                 params.reactNativeBundleId.set(
                     reactNativeTask.safeFlatMap {
                         it.bundleIdOutputFile
-                    }
+                    },
                 )
             }
         } catch (exception: Exception) {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/ClassInstrumentationFilter.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/ClassInstrumentationFilter.kt
@@ -7,7 +7,7 @@ import java.util.regex.Pattern
  * A filter that determines whether a class should be skipped, according to user-defined rules.
  */
 class ClassInstrumentationFilter(
-    internal val skipList: List<String>
+    internal val skipList: List<String>,
 ) : Serializable {
 
     private companion object {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/EmbraceClassVisitorFactory.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/EmbraceClassVisitorFactory.kt
@@ -39,7 +39,7 @@ abstract class EmbraceClassVisitorFactory : AsmClassVisitorFactory<BytecodeInstr
             variantOutputInfo,
             reactNativeBundleId,
             api,
-            visitor
+            visitor,
         )?.let {
             visitor = it
         }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/BooleanReturnValueMethodVisitor.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/BooleanReturnValueMethodVisitor.kt
@@ -9,7 +9,7 @@ import org.objectweb.asm.Opcodes
 class BooleanReturnValueMethodVisitor(
     val replacedValue: Boolean,
     api: Int,
-    nextVisitor: MethodVisitor
+    nextVisitor: MethodVisitor,
 ) : MethodVisitor(api, nextVisitor) {
 
     override fun visitInsn(opcode: Int) {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/ConfigClassVisitorFactory.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/ConfigClassVisitorFactory.kt
@@ -18,7 +18,8 @@ object ConfigClassVisitorFactory {
         NetworkCaptureConfig,
         ProjectConfig,
         RedactionConfig,
-        Base64SharedObjectFilesMap;
+        Base64SharedObjectFilesMap,
+        ;
 
         val className = "io.embrace.android.embracesdk.internal.config.instrumented.${name}Impl"
 

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/IntReturnValueMethodVisitor.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/IntReturnValueMethodVisitor.kt
@@ -9,7 +9,7 @@ import org.objectweb.asm.Opcodes
 class IntReturnValueMethodVisitor(
     val replacedValue: Int,
     api: Int,
-    nextVisitor: MethodVisitor
+    nextVisitor: MethodVisitor,
 ) : MethodVisitor(api, nextVisitor) {
 
     override fun visitInsn(opcode: Int) {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/LongReturnValueMethodVisitor.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/LongReturnValueMethodVisitor.kt
@@ -9,7 +9,7 @@ import org.objectweb.asm.Opcodes
 class LongReturnValueMethodVisitor(
     val replacedValue: Long,
     api: Int,
-    nextVisitor: MethodVisitor
+    nextVisitor: MethodVisitor,
 ) : MethodVisitor(api, nextVisitor) {
 
     override fun visitInsn(opcode: Int) {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/MapReturnValueMethodVisitor.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/MapReturnValueMethodVisitor.kt
@@ -9,7 +9,7 @@ import org.objectweb.asm.Opcodes
 class MapReturnValueMethodVisitor(
     val replacedValue: Map<String, String>,
     api: Int,
-    nextVisitor: MethodVisitor
+    nextVisitor: MethodVisitor,
 ) : MethodVisitor(api, nextVisitor) {
 
     override fun visitCode() {
@@ -30,7 +30,7 @@ class MapReturnValueMethodVisitor(
                 "java/util/HashMap",
                 "put",
                 "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
-                false
+                false,
             )
             visitInsn(Opcodes.POP) // pop return value off stack
         }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/StringListReturnValueMethodVisitor.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/StringListReturnValueMethodVisitor.kt
@@ -9,7 +9,7 @@ import org.objectweb.asm.Opcodes
 class StringListReturnValueMethodVisitor(
     val replacedValue: List<String>,
     api: Int,
-    nextVisitor: MethodVisitor
+    nextVisitor: MethodVisitor,
 ) : MethodVisitor(api, nextVisitor) {
 
     override fun visitCode() {
@@ -29,7 +29,7 @@ class StringListReturnValueMethodVisitor(
                 "java/util/ArrayList",
                 "add",
                 "(Ljava/lang/Object;)Z",
-                false
+                false,
             )
             visitInsn(Opcodes.POP) // pop return value off stack
         }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/StringReturnValueMethodVisitor.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/StringReturnValueMethodVisitor.kt
@@ -9,7 +9,7 @@ import org.objectweb.asm.Opcodes
 class StringReturnValueMethodVisitor(
     val replacedValue: String,
     api: Int,
-    nextVisitor: MethodVisitor
+    nextVisitor: MethodVisitor,
 ) : MethodVisitor(api, nextVisitor) {
 
     override fun visitInsn(opcode: Int) {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/InstrumentedConfigClass.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/InstrumentedConfigClass.kt
@@ -6,7 +6,7 @@ import org.objectweb.asm.MethodVisitor
  * Holds data on how a SDK config class should be instrumented with configuration values.
  */
 class InstrumentedConfigClass(
-    private val methods: MutableList<InstrumentedConfigMethod> = mutableListOf()
+    private val methods: MutableList<InstrumentedConfigMethod> = mutableListOf(),
 ) {
 
     fun addMethod(method: InstrumentedConfigMethod) {
@@ -21,7 +21,7 @@ class InstrumentedConfigClass(
         name: String,
         descriptor: String,
         api: Int,
-        visitor: MethodVisitor
+        visitor: MethodVisitor,
     ): MethodVisitor {
         val match = methods.singleOrNull {
             it.isConfigInstrumentationTarget(name, descriptor)

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/InstrumentedConfigMethod.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/InstrumentedConfigMethod.kt
@@ -14,7 +14,7 @@ import org.objectweb.asm.MethodVisitor
 class InstrumentedConfigMethod(
     private val functionName: String,
     private val returnType: ReturnType,
-    private val valueProvider: () -> Any?
+    private val valueProvider: () -> Any?,
 ) {
 
     fun isConfigInstrumentationTarget(name: String, descriptor: String): Boolean {
@@ -28,32 +28,32 @@ class InstrumentedConfigMethod(
             ReturnType.BOOLEAN -> BooleanReturnValueMethodVisitor(
                 result as Boolean,
                 api,
-                visitor
+                visitor,
             )
             ReturnType.INT -> IntReturnValueMethodVisitor(
                 result as Int,
                 api,
-                visitor
+                visitor,
             )
             ReturnType.LONG -> LongReturnValueMethodVisitor(
                 result as Long,
                 api,
-                visitor
+                visitor,
             )
             ReturnType.STRING -> StringReturnValueMethodVisitor(
                 result as String,
                 api,
-                visitor
+                visitor,
             )
             ReturnType.STRING_LIST -> io.embrace.android.gradle.plugin.instrumentation.config.StringListReturnValueMethodVisitor(
                 result as List<String>,
                 api,
-                visitor
+                visitor,
             )
             ReturnType.MAP -> MapReturnValueMethodVisitor(
                 result as Map<String, String>,
                 api,
-                visitor
+                visitor,
             )
         }
     }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/EnabledFeatureConfigInstrumentation.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/EnabledFeatureConfigInstrumentation.kt
@@ -12,7 +12,7 @@ fun createEnabledFeatureConfigInstrumentation(cfg: VariantConfig) = modelSdkConf
         boolMethod("isViewClickCoordinateCaptureEnabled") { taps?.captureCoordinates }
         boolMethod("isPowerSaveModeCaptureEnabled") { automaticDataCaptureConfig?.powerSaveModeServiceEnabled }
         boolMethod(
-            "isNetworkConnectivityCaptureEnabled"
+            "isNetworkConnectivityCaptureEnabled",
         ) { automaticDataCaptureConfig?.networkConnectivityServiceEnabled }
         boolMethod("isThreadBlockageCaptureEnabled") { automaticDataCaptureConfig?.threadBlockageServiceEnabled }
         boolMethod("isDiskUsageCaptureEnabled") { app?.reportDiskUsage }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/AppExitInfoLocalConfig.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/AppExitInfoLocalConfig.kt
@@ -7,7 +7,7 @@ import java.io.Serializable
 @JsonClass(generateAdapter = true)
 data class AppExitInfoLocalConfig(
     @Json(name = "aei_enabled")
-    val aeiCaptureEnabled: Boolean? = null
+    val aeiCaptureEnabled: Boolean? = null,
 ) : Serializable {
 
     private companion object {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/AppLocalConfig.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/AppLocalConfig.kt
@@ -8,7 +8,7 @@ import java.io.Serializable
 data class AppLocalConfig(
 
     @Json(name = "report_disk_usage")
-    val reportDiskUsage: Boolean? = null
+    val reportDiskUsage: Boolean? = null,
 ) : Serializable {
 
     private companion object {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/BackgroundActivityLocalConfig.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/BackgroundActivityLocalConfig.kt
@@ -10,7 +10,7 @@ import java.io.Serializable
 @JsonClass(generateAdapter = true)
 data class BackgroundActivityLocalConfig(
     @Json(name = "capture_enabled")
-    val backgroundActivityCaptureEnabled: Boolean? = null
+    val backgroundActivityCaptureEnabled: Boolean? = null,
 ) : Serializable {
 
     private companion object {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/BaseUrlLocalConfig.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/BaseUrlLocalConfig.kt
@@ -13,7 +13,7 @@ data class BaseUrlLocalConfig(
     val config: String? = null,
 
     @Json(name = "data")
-    val data: String? = null
+    val data: String? = null,
 ) : Serializable {
 
     private companion object {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/ComposeLocalConfig.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/ComposeLocalConfig.kt
@@ -7,7 +7,7 @@ import java.io.Serializable
 @JsonClass(generateAdapter = true)
 data class ComposeLocalConfig(
     @Json(name = "capture_compose_onclick")
-    val captureComposeOnClick: Boolean? = null
+    val captureComposeOnClick: Boolean? = null,
 ) : Serializable {
 
     private companion object {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/CrashHandlerLocalConfig.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/CrashHandlerLocalConfig.kt
@@ -10,7 +10,7 @@ import java.io.Serializable
 @JsonClass(generateAdapter = true)
 data class CrashHandlerLocalConfig(
     @Json(name = "enabled")
-    val enabled: Boolean? = null
+    val enabled: Boolean? = null,
 ) : Serializable {
 
     private companion object {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/DomainLocalConfig.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/DomainLocalConfig.kt
@@ -20,7 +20,7 @@ data class DomainLocalConfig(
      * Limit for the number of requests to be tracked.
      */
     @Json(name = "domain_limit")
-    val limit: Int
+    val limit: Int,
 ) : Serializable {
 
     private companion object {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/OpenTelemetryLocalConfig.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/OpenTelemetryLocalConfig.kt
@@ -7,7 +7,7 @@ import java.io.Serializable
 @JsonClass(generateAdapter = true)
 data class OpenTelemetryLocalConfig(
     @Json(name = "enable_otel_kotlin_sdk")
-    val otelKotlinSdkEnabled: Boolean? = null
+    val otelKotlinSdkEnabled: Boolean? = null,
 ) : Serializable {
 
     private companion object {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/SdkLocalConfig.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/SdkLocalConfig.kt
@@ -106,7 +106,7 @@ data class SdkLocalConfig(
     val appExitInfoConfig: AppExitInfoLocalConfig? = null,
 
     @Json(name = "app_framework")
-    val appFramework: String? = null
+    val appFramework: String? = null,
 ) : Serializable {
 
     private companion object {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/TapsLocalConfig.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/TapsLocalConfig.kt
@@ -7,7 +7,7 @@ import java.io.Serializable
 @JsonClass(generateAdapter = true)
 data class TapsLocalConfig(
     @Json(name = "capture_coordinates")
-    val captureCoordinates: Boolean? = null
+    val captureCoordinates: Boolean? = null,
 ) : Serializable {
 
     private companion object {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/ThreadBlockageLocalConfig.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/ThreadBlockageLocalConfig.kt
@@ -7,7 +7,7 @@ import java.io.Serializable
 @JsonClass(generateAdapter = true)
 data class ThreadBlockageLocalConfig(
     @Json(name = "capture_unity_thread")
-    val captureUnityThread: Boolean? = null
+    val captureUnityThread: Boolean? = null,
 ) : Serializable {
 
     private companion object {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/UnityConfig.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/UnityConfig.kt
@@ -10,7 +10,7 @@ import java.io.Serializable
 @JsonClass(generateAdapter = true)
 data class UnityConfig(
     @Json(name = "symbols_archive_name")
-    val symbolsArchiveName: String?
+    val symbolsArchiveName: String?,
 ) : Serializable {
 
     private companion object {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/VariantConfig.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/VariantConfig.kt
@@ -15,7 +15,7 @@ data class VariantConfig(
     val buildId: String? = null,
     val buildType: String? = null,
     val buildFlavor: String? = null,
-    val embraceConfig: EmbraceVariantConfig? = null
+    val embraceConfig: EmbraceVariantConfig? = null,
 ) : Serializable {
 
     companion object {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/ViewLocalConfig.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/ViewLocalConfig.kt
@@ -8,7 +8,7 @@ import java.io.Serializable
 data class ViewLocalConfig(
 
     @Json(name = "enable_automatic_activity_capture")
-    val enableAutomaticActivityCapture: Boolean? = null
+    val enableAutomaticActivityCapture: Boolean? = null,
 ) : Serializable {
 
     private companion object {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/WebViewLocalConfig.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/WebViewLocalConfig.kt
@@ -10,7 +10,7 @@ data class WebViewLocalConfig(
     val captureWebViews: Boolean? = null,
 
     @Json(name = "capture_query_params")
-    val captureQueryParams: Boolean? = null
+    val captureQueryParams: Boolean? = null,
 ) : Serializable {
 
     private companion object {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/visitor/ConfigInstrumentationClassVisitor.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/visitor/ConfigInstrumentationClassVisitor.kt
@@ -10,7 +10,7 @@ import org.objectweb.asm.MethodVisitor
 class ConfigInstrumentationClassVisitor(
     private val instrumentedConfigClass: InstrumentedConfigClass,
     api: Int,
-    cv: ClassVisitor?
+    cv: ClassVisitor?,
 ) : ClassVisitor(api, cv) {
 
     override fun visitMethod(
@@ -18,7 +18,7 @@ class ConfigInstrumentationClassVisitor(
         name: String,
         descriptor: String,
         signature: String?,
-        exceptions: Array<out String>?
+        exceptions: Array<out String>?,
     ): MethodVisitor {
         val visitor = super.visitMethod(access, name, descriptor, signature, exceptions)
         return instrumentedConfigClass.getMethodVisitor(name, descriptor, api, visitor)

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/json/InstrumentationConfigFeaturesReader.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/json/InstrumentationConfigFeaturesReader.kt
@@ -31,14 +31,14 @@ private fun InstrumentationConfigFeature.convertInstrumentationConfigFeature(): 
         name = name,
         targetParams = BytecodeClassInsertionParams(
             name = target.name,
-            descriptor = target.descriptor
+            descriptor = target.descriptor,
         ),
         insertionParams = BytecodeMethodInsertionParams(
             owner = insert.owner,
             name = insert.name,
             descriptor = insert.descriptor,
             operandStackIndices = insert.operandStackIndices,
-            insertAtEnd = insert.insertAtEnd
+            insertAtEnd = insert.insertAtEnd,
         ),
         visitStrategy = convertVisitStrategy(),
         addOverrideParams = addOverride?.let {
@@ -47,7 +47,7 @@ private fun InstrumentationConfigFeature.convertInstrumentationConfigFeature(): 
                 name = it.name,
                 descriptor = it.descriptor,
             )
-        }
+        },
     )
 
 private fun InstrumentationConfigFeature.convertVisitStrategy(): ClassVisitStrategy {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/json/InstrumentationConfigInsert.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/json/InstrumentationConfigInsert.kt
@@ -8,5 +8,5 @@ internal data class InstrumentationConfigInsert(
     val name: String,
     val descriptor: String,
     val operandStackIndices: List<Int>,
-    val insertAtEnd: Boolean = false
+    val insertAtEnd: Boolean = false,
 )

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/InsertSuperOverrideClassVisitor.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/InsertSuperOverrideClassVisitor.kt
@@ -31,13 +31,13 @@ class InsertSuperOverrideClassVisitor(
                 InstrumentationTargetMethodEndVisitor(
                     api = api,
                     methodVisitor = nextMethodVisitor,
-                    params = feature.insertionParams
+                    params = feature.insertionParams,
                 )
             } else {
                 InstrumentationTargetMethodVisitor(
                     api = api,
                     methodVisitor = nextMethodVisitor,
-                    params = feature.insertionParams
+                    params = feature.insertionParams,
                 )
             }
         } else {
@@ -53,7 +53,7 @@ class InsertSuperOverrideClassVisitor(
                 feature.targetParams.name,
                 feature.targetParams.descriptor,
                 null,
-                emptyArray()
+                emptyArray(),
             )
             nextMethodVisitor.addSuperCall()
         }
@@ -71,7 +71,7 @@ class InsertSuperOverrideClassVisitor(
             feature.addOverrideParams?.owner,
             feature.addOverrideParams?.name,
             feature.addOverrideParams?.descriptor,
-            false
+            false,
         )
 
         // load local variables required for method call (if any) and push onto the operand stack
@@ -86,7 +86,7 @@ class InsertSuperOverrideClassVisitor(
             params.owner,
             params.name,
             params.descriptor,
-            false
+            false,
         )
 
         visitEnd()

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/InstrumentationTargetClassVisitor.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/InstrumentationTargetClassVisitor.kt
@@ -26,13 +26,13 @@ class InstrumentationTargetClassVisitor(
                 InstrumentationTargetMethodEndVisitor(
                     api = api,
                     methodVisitor = nextMethodVisitor,
-                    params = feature.insertionParams
+                    params = feature.insertionParams,
                 )
             } else {
                 InstrumentationTargetMethodVisitor(
                     api = api,
                     methodVisitor = nextMethodVisitor,
-                    params = feature.insertionParams
+                    params = feature.insertionParams,
                 )
             }
         } else {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/InstrumentationTargetMethodEndVisitor.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/InstrumentationTargetMethodEndVisitor.kt
@@ -33,7 +33,7 @@ class InstrumentationTargetMethodEndVisitor(
             params.owner,
             params.name,
             params.descriptor,
-            false
+            false,
         )
     }
 

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/InstrumentationTargetMethodVisitor.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/visitor/InstrumentationTargetMethodVisitor.kt
@@ -25,7 +25,7 @@ internal class InstrumentationTargetMethodVisitor(
             params.owner,
             params.name,
             params.descriptor,
-            false
+            false,
         )
 
         // call super last to reduce chance of interference with other bytecode instrumentation

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/model/AndroidCompactedVariantData.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/model/AndroidCompactedVariantData.kt
@@ -28,7 +28,7 @@ data class AndroidCompactedVariantData(
                 variant.buildType ?: "",
                 debuggable,
                 fetchProductFlavors(variant),
-                variant.name
+                variant.name,
             )
         }
 

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/model/VariantOutputInfo.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/model/VariantOutputInfo.kt
@@ -36,7 +36,7 @@ fun Variant.toVariantOutputInfoProvider(project: Project): Provider<VariantOutpu
         VariantOutputInfo(
             versionName = UNKNOWN,
             versionCode = UNKNOWN,
-            packageName = UNKNOWN
+            packageName = UNKNOWN,
         )
     }
 
@@ -53,7 +53,7 @@ fun Variant.toVariantOutputInfoProvider(project: Project): Provider<VariantOutpu
             VariantOutputInfo(
                 versionName = versionPair.first,
                 versionCode = versionPair.second,
-                packageName = pkg
+                packageName = pkg,
             )
         }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/network/EmbraceEndpoint.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/network/EmbraceEndpoint.kt
@@ -7,5 +7,5 @@ enum class EmbraceEndpoint(val url: String) {
     NDK("/v2/store/ndk"),
     PROGUARD("/v2/store/proguard"),
     METHOD_MAP("/v2/store/methodmap"),
-    LINE_MAP("/v2/store/linemap")
+    LINE_MAP("/v2/store/linemap"),
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/network/NetworkService.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/network/NetworkService.kt
@@ -14,7 +14,7 @@ interface NetworkService {
 
     fun postNdkHandshake(
         appId: String,
-        handshake: NdkUploadHandshakeRequest
+        handshake: NdkUploadHandshakeRequest,
     ): HttpCallResult
 
     fun uploadFile(params: RequestParams, file: File): HttpCallResult

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/network/OkHttpNetworkService.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/network/OkHttpNetworkService.kt
@@ -58,13 +58,13 @@ class OkHttpNetworkService(
         return makePostRequest<BuildTelemetryRequest, String>(
             endpoint = EmbraceEndpoint.BUILD_DATA,
             payload = request,
-            deserializationAction = defaultBodyDeserializer
+            deserializationAction = defaultBodyDeserializer,
         )
     }
 
     override fun postNdkHandshake(
         appId: String,
-        handshake: NdkUploadHandshakeRequest
+        handshake: NdkUploadHandshakeRequest,
     ): HttpCallResult {
         return makePostRequest<NdkUploadHandshakeRequest, NdkUploadHandshakeResponse>(
             endpoint = EmbraceEndpoint.NDK_HANDSHAKE,
@@ -78,7 +78,7 @@ class OkHttpNetworkService(
         file: File,
         variantName: String,
         arch: String,
-        id: String
+        id: String,
     ): HttpCallResult {
         return makeMultipartRequest(params, file) {
             addFormDataPart(KEY_VARIANT, variantName)
@@ -101,7 +101,7 @@ class OkHttpNetworkService(
     private fun makeMultipartRequest(
         params: RequestParams,
         file: File,
-        action: MultipartBody.Builder.() -> Unit = {}
+        action: MultipartBody.Builder.() -> Unit = {},
     ): HttpCallResult {
         return makeRequest(
             requestProvider = {
@@ -111,7 +111,7 @@ class OkHttpNetworkService(
                     .post(requestBody.build())
                     .build()
             },
-            deserializationAction = defaultBodyDeserializer
+            deserializationAction = defaultBodyDeserializer,
         )
     }
 
@@ -119,7 +119,7 @@ class OkHttpNetworkService(
         endpoint: EmbraceEndpoint,
         payload: T,
         appId: String? = null,
-        deserializationAction: (stream: InputStream) -> O
+        deserializationAction: (stream: InputStream) -> O,
     ): HttpCallResult {
         val body = StreamedRequestBody(mediaTypeJson) {
             serializer.get().toJson(payload, T::class.java, it)
@@ -130,7 +130,7 @@ class OkHttpNetworkService(
                     .post(body)
                     .build()
             },
-            deserializationAction = deserializationAction
+            deserializationAction = deserializationAction,
         )
     }
 
@@ -176,7 +176,7 @@ class OkHttpNetworkService(
             is HttpCallResult.Error -> {
                 logger.error(
                     "Failed to make request",
-                    result.exception
+                    result.exception,
                 )
             }
         }
@@ -184,7 +184,7 @@ class OkHttpNetworkService(
 
     private inline fun <reified O> handleServerResponse(
         response: Response,
-        deserializationAction: (stream: InputStream) -> O
+        deserializationAction: (stream: InputStream) -> O,
     ): HttpCallResult {
         val result = when {
             response.isSuccessful -> {
@@ -202,7 +202,7 @@ class OkHttpNetworkService(
 
     private fun prepareCommonMultipartBody(
         params: RequestParams,
-        file: File
+        file: File,
     ): MultipartBody.Builder {
         return MultipartBody.Builder()
             .setType(MultipartBody.FORM)
@@ -216,7 +216,7 @@ class OkHttpNetworkService(
             .addFormDataPart(
                 KEY_MAPPING_FILE,
                 params.fileName,
-                file.asRequestBody(mediaTypeText)
+                file.asRequestBody(mediaTypeText),
             )
     }
 

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/network/StreamedRequestBody.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/network/StreamedRequestBody.kt
@@ -7,7 +7,7 @@ import java.io.OutputStream
 
 class StreamedRequestBody(
     private val mediaType: MediaType,
-    private val serializationAction: (stream: OutputStream) -> Unit
+    private val serializationAction: (stream: OutputStream) -> Unit,
 ) : RequestBody() {
     override fun contentType() = mediaType
 

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/EmbraceUploadTaskImpl.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/EmbraceUploadTaskImpl.kt
@@ -11,7 +11,7 @@ import javax.inject.Inject
 
 @DisableCachingByDefault(because = "Upload tasks perform network I/O and should not be cached")
 abstract class EmbraceUploadTaskImpl @Inject constructor(
-    objectFactory: ObjectFactory
+    objectFactory: ObjectFactory,
 ) : DefaultTask(), EmbraceUploadTask {
 
     @get:Input

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/common/FileCompressionTask.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/common/FileCompressionTask.kt
@@ -23,7 +23,7 @@ import javax.inject.Inject
  */
 @DisableCachingByDefault(because = "File compression output is written to disk and does not benefit from caching")
 abstract class FileCompressionTask @Inject constructor(
-    objectFactory: ObjectFactory
+    objectFactory: ObjectFactory,
 ) : DefaultTask(), EmbraceTask {
 
     @get:Input

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/il2cpp/Il2CppInfo.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/il2cpp/Il2CppInfo.kt
@@ -8,7 +8,7 @@ import io.embrace.android.gradle.plugin.network.EmbraceEndpoint
 internal sealed class Il2CppInfo(
     name: String,
     extension: String,
-    val endpoint: EmbraceEndpoint
+    val endpoint: EmbraceEndpoint,
 ) {
 
     /**

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/il2cpp/Il2CppUploadTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/il2cpp/Il2CppUploadTaskRegistration.kt
@@ -104,7 +104,7 @@ class Il2CppUploadTaskRegistration : EmbraceTaskRegistration {
         val compressionTask = project.registerTask(
             info.compressionTaskName,
             FileCompressionTask::class.java,
-            variant
+            variant,
         ) { task: FileCompressionTask ->
             val fileProvider = project.provider {
                 File(il2cppSymbolsDir, info.filename)
@@ -113,8 +113,8 @@ class Il2CppUploadTaskRegistration : EmbraceTaskRegistration {
             task.originalFile.fileProvider(fileProvider)
             task.compressedFile.convention(
                 project.layout.buildDirectory.file(
-                    "outputs/embrace/il2cpp/compressed/${variantConfig.variantName}/${info.filename}"
-                )
+                    "outputs/embrace/il2cpp/compressed/${variantConfig.variantName}/${info.filename}",
+                ),
             )
         }
         return compressionTask
@@ -133,7 +133,7 @@ class Il2CppUploadTaskRegistration : EmbraceTaskRegistration {
         val uploadTask = project.registerTask(
             info.uploadTaskName,
             MultipartUploadTask::class.java,
-            variant
+            variant,
         ) { task ->
             // buildIdProvider is ValueSource-backed: Gradle re-evaluates it on every build even
             // when the configuration cache is active, ensuring a fresh build ID each time.
@@ -148,7 +148,7 @@ class Il2CppUploadTaskRegistration : EmbraceTaskRegistration {
                         failBuildOnUploadErrors = behavior.failBuildOnUploadErrors.get(),
                         baseUrl = behavior.baseUrl,
                     )
-                }
+                },
             )
 
             // link output of compression task to the input of this task

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/ArchitecturesToHashedSharedObjectFilesMap.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/ArchitecturesToHashedSharedObjectFilesMap.kt
@@ -12,5 +12,5 @@ import com.squareup.moshi.JsonClass
  */
 @JsonClass(generateAdapter = true)
 data class ArchitecturesToHashedSharedObjectFilesMap(
-    val symbols: Map<String, Map<String, String>>
+    val symbols: Map<String, Map<String, String>>,
 )

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadHandshakeRequest.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadHandshakeRequest.kt
@@ -13,7 +13,7 @@ data class NdkUploadHandshakeRequest(
     @Json(name = "variant")
     val variant: String?,
     @Json(name = "archs")
-    val archSymbols: Map<String, Map<String, String>>
+    val archSymbols: Map<String, Map<String, String>>,
 ) : Serializable {
 
     private companion object {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadHandshakeResponse.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadHandshakeResponse.kt
@@ -7,7 +7,7 @@ import java.io.Serializable
 @JsonClass(generateAdapter = true)
 data class NdkUploadHandshakeResponse(
     @Json(name = "archs")
-    val symbols: Map<String, List<String>>?
+    val symbols: Map<String, List<String>>?,
 ) : Serializable {
 
     private companion object {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadTasksRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/NdkUploadTasksRegistration.kt
@@ -48,12 +48,12 @@ class NdkUploadTasksRegistration(
         val compressionTaskProvider = project.registerTask(
             CompressSharedObjectFilesTask.NAME,
             CompressSharedObjectFilesTask::class.java,
-            data
+            data,
         ) { task ->
             task.architecturesDirectory.set(sharedObjectFilesProvider)
             task.failBuildOnUploadErrors.set(behavior.failBuildOnUploadErrors)
             task.compressedSharedObjectFilesDirectory.set(
-                project.layout.buildDirectory.dir("intermediates/embrace/compressed/${data.name}")
+                project.layout.buildDirectory.dir("intermediates/embrace/compressed/${data.name}"),
             )
 
             // dependsOn doesn't accept null providers, so we use an empty list if the task is not found.
@@ -66,21 +66,21 @@ class NdkUploadTasksRegistration(
         val hashTaskProvider = project.registerTask(
             HashSharedObjectFilesTask.NAME,
             HashSharedObjectFilesTask::class.java,
-            data
+            data,
         ) { task ->
             task.compressedSharedObjectFilesDirectory.set(
-                compressionTaskProvider.flatMap { it.compressedSharedObjectFilesDirectory }
+                compressionTaskProvider.flatMap { it.compressedSharedObjectFilesDirectory },
             )
             task.failBuildOnUploadErrors.set(behavior.failBuildOnUploadErrors)
             task.architecturesToHashedSharedObjectFilesMap.set(
-                project.layout.buildDirectory.file("intermediates/embrace/hashes/${data.name}/hashes.json")
+                project.layout.buildDirectory.file("intermediates/embrace/hashes/${data.name}/hashes.json"),
             )
         }
 
         val uploadTask = project.registerTask(
             UploadSharedObjectFilesTask.NAME,
             UploadSharedObjectFilesTask::class.java,
-            data
+            data,
         ) { task ->
             // TODO: An error thrown in registration will make the build will fail. Should we use failBuildOnUploadErrors for this too?
             task.failBuildOnUploadErrors.set(behavior.failBuildOnUploadErrors)
@@ -93,31 +93,31 @@ class NdkUploadTasksRegistration(
                         failBuildOnUploadErrors = failBuildOnUploadErrors,
                         baseUrl = behavior.baseUrl,
                     )
-                }
+                },
             )
 
             task.compressedSharedObjectFilesDirectory.set(
-                compressionTaskProvider.flatMap { it.compressedSharedObjectFilesDirectory }
+                compressionTaskProvider.flatMap { it.compressedSharedObjectFilesDirectory },
             )
 
             task.architecturesToHashedSharedObjectFilesMapJson.set(
-                hashTaskProvider.flatMap { it.architecturesToHashedSharedObjectFilesMap }
+                hashTaskProvider.flatMap { it.architecturesToHashedSharedObjectFilesMap },
             )
         }
 
         project.registerTask(
             EncodeFileToBase64Task.NAME,
             EncodeFileToBase64Task::class.java,
-            data
+            data,
         ) { task ->
             task.inputFile.set(
-                hashTaskProvider.flatMap { it.architecturesToHashedSharedObjectFilesMap }
+                hashTaskProvider.flatMap { it.architecturesToHashedSharedObjectFilesMap },
             )
 
             task.failBuildOnUploadErrors.set(behavior.failBuildOnUploadErrors)
 
             task.outputFile.set(
-                project.layout.buildDirectory.file("intermediates/embrace/ndk/${data.name}/encoded_map.txt")
+                project.layout.buildDirectory.file("intermediates/embrace/ndk/${data.name}/encoded_map.txt"),
             )
 
             task.dependsOn(uploadTask)
@@ -139,7 +139,7 @@ class NdkUploadTasksRegistration(
                 project.provider { getNativeSharedObjectFilesFromCustomDirectory(customSymbolsDirectory, project) }
             } else {
                 getDefaultNativeSharedObjectFiles(mergeNativeLibsTaskProvider)
-            }
+            },
         )
     }
 

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/UploadSharedObjectFilesTask.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/ndk/UploadSharedObjectFilesTask.kt
@@ -74,7 +74,7 @@ abstract class UploadSharedObjectFilesTask @Inject constructor(
     private fun getArchToFilenameToHashMap() = try {
         serializer.fromJson(
             architecturesToHashedSharedObjectFilesMapJson.get().asFile.bufferedReader().use { it.readText() },
-            ArchitecturesToHashedSharedObjectFilesMap::class.java
+            ArchitecturesToHashedSharedObjectFilesMap::class.java,
         ).symbols
     } catch (exception: Exception) {
         error("Failed to read the architectures to hashed shared object files map: ${exception.message}")
@@ -90,7 +90,7 @@ abstract class UploadSharedObjectFilesTask @Inject constructor(
             requestParams.get().appId,
             requestParams.get().apiToken,
             variantData.get().name,
-            architecturesToHashedSharedObjectFilesMap
+            architecturesToHashedSharedObjectFilesMap,
         )
         val okHttpNetworkService = OkHttpNetworkService(requestParams.get().baseUrl)
         val handshakeResult = NdkUploadHandshake(okHttpNetworkService).getRequestedSymbols(params, failBuildOnUploadErrors.get())

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/r8/JvmMappingUploadTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/r8/JvmMappingUploadTaskRegistration.kt
@@ -66,14 +66,14 @@ class JvmMappingUploadTaskRegistration : EmbraceTaskRegistration {
         val compressionTask = project.registerTask(
             compressionTaskName,
             FileCompressionTask::class.java,
-            variant
+            variant,
         ) { task: FileCompressionTask ->
             // automatically link as a task dependency
             task.originalFile.fileProvider(mappingFile)
             task.compressedFile.convention(
                 project.layout.buildDirectory.file(
-                    "outputs/embrace/mapping/compressed/${variant.name}/$anchorTaskWithoutVariant/$FILE_NAME_MAPPING_TXT"
-                )
+                    "outputs/embrace/mapping/compressed/${variant.name}/$anchorTaskWithoutVariant/$FILE_NAME_MAPPING_TXT",
+                ),
             )
         }
 
@@ -81,7 +81,7 @@ class JvmMappingUploadTaskRegistration : EmbraceTaskRegistration {
         val uploadTask = project.registerTask(
             uploadTaskName,
             MultipartUploadTask::class.java,
-            variant
+            variant,
         ) { task ->
             val variantConfig = variantConfigurationsListProperty.get().first { it.variantName == variant.name }
             // buildIdProvider is ValueSource-backed: Gradle re-evaluates it on every build even
@@ -97,13 +97,13 @@ class JvmMappingUploadTaskRegistration : EmbraceTaskRegistration {
                         baseUrl = behavior.baseUrl,
                         failBuildOnUploadErrors = behavior.failBuildOnUploadErrors.get(),
                     )
-                }
+                },
             )
 
             // link output of compression task to the input of this task
             // dependencies to mapping file compression will be added automatically
             task.uploadFile.set(
-                compressionTask.flatMap { it.compressedFile }
+                compressionTask.flatMap { it.compressedFile },
             )
         }
 
@@ -152,7 +152,7 @@ class JvmMappingUploadTaskRegistration : EmbraceTaskRegistration {
             "dexguardApk$name",
             "dexguardAab$name",
             "minify${name}WithProguard",
-            "minify${name}WithR8"
+            "minify${name}WithR8",
         )
         val tasks = targetObfuscationTasks.filter { taskName ->
             isTaskRegistered(project.tryGetTaskProvider(taskName))

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/reactnative/GenerateRnSourcemapTask.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/reactnative/GenerateRnSourcemapTask.kt
@@ -70,7 +70,7 @@ abstract class GenerateRnSourcemapTask @Inject constructor(
         val jsonFile = generateBundleZipFile(
             bundleFile,
             sourceMapFile,
-            sourceMapAndBundleJsonFile
+            sourceMapAndBundleJsonFile,
         )
         uploadBundleFiles(jsonFile, bundleId)
 
@@ -83,7 +83,7 @@ abstract class GenerateRnSourcemapTask @Inject constructor(
         val networkService = OkHttpNetworkService(requestParams.get().baseUrl)
         val result = networkService.uploadRnSourcemapFile(
             requestParams.get().copy(buildId = bundleId),
-            jsonFile
+            jsonFile,
         )
         handleHttpCallResult(result, requestParams.get())
     }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/reactnative/GenerateRnSourcemapTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/reactnative/GenerateRnSourcemapTaskRegistration.kt
@@ -37,7 +37,7 @@ class GenerateRnSourcemapTaskRegistration : EmbraceTaskRegistration {
         project.registerTask(
             GenerateRnSourcemapTask.NAME,
             GenerateRnSourcemapTask::class.java,
-            data
+            data,
         ) { rnTask ->
             val embraceConfig = variantConfigurationsListProperty.get().first { it.variantName == variant.name }.embraceConfig
             rnTask.requestParams.set(
@@ -50,7 +50,7 @@ class GenerateRnSourcemapTaskRegistration : EmbraceTaskRegistration {
                         baseUrl = behavior.baseUrl,
                         failBuildOnUploadErrors = failBuildOnUploadErrors,
                     )
-                }
+                },
             )
 
             val variantCapitalized = variant.name.capitalizedString()
@@ -61,12 +61,12 @@ class GenerateRnSourcemapTaskRegistration : EmbraceTaskRegistration {
 
             rnTask.sourcemapAndBundleFile.set(
                 project.layout.buildDirectory.file(
-                    "outputs/embrace/${data.name}/$FILE_NAME_SOURCE_MAP_JSON"
-                )
+                    "outputs/embrace/${data.name}/$FILE_NAME_SOURCE_MAP_JSON",
+                ),
             )
 
             rnTask.bundleIdOutputFile.set(
-                project.layout.buildDirectory.file("intermediates/embrace/react/${data.name}/bundleId.txt")
+                project.layout.buildDirectory.file("intermediates/embrace/react/${data.name}/bundleId.txt"),
             )
 
             // We need an explicit dependsOn because it seems task.outputs.files.asFileTree.elements, inside getBundleFileProvider

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/registration/TaskRegistrar.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/registration/TaskRegistrar.kt
@@ -87,7 +87,7 @@ class TaskRegistrar(
         }
 
         GenerateRnSourcemapTaskRegistration().register(
-            createRegistrationParams(variant, ref, buildIdProvider)
+            createRegistrationParams(variant, ref, buildIdProvider),
         )
     }
 
@@ -122,7 +122,7 @@ class TaskRegistrar(
             project,
             variantConfigurationsListProperty,
             behavior,
-            agpWrapper
+            agpWrapper,
         )
     }
 

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/fakes/FakeConfigFileDirectory.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/fakes/FakeConfigFileDirectory.kt
@@ -9,7 +9,7 @@ import java.io.File
 
 class FakeConfigFileDirectory(
     private val dirPath: String = "root",
-    private val hasConfigFile: Boolean = false
+    private val hasConfigFile: Boolean = false,
 ) : Directory {
     var subDirectoriesWithConfigFiles: MutableSet<String> = mutableSetOf()
 
@@ -21,7 +21,7 @@ class FakeConfigFileDirectory(
 
     override fun dir(path: String): Directory = FakeConfigFileDirectory(
         "$dirPath/$path",
-        subDirectoriesWithConfigFiles.contains(path)
+        subDirectoriesWithConfigFiles.contains(path),
     )
 
     override fun dir(path: Provider<out CharSequence>): Provider<Directory> {

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/config/variant/BuildVariantConfigFromFileTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/config/variant/BuildVariantConfigFromFileTest.kt
@@ -20,7 +20,7 @@ class BuildVariantConfigFromFileTest {
         buildVariantConfig(
             fakeVariantInfo,
             projectDirectory,
-            emptyList()
+            emptyList(),
         )
     }
 
@@ -29,7 +29,7 @@ class BuildVariantConfigFromFileTest {
         val variantConfiguration = buildVariantConfig(
             fakeVariantInfo,
             projectDirectory,
-            listOf(VariantConfigurationFileFinder(projectDirectory, listOf()))
+            listOf(VariantConfigurationFileFinder(projectDirectory, listOf())),
         )
 
         assertNull(variantConfiguration)
@@ -41,7 +41,7 @@ class BuildVariantConfigFromFileTest {
         buildVariantConfig(
             fakeVariantInfo,
             projectDirectory,
-            listOf(fileFinder)
+            listOf(fileFinder),
         )
     }
 
@@ -59,7 +59,7 @@ class BuildVariantConfigFromFileTest {
         val variantConfiguration = buildVariantConfig(
             fakeVariantInfo,
             projectDirectory,
-            listOf(fileFinder)
+            listOf(fileFinder),
         )
 
         assertEquals("abcde", variantConfiguration?.appId)
@@ -85,7 +85,7 @@ class BuildVariantConfigFromFileTest {
             fakeVariantInfo,
             projectDirectory,
             listOf(fileFinder),
-            fakeSystemWrapper
+            fakeSystemWrapper,
         )
 
         assertEquals("env12345678901234567890123456789", variantConfiguration?.apiToken)
@@ -108,7 +108,7 @@ class BuildVariantConfigFromFileTest {
             fakeVariantInfo,
             projectDirectory,
             listOf(fileFinder),
-            fakeSystemWrapper
+            fakeSystemWrapper,
         )
 
         assertEquals("config78901234567890123456789012", variantConfiguration?.apiToken)
@@ -132,7 +132,7 @@ class BuildVariantConfigFromFileTest {
             fakeVariantInfo,
             projectDirectory,
             listOf(fileFinder),
-            fakeSystemWrapper
+            fakeSystemWrapper,
         )
 
         assertEquals("env12", variantConfiguration?.appId)
@@ -155,7 +155,7 @@ class BuildVariantConfigFromFileTest {
             fakeVariantInfo,
             projectDirectory,
             listOf(fileFinder),
-            fakeSystemWrapper
+            fakeSystemWrapper,
         )
 
         assertEquals("confg", variantConfiguration?.appId)
@@ -226,6 +226,6 @@ class BuildVariantConfigFromFileTest {
         buildTypeName = "buildType-name",
         isBuildTypeDebuggable = false,
         productFlavors = listOf("product-flavor", "2nd-product-flavor"),
-        sourceMapPath = "source"
+        sourceMapPath = "source",
     )
 }

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/config/variant/VariantConfigFileFinderTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/config/variant/VariantConfigFileFinderTest.kt
@@ -91,7 +91,7 @@ class VariantConfigFileFinderTest {
     private fun validateConfigFile(fileFinder: VariantConfigurationFileFinder, path: String) {
         assertEquals(
             "${projectDir.asFile.path}/$path/$VARIANT_CONFIG_FILE_NAME",
-            checkNotNull(fileFinder.fetchFile()).path
+            checkNotNull(fileFinder.fetchFile()).path,
         )
     }
 
@@ -102,7 +102,7 @@ class VariantConfigFileFinderTest {
             buildTypeName = "buildType-name",
             isBuildTypeDebuggable = false,
             productFlavors = listOf("product-flavor", "2nd-product-flavor"),
-            sourceMapPath = "source"
+            sourceMapPath = "source",
         )
     }
 }

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/config/variant/VariantConfigValidatorTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/config/variant/VariantConfigValidatorTest.kt
@@ -40,7 +40,7 @@ class VariantConfigValidatorTest {
         apiToken,
         ndkEnabled,
         null,
-        null
+        null,
     )
 
     private fun assertValidationFailure(

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/EmbraceClassVisitorFactoryTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/EmbraceClassVisitorFactoryTest.kt
@@ -36,7 +36,7 @@ class EmbraceClassVisitorFactoryTest {
         val filter = ClassInstrumentationFilter(mutableListOf("kotlin.Boolean"))
         val params = TestBytecodeInstrumentationParams(
             disabled = false,
-            classInstrumentationFilter = filter
+            classInstrumentationFilter = filter,
         )
         val factory = TestVisitorFactoryImpl(params = params)
         assertTrue(factory.isInstrumentable(clzDataString))
@@ -50,7 +50,7 @@ class EmbraceClassVisitorFactoryTest {
         val config = createInstrumentationConfig(
             instrumentOnClick = false,
             instrumentOnLongClick = false,
-            instrumentWebview = false
+            instrumentWebview = false,
         )
         val observed = fetchClassVisitor(config, ctx, visitor)
         assertSame(visitor, observed)
@@ -77,7 +77,7 @@ class EmbraceClassVisitorFactoryTest {
         val config = createInstrumentationConfig(
             instrumentOnClick = false,
             instrumentOnLongClick = false,
-            instrumentOkHttp = false
+            instrumentOkHttp = false,
         )
         val observed = fetchClassVisitor(config, ctx, visitor)
         assertSame(visitor, observed)
@@ -99,10 +99,10 @@ class EmbraceClassVisitorFactoryTest {
     private fun fetchClassVisitor(
         testParams: TestBytecodeInstrumentationParams,
         ctx: ClassContext,
-        visitor: TestClassVisitor
+        visitor: TestClassVisitor,
     ) = TestVisitorFactoryImpl(params = testParams).createClassVisitor(
         ctx,
-        visitor
+        visitor,
     )
 
     private fun createInstrumentationConfig(

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/InstrumentedConfigClassTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/InstrumentedConfigClassTest.kt
@@ -97,7 +97,7 @@ class InstrumentedConfigClassTest {
         val visitor = cfg.getMethodVisitor("getStringList", "()Ljava/util/List;", api, nextVisitor)
         assertEquals(
             listOf("hello"),
-            (visitor as io.embrace.android.gradle.plugin.instrumentation.config.StringListReturnValueMethodVisitor).replacedValue
+            (visitor as io.embrace.android.gradle.plugin.instrumentation.config.StringListReturnValueMethodVisitor).replacedValue,
         )
 
         // name doesn't match

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/BaseUrlConfigInstrumentationKtTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/BaseUrlConfigInstrumentationKtTest.kt
@@ -13,12 +13,12 @@ class BaseUrlConfigInstrumentationKtTest {
         null,
         null,
         null,
-        null
+        null,
     )
 
     private val methods = listOf(
         ConfigMethod("getConfig", "()Ljava/lang/String;", "config.example.com"),
-        ConfigMethod("getData", "()Ljava/lang/String;", "data.example.com")
+        ConfigMethod("getData", "()Ljava/lang/String;", "data.example.com"),
     )
 
     @Test
@@ -41,12 +41,12 @@ class BaseUrlConfigInstrumentationKtTest {
                     SdkLocalConfig(
                         baseUrls = BaseUrlLocalConfig(
                             config = "config.example.com",
-                            data = "data.example.com"
-                        )
+                            data = "data.example.com",
+                        ),
                     ),
-                    null
-                )
-            )
+                    null,
+                ),
+            ),
         )
         methods.forEach { method ->
             verifyConfigMethodVisitor(instrumentation, method)

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/ConfigInstrumentationAssertions.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/ConfigInstrumentationAssertions.kt
@@ -22,7 +22,7 @@ fun verifyConfigMethodVisitor(
         method.name,
         method.descriptor,
         ASM_API_VERSION,
-        nextVisitor
+        nextVisitor,
     )
     assertEquals(
         "Expected ${method.name} to return ${method.result}",
@@ -35,6 +35,6 @@ fun verifyConfigMethodVisitor(
             is StringListReturnValueMethodVisitor -> visitor.replacedValue
             is MapReturnValueMethodVisitor -> visitor.replacedValue
             else -> null
-        }
+        },
     )
 }

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/ConfigMethod.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/ConfigMethod.kt
@@ -3,5 +3,5 @@ package io.embrace.android.gradle.plugin.instrumentation.config.arch.sdk
 data class ConfigMethod(
     val name: String,
     val descriptor: String,
-    val result: Any? = null
+    val result: Any? = null,
 )

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/EnabledFeatureConfigInstrumentationKtTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/EnabledFeatureConfigInstrumentationKtTest.kt
@@ -24,7 +24,7 @@ class EnabledFeatureConfigInstrumentationKtTest {
         null,
         null,
         null,
-        null
+        null,
     )
 
     private val methods = listOf(
@@ -72,13 +72,13 @@ class EnabledFeatureConfigInstrumentationKtTest {
                     true,
                     SdkLocalConfig(
                         threadBlockage = ThreadBlockageLocalConfig(
-                            captureUnityThread = true
+                            captureUnityThread = true,
                         ),
                         app = AppLocalConfig(
-                            reportDiskUsage = true
+                            reportDiskUsage = true,
                         ),
                         appExitInfoConfig = AppExitInfoLocalConfig(
-                            aeiCaptureEnabled = true
+                            aeiCaptureEnabled = true,
                         ),
                         automaticDataCaptureConfig = AutomaticDataCaptureLocalConfig(
                             powerSaveModeServiceEnabled = true,
@@ -89,40 +89,40 @@ class EnabledFeatureConfigInstrumentationKtTest {
                             endStartupWithAppReadyEnabled = true,
                         ),
                         backgroundActivityConfig = BackgroundActivityLocalConfig(
-                            backgroundActivityCaptureEnabled = true
+                            backgroundActivityCaptureEnabled = true,
                         ),
                         captureFcmPiiData = true,
                         composeConfig = ComposeLocalConfig(
-                            captureComposeOnClick = true
+                            captureComposeOnClick = true,
                         ),
                         crashHandler = CrashHandlerLocalConfig(
-                            enabled = true
+                            enabled = true,
                         ),
                         otel = OpenTelemetryLocalConfig(
-                            otelKotlinSdkEnabled = false
+                            otelKotlinSdkEnabled = false,
                         ),
                         networking = NetworkLocalConfig(
                             captureRequestContentLength = true,
                             enableNativeMonitoring = true,
                             enableHucLiteInstrumentation = true,
                             enableNetworkSpanForwarding = true,
-                            enableTraceparentInjection = true
+                            enableTraceparentInjection = true,
                         ),
                         sigHandlerDetection = true,
                         taps = TapsLocalConfig(
-                            captureCoordinates = true
+                            captureCoordinates = true,
                         ),
                         webViewConfig = WebViewLocalConfig(
                             captureWebViews = true,
-                            captureQueryParams = true
+                            captureQueryParams = true,
                         ),
                         viewConfig = ViewLocalConfig(
-                            enableAutomaticActivityCapture = true
-                        )
+                            enableAutomaticActivityCapture = true,
+                        ),
                     ),
-                    null
-                )
-            )
+                    null,
+                ),
+            ),
         )
         methods.forEach { method ->
             verifyConfigMethodVisitor(instrumentation, method)
@@ -140,11 +140,11 @@ class EnabledFeatureConfigInstrumentationKtTest {
                     SdkLocalConfig(
                         automaticDataCaptureConfig = AutomaticDataCaptureLocalConfig(
                             uiLoadPerfTracingDisabled = true,
-                        )
+                        ),
                     ),
-                    null
-                )
-            )
+                    null,
+                ),
+            ),
         )
 
         listOf(
@@ -166,11 +166,11 @@ class EnabledFeatureConfigInstrumentationKtTest {
                     SdkLocalConfig(
                         automaticDataCaptureConfig = AutomaticDataCaptureLocalConfig(
                             uiLoadPerfTracingSelectedOnly = true,
-                        )
+                        ),
                     ),
-                    null
-                )
-            )
+                    null,
+                ),
+            ),
         )
 
         listOf(
@@ -193,11 +193,11 @@ class EnabledFeatureConfigInstrumentationKtTest {
                         automaticDataCaptureConfig = AutomaticDataCaptureLocalConfig(
                             uiLoadPerfTracingDisabled = true,
                             uiLoadPerfTracingSelectedOnly = true,
-                        )
+                        ),
                     ),
-                    null
-                )
-            )
+                    null,
+                ),
+            ),
         )
 
         listOf(
@@ -217,11 +217,11 @@ class EnabledFeatureConfigInstrumentationKtTest {
                     null,
                     true,
                     SdkLocalConfig(
-                        automaticDataCaptureConfig = AutomaticDataCaptureLocalConfig()
+                        automaticDataCaptureConfig = AutomaticDataCaptureLocalConfig(),
                     ),
-                    null
-                )
-            )
+                    null,
+                ),
+            ),
         )
 
         listOf(

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/NetworkCaptureConfigInstrumentationKtTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/NetworkCaptureConfigInstrumentationKtTest.kt
@@ -14,7 +14,7 @@ class NetworkCaptureConfigInstrumentationKtTest {
         null,
         null,
         null,
-        null
+        null,
     )
 
     private val methods = listOf(
@@ -50,14 +50,14 @@ class NetworkCaptureConfigInstrumentationKtTest {
                                 disabledUrlPatterns = listOf("pattern1", "pattern2"),
                                 domains = listOf(
                                     DomainLocalConfig("domain1", 1),
-                                    DomainLocalConfig("domain2", 2)
+                                    DomainLocalConfig("domain2", 2),
                                 ),
-                                traceparentOnlyAllowDomains = listOf("foo.test.com", ".example.com")
-                            )
+                                traceparentOnlyAllowDomains = listOf("foo.test.com", ".example.com"),
+                            ),
                         ),
-                        null
-                    )
-                )
+                        null,
+                    ),
+                ),
             )
         methods.forEach { method ->
             verifyConfigMethodVisitor(instrumentation, method)

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/ProjectConfigInstrumentationKtTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/ProjectConfigInstrumentationKtTest.kt
@@ -19,7 +19,7 @@ class ProjectConfigInstrumentationKtTest {
             null,
             null,
             null,
-        )
+        ),
     )
 
     private val variantOutputInfo = VariantOutputInfo("", "", "")
@@ -28,7 +28,7 @@ class ProjectConfigInstrumentationKtTest {
         ConfigMethod("getAppFramework", "()Ljava/lang/String;", "native"),
         ConfigMethod("getBuildId", "()Ljava/lang/String;", "my_id"),
         ConfigMethod("getBuildType", "()Ljava/lang/String;", "build_type"),
-        ConfigMethod("getBuildFlavor", "()Ljava/lang/String;", "build_flavor")
+        ConfigMethod("getBuildFlavor", "()Ljava/lang/String;", "build_flavor"),
     )
 
     @Test
@@ -50,14 +50,14 @@ class ProjectConfigInstrumentationKtTest {
                     apiToken = null,
                     ndkEnabled = null,
                     sdkConfig = SdkLocalConfig(appFramework = "native"),
-                    unityConfig = null
+                    unityConfig = null,
                 ),
                 buildId = "my_id",
                 buildType = "build_type",
-                buildFlavor = "build_flavor"
+                buildFlavor = "build_flavor",
             ),
             reactNativeBundleId = "a1B2c3",
-            variantOutputInfo
+            variantOutputInfo,
         )
         verifyConfigMethodVisitor(instrumentation, ConfigMethod("getAppId", "()Ljava/lang/String;", "abcde"))
         methods.forEach { method ->

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/RedactionConfigInstrumentationKtTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/RedactionConfigInstrumentationKtTest.kt
@@ -12,11 +12,11 @@ class RedactionConfigInstrumentationKtTest {
         null,
         null,
         null,
-        null
+        null,
     )
 
     private val methods = listOf(
-        ConfigMethod("getSensitiveKeysDenylist", "()Ljava/util/List;", listOf("password"))
+        ConfigMethod("getSensitiveKeysDenylist", "()Ljava/util/List;", listOf("password")),
     )
 
     @Test
@@ -37,11 +37,11 @@ class RedactionConfigInstrumentationKtTest {
                     null,
                     null,
                     SdkLocalConfig(
-                        sensitiveKeysDenylist = listOf("password")
+                        sensitiveKeysDenylist = listOf("password"),
                     ),
-                    null
-                )
-            )
+                    null,
+                ),
+            ),
         )
         methods.forEach { method ->
             verifyConfigMethodVisitor(instrumentation, method)

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/fakes/TestBytecodeInstrumentationParams.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/fakes/TestBytecodeInstrumentationParams.kt
@@ -24,11 +24,11 @@ class TestBytecodeInstrumentationParams(
 
     override val config: Property<VariantConfig> =
         DefaultProperty(PropertyHost.NO_OP, VariantConfig::class.javaObjectType).convention(
-            VariantConfig("", "", null, null, null)
+            VariantConfig("", "", null, null, null),
         )
     override val variantOutputInfo: Property<VariantOutputInfo> =
         DefaultProperty(PropertyHost.NO_OP, VariantOutputInfo::class.javaObjectType).convention(
-            VariantOutputInfo("", "", "")
+            VariantOutputInfo("", "", ""),
         )
     override val encodedSharedObjectFilesMap: RegularFileProperty = ProjectBuilder.builder().build().objects.fileProperty()
     override val reactNativeBundleId: RegularFileProperty = ProjectBuilder.builder().build().objects.fileProperty()
@@ -36,7 +36,7 @@ class TestBytecodeInstrumentationParams(
         DefaultProperty(PropertyHost.NO_OP, Boolean::class.javaObjectType).convention(disabled)
     override val classInstrumentationFilter: Property<ClassInstrumentationFilter> =
         DefaultProperty(PropertyHost.NO_OP, ClassInstrumentationFilter::class.javaObjectType).convention(
-            classInstrumentationFilter
+            classInstrumentationFilter,
         )
     override val shouldInstrumentFirebaseMessaging: Property<Boolean> =
         DefaultProperty(PropertyHost.NO_OP, Boolean::class.javaObjectType).convention(instrumentFirebaseMessaging)

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/fakes/TestClassData.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/fakes/TestClassData.kt
@@ -6,5 +6,5 @@ class TestClassData(
     override val className: String,
     override val classAnnotations: List<String> = emptyList(),
     override val interfaces: List<String> = emptyList(),
-    override val superClasses: List<String> = emptyList()
+    override val superClasses: List<String> = emptyList(),
 ) : ClassData

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/fakes/TestVisitorFactoryImpl.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/fakes/TestVisitorFactoryImpl.kt
@@ -11,7 +11,7 @@ import org.gradle.api.provider.Property
 
 internal class TestVisitorFactoryImpl(
     override val instrumentationContext: InstrumentationContext = TestInstrumentationContext(),
-    params: BytecodeInstrumentationParams = TestBytecodeInstrumentationParams()
+    params: BytecodeInstrumentationParams = TestBytecodeInstrumentationParams(),
 ) : EmbraceClassVisitorFactory() {
     override val parameters: Property<BytecodeInstrumentationParams> =
         DefaultProperty(PropertyHost.NO_OP, BytecodeInstrumentationParams::class.javaObjectType).convention(params)

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/ndk/NdkUploadHandshakeTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/ndk/NdkUploadHandshakeTest.kt
@@ -22,14 +22,14 @@ class NdkUploadHandshakeTest {
     fun setUp() {
         mockNetworkService = mockk()
         ndkUploadHandshake = NdkUploadHandshake(
-            networkService = mockNetworkService
+            networkService = mockNetworkService,
         )
 
         ndkUploadHandshakeRequest = NdkUploadHandshakeRequest(
             appId = APP_ID,
             apiToken = API_TOKEN,
             variant = VARIANT,
-            archSymbols = emptyMap()
+            archSymbols = emptyMap(),
         )
     }
 
@@ -39,7 +39,7 @@ class NdkUploadHandshakeTest {
             appId = APP_ID,
             apiToken = API_TOKEN,
             variant = VARIANT,
-            archSymbols = emptyMap()
+            archSymbols = emptyMap(),
         )
         val expectedRequest = """
             {
@@ -63,8 +63,8 @@ class NdkUploadHandshakeTest {
                 "x86_64" to mapOf("libnative.so" to "f067beecae4f901c81c642d002810944460efd7b"),
                 "x86" to mapOf("libnative.so" to "3c84ca4cf150a346db8d195426e520b7a45a0118"),
                 "armeabi-v7a" to mapOf("libnative.so" to "b621b4bac764b4a1d6166984d63d9958187439a6"),
-                "arm64-v8a" to mapOf("libnative.so" to "7d8c51cd16d00a369a1b923e1e9aed88c501beee")
-            )
+                "arm64-v8a" to mapOf("libnative.so" to "7d8c51cd16d00a369a1b923e1e9aed88c501beee"),
+            ),
         )
         val expectedRequest = """
             {
@@ -132,8 +132,8 @@ class NdkUploadHandshakeTest {
                 "x86" to listOf("libnative.so"),
                 "x86_64" to listOf("libnative.so"),
                 "armeabi-v7a" to listOf("libnative.so"),
-                "arm64-v8a" to listOf("libnative.so")
-            )
+                "arm64-v8a" to listOf("libnative.so"),
+            ),
         )
         assertEquals(expectedResponse, deserializedResponse)
     }

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/ndk/NdkUploadTasksRegistrationTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/ndk/NdkUploadTasksRegistrationTest.kt
@@ -42,7 +42,7 @@ class NdkUploadTasksRegistrationTest {
     private val testVariantName = "variantName"
     private val testVariantConfig = VariantConfig(
         variantName = testVariantName,
-        embraceConfig = createEmbraceVariantConfig()
+        embraceConfig = createEmbraceVariantConfig(),
     )
     private val testAndroidCompactedVariantData = AndroidCompactedVariantData(
         name = testVariantName,
@@ -69,7 +69,7 @@ class NdkUploadTasksRegistrationTest {
         embraceExtension = project.extensions.create("embrace", EmbraceExtension::class.java)
         testBehavior = PluginBehaviorImpl(
             project,
-            embraceExtension
+            embraceExtension,
         )
         testRegistrationParams = RegistrationParams(
             project,
@@ -84,7 +84,7 @@ class NdkUploadTasksRegistrationTest {
     private fun registerTestTask(project: Project, taskName: String): TaskProvider<DefaultTask> =
         project.tasks.register(
             taskName,
-            DefaultTask::class.java
+            DefaultTask::class.java,
         )
 
     @Test
@@ -92,8 +92,8 @@ class NdkUploadTasksRegistrationTest {
         verifyNoUploadTasksRegistered(
             VariantConfig(
                 variantName = testVariantName,
-                embraceConfig = createEmbraceVariantConfig(ndkEnabled = false)
-            )
+                embraceConfig = createEmbraceVariantConfig(ndkEnabled = false),
+            ),
         )
     }
 
@@ -102,8 +102,8 @@ class NdkUploadTasksRegistrationTest {
         val registration = createNdkUploadTasksRegistration(
             variantConfig = VariantConfig(
                 variantName = testVariantName,
-                embraceConfig = createEmbraceVariantConfig(ndkEnabled = null)
-            )
+                embraceConfig = createEmbraceVariantConfig(ndkEnabled = null),
+            ),
         )
         registerTestTask(project, "merge${testAndroidCompactedVariantData.name.capitalizedString()}NativeLibs")
         registration.register(testRegistrationParams)
@@ -137,7 +137,7 @@ class NdkUploadTasksRegistrationTest {
 
         // Then an exception is thrown when trying to access architecturesDirectory
         val compressionTask = project.tasks.findByName(
-            "${CompressSharedObjectFilesTask.NAME}${testAndroidCompactedVariantData.name.capitalizedString()}"
+            "${CompressSharedObjectFilesTask.NAME}${testAndroidCompactedVariantData.name.capitalizedString()}",
         ) as CompressSharedObjectFilesTask
 
         val exception = assertThrows(MissingValueException::class.java) {
@@ -147,7 +147,7 @@ class NdkUploadTasksRegistrationTest {
         assertEquals(
             "Cannot query the value of task ':compressSharedObjectFilesVariantName' property" +
                 " 'architecturesDirectory' because it has no value available.",
-            exception.message
+            exception.message,
         )
     }
 
@@ -163,7 +163,7 @@ class NdkUploadTasksRegistrationTest {
 
         // Then an exception is thrown when trying to access architecturesDirectory
         val compressionTask = project.tasks.findByName(
-            "${CompressSharedObjectFilesTask.NAME}$variantName"
+            "${CompressSharedObjectFilesTask.NAME}$variantName",
         ) as CompressSharedObjectFilesTask
 
         val exception = assertThrows(PropertyQueryException::class.java) {
@@ -177,7 +177,7 @@ class NdkUploadTasksRegistrationTest {
         variantConfig: VariantConfig? = null,
     ) = NdkUploadTasksRegistration(
         behavior ?: testBehavior,
-        variantConfig ?: testVariantConfig
+        variantConfig ?: testVariantConfig,
     )
 
     private fun createEmbraceVariantConfig(
@@ -191,7 +191,7 @@ class NdkUploadTasksRegistrationTest {
         apiToken = apiToken,
         ndkEnabled = ndkEnabled,
         sdkConfig = sdkConfig,
-        unityConfig = unityConfig
+        unityConfig = unityConfig,
     )
 
     private fun assertTaskNotRegistered(taskName: String, variantName: String) {

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/util/BuildIdValueSourceTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/util/BuildIdValueSourceTest.kt
@@ -30,7 +30,7 @@ class BuildIdValueSourceTest {
 
         assertTrue(
             "Build ID must be 32-char uppercase hex, was: $id",
-            id.matches(Regex("[A-F0-9]{32}"))
+            id.matches(Regex("[A-F0-9]{32}")),
         )
     }
 }

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/util/HashUtilsTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/util/HashUtilsTest.kt
@@ -14,7 +14,7 @@ class HashUtilsTest {
         }
         assertEquals(
             "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
-            calculateSha1ForFile(file)
+            calculateSha1ForFile(file),
         )
     }
 }

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/util/serialization/MoshiSerializerTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/util/serialization/MoshiSerializerTest.kt
@@ -67,5 +67,5 @@ class MoshiSerializerTest {
 @JsonClass(generateAdapter = true)
 class TestObject(
     @Json(name = "name") val name: String,
-    @Json(name = "team") val team: String
+    @Json(name = "team") val team: String,
 )

--- a/embrace-internal-api/src/test/kotlin/io/embrace/android/embracesdk/internal/api/NoopReactNativeInternalInterfaceTest.kt
+++ b/embrace-internal-api/src/test/kotlin/io/embrace/android/embracesdk/internal/api/NoopReactNativeInternalInterfaceTest.kt
@@ -17,7 +17,7 @@ internal class NoopReactNativeInternalInterfaceTest {
     @Before
     fun setUp() {
         impl = NoopReactNativeInternalInterface(
-            NoopEmbraceInternalInterface
+            NoopEmbraceInternalInterface,
         )
     }
 

--- a/embrace-internal-api/src/test/kotlin/io/embrace/android/embracesdk/internal/api/NoopUnityInternalInterfaceTest.kt
+++ b/embrace-internal-api/src/test/kotlin/io/embrace/android/embracesdk/internal/api/NoopUnityInternalInterfaceTest.kt
@@ -12,7 +12,7 @@ internal class NoopUnityInternalInterfaceTest {
     @Before
     fun setUp() {
         impl = NoopUnityInternalInterface(
-            NoopEmbraceInternalInterface
+            NoopEmbraceInternalInterface,
         )
     }
 

--- a/embrace-lint/src/main/kotlin/io/embrace/android/lint/EmbraceLintRegistry.kt
+++ b/embrace-lint/src/main/kotlin/io/embrace/android/lint/EmbraceLintRegistry.kt
@@ -17,6 +17,6 @@ class EmbraceLintRegistry : IssueRegistry() {
     override val vendor: Vendor = Vendor(
         vendorName = "Embrace",
         feedbackUrl = "https://embrace.io",
-        contact = "support@embrace.io"
+        contact = "support@embrace.io",
     )
 }

--- a/embrace-lint/src/main/kotlin/io/embrace/android/lint/EmbracePublicApiPackageRule.kt
+++ b/embrace-lint/src/main/kotlin/io/embrace/android/lint/EmbracePublicApiPackageRule.kt
@@ -51,8 +51,8 @@ class EmbracePublicApiPackageRule : Detector(), Detector.UastScanner {
             severity = Severity.ERROR,
             implementation = Implementation(
                 EmbracePublicApiPackageRule::class.java,
-                Scope.JAVA_FILE_SCOPE
-            )
+                Scope.JAVA_FILE_SCOPE,
+            ),
         )
     }
 }

--- a/embrace-lint/src/test/kotlin/io/embrace/android/lint/EmbracePublicApiPackageRuleTest.kt
+++ b/embrace-lint/src/test/kotlin/io/embrace/android/lint/EmbracePublicApiPackageRuleTest.kt
@@ -20,8 +20,8 @@ class EmbracePublicApiPackageRuleTest : LintDetectorTest() {
                 package io.embrace.android.embracesdk;
 
                 public class MyClass {}
-                """
-            )
+                """,
+            ),
         )
             .run()
             .expectErrorCount(1)
@@ -35,8 +35,8 @@ class EmbracePublicApiPackageRuleTest : LintDetectorTest() {
                 package io.embrace.android.embracesdk
 
                 class MyClass
-                """
-            )
+                """,
+            ),
         )
             .run()
             .expectErrorCount(1)
@@ -50,8 +50,8 @@ class EmbracePublicApiPackageRuleTest : LintDetectorTest() {
                 package com.example.allowed;
 
                 public class MyClass {}
-                """
-            )
+                """,
+            ),
         )
             .run()
             .expectClean()
@@ -65,8 +65,8 @@ class EmbracePublicApiPackageRuleTest : LintDetectorTest() {
                 package com.example.allowed
 
                 class MyClass
-                """
-            )
+                """,
+            ),
         )
             .run()
             .expectClean()

--- a/embrace-test-common/src/main/kotlin/io/embrace/android/embracesdk/MultipartFormReader.kt
+++ b/embrace-test-common/src/main/kotlin/io/embrace/android/embracesdk/MultipartFormReader.kt
@@ -26,8 +26,8 @@ class MultipartFormReader {
                         contentDisposition = part.headers["Content-Disposition"]
                             ?: error("Missing Content-Disposition"),
                         data = part.body.readUtf8(),
-                        contentType = part.headers["Content-Type"]
-                    )
+                        contentType = part.headers["Content-Type"],
+                    ),
                 )
             }
         }
@@ -57,7 +57,7 @@ fun FormPart.validateBodyBuildId(expectedBuildId: String? = null) {
 fun FormPart.validateMappingFile(expectedFileName: String) {
     assertEquals(
         "form-data; name=\"file\"; filename=\"${expectedFileName}\"",
-        contentDisposition
+        contentDisposition,
     )
     assertEquals("text/plain", contentType)
     assertTrue(checkNotNull(data?.length) > 0)

--- a/embrace-test-common/src/main/kotlin/io/embrace/android/embracesdk/concurrency/BlockingScheduledExecutorService.kt
+++ b/embrace-test-common/src/main/kotlin/io/embrace/android/embracesdk/concurrency/BlockingScheduledExecutorService.kt
@@ -116,7 +116,7 @@ class BlockingScheduledExecutorService(
         rejectIfShutdown()
         val futureTask = BlockedFutureScheduledTask<Unit>(
             runnable = command,
-            executionTimeMs = fakeClock.now() + unit.toMillis(delay)
+            executionTimeMs = fakeClock.now() + unit.toMillis(delay),
         )
 
         submitOrQueue(delay, futureTask)
@@ -135,7 +135,7 @@ class BlockingScheduledExecutorService(
         rejectIfShutdown()
         val futureTask = BlockedFutureScheduledTask(
             callable = callable,
-            executionTimeMs = fakeClock.now() + unit.toMillis(delay)
+            executionTimeMs = fakeClock.now() + unit.toMillis(delay),
         )
 
         submitOrQueue(delay, futureTask)
@@ -157,7 +157,7 @@ class BlockingScheduledExecutorService(
         val futureTask = BlockedFutureScheduledTask<Unit>(
             runnable = command,
             executionTimeMs = fakeClock.now() + unit.toMillis(initialDelay),
-            periodMs = unit.toMillis(period)
+            periodMs = unit.toMillis(period),
         )
 
         if (initialDelay <= 0L) {
@@ -184,7 +184,7 @@ class BlockingScheduledExecutorService(
             runnable = command,
             executionTimeMs = fakeClock.now() + unit.toMillis(initialDelay),
             periodMs = unit.toMillis(delay),
-            runFromLastExecution = true
+            runFromLastExecution = true,
         )
 
         if (initialDelay <= 0L) {

--- a/embrace-test-common/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeInternalLogger.kt
+++ b/embrace-test-common/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeInternalLogger.kt
@@ -8,7 +8,7 @@ import io.embrace.android.embracesdk.internal.utils.Provider
 class FakeInternalLogger(
     var throwOnInternalError: Boolean = true,
     override var errorHandlerProvider: Provider<InternalErrorHandler?> = { null },
-    val ignoredErrors: List<InternalErrorType> = emptyList()
+    val ignoredErrors: List<InternalErrorType> = emptyList(),
 ) : InternalLogger {
 
     data class LogMessage(

--- a/embrace-test-common/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNetworkConnectivityService.kt
+++ b/embrace-test-common/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeNetworkConnectivityService.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 
 class FakeNetworkConnectivityService(
     initialConnectivityStatus: ConnectivityStatus = ConnectivityStatus.Unverified,
-    private val executor: BlockingScheduledExecutorService? = null
+    private val executor: BlockingScheduledExecutorService? = null,
 ) : NetworkConnectivityService {
 
     private val networkConnectivityListeners = CopyOnWriteArrayList<NetworkConnectivityListener>()


### PR DESCRIPTION
Change detekt and editorconfig setting to allow and check for trailing comma usage