### PR TITLE
Don't look for specific value for sequence_id due to potential races

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionApiTest.kt
@@ -85,7 +85,6 @@ internal class UserSessionApiTest {
                     "emb.usage.set_username" to "1",
                     "emb.usage.set_user_email" to "1",
                     "emb.usage.set_user_identifier" to "1",
-                    EmbSessionAttributes.EMB_PRIVATE_SEQUENCE_ID to "8",
                     EmbSessionAttributes.EMB_STARTUP_DURATION to "0"
                 ).toSortedMap()
 
@@ -97,6 +96,7 @@ internal class UserSessionApiTest {
     private companion object {
         // Attributes we want to know exist, but whose value we don't need to validate
         val validateExistenceOnly = setOf(
+            EmbSessionAttributes.EMB_PRIVATE_SEQUENCE_ID,
             SessionAttributes.SESSION_ID,
             EmbTelemetryAttributes.EMB_KOTLIN_ON_CLASSPATH,
             EmbTelemetryAttributes.EMB_OKHTTP3,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityCaptureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityCaptureTest.kt
@@ -207,14 +207,12 @@ internal class BackgroundActivityCaptureTest {
                 sessionPartSpan1.assertExpectedSessionPartSpanAttributes(
                     startMs = session1StartMs,
                     endMs = session1EndMs,
-                    sequenceId = 1,
                     coldStart = true,
                 )
 
                 sessionPartSpan2.assertExpectedSessionPartSpanAttributes(
                     startMs = session2StartMs,
                     endMs = session2EndMs,
-                    sequenceId = 13,
                     coldStart = false,
                 )
 
@@ -234,14 +232,12 @@ internal class BackgroundActivityCaptureTest {
     private fun Span.assertExpectedSessionPartSpanAttributes(
         startMs: Long,
         endMs: Long,
-        sequenceId: Int,
         coldStart: Boolean,
     ) {
         assertEquals(startMs, startTimeNanos?.nanosToMillis())
         assertEquals(endMs, endTimeNanos?.nanosToMillis())
         attributes?.assertMatches(
             mapOf(
-                EmbSessionAttributes.EMB_PRIVATE_SEQUENCE_ID to sequenceId,
                 EmbSessionAttributes.EMB_COLD_START to coldStart,
                 EmbSessionAttributes.EMB_STATE to "foreground",
                 EmbSessionAttributes.EMB_CLEAN_EXIT to "true",

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_2.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_2.json
@@ -53,7 +53,7 @@
     },
     {
       "key": "emb.private.sequence_id",
-      "value": "8"
+      "value": "__EMBRACE_TEST_IGNORE__"
     },
     {
       "key": "emb.process_identifier",

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_3.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_3.json
@@ -57,7 +57,7 @@
     },
     {
       "key": "emb.private.sequence_id",
-      "value": "16"
+      "value": "__EMBRACE_TEST_IGNORE__"
     },
     {
       "key": "emb.process_identifier",

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_4.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_4.json
@@ -61,7 +61,7 @@
     },
     {
       "key": "emb.private.sequence_id",
-      "value": "20"
+      "value": "__EMBRACE_TEST_IGNORE__"
     },
     {
       "key": "emb.process_identifier",

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_5.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_5.json
@@ -53,7 +53,7 @@
     },
     {
       "key": "emb.private.sequence_id",
-      "value": "26"
+      "value": "__EMBRACE_TEST_IGNORE__"
     },
     {
       "key": "emb.process_identifier",


### PR DESCRIPTION
Fix flakey tests that try to validate a sequence ID whose value can be affected by race conditions and the order of span creation