### PR TITLE
feat(VitalsScheduler): allow multiple scheduled settle `Runnable`s to be scheduled and canceled independently

### DIFF
--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/SettleTracker.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/SettleTracker.kt
@@ -1,0 +1,98 @@
+package io.embrace.android.embracesdk.internal.vitals
+
+import android.os.SystemClock
+
+/**
+ * A settle channel: detects when a subsystem has gone quiet for an idle threshold. Each settle has a dynamic [threshold] which must pass
+ * without [activity](notifyActivity) before [onSettled] is called.
+ *
+ * This class is not thread-safe and should only be used from a single thread. Callbacks are triggered on the [scheduler] thread.
+ */
+internal class SettleTracker(
+    private val scheduler: VitalsScheduler,
+    private val threshold: ThresholdProvider,
+    private val onSettled: SettleCallback,
+) {
+
+    private val runnable = Runnable { checkSettled() }
+    private var active = false
+
+    /**
+     * The latest activity baseline seen ([SystemClock.uptimeMillis]) — the most recent [notifyActivity] timestamp. Reset to 0 by [cancel].
+     */
+    var lastActivityMs = 0L
+        private set
+
+    /**
+     * Mark the `SettleTracker` as "unsettled" as-of [activityMs] so that [onSettled] will not be called until at least [threshold] millis
+     * after [activityMs]. The first event of a moment schedules the settle check, subsequent calls move when [onSettled] will be called.
+     */
+    fun notifyActivity(activityMs: Long) {
+        if (activityMs > lastActivityMs) {
+            lastActivityMs = activityMs
+        }
+        if (!active) {
+            // First activity of the moment: nothing is scheduled yet, so schedule once. While active, a
+            // check is always pending, so a later event need only move the baseline above.
+            active = true
+            scheduleCheck()
+        }
+    }
+
+    /**
+     * Ensure that the [SettleTracker] is active and scheduled for an appropriate time. This should be called when there has been no
+     * activity, but the settling threshold may have changed. That is: you don't want to change [lastActivityMs] but the time until the
+     * [onSettled] may have changed.
+     */
+    fun reschedule() {
+        if (active) {
+            scheduleCheck()
+        }
+    }
+
+    /**
+     * Stops tracking and clears the baseline, so the next [notifyActivity] starts a fresh moment.
+     */
+    fun cancel() {
+        active = false
+        lastActivityMs = 0L
+        scheduler.cancelSettle(runnable)
+    }
+
+    private fun scheduleCheck() {
+        val delayMs = (lastActivityMs + threshold.thresholdMs() - nowMs()).coerceAtLeast(0L)
+        scheduler.scheduleSettle(delayMs, runnable)
+    }
+
+    private fun checkSettled() {
+        if (!active) {
+            return
+        }
+
+        if (nowMs() - lastActivityMs >= threshold.thresholdMs()) {
+            active = false
+            // The caller performs its state-specific completion and is responsible for cancel().
+            onSettled(lastActivityMs)
+        } else {
+            scheduleCheck()
+        }
+    }
+
+    private fun nowMs(): Long = SystemClock.uptimeMillis()
+
+    /**
+     * Supplies the idle threshold (in millis) for a [SettleTracker]. There is no guarantee about when this is called, but the
+     * [SettleCallback] is only called once at least [thresholdMs] has passed since [SettleTracker.lastActivityMs] on
+     * [SystemClock.uptimeMillis].
+     */
+    internal fun interface ThresholdProvider {
+        fun thresholdMs(): Long
+    }
+
+    /**
+     * Notified when the UI settles, with the activity baseline (in millis) it settled at.
+     */
+    internal fun interface SettleCallback {
+        operator fun invoke(lastActivityMs: Long)
+    }
+}

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsScheduler.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsScheduler.kt
@@ -6,7 +6,7 @@ import android.os.HandlerThread
 internal interface VitalsScheduler {
     fun post(action: Runnable)
     fun scheduleSettle(delayMs: Long, action: Runnable)
-    fun cancelSettle()
+    fun cancelSettle(action: Runnable)
 }
 
 internal class HandlerVitalsScheduler : VitalsScheduler {
@@ -20,8 +20,6 @@ internal class HandlerVitalsScheduler : VitalsScheduler {
     lateinit var handler: Handler
         private set
 
-    private var settle: Runnable? = null
-
     /**
      * Starts the backing thread and prepares its [handler].
      */
@@ -32,11 +30,13 @@ internal class HandlerVitalsScheduler : VitalsScheduler {
     }
 
     /**
-     * Cancels any pending settle and stops the backing thread.
+     * Cancels all pending settles and stops the backing thread.
      */
     fun stop() {
-        cancelSettle()
-        handlerThread?.quitSafely()
+        handlerThread?.let { thread ->
+            handler.removeCallbacksAndMessages(null)
+            thread.quitSafely()
+        }
         handlerThread = null
     }
 
@@ -45,14 +45,12 @@ internal class HandlerVitalsScheduler : VitalsScheduler {
     }
 
     override fun scheduleSettle(delayMs: Long, action: Runnable) {
-        cancelSettle()
-        settle = action
+        handler.removeCallbacks(action)
         handler.postDelayed(action, delayMs)
     }
 
-    override fun cancelSettle() {
-        settle?.let(handler::removeCallbacks)
-        settle = null
+    override fun cancelSettle(action: Runnable) {
+        handler.removeCallbacks(action)
     }
 
     private companion object {

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTracker.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTracker.kt
@@ -187,7 +187,7 @@ internal class FocalMomentTracker(
         }
         capturing = false
         held = false
-        scheduler.cancelSettle()
+        scheduler.cancelSettle(settleRunnable)
         val durationMs = (endNanos - focalMomentStartNanos) / NANOS_PER_MS
         reporter.onFocalMomentEnd(outcome, focalMomentStartEpochMs, durationMs)
     }
@@ -200,7 +200,7 @@ internal class FocalMomentTracker(
         bufferedEndNanos = endNanos
         capturing = false
         held = true
-        scheduler.cancelSettle()
+        scheduler.cancelSettle(settleRunnable)
     }
 
     private fun nowNanos(): Long = SystemClock.uptimeMillis() * NANOS_PER_MS

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTracker.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTracker.kt
@@ -5,6 +5,7 @@ import androidx.annotation.MainThread
 import androidx.annotation.WorkerThread
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.vitals.FocalInteractionCallbacks
+import io.embrace.android.embracesdk.internal.vitals.SettleTracker
 import io.embrace.android.embracesdk.internal.vitals.VitalsScheduler
 
 /**
@@ -13,30 +14,31 @@ import io.embrace.android.embracesdk.internal.vitals.VitalsScheduler
  * the idle threshold; each frame's jank is fed to [reporter], which emits a [SmoothnessResult] on close.
  *
  * The whole state machine runs on the Vitals handler thread: [onFrame] is delivered there, the settle
- * timeout fires there, and the main-thread touch/screen callbacks hop onto it via `scheduler.post`, so
+ * timeout elapses there, and the main-thread touch/screen callbacks hop onto it via `scheduler.post`, so
  * the state needs no synchronization.
  */
 internal class FocalMomentTracker(
     private val scheduler: VitalsScheduler,
     private val reporter: SmoothnessReporter,
     private val clock: Clock,
-    private val idleThresholdNanos: Long = IDLE_THRESHOLD_NANOS,
-    private val heldIdleThresholdNanos: Long = HELD_IDLE_THRESHOLD_NANOS,
+    private val idleThresholdMs: Long = IDLE_THRESHOLD_MS,
+    private val heldIdleThresholdMs: Long = HELD_IDLE_THRESHOLD_MS,
 ) : FocalInteractionCallbacks {
 
     // Reused hop Runnable instances (main thread -> Vitals thread); allocate them here to make certain they're off the hot path
     private val interactionRunnable = Runnable { startOrResume() }
     private val interactionEndRunnable = Runnable { handleInteractionEnd() }
     private val screenChangeRunnable = Runnable { handleScreenChange() }
-    private val settleRunnable = Runnable { settleCheck() }
+
+    // The settle baseline (the latest of redraw vsync / move) lives inside [settle]; we feed every activity
+    // event to it via notifyActivity rather than holding the per-source timestamps here.
+    private val settle = SettleTracker(scheduler, ::currentThresholdMs, ::onSettled)
 
     private var capturing = false
     private var held = false
     private var focalMomentStartNanos = 0L
     private var focalMomentStartEpochMs = 0L
-    private var lastRedrawVsyncNanos = 0L
     private var interacting = false
-    private var lastMoveNanos = 0L
     private var bufferedEndNanos = 0L
 
     @MainThread
@@ -57,15 +59,15 @@ internal class FocalMomentTracker(
     @WorkerThread
     override fun onFrame(vsyncNanos: Long, frameDispatchNanos: Long, jankNanos: Long) {
         if (capturing) {
-            recordFrame(vsyncNanos, frameDispatchNanos, jankNanos)
-            armSettle()
+            recordFrame(frameDispatchNanos, jankNanos)
+            settle.notifyActivity(vsyncNanos / NANOS_PER_MS)
         } else if (held) {
-            if (vsyncNanos - bufferedEndNanos < idleThresholdNanos) {
+            if (vsyncNanos - bufferedEndNanos < idleThresholdMs * NANOS_PER_MS) {
                 // Frame is contiguous with the buffered settle: resume capturing so its jank is included.
                 held = false
                 capturing = true
-                recordFrame(vsyncNanos, frameDispatchNanos, jankNanos)
-                armSettle()
+                recordFrame(frameDispatchNanos, jankNanos)
+                settle.notifyActivity(vsyncNanos / NANOS_PER_MS)
             } else {
                 // Idle gap before this frame: emit the buffered settle and discard the orphan frame.
                 flushHeld()
@@ -81,8 +83,7 @@ internal class FocalMomentTracker(
             startFocalMoment()
         } else if (capturing) {
             interacting = true
-            lastMoveNanos = nowNanos()
-            armSettle()
+            settle.notifyActivity(nowMs())
         } else {
             startFocalMoment()
         }
@@ -91,8 +92,10 @@ internal class FocalMomentTracker(
     @WorkerThread
     private fun handleInteractionEnd() {
         interacting = false
+        // The threshold just dropped from held to idle, moving the deadline earlier; re-post so the settle
+        // runs on the shorter idle window rather than waiting out the original held one.
         if (capturing) {
-            armSettle()
+            settle.reschedule()
         }
     }
 
@@ -108,25 +111,18 @@ internal class FocalMomentTracker(
 
     @WorkerThread
     private fun startFocalMoment() {
-        val now = nowNanos()
-        focalMomentStartNanos = now
+        val nowMs = nowMs()
+        focalMomentStartNanos = nowMs * NANOS_PER_MS
         focalMomentStartEpochMs = clock.now()
-        lastRedrawVsyncNanos = now
         held = false
         interacting = true
-        lastMoveNanos = now
         capturing = true
         reporter.onFocalMomentStart()
-        armSettle()
+        settle.notifyActivity(nowMs)
     }
 
     @WorkerThread
-    private fun recordFrame(vsyncNanos: Long, frameDispatchNanos: Long, jankNanos: Long) {
-        // The frame becomes visible at its vsync; that's when the user sees it, so the moment runs to there.
-        if (vsyncNanos > lastRedrawVsyncNanos) {
-            lastRedrawVsyncNanos = vsyncNanos
-        }
-
+    private fun recordFrame(frameDispatchNanos: Long, jankNanos: Long) {
         // A jank frame is counted in full, so the moment must also cover the render that produced it. We
         // back-date the start to when the engine dispatched the frame's work, if that predates the
         // moment, shifting the reported start epoch by the same amount so the end stays put.
@@ -139,36 +135,19 @@ internal class FocalMomentTracker(
     }
 
     /**
-     * (Re)schedules the settle check for the current activity baseline plus its threshold.
+     * Invoked by [settle] when the interaction has been quiet for the current threshold: buffer the settle
+     * at the last activity baseline. A late callback after the moment already closed is ignored.
      */
     @WorkerThread
-    private fun armSettle() {
-        val delayNanos = (lastActivityNanos() + currentThresholdNanos() - nowNanos()).coerceAtLeast(0L)
-        scheduler.scheduleSettle(delayNanos / NANOS_PER_MS, settleRunnable)
-    }
-
-    /**
-     * Fired by the scheduler: settle if the interaction is quiet enough, else re-arm for the remainder.
-     */
-    @WorkerThread
-    private fun settleCheck() {
+    private fun onSettled(lastActivityMs: Long) {
         if (!capturing) {
             return
         }
-
-        val lastActivity = lastActivityNanos()
-        if (nowNanos() - lastActivity >= currentThresholdNanos()) {
-            enterHeld(endNanos = lastActivity)
-        } else {
-            armSettle()
-        }
+        enterHeld(endNanos = lastActivityMs * NANOS_PER_MS)
     }
 
     @WorkerThread
-    private fun lastActivityNanos(): Long = maxOf(lastRedrawVsyncNanos, lastMoveNanos)
-
-    @WorkerThread
-    private fun currentThresholdNanos(): Long = if (interacting) heldIdleThresholdNanos else idleThresholdNanos
+    private fun currentThresholdMs(): Long = if (interacting) heldIdleThresholdMs else idleThresholdMs
 
     /**
      * Emits a buffered settled result if one is pending.
@@ -187,7 +166,7 @@ internal class FocalMomentTracker(
         }
         capturing = false
         held = false
-        scheduler.cancelSettle(settleRunnable)
+        settle.cancel()
         val durationMs = (endNanos - focalMomentStartNanos) / NANOS_PER_MS
         reporter.onFocalMomentEnd(outcome, focalMomentStartEpochMs, durationMs)
     }
@@ -200,19 +179,21 @@ internal class FocalMomentTracker(
         bufferedEndNanos = endNanos
         capturing = false
         held = true
-        scheduler.cancelSettle(settleRunnable)
+        settle.cancel()
     }
 
-    private fun nowNanos(): Long = SystemClock.uptimeMillis() * NANOS_PER_MS
+    private fun nowMs(): Long = SystemClock.uptimeMillis()
+
+    private fun nowNanos(): Long = nowMs() * NANOS_PER_MS
 
     private companion object {
         const val NANOS_PER_MS = 1_000_000L
-        const val IDLE_THRESHOLD_NANOS = 100L * 1_000_000L
+        const val IDLE_THRESHOLD_MS = 100L
 
         /**
          * The "press and hold" threshold, if we don't get a "move" event (which we really should) within this time we consider the
          * interaction / focal moment settled.
          */
-        const val HELD_IDLE_THRESHOLD_NANOS = 500L * 1_000_000L
+        const val HELD_IDLE_THRESHOLD_MS = 500L
     }
 }

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTracker.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTracker.kt
@@ -60,14 +60,14 @@ internal class FocalMomentTracker(
     override fun onFrame(vsyncNanos: Long, frameDispatchNanos: Long, jankNanos: Long) {
         if (capturing) {
             recordFrame(frameDispatchNanos, jankNanos)
-            settle.notifyActivity(vsyncNanos / NANOS_PER_MS)
+            settle.notifyActivity(vsyncNanos.nanosToMillis())
         } else if (held) {
-            if (vsyncNanos - bufferedEndNanos < idleThresholdMs * NANOS_PER_MS) {
+            if (vsyncNanos - bufferedEndNanos < idleThresholdMs.millisToNanos()) {
                 // Frame is contiguous with the buffered settle: resume capturing so its jank is included.
                 held = false
                 capturing = true
                 recordFrame(frameDispatchNanos, jankNanos)
-                settle.notifyActivity(vsyncNanos / NANOS_PER_MS)
+                settle.notifyActivity(vsyncNanos.nanosToMillis())
             } else {
                 // Idle gap before this frame: emit the buffered settle and discard the orphan frame.
                 flushHeld()
@@ -112,7 +112,7 @@ internal class FocalMomentTracker(
     @WorkerThread
     private fun startFocalMoment() {
         val nowMs = nowMs()
-        focalMomentStartNanos = nowMs * NANOS_PER_MS
+        focalMomentStartNanos = nowMs.millisToNanos()
         focalMomentStartEpochMs = clock.now()
         held = false
         interacting = true
@@ -127,7 +127,7 @@ internal class FocalMomentTracker(
         // back-date the start to when the engine dispatched the frame's work, if that predates the
         // moment, shifting the reported start epoch by the same amount so the end stays put.
         if (frameDispatchNanos < focalMomentStartNanos) {
-            focalMomentStartEpochMs -= (focalMomentStartNanos - frameDispatchNanos) / NANOS_PER_MS
+            focalMomentStartEpochMs -= (focalMomentStartNanos - frameDispatchNanos).nanosToMillis()
             focalMomentStartNanos = frameDispatchNanos
         }
 
@@ -143,7 +143,7 @@ internal class FocalMomentTracker(
         if (!capturing) {
             return
         }
-        enterHeld(endNanos = lastActivityMs * NANOS_PER_MS)
+        enterHeld(endNanos = lastActivityMs.millisToNanos())
     }
 
     @WorkerThread
@@ -167,7 +167,7 @@ internal class FocalMomentTracker(
         capturing = false
         held = false
         settle.cancel()
-        val durationMs = (endNanos - focalMomentStartNanos) / NANOS_PER_MS
+        val durationMs = (endNanos - focalMomentStartNanos).nanosToMillis()
         reporter.onFocalMomentEnd(outcome, focalMomentStartEpochMs, durationMs)
     }
 
@@ -184,10 +184,15 @@ internal class FocalMomentTracker(
 
     private fun nowMs(): Long = SystemClock.uptimeMillis()
 
-    private fun nowNanos(): Long = nowMs() * NANOS_PER_MS
+    private fun nowNanos(): Long = nowMs().millisToNanos()
+
+    /** This nanosecond timestamp/duration as whole milliseconds, truncating any sub-millisecond remainder. */
+    private fun Long.nanosToMillis(): Long = this / NANOS_PER_MS
+
+    /** This millisecond timestamp/duration as nanoseconds. */
+    private fun Long.millisToNanos(): Long = this * NANOS_PER_MS
 
     private companion object {
-        const val NANOS_PER_MS = 1_000_000L
         const val IDLE_THRESHOLD_MS = 100L
 
         /**
@@ -195,5 +200,7 @@ internal class FocalMomentTracker(
          * interaction / focal moment settled.
          */
         const val HELD_IDLE_THRESHOLD_MS = 500L
+
+        const val NANOS_PER_MS = 1_000_000L
     }
 }

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/SettleTrackerTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/SettleTrackerTest.kt
@@ -1,0 +1,121 @@
+package io.embrace.android.embracesdk.internal.vitals
+
+import android.os.SystemClock
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.internal.vitals.fake.FakeVitalsScheduler
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.shadows.ShadowSystemClock
+import java.time.Duration
+
+@RunWith(AndroidJUnit4::class)
+internal class SettleTrackerTest {
+
+    private val scheduler = FakeVitalsScheduler()
+    private val settledAt = mutableListOf<Long>()
+
+    // A threshold the test can change to model a shrinking/growing window (e.g. smoothness held -> idle).
+    private var thresholdMs = 100L
+    private val settle = SettleTracker(scheduler, { thresholdMs }, settledAt::add)
+
+    // SystemClock is paused by Robolectric until advance() moves it; baselines are relative to start.
+    private val start = SystemClock.uptimeMillis()
+
+    @Test
+    fun `the first activity schedules the check and later activity only moves the baseline`() {
+        settle.notifyActivity(start)
+        assertTrue(scheduler.scheduled)
+        assertEquals("first activity schedules once", 1, scheduler.scheduleCount)
+        assertEquals(100L, scheduler.lastDelayMs)
+
+        // Further activity while scheduled must not re-post — the pending check re-evaluates at expiry.
+        advance(20)
+        settle.notifyActivity(start + 20)
+        settle.notifyActivity(start + 40)
+        assertEquals("steady-state activity does no handler work", 1, scheduler.scheduleCount)
+        assertEquals(start + 40, settle.lastActivityMs)
+    }
+
+    @Test
+    fun `it settles only once quiet for the threshold, re-scheduling for the remainder otherwise`() {
+        settle.notifyActivity(start)
+
+        // 60ms since the baseline: under threshold -> reschedule, no settle.
+        advance(60)
+        scheduler.runPending()
+        assertTrue(settledAt.isEmpty())
+        assertTrue(scheduler.scheduled)
+        assertEquals("re-scheduled for the remainder", 2, scheduler.scheduleCount)
+
+        // 100ms since the baseline: at threshold -> settle at the baseline.
+        advance(40)
+        scheduler.runPending()
+        assertEquals(listOf(start), settledAt)
+    }
+
+    @Test
+    fun `a moved baseline pushes the settle out`() {
+        settle.notifyActivity(start)
+        advance(60)
+        settle.notifyActivity(start + 60) // fresh activity moves the baseline
+
+        // 100ms after the original baseline, but only 40ms after the latest activity: not settled.
+        advance(40)
+        scheduler.runPending()
+        assertTrue(settledAt.isEmpty())
+
+        // 100ms after the latest activity: settles at that baseline.
+        advance(60)
+        scheduler.runPending()
+        assertEquals(listOf(start + 60), settledAt)
+    }
+
+    @Test
+    fun `reschedule re-posts the settle when the threshold shrinks`() {
+        thresholdMs = 500L
+        settle.notifyActivity(start)
+        assertEquals(500L, scheduler.lastDelayMs)
+
+        // The window shrinks; reschedule re-posts at the now-earlier deadline.
+        thresholdMs = 100L
+        settle.reschedule()
+        assertEquals(2, scheduler.scheduleCount)
+        assertEquals(100L, scheduler.lastDelayMs)
+
+        advance(100)
+        scheduler.runPending()
+        assertEquals(listOf(start), settledAt)
+    }
+
+    @Test
+    fun `reschedule is a no-op when nothing is active`() {
+        settle.reschedule()
+        assertFalse(scheduler.scheduled)
+        assertEquals(0, scheduler.scheduleCount)
+    }
+
+    @Test
+    fun `cancel clears the baseline and the pending settle, and the next activity starts fresh`() {
+        settle.notifyActivity(start)
+        advance(30)
+        settle.cancel()
+        assertFalse(scheduler.scheduled)
+        assertEquals(0L, settle.lastActivityMs)
+
+        // Running the check after cancel does nothing (the tracker is inactive).
+        scheduler.runPending()
+        assertTrue(settledAt.isEmpty())
+
+        // The next moment schedules anew from the new baseline.
+        settle.notifyActivity(start + 30)
+        assertTrue(scheduler.scheduled)
+        advance(100)
+        scheduler.runPending()
+        assertEquals(listOf(start + 30), settledAt)
+    }
+
+    private fun advance(millis: Long) = ShadowSystemClock.advanceBy(Duration.ofMillis(millis))
+}

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/fake/FakeVitalsScheduler.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/fake/FakeVitalsScheduler.kt
@@ -1,0 +1,33 @@
+package io.embrace.android.embracesdk.internal.vitals.fake
+
+import io.embrace.android.embracesdk.internal.vitals.VitalsScheduler
+
+/**
+ * Records what was scheduled and lets the test run the pending settle check. Ignores the delay (the test
+ * drives time via [org.robolectric.shadows.ShadowSystemClock], and the tracker decides settle-vs-reschedule by reading the clock).
+ */
+internal class FakeVitalsScheduler : VitalsScheduler {
+    private var pending: Runnable? = null
+    var scheduleCount = 0
+    var lastDelayMs = -1L
+    val scheduled: Boolean get() = pending != null
+
+    override fun post(action: Runnable) = action.run()
+
+    override fun scheduleSettle(delayMs: Long, action: Runnable) {
+        scheduleCount++
+        lastDelayMs = delayMs
+        pending = action
+    }
+
+    override fun cancelSettle(action: Runnable) {
+        if (pending === action) {
+            pending = null
+        }
+    }
+
+    /**
+     * Runs the pending settle check, as the scheduler would once the delay elapses.
+     */
+    fun runPending() = pending?.run() ?: Unit
+}

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTrackerTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTrackerTest.kt
@@ -3,7 +3,7 @@ package io.embrace.android.embracesdk.internal.vitals.smoothness
 import android.os.SystemClock
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.internal.clock.Clock
-import io.embrace.android.embracesdk.internal.vitals.VitalsScheduler
+import io.embrace.android.embracesdk.internal.vitals.fake.FakeVitalsScheduler
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -14,26 +14,7 @@ import java.time.Duration
 
 @RunWith(AndroidJUnit4::class)
 internal class FocalMomentTrackerTest {
-
-    /** Runs posted (hopped) work synchronously and lets the test fire the single pending settle. */
-    private class FakeScheduler : VitalsScheduler {
-        private var pending: Runnable? = null
-        val settleArmed: Boolean get() = pending != null
-        override fun post(action: Runnable) = action.run()
-        override fun scheduleSettle(delayMs: Long, action: Runnable) {
-            pending = action
-        }
-
-        override fun cancelSettle(action: Runnable) {
-            if (pending === action) {
-                pending = null
-            }
-        }
-
-        fun fireSettle() = pending?.run() ?: Unit
-    }
-
-    private val scheduler = FakeScheduler()
+    private val scheduler = FakeVitalsScheduler()
     private val emitted = mutableListOf<SmoothnessResult>()
 
     private val tracker = FocalMomentTracker(
@@ -49,7 +30,7 @@ internal class FocalMomentTrackerTest {
     @Test
     fun `after release the aftermath settles at the tighter threshold and emits on flush`() {
         tracker.onInteractionStart()
-        assertTrue(scheduler.settleArmed)
+        assertTrue(scheduler.scheduled)
 
         redraw(vsyncNanos = start + 16.ms, jankNanos = 4.ms)
         tracker.onInteractionEnd() // finger up -> 100ms threshold
@@ -57,12 +38,12 @@ internal class FocalMomentTrackerTest {
         // 34ms since last activity: under the tight threshold, not settled
         settleAfter(50)
         assertTrue("not settled yet", emitted.isEmpty())
-        assertTrue(scheduler.settleArmed)
+        assertTrue(scheduler.scheduled)
 
         // 134ms since last activity: past the tight threshold (a held finger would still wait on 500ms)
         settleAfter(100)
         assertTrue("held, not emitted", emitted.isEmpty())
-        assertFalse(scheduler.settleArmed)
+        assertFalse(scheduler.scheduled)
 
         // detach flushes, dated from start to last activity (16ms in)
         tracker.onScreenStop()
@@ -78,12 +59,12 @@ internal class FocalMomentTrackerTest {
 
         // 134ms since activity: past the tight threshold but the finger is still down, so not settled
         settleAfter(150)
-        assertTrue("held finger uses the longer grace", scheduler.settleArmed)
+        assertTrue("held finger uses the longer grace", scheduler.scheduled)
         assertTrue(emitted.isEmpty())
 
         // 534ms since activity: past the held grace
         settleAfter(400)
-        assertFalse(scheduler.settleArmed)
+        assertFalse(scheduler.scheduled)
 
         tracker.onScreenStop()
         assertEquals(FocalOutcome.SETTLED, emitted.single().outcome)
@@ -100,12 +81,12 @@ internal class FocalMomentTrackerTest {
 
         // without the move this would have settled by 500ms; the move pushed the baseline out
         settleAfter(100) // now 500ms; 100ms since the move
-        assertTrue("not settled: the move refreshed liveness", scheduler.settleArmed)
+        assertTrue("not settled: the move refreshed liveness", scheduler.scheduled)
         assertTrue(emitted.isEmpty())
 
         // settles 500ms after the move
         settleAfter(400) // now 900ms; 500ms since the move
-        assertFalse(scheduler.settleArmed)
+        assertFalse(scheduler.scheduled)
     }
 
     @Test
@@ -115,14 +96,14 @@ internal class FocalMomentTrackerTest {
 
         // no further activity: the held grace elapses and the focal moment enters held
         settleAfter(600)
-        assertFalse(scheduler.settleArmed)
+        assertFalse(scheduler.scheduled)
         assertTrue("held, not yet emitted", emitted.isEmpty())
 
         // the finger never lifted; resuming the drag flushes the buffered settle and opens a new one
         tracker.onInteractionMove()
         assertEquals(FocalOutcome.SETTLED, emitted.single().outcome)
         assertEquals(16L, emitted.single().durationMs)
-        assertTrue("a fresh interaction opened", scheduler.settleArmed)
+        assertTrue("a fresh interaction opened", scheduler.scheduled)
     }
 
     @Test
@@ -132,11 +113,11 @@ internal class FocalMomentTrackerTest {
 
         // 99ms: one ms short of the tight threshold (a held finger would wait 500ms)
         settleAfter(99)
-        assertTrue(scheduler.settleArmed)
+        assertTrue(scheduler.scheduled)
 
         // 100ms: at the tight threshold -> held
         settleAfter(1)
-        assertFalse(scheduler.settleArmed)
+        assertFalse(scheduler.scheduled)
     }
 
     @Test
@@ -149,7 +130,7 @@ internal class FocalMomentTrackerTest {
         val result = emitted.single()
         assertEquals(FocalOutcome.INTERRUPTED, result.outcome)
         assertEquals(40L, result.durationMs)
-        assertFalse("startup opens nothing", scheduler.settleArmed)
+        assertFalse("startup opens nothing", scheduler.scheduled)
     }
 
     @Test
@@ -163,7 +144,7 @@ internal class FocalMomentTrackerTest {
         }
 
         assertTrue("an active interaction has no cap", emitted.isEmpty())
-        assertTrue(scheduler.settleArmed)
+        assertTrue(scheduler.scheduled)
     }
 
     @Test
@@ -176,7 +157,7 @@ internal class FocalMomentTrackerTest {
         val result = emitted.single()
         assertEquals(FocalOutcome.INTERRUPTED, result.outcome)
         assertEquals(30L, result.durationMs)
-        assertFalse(scheduler.settleArmed)
+        assertFalse(scheduler.scheduled)
     }
 
     @Test
@@ -185,18 +166,18 @@ internal class FocalMomentTrackerTest {
         tracker.onInteractionEnd() // finger up -> tight threshold
         redraw(vsyncNanos = start + 16.ms) // last known frame
 
-        // The main thread was blocked building a slow frame; the settle timeout fires before that
+        // The main thread was blocked building a slow frame; the settle timeout elapses before that
         // frame's metrics are delivered.
         settleAfter(200)
-        assertFalse("held, not emitted", scheduler.settleArmed)
+        assertFalse("held, not emitted", scheduler.scheduled)
         assertTrue(emitted.isEmpty())
 
         // the slow frame's metrics finally arrive (contiguous vsync) and wake the held tracker
         redraw(vsyncNanos = start + 20.ms, jankNanos = 8.ms)
-        assertTrue("resumed", scheduler.settleArmed)
+        assertTrue("resumed", scheduler.scheduled)
 
         // it re-settles, and the flush includes the late frame's jank
-        scheduler.fireSettle()
+        scheduler.runPending()
         tracker.onScreenStop()
 
         val result = emitted.single()
@@ -220,7 +201,7 @@ internal class FocalMomentTrackerTest {
         )
 
         settleAfter(200)
-        assertFalse("held", scheduler.settleArmed)
+        assertFalse("held", scheduler.scheduled)
 
         tracker.onScreenStop()
         val result = emitted.single()
@@ -240,7 +221,7 @@ internal class FocalMomentTrackerTest {
         redraw(vsyncNanos = start + 16.ms)
         settleAfter(120) // past the tight threshold -> held
         assertTrue(emitted.isEmpty())
-        assertFalse(scheduler.settleArmed)
+        assertFalse(scheduler.scheduled)
 
         // a redraw long after the gap (e.g. an async repaint with no trigger) flushes the settle
         redraw(vsyncNanos = start + 5000.ms, jankNanos = 4.ms)
@@ -249,7 +230,7 @@ internal class FocalMomentTrackerTest {
         assertEquals(FocalOutcome.SETTLED, result.outcome)
         assertEquals(16L, result.durationMs)
         assertEquals("orphan frame is part of no focal moment", 0.0, result.normalizedDroppedFrames, 0.0)
-        assertFalse(scheduler.settleArmed)
+        assertFalse(scheduler.scheduled)
     }
 
     @Test
@@ -275,10 +256,10 @@ internal class FocalMomentTrackerTest {
 
     private fun advance(millis: Long) = ShadowSystemClock.advanceBy(Duration.ofMillis(millis))
 
-    /** Advances the clock by [millis] and then fires the pending settle check. */
+    /** Advances the clock by [millis] and then runs the pending settle check. */
     private fun settleAfter(millis: Long) {
         advance(millis)
-        scheduler.fireSettle()
+        scheduler.runPending()
     }
 
     /**

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTrackerTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTrackerTest.kt
@@ -24,8 +24,10 @@ internal class FocalMomentTrackerTest {
             pending = action
         }
 
-        override fun cancelSettle() {
-            pending = null
+        override fun cancelSettle(action: Runnable) {
+            if (pending === action) {
+                pending = null
+            }
         }
 
         fun fireSettle() = pending?.run() ?: Unit

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTrackerTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTrackerTest.kt
@@ -20,7 +20,7 @@ internal class FocalMomentTrackerTest {
     private val tracker = FocalMomentTracker(
         scheduler = scheduler,
         reporter = SmoothnessReporter(emit = emitted::add),
-        clock = Clock { 0L },
+        clock = { 0L },
     )
 
     // The tracker reads time from SystemClock.uptimeMillis; Robolectric keeps it paused until advance()


### PR DESCRIPTION
## Goal

Added the `SettleTracker` to encapsulate the state and logic for tracking UI settling with a variable duration threshold. The `SettleTracker` handles the efficient scheduling and cancelling of the "settled" marker (only one task is scheduled at a time per `SettleTracker`, and we avoid cancelling the task where possible).

The `VitalsScheduler` now uses the `Runnable` tasks as a key, so that any number of different settle thresholds can be tracked concurrently. This allows different vitals to consider different durations for settling (ie: smoothness uses 100ms, while screen load uses 1000ms).

<!-- Describe how this change has been tested -->