### PR TITLE
Use boolean on network span to determine if it should be forwarded

### DIFF
--- a/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceImpl.kt
+++ b/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceImpl.kt
@@ -100,6 +100,7 @@ class NetworkRequestDataSourceImpl(
             spanToken.asW3cTraceparent()?.also { traceparent ->
                 if (configService.networkSpanForwardingBehavior.shouldForwardForDomain(domain)) {
                     spanToken.setSystemAttribute(EmbNetworkRequestAttributes.EMB_W3C_TRACEPARENT, traceparent)
+                    spanToken.setSystemAttribute(EmbNetworkRequestAttributes.EMB_FORWARD_TELEMETRY, "true")
                 }
                 activeRequests[traceparent] = spanToken
             }
@@ -130,6 +131,7 @@ class NetworkRequestDataSourceImpl(
         ErrorAttributes.ERROR_TYPE to request.errorType,
         ExceptionAttributes.EXCEPTION_MESSAGE to request.errorMessage,
         EmbNetworkRequestAttributes.EMB_W3C_TRACEPARENT to request.w3cTraceparent,
+        EmbNetworkRequestAttributes.EMB_FORWARD_TELEMETRY to request.w3cTraceparent?.let { "true" },
         EmbNetworkRequestAttributes.EMB_TRACE_ID to getValidTraceId(request.traceId),
     ).toNonNullMap().mapValues { it.value.toString() }
 

--- a/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceStatefulApiTest.kt
+++ b/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceStatefulApiTest.kt
@@ -79,6 +79,7 @@ internal class NetworkRequestDataSourceStatefulApiTest {
                 HttpAttributes.HTTP_REQUEST_BODY_SIZE to "100",
                 HttpAttributes.HTTP_RESPONSE_BODY_SIZE to "1000",
                 EmbNetworkRequestAttributes.EMB_W3C_TRACEPARENT to firstRequestSpan.asW3cTraceparent(),
+                EmbNetworkRequestAttributes.EMB_FORWARD_TELEMETRY to "true",
                 EmbNetworkRequestAttributes.EMB_TRACE_ID to "fake-trace-id",
             ),
         )

--- a/embrace-android-instrumentation-okhttp/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpDataSourceTest.kt
+++ b/embrace-android-instrumentation-okhttp/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpDataSourceTest.kt
@@ -368,6 +368,7 @@ internal class OkHttpDataSourceTest {
             val attrs = span.attributes
             assertEquals("200", attrs[HttpAttributes.HTTP_RESPONSE_STATUS_CODE])
             assertNull(attrs[EmbNetworkRequestAttributes.EMB_W3C_TRACEPARENT])
+            assertNull(attrs[EmbNetworkRequestAttributes.EMB_FORWARD_TELEMETRY])
         }
     }
 
@@ -381,6 +382,7 @@ internal class OkHttpDataSourceTest {
             val traceparent = span.asW3cTraceparent()
             assertEquals("200", attrs[HttpAttributes.HTTP_RESPONSE_STATUS_CODE])
             assertEquals(traceparent, attrs[EmbNetworkRequestAttributes.EMB_W3C_TRACEPARENT])
+            assertEquals("true", attrs[EmbNetworkRequestAttributes.EMB_FORWARD_TELEMETRY])
             assertEquals(traceparent, response.networkResponse?.request?.header(TRACEPARENT_HEADER))
         }
     }
@@ -396,6 +398,7 @@ internal class OkHttpDataSourceTest {
             val attrs = span.attributes
             assertNull(attrs[HttpAttributes.HTTP_RESPONSE_STATUS_CODE])
             assertEquals(span.asW3cTraceparent(), attrs[EmbNetworkRequestAttributes.EMB_W3C_TRACEPARENT])
+            assertEquals("true", attrs[EmbNetworkRequestAttributes.EMB_FORWARD_TELEMETRY])
         }
     }
 
@@ -408,6 +411,7 @@ internal class OkHttpDataSourceTest {
             val attrs = span.attributes
             assertNull(attrs[HttpAttributes.HTTP_RESPONSE_STATUS_CODE])
             assertEquals(span.asW3cTraceparent(), attrs[EmbNetworkRequestAttributes.EMB_W3C_TRACEPARENT])
+            assertEquals("true", attrs[EmbNetworkRequestAttributes.EMB_FORWARD_TELEMETRY])
         }
     }
 
@@ -422,6 +426,7 @@ internal class OkHttpDataSourceTest {
         assertNetworkRequestReceived { span ->
             assertEquals(appTraceparent, response.networkResponse?.request?.header(TRACEPARENT_HEADER))
             assertEquals(span.asW3cTraceparent(), span.attributes[EmbNetworkRequestAttributes.EMB_W3C_TRACEPARENT])
+            assertEquals("true", span.attributes[EmbNetworkRequestAttributes.EMB_FORWARD_TELEMETRY])
         }
     }
 
@@ -434,6 +439,7 @@ internal class OkHttpDataSourceTest {
         assertNetworkRequestReceived { span ->
             assertEquals(span.asW3cTraceparent(), response.networkResponse?.request?.header(TRACEPARENT_HEADER))
             assertNull(span.attributes[EmbNetworkRequestAttributes.EMB_W3C_TRACEPARENT])
+            assertNull(span.attributes[EmbNetworkRequestAttributes.EMB_FORWARD_TELEMETRY])
         }
     }
 
@@ -452,6 +458,7 @@ internal class OkHttpDataSourceTest {
         assertNetworkRequestReceived { span ->
             assertNull(response.networkResponse?.request?.header(TRACEPARENT_HEADER))
             assertNull(span.attributes[EmbNetworkRequestAttributes.EMB_W3C_TRACEPARENT])
+            assertNull(span.attributes[EmbNetworkRequestAttributes.EMB_FORWARD_TELEMETRY])
         }
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
@@ -390,6 +390,7 @@ internal class NetworkRequestApiTest {
                         HttpAttributes.HTTP_REQUEST_METHOD to expectedRequest.httpMethod,
                         EmbNetworkRequestAttributes.EMB_TRACE_ID to expectedRequest.traceId,
                         EmbNetworkRequestAttributes.EMB_W3C_TRACEPARENT to expectedRequest.w3cTraceparent,
+                        EmbNetworkRequestAttributes.EMB_FORWARD_TELEMETRY to expectedRequest.w3cTraceparent?.let { "true" },
                         HttpAttributes.HTTP_RESPONSE_STATUS_CODE to when {
                             completed -> expectedRequest.responseCode
                             else -> null

--- a/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbNetworkRequestAttributes.kt
+++ b/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbNetworkRequestAttributes.kt
@@ -11,6 +11,12 @@ package io.embrace.android.embracesdk.semconv
 object EmbNetworkRequestAttributes {
 
     /**
+     * IIndicates the span should be forwarded to the customer's backend.
+     */
+    @ExperimentalSemconv
+    const val EMB_FORWARD_TELEMETRY: String = "emb.forward_telemetry"
+
+    /**
      * The Embrace trace ID used for correlation.
      */
     @ExperimentalSemconv

--- a/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbNetworkRequestAttributes.kt
+++ b/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbNetworkRequestAttributes.kt
@@ -11,7 +11,7 @@ package io.embrace.android.embracesdk.semconv
 object EmbNetworkRequestAttributes {
 
     /**
-     * IIndicates the span should be forwarded to the customer's backend.
+     * Indicates the span should be forwarded to the customer's backend.
      */
     @ExperimentalSemconv
     const val EMB_FORWARD_TELEMETRY: String = "emb.forward_telemetry"

--- a/embrace-android-semconv/src/main/semconv/embrace_android.yaml
+++ b/embrace-android-semconv/src/main/semconv/embrace_android.yaml
@@ -241,6 +241,11 @@ groups:
         brief: "The W3C traceparent header value forwarded with the network request."
         stability: development
         examples: ["00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"]
+      - id: emb.forward_telemetry
+        type: boolean
+        brief: "Indicates the span should be forwarded to the customer's backend."
+        stability: development
+        examples: [true]
       - id: emb.trace_id
         type: string
         brief: "The Embrace trace ID used for correlation."


### PR DESCRIPTION
Use a boolean to determine which network span should be forwarded. The value of `emb.w3c_traceparent` is effectively deprecated after this change.