### PR TITLE
Add user.id to telemetry attributes if user identifier is set

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModule.kt
@@ -76,4 +76,9 @@ interface OpenTelemetryModule {
      * Provide the session-related IDs to be stamped on OTel signals
      */
     fun setSessionIdsProvider(sessionIdsProvider: SessionIdsProvider)
+
+    /**
+     * Provide the current user ID to be stamped on OTel spans at the time they start
+     */
+    fun setUserIdProvider(userIdProvider: () -> String?)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
@@ -34,9 +34,8 @@ class OpenTelemetryModuleImpl(
 ) : OpenTelemetryModule {
 
     private val processIdentifierProvider: () -> String by lazy { IdGenerator.Companion::generateLaunchInstanceId }
-
     private var storedSessionIdsProvider: SessionIdsProvider? = null
-
+    private var storedUserIdProvider: (() -> String?)? = null
     private var otelBehavior: OtelBehavior? = null
 
     override val spanRepository: SpanRepository by lazy {
@@ -57,6 +56,7 @@ class OpenTelemetryModuleImpl(
             packageName = initModule.instrumentedConfig.project.getPackageName() ?: "UNKNOWN",
             systemInfo = initModule.systemInfo,
             sessionIdsProvider = { storedSessionIdsProvider },
+            userIdProvider = { storedUserIdProvider?.invoke() },
             processIdentifierProvider = processIdentifierProvider,
         )
     }
@@ -93,6 +93,10 @@ class OpenTelemetryModuleImpl(
 
     override fun setSessionIdsProvider(sessionIdsProvider: SessionIdsProvider) {
         storedSessionIdsProvider = sessionIdsProvider
+    }
+
+    override fun setUserIdProvider(userIdProvider: () -> String?) {
+        storedUserIdProvider = userIdProvider
     }
 
     private fun setupOtelBehavior(otelBehavior: OtelBehavior) {

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
@@ -31,6 +31,7 @@ class OtelSdkConfig(
     val packageName: String,
     private val systemInfo: SystemInfo,
     private val sessionIdsProvider: () -> SessionIdsProvider? = { null },
+    private val userIdProvider: () -> String? = { null },
     private val processIdentifierProvider: () -> String = IdGenerator.Companion::generateLaunchInstanceId,
 ) {
 
@@ -87,6 +88,7 @@ class OtelSdkConfig(
     val spanProcessor: SpanProcessor by lazy {
         EmbraceSpanProcessor(
             sessionIdsProvider,
+            userIdProvider,
             processIdentifier,
             spanExporter,
         )

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanProcessor.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanProcessor.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.semconv.SessionAttributes
+import io.opentelemetry.kotlin.semconv.UserAttributes
 import io.opentelemetry.kotlin.tracing.export.SpanExporter
 import io.opentelemetry.kotlin.tracing.export.SpanProcessor
 import io.opentelemetry.kotlin.tracing.model.ReadWriteSpan
@@ -14,6 +15,7 @@ import java.util.concurrent.atomic.AtomicLong
 
 class EmbraceSpanProcessor(
     private val sessionIdsProvider: () -> SessionIdsProvider?,
+    private val userIdProvider: () -> String? = { null },
     private val processIdentifier: String,
     private val spanExporter: SpanExporter,
 ) : SpanProcessor {
@@ -28,6 +30,9 @@ class EmbraceSpanProcessor(
             span.setStringAttribute(EmbSessionAttributes.EMB_SESSION_PART_ID, ids.sessionPartId)
             span.setStringAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID, ids.userSessionId)
             span.setStringAttribute(SessionAttributes.SESSION_ID, ids.userSessionId)
+        }
+        userIdProvider()?.let { userId ->
+            span.setStringAttribute(UserAttributes.USER_ID, userId)
         }
     }
 

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanProcessorTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanProcessorTest.kt
@@ -32,7 +32,7 @@ class EmbraceSpanProcessorTest {
     fun `test export`() {
         val processor = createProcessor()
         processor.onStart(span, context)
-        assertEquals("1", span.attributes[EmbSessionAttributes.EMB_PRIVATE_SEQUENCE_ID], )
+        assertEquals("1", span.attributes[EmbSessionAttributes.EMB_PRIVATE_SEQUENCE_ID])
         assertEquals("pid", span.attributes[EmbSessionAttributes.EMB_PROCESS_IDENTIFIER])
         assertEquals("user-sid", span.attributes[SessionAttributes.SESSION_ID])
         assertEquals("user-sid", span.attributes[EmbSessionAttributes.EMB_USER_SESSION_ID])

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanProcessorTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanProcessorTest.kt
@@ -6,36 +6,47 @@ import io.embrace.android.embracesdk.fakes.FakeSpanExporter
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.opentelemetry.kotlin.NoopOpenTelemetry
 import io.opentelemetry.kotlin.semconv.SessionAttributes
+import io.opentelemetry.kotlin.semconv.UserAttributes
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
 import org.junit.Test
 
 class EmbraceSpanProcessorTest {
 
+    private val processIdentifier = "pid"
+    private val context = NoopOpenTelemetry.context.implicit()
+
+    private lateinit var spanExporter: FakeSpanExporter
+    private lateinit var sessionIdsProvider: FakeSessionIdsProvider
+    private lateinit var span: FakeReadWriteSpan
+
+    @Before
+    fun setup() {
+        spanExporter = FakeSpanExporter()
+        sessionIdsProvider = FakeSessionIdsProvider(userSessionId = "user-sid", sessionPartId = "part-sid")
+        span = FakeReadWriteSpan()
+    }
+
     @Test
     fun `test export`() {
-        val spanExporter = FakeSpanExporter()
-        val provider = FakeSessionIdsProvider(userSessionId = "user-sid", sessionPartId = "part-sid")
-        val processor = EmbraceSpanProcessor({ provider }, "pid", spanExporter)
-        val span = FakeReadWriteSpan()
-        processor.onStart(span, NoopOpenTelemetry.context.implicit())
-
-        assertEquals(span.attributes[EmbSessionAttributes.EMB_PRIVATE_SEQUENCE_ID], "1")
-        assertEquals(span.attributes[EmbSessionAttributes.EMB_PROCESS_IDENTIFIER], "pid")
-        assertEquals(span.attributes[SessionAttributes.SESSION_ID], "user-sid")
-        assertEquals(span.attributes[EmbSessionAttributes.EMB_USER_SESSION_ID], "user-sid")
-        assertEquals(span.attributes[EmbSessionAttributes.EMB_SESSION_PART_ID], "part-sid")
-
+        val processor = createProcessor()
+        processor.onStart(span, context)
+        assertEquals("1", span.attributes[EmbSessionAttributes.EMB_PRIVATE_SEQUENCE_ID], )
+        assertEquals("pid", span.attributes[EmbSessionAttributes.EMB_PROCESS_IDENTIFIER])
+        assertEquals("user-sid", span.attributes[SessionAttributes.SESSION_ID])
+        assertEquals("user-sid", span.attributes[EmbSessionAttributes.EMB_USER_SESSION_ID])
+        assertEquals("part-sid", span.attributes[EmbSessionAttributes.EMB_SESSION_PART_ID])
         processor.onEnd(span)
         assertEquals(span, spanExporter.exportedSpans.single())
     }
 
     @Test
     fun `empty string set for session attributes when ids are absent`() {
-        val spanExporter = FakeSpanExporter()
-        val provider = FakeSessionIdsProvider(userSessionId = "", sessionPartId = "")
-        val processor = EmbraceSpanProcessor({ provider }, "pid", spanExporter)
-        val span = FakeReadWriteSpan()
-        processor.onStart(span, NoopOpenTelemetry.context.implicit())
+        sessionIdsProvider.userSessionId = ""
+        sessionIdsProvider.sessionPartId = ""
+        val processor = createProcessor()
+        processor.onStart(span, context)
 
         assertEquals("", span.attributes[EmbSessionAttributes.EMB_SESSION_PART_ID])
         assertEquals("", span.attributes[EmbSessionAttributes.EMB_USER_SESSION_ID])
@@ -44,14 +55,34 @@ class EmbraceSpanProcessorTest {
 
     @Test
     fun `empty string set for user session id when only session part id is absent`() {
-        val spanExporter = FakeSpanExporter()
-        val provider = FakeSessionIdsProvider(userSessionId = "", sessionPartId = "part-sid")
-        val processor = EmbraceSpanProcessor({ provider }, "pid", spanExporter)
-        val span = FakeReadWriteSpan()
-        processor.onStart(span, NoopOpenTelemetry.context.implicit())
+        sessionIdsProvider.userSessionId = ""
+        val processor = createProcessor()
+        processor.onStart(span, context)
 
         assertEquals("part-sid", span.attributes[EmbSessionAttributes.EMB_SESSION_PART_ID])
         assertEquals("", span.attributes[EmbSessionAttributes.EMB_USER_SESSION_ID])
         assertEquals("", span.attributes[SessionAttributes.SESSION_ID])
     }
+
+    @Test
+    fun `user id is stamped on span when provider returns a value`() {
+        val processor = createProcessor(userIdProvider = { "user-123" })
+        processor.onStart(span, context)
+        assertEquals("user-123", span.attributes[UserAttributes.USER_ID])
+    }
+
+    @Test
+    fun `user id attribute is absent when provider returns null`() {
+        val processor = createProcessor()
+        processor.onStart(span, context)
+        assertFalse(span.attributes.containsKey(UserAttributes.USER_ID))
+    }
+
+    private fun createProcessor(userIdProvider: () -> String? = { null }) =
+        EmbraceSpanProcessor(
+            sessionIdsProvider = { sessionIdsProvider },
+            userIdProvider = userIdProvider,
+            processIdentifier = processIdentifier,
+            spanExporter = spanExporter,
+        )
 }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanServiceTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanServiceTest.kt
@@ -50,8 +50,7 @@ internal class EmbraceSpanServiceTest {
             packageName = "com.test.app",
             systemInfo = SystemInfo(),
             sessionIdsProvider = { FakeSessionIdsProvider(userSessionId = "fake-session-id") },
-            processIdentifierProvider = { "fake-pid" },
-        )
+        ) { "fake-pid" }
         val otelSdkWrapper = OtelSdkWrapper(
             otelClock = fakeClock,
             configuration = otelSdkConfig,

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
@@ -624,8 +624,7 @@ internal class SpanServiceImplTest {
             packageName = "com.test.app",
             systemInfo = SystemInfo(),
             sessionIdsProvider = { FakeSessionIdsProvider(userSessionId = "fake-session-id") },
-            processIdentifierProvider = { "fake-pid" },
-        )
+        ) { "fake-pid" }
         val otelSdkWrapper = OtelSdkWrapper(
             otelClock = fakeClock,
             configuration = otelSdkConfig,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalLoggerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalLoggerTest.kt
@@ -29,6 +29,7 @@ import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
 import io.opentelemetry.kotlin.semconv.LogAttributes
 import io.opentelemetry.kotlin.semconv.ServiceAttributes
 import io.opentelemetry.kotlin.semconv.SessionAttributes
+import io.opentelemetry.kotlin.semconv.UserAttributes
 import io.opentelemetry.kotlin.tracing.SpanContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -204,6 +205,33 @@ internal class ExternalLoggerTest {
             },
             otelExportAssertion = {
                 assertJavaOTelLogRecord(checkNotNull(exportedOTelLog))
+            }
+        )
+    }
+
+    @Test
+    fun `user id is stamped on exported log when set`() {
+        testRule.runTest(
+            instrumentedConfig = instrumentedConfig,
+            persistedRemoteConfig = remoteConfig,
+            preSdkStartAction = {
+                setupExporter()
+            },
+            testCaseAction = {
+                initializeOTel()
+                recordSession {
+                    embLogger.emit(body = "no-user")
+                    embrace.setUserIdentifier("user-abc")
+                    embLogger.emit(body = "with-user")
+                    embrace.setUserIdentifier(null)
+                    embLogger.emit(body = "without-user")
+                }
+            },
+            assertAction = {
+                val logs = logExporter.exportedLogs.associateBy { checkNotNull(it.body) }
+                assertNull(checkNotNull(logs["no-user"]).attributes[UserAttributes.USER_ID])
+                assertEquals("user-abc",checkNotNull(logs["with-user"]).attributes[UserAttributes.USER_ID])
+                assertNull(checkNotNull(logs["without-user"]).attributes[UserAttributes.USER_ID])
             }
         )
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalTracerTest.kt
@@ -19,9 +19,10 @@ import io.embrace.android.embracesdk.testframework.actions.EmbracePreSdkStartInt
 import io.opentelemetry.kotlin.OpenTelemetry
 import io.opentelemetry.kotlin.getTracer
 import io.opentelemetry.kotlin.semconv.ExceptionAttributes
+import io.opentelemetry.kotlin.semconv.UserAttributes
+import io.opentelemetry.kotlin.tracing.StatusData
 import io.opentelemetry.kotlin.tracing.Tracer
 import io.opentelemetry.kotlin.tracing.data.SpanData
-import io.opentelemetry.kotlin.tracing.StatusData
 import io.opentelemetry.kotlin.tracing.recordException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -250,6 +251,38 @@ internal class ExternalTracerTest {
         )
     }
 
+
+    @Test
+    fun `user id on exported span reflects the value at span start`() {
+        testRule.runTest(
+            persistedRemoteConfig = remoteConfig,
+            preSdkStartAction = {
+                setupExporter()
+            },
+            testCaseAction = {
+                initializeTracer()
+                recordSession {
+                    embTracer.startSpan("no-user-span").end()
+                    embrace.setUserIdentifier("user-abc")
+                    val ongoingSpan = embTracer.startSpan("ongoing-span")
+                    embTracer.startSpan("user-span").end()
+                    embrace.setUserIdentifier("user-xyz")
+                    embTracer.startSpan("changed-user-span").end()
+                    ongoingSpan.end()
+                    embrace.setUserIdentifier(null)
+                    embTracer.startSpan("cleared-user-span").end()
+                }
+            },
+            assertAction = {
+                val spans = spanExporter.exportedSpans.associateBy { it.name }
+                assertNull(checkNotNull(spans["no-user-span"]).attributes[UserAttributes.USER_ID])
+                assertEquals("user-abc", checkNotNull(spans["user-span"]).attributes[UserAttributes.USER_ID])
+                assertEquals("user-abc", checkNotNull(spans["ongoing-span"]).attributes[UserAttributes.USER_ID])
+                assertEquals("user-xyz", checkNotNull(spans["changed-user-span"]).attributes[UserAttributes.USER_ID])
+                assertNull(checkNotNull(spans["cleared-user-span"]).attributes[UserAttributes.USER_ID])
+            }
+        )
+    }
 
     @Test
     fun `getOpenTelemetryKotlin returns noop before SDK start`() {

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
@@ -15,6 +15,7 @@ import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.opentelemetry.kotlin.semconv.SessionAttributes
+import io.opentelemetry.kotlin.semconv.UserAttributes
 import java.util.ServiceLoader
 
 /**
@@ -50,6 +51,7 @@ internal fun ModuleGraph.postInit() {
         instrumentationModule.instrumentationRegistry::getCurrentStates
 
     openTelemetryModule.setSessionIdsProvider(userSessionOrchestrationModule.sessionIdsProvider)
+    openTelemetryModule.setUserIdProvider { essentialServiceModule.userService.getUserInfo().userId }
 
     // Start the orchestrator and create the first session part once all the module dependencies have been created and wired up
     userSessionOrchestrationModule.sessionOrchestrator.start()
@@ -195,6 +197,9 @@ private fun ModuleGraph.eventMetadataSupplierProvider(): Provider<Map<String, St
             put(EmbSessionAttributes.EMB_USER_SESSION_ID, sessionIds.userSessionId)
             put(SessionAttributes.SESSION_ID, sessionIds.userSessionId)
             put(EmbSessionAttributes.EMB_STATE, sessionState.description)
+            essentialServiceModule.userService.getUserInfo().userId?.let {
+                put(UserAttributes.USER_ID, it)
+            }
             putAll(
                 essentialServiceModule.userSessionPropertiesService
                     .getProperties()

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
@@ -62,4 +62,8 @@ class FakeOpenTelemetryModule(
     override fun setSessionIdsProvider(sessionIdsProvider: SessionIdsProvider) {
         // no-op
     }
+
+    override fun setUserIdProvider(userIdProvider: () -> String?) {
+        // no-op
+    }
 }


### PR DESCRIPTION
Set the user ID an app sets by calling `setUserIdentifier` in spans and logs as an attribute using the OTel semantic convention for user IDs (i.e. `user.id`). 