### PR TITLE
Use traceparent on request as parent of network span if possible

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/TelemetryDestinationImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/destination/TelemetryDestinationImpl.kt
@@ -82,6 +82,7 @@ class TelemetryDestinationImpl(
         schemaType: SchemaType,
         startTimeMs: Long,
         name: String,
+        parentSpanId: String?,
         autoTerminate: Boolean,
         private: Boolean,
     ): SpanToken {
@@ -89,8 +90,17 @@ class TelemetryDestinationImpl(
             autoTerminate -> AutoTerminationMode.ON_BACKGROUND
             else -> AutoTerminationMode.NONE
         }
+
+        val parent = if (parentSpanId != null) {
+            // Only allow parents created by this SDK instance to parent a new span
+            spanService.getSpan(parentSpanId)
+        } else {
+            null
+        }
+
         val span = spanService.startSpan(
             name = name,
+            parent = parent,
             startTimeMs = startTimeMs,
             autoTerminationMode = mode,
             private = private,

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/destination/TelemetryDestinationImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/destination/TelemetryDestinationImplTest.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.fakes.FakeCurrentSessionPartSpan
 import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.FakeEventService
 import io.embrace.android.embracesdk.fakes.FakeSpanService
+import io.embrace.android.embracesdk.fakes.getTraceIdFromTraceparent
 import io.embrace.android.embracesdk.internal.arch.attrs.asPair
 import io.embrace.android.embracesdk.internal.arch.datasource.LogSeverity
 import io.embrace.android.embracesdk.internal.arch.datasource.SpanEventImpl
@@ -171,8 +172,48 @@ internal class TelemetryDestinationImplTest {
         val span = impl.startSpanCapture(SchemaType.Breadcrumb("Whoops"), 5)
         assertNotNull(span)
         verifyAndResetSessionUpdate()
-        span?.stop()
+        span.stop()
         verifyAndResetSessionUpdate()
+    }
+
+    @Test
+    fun `span started without a parent is a root span`() {
+        impl.startSpanCapture(
+            schemaType = SchemaType.NetworkRequest(emptyMap()),
+            startTimeMs = 5,
+        )
+
+        assertNull(spanService.createdSpans.single().parent)
+    }
+
+    @Test
+    fun `span started with a resolvable parent shares the same trace id with that parent`() {
+        val parentSpan = FakeEmbraceSdkSpan.started()
+        val parentSpanId = checkNotNull(parentSpan.spanId)
+        spanService.addKnownSpan(parentSpan)
+
+        val token = impl.startSpanCapture(
+            schemaType = SchemaType.NetworkRequest(emptyMap()),
+            startTimeMs = 5,
+            parentSpanId = parentSpanId,
+        )
+
+        val childTraceId = checkNotNull(token.asW3cTraceparent()).getTraceIdFromTraceparent()
+        assertEquals(parentSpan.traceId, childTraceId)
+    }
+
+    @Test
+    fun `span started without a parent that can be resolved has no parent`() {
+        val parentSpan = FakeEmbraceSdkSpan.started()
+        val parentSpanId = checkNotNull(parentSpan.spanId)
+
+        impl.startSpanCapture(
+            schemaType = SchemaType.NetworkRequest(emptyMap()),
+            startTimeMs = 5,
+            parentSpanId = parentSpanId,
+        )
+
+        assertNull(spanService.createdSpans.single().parent)
     }
 
     @Test

--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanToken.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanToken.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.internal.arch.datasource.SpanToken
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
+import io.embrace.android.embracesdk.internal.utils.UuidSource
 
 class FakeSpanToken(
     val name: String,
@@ -18,12 +19,17 @@ class FakeSpanToken(
     val private: Boolean,
     initialAttrs: Map<String, String>,
     val events: MutableList<SpanEvent>,
+    uuidSource: UuidSource,
 ) : SpanToken {
 
     val attributes: Map<String, String>
         get() = attrs.toMap()
 
     private val attrs: MutableMap<String, String> = initialAttrs.toMutableMap()
+
+    private val traceId: String = parent?.asW3cTraceparent()?.getTraceIdFromTraceparent() ?: uuidSource.createUuid().lowercase()
+
+    private val spanId: String = uuidSource.createUuid().lowercase().take(16)
 
     override fun stop(endTimeMs: Long?, errorCode: ErrorCodeAttribute?) {
         this.endTimeMs = endTimeMs ?: 0
@@ -44,7 +50,7 @@ class FakeSpanToken(
 
     override fun getStartTimeMs(): Long = startTimeMs
 
-    override fun asW3cTraceparent(): String = hashCode().toString()
+    override fun asW3cTraceparent(): String = "00-$traceId-$spanId-01"
 
     override fun addSystemEvent(
         name: String,
@@ -54,3 +60,5 @@ class FakeSpanToken(
         events.add(SpanEventImpl(name, eventTimeMs.millisToNanos(), attributes))
     }
 }
+
+fun String.getTraceIdFromTraceparent() = split("-")[1]

--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTelemetryDestination.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTelemetryDestination.kt
@@ -9,8 +9,11 @@ import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestinati
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
+import io.embrace.android.embracesdk.internal.utils.UuidSource
 
-class FakeTelemetryDestination : TelemetryDestination {
+class FakeTelemetryDestination(
+    private val uuidSource: UuidSource = TestUuidSource(),
+) : TelemetryDestination {
 
     val logEvents: MutableList<FakeLogData> = mutableListOf()
     val addedEvents = mutableListOf<FakeSessionEvent>()
@@ -51,20 +54,40 @@ class FakeTelemetryDestination : TelemetryDestination {
         schemaType: SchemaType,
         startTimeMs: Long,
         name: String,
+        parentSpanId: String?,
         autoTerminate: Boolean,
         private: Boolean,
     ): SpanToken {
+        // Model the resolved parent as its own span token, named for the span id it represents, so the
+        // resulting span can adopt it as a parent and derive its traceparent from it.
+        val parent = parentSpanId?.let { spanId ->
+            FakeSpanToken(
+                name = spanId,
+                startTimeMs = startTimeMs,
+                endTimeMs = null,
+                errorCode = null,
+                parent = null,
+                type = schemaType.telemetryType,
+                internal = true,
+                private = false,
+                initialAttrs = emptyMap(),
+                events = mutableListOf(),
+                uuidSource = uuidSource,
+            )
+        }
+
         val token = FakeSpanToken(
             name = name,
             startTimeMs = startTimeMs,
             endTimeMs = null,
             errorCode = null,
-            parent = null,
+            parent = parent,
             type = schemaType.telemetryType,
             internal = true,
             private = false,
             initialAttrs = schemaType.attributes() + mapOf(schemaType.telemetryType.asPair()),
             events = mutableListOf(),
+            uuidSource = uuidSource,
         )
 
         createdSpans.add(token)
@@ -89,6 +112,7 @@ class FakeTelemetryDestination : TelemetryDestination {
             private = false,
             initialAttrs = emptyMap(),
             events = mutableListOf(),
+            uuidSource = uuidSource,
         )
 
         createdSpans.add(token)
@@ -118,6 +142,7 @@ class FakeTelemetryDestination : TelemetryDestination {
             private = private,
             initialAttrs = attributes,
             events = events.toMutableList(),
+            uuidSource = uuidSource,
         )
         createdSpans.add(token)
     }

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/TelemetryDestination.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/TelemetryDestination.kt
@@ -43,12 +43,13 @@ interface TelemetryDestination {
     fun removeSessionPartAttribute(key: String)
 
     /**
-     * Starts a new span with the given [schemaType] and [startTimeMs].
+     * Starts a new span with the given parameters
      */
     fun startSpanCapture(
         schemaType: SchemaType,
         startTimeMs: Long,
         name: String = schemaType.fixedObjectName,
+        parentSpanId: String? = null,
         autoTerminate: Boolean = false,
         private: Boolean = false,
     ): SpanToken

--- a/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceImpl.kt
+++ b/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceImpl.kt
@@ -95,6 +95,7 @@ class NetworkRequestDataSourceImpl(
                 schemaType = SchemaType.NetworkRequest(requestStartAttributes(startData)),
                 startTimeMs = startData.sdkClockStartTime,
                 name = getNetworkSpanName(startData.httpMethod, startData.url),
+                parentSpanId = extractSpanId(startData.traceparent),
             )
 
             spanToken.asW3cTraceparent()?.also { traceparent ->
@@ -153,4 +154,15 @@ class NetworkRequestDataSourceImpl(
     ).toNonNullMap().mapValues { it.value.toString() }
 
     private fun getNetworkSpanName(httpMethod: String, url: String) = "$httpMethod ${getUrlPath(stripUrl(url))}"
+
+    /**
+     * Returns the span-id component of a valid W3C traceparent, or null if [traceparent] is null or not a W3C traceparent.
+     */
+    private fun extractSpanId(traceparent: String?): String? =
+        traceparent?.let { TRACEPARENT_REGEX.matchEntire(it)?.groupValues?.get(1) }
+
+    private companion object {
+        // version(2)-traceId(32)-spanId(16)-flags(2), lowercase hex per the W3C traceparent spec.
+        private val TRACEPARENT_REGEX = Regex("^[0-9a-f]{2}-[0-9a-f]{32}-([0-9a-f]{16})-[0-9a-f]{2}$")
+    }
 }

--- a/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceImpl.kt
+++ b/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceImpl.kt
@@ -95,7 +95,7 @@ class NetworkRequestDataSourceImpl(
                 schemaType = SchemaType.NetworkRequest(requestStartAttributes(startData)),
                 startTimeMs = startData.sdkClockStartTime,
                 name = getNetworkSpanName(startData.httpMethod, startData.url),
-                parentSpanId = extractSpanId(startData.traceparent),
+                parentSpanId = startData.traceparent?.getSpanIdFromTraceparent(),
             )
 
             spanToken.asW3cTraceparent()?.also { traceparent ->
@@ -156,13 +156,12 @@ class NetworkRequestDataSourceImpl(
     private fun getNetworkSpanName(httpMethod: String, url: String) = "$httpMethod ${getUrlPath(stripUrl(url))}"
 
     /**
-     * Returns the span-id component of a valid W3C traceparent, or null if [traceparent] is null or not a W3C traceparent.
+     * Returns the span-id of this string if it is a valid W3C traceparent, or null if it is not.
      */
-    private fun extractSpanId(traceparent: String?): String? =
-        traceparent?.let { TRACEPARENT_REGEX.matchEntire(it)?.groupValues?.get(1) }
+    private fun String.getSpanIdFromTraceparent(): String? = SPAN_ID_FROM_TRACEPARENT_REGEX.matchEntire(this)?.groupValues?.get(1)
 
     private companion object {
         // version(2)-traceId(32)-spanId(16)-flags(2), lowercase hex per the W3C traceparent spec.
-        private val TRACEPARENT_REGEX = Regex("^[0-9a-f]{2}-[0-9a-f]{32}-([0-9a-f]{16})-[0-9a-f]{2}$")
+        private val SPAN_ID_FROM_TRACEPARENT_REGEX = Regex("[0-9a-f]{2}-[0-9a-f]{32}-([0-9a-f]{16})-[0-9a-f]{2}")
     }
 }

--- a/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/RequestStartData.kt
+++ b/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/RequestStartData.kt
@@ -4,4 +4,8 @@ data class RequestStartData(
     val url: String,
     val httpMethod: String,
     val sdkClockStartTime: Long,
+    /**
+     * The value of the traceparent header found in the request
+     */
+    val traceparent: String? = null,
 )

--- a/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/RequestStartData.kt
+++ b/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/RequestStartData.kt
@@ -1,11 +1,23 @@
 package io.embrace.android.embracesdk.internal.instrumentation.network
 
+/**
+ * Data used for instrumentation of the execution of an HTTP network request
+ */
 data class RequestStartData(
+    /**
+     * URL used to track the request in instrumentation, not necessarily the exact URL that was executed
+     */
     val url: String,
+    /**
+     * HTTP method of the request
+     */
     val httpMethod: String,
+    /**
+     * Timestamp normalized to the SDK clock for the start of the execution of the request (milliseconds)
+     */
     val sdkClockStartTime: Long,
     /**
-     * The value of the traceparent header found in the request
+     * The raw value of the traceparent header found in the request
      */
     val traceparent: String? = null,
 )

--- a/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceStatefulApiTest.kt
+++ b/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceStatefulApiTest.kt
@@ -12,6 +12,7 @@ import io.opentelemetry.kotlin.semconv.HttpAttributes
 import io.opentelemetry.kotlin.semconv.UserAgentAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -239,6 +240,38 @@ internal class NetworkRequestDataSourceStatefulApiTest {
         )
     }
 
+    @Test
+    fun `network span adopts the span represented by the traceparent as its parent if it is in the correct format`() {
+        startRequest(
+            url = "https://www.example.com/api",
+            traceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+        )
+        assertNotNull(harness.getNetworkSpans().single().parent)
+    }
+
+    @Test
+    fun `network span has no parent when inbound traceparent is absent or malformed`() {
+        val malformedTraceparents = listOf(
+            null,
+            "",
+            "not-a-traceparent",
+            "b7ad6b7169203331",
+            "0af7651916cd43dd8448eb211c80319c",
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331",
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01-extra",
+            "00-0af7-b7ad6b7169203331-01",
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad-01",
+            "00-0AF7651916CD43DD8448EB211C80319C-B7AD6B7169203331-01",
+        )
+        malformedTraceparents.forEachIndexed { index, traceparent ->
+            startRequest(url = "https://www.example.com/$index", traceparent = traceparent)
+        }
+
+        val spans = harness.getNetworkSpans()
+        assertEquals(malformedTraceparents.size, spans.size)
+        spans.forEach { assertNull(it.parent) }
+    }
+
     private fun runRequest(
         url: String,
         httpMethod: String = "GET",
@@ -270,12 +303,14 @@ internal class NetworkRequestDataSourceStatefulApiTest {
         url: String,
         httpMethod: String = "GET",
         startTime: Long = 100,
+        traceparent: String? = null,
     ): String? =
         harness.dataSource.startRequest(
             startData = RequestStartData(
                 url = url,
                 httpMethod = httpMethod,
                 sdkClockStartTime = startTime,
+                traceparent = traceparent,
             ),
         )
 

--- a/embrace-android-instrumentation-okhttp/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpDataSource.kt
+++ b/embrace-android-instrumentation-okhttp/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpDataSource.kt
@@ -72,6 +72,7 @@ internal class OkHttpDataSource(
                 url = getOverriddenURLString(EmbraceOkHttpPathOverrideRequest(request)),
                 httpMethod = request.method,
                 sdkClockStartTime = sdkClockStartTime,
+                traceparent = request.header(TRACEPARENT_HEADER_NAME),
             ),
         ) ?: return null
 

--- a/embrace-android-instrumentation-okhttp/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpDataSourceTest.kt
+++ b/embrace-android-instrumentation-okhttp/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpDataSourceTest.kt
@@ -34,6 +34,7 @@ import okhttp3.mockwebserver.MockWebServer
 import okio.Buffer
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
@@ -125,9 +126,9 @@ internal class OkHttpDataSourceTest {
         }
 
         val dataSource = OkHttpDataSource(
-            args,
-            { networkRequestDataSource },
-            { networkCaptureDataSource },
+            args = args,
+            networkRequestDataSourceProvider = { networkRequestDataSource },
+            networkCaptureDataSourceProvider = { networkCaptureDataSource },
         )
         val applicationInterceptor = EmbraceOkHttpInterceptor(InterceptorType.APPLICATION) { dataSource }
         val preNetworkInterceptorTestInterceptor = TestInspectionInterceptor(
@@ -459,6 +460,35 @@ internal class OkHttpDataSourceTest {
             assertNull(response.networkResponse?.request?.header(TRACEPARENT_HEADER))
             assertNull(span.attributes[EmbNetworkRequestAttributes.EMB_W3C_TRACEPARENT])
             assertNull(span.attributes[EmbNetworkRequestAttributes.EMB_FORWARD_TELEMETRY])
+        }
+    }
+
+    @Test
+    fun `network span start uses the span represented by the value of the traceparent header as its parent`() {
+        postRequestBuilder.header(TRACEPARENT_HEADER, "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+        server.enqueue(createBaseMockResponse())
+        runPostRequest()
+        assertNetworkRequestReceived { span ->
+            assertNotNull(span.parent)
+        }
+    }
+
+    @Test
+    fun `network span start does not pass in a parent if the traceparent value is not in the right format`() {
+        postRequestBuilder.header(TRACEPARENT_HEADER, "fake-traceparent")
+        server.enqueue(createBaseMockResponse())
+        runPostRequest()
+        assertNetworkRequestReceived { span ->
+            assertNull(span.parent)
+        }
+    }
+
+    @Test
+    fun `network span start does not pass in a parent when there is no inbound traceparent`() {
+        server.enqueue(createBaseMockResponse())
+        runPostRequest()
+        assertNetworkRequestReceived { span ->
+            assertNull(span.parent)
         }
     }
 

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanService.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.otel.spans.OtelSpanStartArgs
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
+import io.embrace.android.embracesdk.internal.otel.spans.createContext
 import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
@@ -13,6 +14,8 @@ import io.embrace.android.embracesdk.spans.ErrorCode
 class FakeSpanService : SpanService {
 
     val createdSpans: MutableList<FakeEmbraceSdkSpan> = mutableListOf()
+
+    private val knownSpans: MutableMap<String, EmbraceSpan> = mutableMapOf()
 
     override fun initializeService(sdkInitStartTimeMs: Long) {
     }
@@ -28,7 +31,7 @@ class FakeSpanService : SpanService {
         autoTerminationMode: AutoTerminationMode,
     ): EmbraceSdkSpan = FakeEmbraceSdkSpan(
         name = name,
-        parentContext = fakeOpenTelemetry().context.root(),
+        parentContext = (parent as? EmbraceSdkSpan)?.createContext(fakeOpenTelemetry()) ?: fakeOpenTelemetry().context.root(),
         type = type,
         internal = internal,
         private = private,
@@ -98,5 +101,9 @@ class FakeSpanService : SpanService {
         return true
     }
 
-    override fun getSpan(spanId: String): EmbraceSpan? = null
+    override fun getSpan(spanId: String): EmbraceSpan? = knownSpans[spanId]
+
+    fun addKnownSpan(span: EmbraceSpan) {
+        knownSpans[checkNotNull(span.spanId)] = span
+    }
 }


### PR DESCRIPTION
Add the ability to pass in a parentId when we start a span using `TelemetryDestination` - it will only be used if the given spanId is known to the SDK, i.e. created in this instance. Use this to take the value of the request header `traceparent` to potentially make the span that maps to it as a parent a network request span.

At tests a each affected level to verify that a parent is associated with the newly-created span properly.