### PR TITLE
Clean up SDK version pinning for roboletric tests

### DIFF
--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/NetworkCallbackConnectivityServiceTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/NetworkCallbackConnectivityServiceTest.kt
@@ -11,7 +11,6 @@ import android.net.NetworkCapabilities.NET_CAPABILITY_VALIDATED
 import android.net.NetworkCapabilities.TRANSPORT_CELLULAR
 import android.net.NetworkCapabilities.TRANSPORT_WIFI
 import android.net.NetworkInfo
-import android.os.Build
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
@@ -24,14 +23,12 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Shadows
-import org.robolectric.annotation.Config
 import org.robolectric.shadow.api.Shadow
 import org.robolectric.shadows.ShadowConnectivityManager
 import org.robolectric.shadows.ShadowNetworkCapabilities
 import org.robolectric.shadows.ShadowNetworkInfo
 
 @RunWith(AndroidJUnit4::class)
-@Config(sdk = [Build.VERSION_CODES.N])
 internal class NetworkCallbackConnectivityServiceTest {
 
     private lateinit var service: NetworkCallbackConnectivityService

--- a/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/EmbraceUrlConnectionDelegateDelegationTest.kt
+++ b/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/EmbraceUrlConnectionDelegateDelegationTest.kt
@@ -1,18 +1,15 @@
 package io.embrace.android.embracesdk.instrumentation.huc
 
-import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.annotation.Config
 import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.HttpsURLConnection
 import javax.net.ssl.SSLSocketFactory
 
-@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
 @RunWith(AndroidJUnit4::class)
 internal class EmbraceUrlConnectionDelegateDelegationTest {
     private lateinit var mockConnection: HttpsURLConnection

--- a/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/EmbraceUrlStreamHandlerTest.kt
+++ b/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/EmbraceUrlStreamHandlerTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.instrumentation.huc
 
-import android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.internal.config.behavior.NetworkSpanForwardingBehaviorImpl.Companion.TRACEPARENT_HEADER_NAME
 import org.junit.Assert.assertNotNull
@@ -9,10 +8,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.annotation.Config
 import java.net.URL
 
-@Config(sdk = [UPSIDE_DOWN_CAKE])
 @RunWith(AndroidJUnit4::class)
 internal class EmbraceUrlStreamHandlerTest {
 

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/StartupTrackerTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/StartupTrackerTest.kt
@@ -115,7 +115,6 @@ internal class StartupTrackerTest {
         }
     }
 
-    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
     @Test
     fun `cold start with different activities being created and foregrounded first`() {
         val firstActivityInitTime = clock.now()
@@ -135,7 +134,6 @@ internal class StartupTrackerTest {
         }
     }
 
-    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
     @Test
     fun `cold start initial activity not tracked will use the second for timing`() {
         val firstActivityInitTime = launchActivity(Robolectric.buildActivity(FakeSplashScreenActivity::class.java)).createTime
@@ -154,7 +152,6 @@ internal class StartupTrackerTest {
         }
     }
 
-    @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
     @Test
     fun `verify startup tracker detached after trace recorded`() {
         val firstLaunchTimes = launchActivity()
@@ -167,7 +164,6 @@ internal class StartupTrackerTest {
         )
     }
 
-    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
     @Test
     fun `lifecycle event emitter attached after activity launch`() {
         launchActivity()
@@ -176,7 +172,6 @@ internal class StartupTrackerTest {
         assertEquals(1, activityLifecycleListener.onCreateInvokedCount)
     }
 
-    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
     @Test
     fun `data only collected if activity is used as startup activity`() {
         launchActivity(Robolectric.buildActivity(FakeSplashScreenActivity::class.java))
@@ -193,7 +188,6 @@ internal class StartupTrackerTest {
         assertNull(drawEventEmitter.lastFirstFrameDeliveredCallback)
     }
 
-    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
     @Test
     fun `render time tracked if first draw event emitted`() {
         launchActivity()
@@ -201,7 +195,6 @@ internal class StartupTrackerTest {
         assertEquals(clock.now(), dataCollector.firstFrameRenderedMs)
     }
 
-    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
     @Test
     fun `first draw event emitted detaches startup tracker and attaches lifecycle event emitter`() {
         defaultActivityController.create(null)

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbClockTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbClockTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.otel.impl
 
-import android.os.Build.VERSION_CODES.TIRAMISU
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.clock.NormalizedIntervalClock
@@ -8,7 +7,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.annotation.Config
 import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
@@ -23,13 +21,8 @@ internal class EmbClockTest {
         openTelemetryClock = EmbClock(embraceClock = embraceClock)
     }
 
-    @Config(sdk = [TIRAMISU])
     @Test
-    fun `verify consistency in 33`() {
-        verifyConsistency()
-    }
-
-    private fun verifyConsistency() {
+    fun `verify consistency`() {
         assertTrue(embraceClock.now() <= TimeUnit.NANOSECONDS.toMillis(openTelemetryClock.now()))
         assertTrue(openTelemetryClock.nanoTime() <= openTelemetryClock.nanoTime())
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ActivityFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ActivityFeatureTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.testcases.features
 
-import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.findSpanOfType
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
@@ -13,9 +12,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.annotation.Config
 
-@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
 @RunWith(AndroidJUnit4::class)
 internal class ActivityFeatureTest {
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/HucInstrumentationEnabledTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/HucInstrumentationEnabledTest.kt
@@ -14,7 +14,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
 internal class HucInstrumentationEnabledTest {
@@ -22,7 +21,6 @@ internal class HucInstrumentationEnabledTest {
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule()
 
-    @Config(sdk = [21])
     @Test
     fun `sdk starts successfully but internal error logged when HUC instrumentation enabled`() {
         testRule.runTest(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/HucLiteInstrumentationEnabledTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/HucLiteInstrumentationEnabledTest.kt
@@ -16,7 +16,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
 internal class HucLiteInstrumentationEnabledTest {
@@ -24,7 +23,6 @@ internal class HucLiteInstrumentationEnabledTest {
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule()
 
-    @Config(sdk = [21])
     @Test
     fun `sdk starts successfully but internal error logged when HUC Lite instrumentation enabled`() {
         testRule.runTest(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LowPowerFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/LowPowerFeatureTest.kt
@@ -27,7 +27,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Shadows
-import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowLooper
 import org.robolectric.shadows.ShadowPowerManager
 
@@ -49,7 +48,6 @@ internal class LowPowerFeatureTest {
         shadowMainLooper = Shadows.shadowOf(Looper.getMainLooper())
     }
 
-    @Config(sdk = [21])
     @Test
     fun `low power feature`() {
         val tickTimeMs = 3000L
@@ -83,7 +81,6 @@ internal class LowPowerFeatureTest {
         )
     }
 
-    @Config(sdk = [21])
     @Test
     fun `power state feature`() {
         val transitions: MutableList<Pair<Long, SchemaType.PowerState.PowerMode>> = mutableListOf()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NavigationStateFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NavigationStateFeatureTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.testcases.features
 
 import android.app.Activity
-import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.assertNavigationStateSpan
 import io.embrace.android.embracesdk.assertions.getNavigationStateSpan
@@ -18,9 +17,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
-import org.robolectric.annotation.Config
 
-@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
 @RunWith(AndroidJUnit4::class)
 internal class NavigationStateFeatureTest {
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NavigationStateNav2FeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NavigationStateNav2FeatureTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.testcases.features
 
 import android.app.Activity
-import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.assertNavigationStateSpan
 import io.embrace.android.embracesdk.assertions.getNavigationStateSpan
@@ -27,9 +26,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.android.controller.ActivityController
-import org.robolectric.annotation.Config
 
-@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
 @RunWith(AndroidJUnit4::class)
 internal class NavigationStateNav2FeatureTest {
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NavigationStateNav3FeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/NavigationStateNav3FeatureTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.testcases.features
 
 import android.app.Activity
-import android.os.Build
 import androidx.compose.runtime.snapshots.Snapshot.Companion.sendApplyNotifications
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.assertNavigationStateSpan
@@ -23,9 +22,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.android.controller.ActivityController
-import org.robolectric.annotation.Config
 
-@Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
 @RunWith(AndroidJUnit4::class)
 internal class NavigationStateNav3FeatureTest {
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PayloadTypesHeaderTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PayloadTypesHeaderTest.kt
@@ -14,7 +14,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.annotation.Config
 
 /**
  * Integration test to verify that the X-EM-PAYLOAD-TYPES header is sent correctly
@@ -49,7 +48,6 @@ internal class PayloadTypesHeaderTest {
         )
     }
 
-    @Config(sdk = [21])
     @Test
     fun `batched logs of different types send a list of header types`() {
         lateinit var logger: InternalLogger
@@ -78,7 +76,6 @@ internal class PayloadTypesHeaderTest {
         )
     }
 
-    @Config(sdk = [21])
     @Test
     fun `flutter exceptions are sent immediately in separate envelopes`() {
         val instrumentedConfig = FakeInstrumentedConfig(
@@ -127,7 +124,6 @@ internal class PayloadTypesHeaderTest {
         )
     }
 
-    @Config(sdk = [21])
     @Test
     fun `unity exceptions are sent immediately in separate envelopes`() {
         val instrumentedConfig = FakeInstrumentedConfig(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ResurrectionFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ResurrectionFeatureTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.testcases.features
 
-import android.os.Build.VERSION_CODES.TIRAMISU
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.getLastLog
 import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
@@ -26,9 +25,7 @@ import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.annotation.Config
 
-@Config(sdk = [TIRAMISU])
 @RunWith(AndroidJUnit4::class)
 internal class ResurrectionFeatureTest {
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/PeriodicSessionPartCacheTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/PeriodicSessionPartCacheTest.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.testcases.session
 
-import android.os.Build.VERSION_CODES.TIRAMISU
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.findSessionPartSpan
 import io.embrace.android.embracesdk.assertions.findSpanSnapshotOfType
@@ -22,13 +21,11 @@ import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.annotation.Config
 import java.util.zip.GZIPInputStream
 
 /**
  * Asserts that the session is periodically cached.
  */
-@Config(sdk = [TIRAMISU])
 @RunWith(AndroidJUnit4::class)
 internal class PeriodicPartCacheTest {
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionResurrectionTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionResurrectionTest.kt
@@ -2,7 +2,6 @@
 
 package io.embrace.android.embracesdk.testcases.session
 
-import android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.getLastLog
 import io.embrace.android.embracesdk.assertions.getLogOfType
@@ -42,9 +41,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.annotation.Config
 
-@Config(sdk = [UPSIDE_DOWN_CAKE])
 @RunWith(AndroidJUnit4::class)
 internal class UserSessionResurrectionTest {
 

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.injection
 
 import android.content.Context
-import android.os.Build.VERSION_CODES.TIRAMISU
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
@@ -26,9 +25,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RuntimeEnvironment
-import org.robolectric.annotation.Config
 
-@Config(sdk = [TIRAMISU])
 @RunWith(AndroidJUnit4::class)
 internal class ModuleInitBootstrapperTest {
 

--- a/embrace-android-utils/src/test/kotlin/io/embrace/android/embracesdk/internal/utils/EmbTraceTest.kt
+++ b/embrace-android-utils/src/test/kotlin/io/embrace/android/embracesdk/internal/utils/EmbTraceTest.kt
@@ -8,7 +8,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 
-@Config(sdk = [VERSION_CODES.UPSIDE_DOWN_CAKE])
 @RunWith(AndroidJUnit4::class)
 internal class EmbTraceTest {
 

--- a/embrace-test-common/src/main/kotlin/io/embrace/android/embracesdk/EmbraceGlobalConfigProvider.kt
+++ b/embrace-test-common/src/main/kotlin/io/embrace/android/embracesdk/EmbraceGlobalConfigProvider.kt
@@ -5,6 +5,6 @@ import org.robolectric.pluginapi.config.GlobalConfigProvider
 
 class EmbraceGlobalConfigProvider : GlobalConfigProvider {
     override fun get(): Config {
-        return Config.Builder().setSdk(35).build()
+        return Config.Builder().setSdk(Config.NEWEST_SDK).build()
     }
 }


### PR DESCRIPTION
<!-- Describe how this change has been tested -->

Remove unnecessary Android version pinning now that we can pit in project-wide with a plugin, which we do, for the latest version supported by Roboletric, which is 35, for the version of roboleric that we use.