### PR TITLE
feat(vitals): implemented ScreenLoadTracker to track screen loads and report ScreenLoadResult events

### DIFF
--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
@@ -160,36 +160,32 @@ internal class AutoDataCaptureBehaviorImplTest {
     @Test
     fun `isNetworkCallbackConnectivityServiceEnabled true when pct is 100`() {
         assertTrue(
-            createAutoDataCaptureBehavior(
-                remoteCfg = RemoteConfig(pctNetworkCallbackConnectivityServiceEnabled = 100.0f),
-            ).isNetworkCallbackConnectivityServiceEnabled(),
+            createAutoDataCaptureBehavior(remoteCfg = RemoteConfig(pctNetworkCallbackConnectivityServiceEnabled = 100.0f))
+                .isNetworkCallbackConnectivityServiceEnabled(),
         )
     }
 
     @Test
     fun `isNetworkCallbackConnectivityServiceEnabled false when pct is 0`() {
         assertFalse(
-            createAutoDataCaptureBehavior(
-                remoteCfg = RemoteConfig(pctNetworkCallbackConnectivityServiceEnabled = 0.0f),
-            ).isNetworkCallbackConnectivityServiceEnabled(),
+            createAutoDataCaptureBehavior(remoteCfg = RemoteConfig(pctNetworkCallbackConnectivityServiceEnabled = 0.0f))
+                .isNetworkCallbackConnectivityServiceEnabled(),
         )
     }
 
     @Test
     fun `navigation state capture enabled when pct is 100`() {
         assertTrue(
-            createBehavior(
-                remote = RemoteConfig(pctNavigationStateCaptureEnabled = 100.0f),
-            ).isNavigationStateCaptureEnabled(),
+            createBehavior(remote = RemoteConfig(pctNavigationStateCaptureEnabled = 100.0f))
+                .isNavigationStateCaptureEnabled(),
         )
     }
 
     @Test
     fun `navigation state capture disabled when pct is 0`() {
         assertFalse(
-            createBehavior(
-                remote = RemoteConfig(pctNavigationStateCaptureEnabled = 0.0f),
-            ).isNavigationStateCaptureEnabled(),
+            createBehavior(remote = RemoteConfig(pctNavigationStateCaptureEnabled = 0.0f))
+                .isNavigationStateCaptureEnabled(),
         )
     }
 
@@ -201,18 +197,16 @@ internal class AutoDataCaptureBehaviorImplTest {
     @Test
     fun `smoothness capture enabled when pct is 100`() {
         assertTrue(
-            createBehavior(
-                remote = RemoteConfig(pctSmoothnessEnabled = 100.0f)
-            ).isSmoothnessCaptureEnabled()
+            createBehavior(remote = RemoteConfig(pctSmoothnessEnabled = 100.0f))
+                .isSmoothnessCaptureEnabled(),
         )
     }
 
     @Test
     fun `smoothness capture disabled when pct is 0`() {
         assertFalse(
-            createBehavior(
-                remote = RemoteConfig(pctSmoothnessEnabled = 0.0f)
-            ).isSmoothnessCaptureEnabled()
+            createBehavior(remote = RemoteConfig(pctSmoothnessEnabled = 0.0f))
+                .isSmoothnessCaptureEnabled(),
         )
     }
 

--- a/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
+++ b/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
@@ -262,12 +262,12 @@ sealed class SchemaType(
         normalizedDroppedFrames: Double,
     ) : SchemaType(
         telemetryType = EmbType.Performance.Smoothness,
-        fixedObjectName = "smoothness"
+        fixedObjectName = "smoothness",
     ) {
         override val schemaAttributes: Map<String, String> = mapOf(
             EmbSmoothnessAttributes.SMOOTHNESS_OUTCOME to outcome,
             EmbSmoothnessAttributes.SMOOTHNESS_FRAME_COUNT to frameCount.toString(),
-            EmbSmoothnessAttributes.SMOOTHNESS_NORMALIZED_DROPPED_FRAMES to normalizedDroppedFrames.toString()
+            EmbSmoothnessAttributes.SMOOTHNESS_NORMALIZED_DROPPED_FRAMES to normalizedDroppedFrames.toString(),
         )
     }
 

--- a/embrace-android-instrumentation-vitals/SCREEN_LOAD.md
+++ b/embrace-android-instrumentation-vitals/SCREEN_LOAD.md
@@ -1,0 +1,54 @@
+## Screen Load Vital
+
+A screen load measures the time from a user's initial interaction until the destination screen has
+*settled* (gone quiet). Settling is the same measurement used to determine the interaction-end for the
+Smoothness vital, but where smoothness measures framerate quality during an interaction, the screen load
+measures how long the destination takes to become interactive.
+
+### The event sequence
+
+A screen load is built from four signals, driven onto the Vitals handler thread by the focal-moment
+tracker:
+
+1. **Tap** (touch up) — a committed user action that may trigger a navigation. Opens a *candidate*.
+2. **Navigation start** — confirms the candidate is a real navigation.
+3. **Navigation end** — the destination is reached; arms the settle.
+4. **Settle** — the destination goes quiet for the idle threshold; the load ends.
+
+The tap is the start because it precedes the navigation and captures the click handler, `startActivity`,
+and the destination launching — but the press-and-hold dwell before release is user behaviour, not load
+latency, so the release (not the touch-down) anchors the load. A *touchless* navigation (e.g. an Activity
+transition with no preceding tap) instead anchors the load at the navigation start itself.
+
+If either the navigation start or the navigation end is missing, the duration is not considered a screen
+load. The screen name comes from the navigation start or end (last writer wins, so an immediate redirect
+resolves to the final destination). The navigation signals are deliberately abstracted internal hooks so
+that other instrumentations (such as `embrace-android-instrumentation-navigation`) can drive them.
+
+### Outcomes
+
+A load that goes quiet on its own is reported as `SETTLED`, ending at its last rendered activity. Once
+navigation end has armed the settle, three other things can end it:
+
+- **`NAVIGATION_INTERRUPTED`** — a new (touchless) navigation starts while the destination is still
+  settling. The destination was shown long enough to navigate away from, so it is treated as loaded: the
+  in-flight load is settled at its last rendered activity (last frame or focus gain, not the interrupting
+  navigation moment), and a fresh load opens for the new destination. A rapid redirect therefore emits two
+  loads — the first (`NAVIGATION_INTERRUPTED`) and the second — rather than folding into one. An
+  interruption preceded by a fresh tap is a `USER_INTERRUPTED` instead, since the tap proves the screen was
+  interactive.
+- **`TIMED_OUT`** — a destination with continuously animating content never goes quiet, so the settle would
+  never occur and the load would run forever. To bound this, a load is given up 30 seconds after it starts.
+  Because the screen never actually settled, the end time is the first frame rendered *after* navigation end
+  — the earliest plausible "loaded" moment — rather than the 30s mark. A timeout reached before navigation
+  end is an incomplete sequence and is not reported.
+- **`USER_INTERRUPTED`** — the user taps the still-settling destination. The screen was interactive enough
+  to act on, so the load ends at that tap rather than waiting for a settle the user has pre-empted. (A tap
+  before navigation end is not a real screen load yet, so it is discarded and starts a fresh candidate.)
+
+### Window focus
+
+The destination's open-transition animation renders no app frames (the system composites it), so the
+frame-driven settle cannot see it. When the window gains input focus — the animation has finished and the
+screen is interactive — that moment is treated as activity, extending an in-flight load to cover the
+animation tail rather than ending it at the last content frame.

--- a/embrace-android-instrumentation-vitals/build.gradle.kts
+++ b/embrace-android-instrumentation-vitals/build.gradle.kts
@@ -10,6 +10,7 @@ android {
 
 dependencies {
     implementation(libs.androidx.annotation)
+    implementation(project(":embrace-android-infra"))
     implementation(project(":embrace-android-instrumentation-api"))
 
     testImplementation(project(":embrace-android-instrumentation-api-fakes"))

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsActivityListener.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsActivityListener.kt
@@ -50,7 +50,6 @@ internal class VitalsActivityListener(
         if (window.callback !is VitalsWindowCallback) {
             window.callback = VitalsWindowCallback(
                 delegate = window.callback,
-                logger = logger,
                 focalCallbacks = focalCallbacks,
             )
         }

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsWindowCallback.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsWindowCallback.kt
@@ -5,7 +5,6 @@ import android.view.KeyboardShortcutGroup
 import android.view.Menu
 import android.view.MotionEvent
 import android.view.Window
-import io.embrace.android.embracesdk.internal.logging.InternalLogger
 
 /**
  * Wraps a [Window.Callback] to report interactions from touch dispatch: a touch-down starts an
@@ -14,19 +13,17 @@ import io.embrace.android.embracesdk.internal.logging.InternalLogger
  */
 internal class VitalsWindowCallback(
     private val delegate: Window.Callback,
-    private val logger: InternalLogger,
     private val focalCallbacks: FocalInteractionCallbacks,
 ) : Window.Callback by delegate {
 
-    override fun dispatchTouchEvent(event: MotionEvent?): Boolean {
+    override fun dispatchTouchEvent(event: MotionEvent): Boolean {
         try {
-            when (event?.actionMasked) {
+            when (event.actionMasked) {
                 MotionEvent.ACTION_DOWN -> focalCallbacks.onInteractionStart()
                 MotionEvent.ACTION_MOVE -> focalCallbacks.onInteractionMove()
                 MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> focalCallbacks.onInteractionEnd()
             }
-        } catch (e: Throwable) {
-            logger.logError("Vitals touch event dispatch failed", e)
+        } catch (_: Throwable) {
         }
         return delegate.dispatchTouchEvent(event)
     }

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadOutcome.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadOutcome.kt
@@ -1,0 +1,32 @@
+package io.embrace.android.embracesdk.internal.vitals.screenload
+
+/**
+ * How a screen load ended.
+ */
+internal enum class ScreenLoadOutcome {
+    /**
+     * The destination settled: it went quiet for the idle threshold within the timeout.
+     */
+    SETTLED,
+
+    /**
+     * The destination never settled within the timeout (e.g. continuously animating content). The load
+     * is reported ending at the first frame after navigation end — the earliest plausible "loaded" moment.
+     */
+    TIMED_OUT,
+
+    /**
+     * The user tapped again after navigation end, while the destination was still settling — the screen
+     * was interactive enough to act on, so the load is reported ending at that tap rather than waiting for
+     * a settle the user pre-empted.
+     */
+    USER_INTERRUPTED,
+
+    /**
+     * A new (touchless) navigation started while the destination was still settling — the screen was shown
+     * long enough to navigate away from, so it is treated as loaded and reported ending at its last
+     * rendered activity (frame or focus gain), not the interrupting navigation moment. A fresh load opens
+     * for the new destination. An interruption preceded by a fresh tap is a [USER_INTERRUPTED] instead.
+     */
+    NAVIGATION_INTERRUPTED,
+}

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadResult.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadResult.kt
@@ -1,0 +1,23 @@
+package io.embrace.android.embracesdk.internal.vitals.screenload
+
+/**
+ * A completed screen-load measurement: the time from the initial interaction until the destination screen settled.
+ */
+internal data class ScreenLoadResult(
+    /**
+     * Wall-clock (epoch millis) start of the load, typically the tap that triggered the navigation event.
+     */
+    val startTimeMs: Long,
+    /**
+     * Load duration (initial interaction to settle), in millis.
+     */
+    val durationMs: Long,
+    /**
+     * The destination screen name (last writer wins between navigation start and end).
+     */
+    val screenName: String,
+    /**
+     * How the load ended.
+     */
+    val outcome: ScreenLoadOutcome,
+)

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadResult.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadResult.kt
@@ -9,6 +9,19 @@ internal data class ScreenLoadResult(
      */
     val startTimeMs: Long,
     /**
+     * Duration from [startTimeMs] until the navigation start event that confirmed this as a screen load.
+     */
+    val navStartDelayMs: Long,
+    /**
+     * Duration from the navigation start event until the navigation end event, i.e. how long the navigation itself took.
+     */
+    val navDurationMs: Long,
+    /**
+     * Duration from the navigation end event until the first frame rendered on the destination, or 0 if no frame arrived
+     * before the load completed.
+     */
+    val firstFrameDurationMs: Long,
+    /**
      * Load duration (initial interaction to settle), in millis.
      */
     val durationMs: Long,

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTracker.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTracker.kt
@@ -1,0 +1,254 @@
+package io.embrace.android.embracesdk.internal.vitals.screenload
+
+import android.os.SystemClock
+import android.os.SystemClock.uptimeMillis
+import androidx.annotation.WorkerThread
+import io.embrace.android.embracesdk.internal.clock.Clock
+import io.embrace.android.embracesdk.internal.clock.nanosToMillis
+import io.embrace.android.embracesdk.internal.vitals.SettleTracker
+import io.embrace.android.embracesdk.internal.vitals.VitalsScheduler
+
+/**
+ * Tracks the screen-load vital: the time from a user's tap until the destination screen settles.
+ *
+ * All times are milliseconds relative to [SystemClock.uptimeMillis], except [ScreenLoadResult.startTimeMs] which is wall-clock epoch.
+ */
+internal class ScreenLoadTracker(
+    private val scheduler: VitalsScheduler,
+    private val clock: Clock,
+    private val emit: (ScreenLoadResult) -> Unit,
+    private val idleThresholdMs: Long = IDLE_THRESHOLD_MS,
+    private val timeoutMs: Long = SETTLE_TIMEOUT_MS,
+) {
+    private val settle = SettleTracker(scheduler, { idleThresholdMs }, ::onSettled)
+
+    private var state = State.IDLE
+    private var screenName = ""
+    private var startUptimeMs = 0L
+    private var startWallMs = 0L
+
+    // A continuously animating screen keeps pushing the settle baseline out, so the load would never
+    // settle. This timeout Runnable force-settles the screen load with a TIMED_OUT outcome.
+    private val timeoutRunnable = Runnable { onTimeout() }
+
+    // The first frame rendered after navigation end (0 until one arrives). On a timeout this is the
+    // reported end of the load - the earliest plausible "loaded" moment, since the destination never
+    // actually settled.
+    private var firstFrameAfterNavEndMs = 0L
+
+    // When the settle was armed by navigation end; the timeout end falls back to this if no frame followed.
+    private var navEndMs = 0L
+
+    /**
+     * Signal a committed tap (touch up) to open a fresh **candidate** screen load (discarding any in-flight). The touch-up / tap event
+     * is the "start" of a screen load duration (assuming that [onNavigationStart] confirms that this tap is a navigation event). The
+     * [eventTime] can be specified relative to [uptimeMillis] to accurately anchor the screen load to the user interaction.
+     *
+     * If the prior load was already settling (the tap landed *after* navigation end), the user acted on a
+     * screen that was interactive enough to touch: emit that load as [ScreenLoadOutcome.USER_INTERRUPTED] rather than dropping it,
+     * then open the new candidate.
+     */
+    @WorkerThread
+    fun onTap(eventTime: Long = uptimeMillis()) {
+        if (state == State.SETTLING) {
+            complete(endMs = eventTime, outcome = ScreenLoadOutcome.USER_INTERRUPTED)
+        }
+        settle.cancel()
+        state = State.CANDIDATE
+        screenName = ""
+        startUptimeMs = eventTime
+
+        val startUptimeDelta = uptimeMillis() - startUptimeMs
+        startWallMs = clock.now() - startUptimeDelta
+        scheduleTimeout()
+    }
+
+    /**
+     * Signal a navigation start, which confirms a real screen load (typically including the time since [onTap]). If the destination
+     * [screenName] is known here it should be specified as non-`null`.
+     */
+    @WorkerThread
+    fun onNavigationStart(screenName: String? = null) {
+        when (state) {
+            State.IDLE -> openLoad()
+            State.CANDIDATE -> {
+                val now = uptimeMillis()
+                if (now <= startUptimeMs + NAVIGATION_TIMEOUT_MS) {
+                    state = State.CONFIRMED
+                } else {
+                    // the previous "tap" event is too far in the past to be considered part of the screen load
+                    // so we move the "start time" to now
+                    openLoad()
+                }
+            }
+
+            State.CONFIRMED -> {}
+            State.SETTLING -> {
+                // flush the current screen load before we start another one
+                complete(endMs = settle.lastActivityMs, outcome = ScreenLoadOutcome.NAVIGATION_INTERRUPTED)
+                openLoad()
+            }
+        }
+
+        // make sure that screenName isn't leftover from a previous navigation
+        this.screenName = screenName ?: ""
+    }
+
+    /**
+     * Signal the end of a navigation, recording that the destination has been reached (updating the screen name if [screenName] is not
+     * `null`).
+     */
+    @WorkerThread
+    fun onNavigationEnd(screenName: String? = null) {
+        if (state != State.CONFIRMED && state != State.SETTLING) {
+            return
+        }
+
+        screenName?.let {
+            this.screenName = it
+        }
+
+        val now = uptimeMillis()
+        if (state == State.CONFIRMED) {
+            // the screen load can now be considered "settling"
+            state = State.SETTLING
+            navEndMs = now
+            firstFrameAfterNavEndMs = 0L
+        }
+
+        settle.notifyActivity(now)
+    }
+
+    /** A frame on the destination pushes the settle baseline out while it keeps rendering. */
+    @WorkerThread
+    fun onFrame(vsyncNanos: Long) {
+        if (state != State.SETTLING) {
+            return
+        }
+
+        val vsyncMs = vsyncNanos.nanosToMillis()
+        if (firstFrameAfterNavEndMs == 0L) {
+            firstFrameAfterNavEndMs = vsyncMs
+        }
+
+        settle.notifyActivity(vsyncMs)
+    }
+
+    /**
+     * The destination's window gained focus: its open animation has finished. These animations render no app frames, so [onFrame] isn't
+     * called. We treat the "focused" event as activity to push the settle baseline out.
+     */
+    @WorkerThread
+    fun onWindowFocused() {
+        if (state != State.SETTLING) {
+            return
+        }
+
+        settle.notifyActivity(uptimeMillis())
+    }
+
+    /**
+     * The load was interrupted (e.g. backgrounded): abandon the candidate, emitting nothing.
+     */
+    @WorkerThread
+    fun onInterrupt() {
+        discard()
+    }
+
+    private fun onSettled(lastActivityMs: Long) {
+        if (state != State.SETTLING) {
+            return
+        }
+
+        complete(endMs = lastActivityMs, outcome = ScreenLoadOutcome.SETTLED)
+    }
+
+    /**
+     * The load ran for [timeoutMs] without settling - a continuously animating destination would loop  forever otherwise. Only a load that
+     * reached [State.SETTLING] (a confirmed navigation start *and* end) is a real screen load; report it ending at the first frame after
+     * navigation end (falling back to the navigation-end moment if none arrived). Any other state is an incomplete sequence: discard it.
+     */
+    private fun onTimeout() {
+        if (state != State.SETTLING) {
+            discard()
+            return
+        }
+
+        val endMs = if (firstFrameAfterNavEndMs != 0L) firstFrameAfterNavEndMs else navEndMs
+        complete(endMs = endMs, outcome = ScreenLoadOutcome.TIMED_OUT)
+    }
+
+    private fun openLoad() {
+        state = State.CONFIRMED
+        screenName = ""
+        startUptimeMs = uptimeMillis()
+        startWallMs = clock.now()
+        scheduleTimeout()
+    }
+
+    private fun complete(endMs: Long, outcome: ScreenLoadOutcome) {
+        val result = ScreenLoadResult(
+            startTimeMs = startWallMs,
+            durationMs = endMs - startUptimeMs,
+            screenName = screenName,
+            outcome = outcome,
+        )
+
+        discard()
+        emit(result)
+    }
+
+    private fun scheduleTimeout() {
+        scheduler.scheduleSettle(timeoutMs, timeoutRunnable)
+    }
+
+    private fun discard() {
+        state = State.IDLE
+        settle.cancel()
+        scheduler.cancelSettle(timeoutRunnable)
+    }
+
+    private companion object {
+        /**
+         * How long the UI must be idle before it is considered settled. See [SettleTracker] for details.
+         */
+        const val IDLE_THRESHOLD_MS = 1000L
+
+        /**
+         * Maximum time allowed for a screen to settle. Once this timeout has passed the screen load is reported with a duration that
+         * does not include the settling time, but with an outcome of [ScreenLoadOutcome.TIMED_OUT].
+         */
+        const val SETTLE_TIMEOUT_MS = 30_000L
+
+        /**
+         * The maximum time between a tap and [onNavigationStart] for the two events to be considered "linked" within a single screen load.
+         */
+        const val NAVIGATION_TIMEOUT_MS = 500L
+    }
+
+    /**
+     * The screen-load sequence is a strict linear progression - each step is gated on the prior one - so a
+     * single state models it exactly and makes the impossible combinations unrepresentable.
+     */
+    private enum class State {
+        /**
+         * No candidate in progress.
+         */
+        IDLE,
+
+        /**
+         * A committed tap opened a candidate; awaiting a navigation start.
+         */
+        CANDIDATE,
+
+        /**
+         * A navigation start confirmed the candidate; awaiting a navigation end.
+         */
+        CONFIRMED,
+
+        /**
+         * A navigation end armed the settle; awaiting the destination to go quiet.
+         */
+        SETTLING,
+    }
+}

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTracker.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTracker.kt
@@ -39,6 +39,9 @@ internal class ScreenLoadTracker(
     // When the settle was armed by navigation end; the timeout end falls back to this if no frame followed.
     private var navEndMs = 0L
 
+    // When the navigation start confirmed the candidate as a real screen load.
+    private var navStartMs = 0L
+
     /**
      * Signal a committed tap (touch up) to open a fresh **candidate** screen load (discarding any in-flight). The touch-up / tap event
      * is the "start" of a screen load duration (assuming that [onNavigationStart] confirms that this tap is a navigation event). The
@@ -75,6 +78,7 @@ internal class ScreenLoadTracker(
                 val now = uptimeMillis()
                 if (now <= startUptimeMs + NAVIGATION_TIMEOUT_MS) {
                     state = State.CONFIRMED
+                    navStartMs = now
                 } else {
                     // the previous "tap" event is too far in the past to be considered part of the screen load
                     // so we move the "start time" to now
@@ -182,6 +186,7 @@ internal class ScreenLoadTracker(
         state = State.CONFIRMED
         screenName = ""
         startUptimeMs = uptimeMillis()
+        navStartMs = startUptimeMs
         startWallMs = clock.now()
         scheduleTimeout()
     }
@@ -189,6 +194,9 @@ internal class ScreenLoadTracker(
     private fun complete(endMs: Long, outcome: ScreenLoadOutcome) {
         val result = ScreenLoadResult(
             startTimeMs = startWallMs,
+            navStartDelayMs = navStartMs - startUptimeMs,
+            navDurationMs = navEndMs - navStartMs,
+            firstFrameDurationMs = if (firstFrameAfterNavEndMs != 0L) firstFrameAfterNavEndMs - navEndMs else 0L,
             durationMs = endMs - startUptimeMs,
             screenName = screenName,
             outcome = outcome,

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTracker.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTracker.kt
@@ -4,6 +4,8 @@ import android.os.SystemClock
 import androidx.annotation.MainThread
 import androidx.annotation.WorkerThread
 import io.embrace.android.embracesdk.internal.clock.Clock
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
+import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.vitals.FocalInteractionCallbacks
 import io.embrace.android.embracesdk.internal.vitals.SettleTracker
 import io.embrace.android.embracesdk.internal.vitals.VitalsScheduler
@@ -186,12 +188,6 @@ internal class FocalMomentTracker(
 
     private fun nowNanos(): Long = nowMs().millisToNanos()
 
-    /** This nanosecond timestamp/duration as whole milliseconds, truncating any sub-millisecond remainder. */
-    private fun Long.nanosToMillis(): Long = this / NANOS_PER_MS
-
-    /** This millisecond timestamp/duration as nanoseconds. */
-    private fun Long.millisToNanos(): Long = this * NANOS_PER_MS
-
     private companion object {
         const val IDLE_THRESHOLD_MS = 100L
 
@@ -200,7 +196,5 @@ internal class FocalMomentTracker(
          * interaction / focal moment settled.
          */
         const val HELD_IDLE_THRESHOLD_MS = 500L
-
-        const val NANOS_PER_MS = 1_000_000L
     }
 }

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/SmoothnessReporter.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/SmoothnessReporter.kt
@@ -40,7 +40,7 @@ internal class SmoothnessReporter(
                 durationMs = durationMs,
                 frameCount = frameCount,
                 normalizedDroppedFrames = normalizedDroppedFrames,
-            )
+            ),
         )
     }
 

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/SettleTrackerTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/SettleTrackerTest.kt
@@ -28,14 +28,13 @@ internal class SettleTrackerTest {
     fun `the first activity schedules the check and later activity only moves the baseline`() {
         settle.notifyActivity(start)
         assertTrue(scheduler.scheduled)
-        assertEquals("first activity schedules once", 1, scheduler.scheduleCount)
-        assertEquals(100L, scheduler.lastDelayMs)
+        assertEquals("first activity schedules once", 1, scheduler.scheduledTaskCount)
 
         // Further activity while scheduled must not re-post — the pending check re-evaluates at expiry.
         advance(20)
         settle.notifyActivity(start + 20)
         settle.notifyActivity(start + 40)
-        assertEquals("steady-state activity does no handler work", 1, scheduler.scheduleCount)
+        assertEquals("steady-state activity does no handler work", 1, scheduler.scheduledTaskCount)
         assertEquals(start + 40, settle.lastActivityMs)
     }
 
@@ -47,8 +46,7 @@ internal class SettleTrackerTest {
         advance(60)
         scheduler.runPending()
         assertTrue(settledAt.isEmpty())
-        assertTrue(scheduler.scheduled)
-        assertEquals("re-scheduled for the remainder", 2, scheduler.scheduleCount)
+        assertTrue("re-scheduled for the remainder", scheduler.scheduled)
 
         // 100ms since the baseline: at threshold -> settle at the baseline.
         advance(40)
@@ -76,17 +74,15 @@ internal class SettleTrackerTest {
     @Test
     fun `reschedule re-posts the settle when the threshold shrinks`() {
         thresholdMs = 500L
-        settle.notifyActivity(start)
-        assertEquals(500L, scheduler.lastDelayMs)
+        settle.notifyActivity(start) // would otherwise settle at start + 500
 
         // The window shrinks; reschedule re-posts at the now-earlier deadline.
         thresholdMs = 100L
         settle.reschedule()
-        assertEquals(2, scheduler.scheduleCount)
-        assertEquals(100L, scheduler.lastDelayMs)
 
-        advance(100)
-        scheduler.runPending()
+        // Firing well before the original 500ms deadline settles, proving the re-post moved it earlier.
+        advance(101)
+        scheduler.runDue()
         assertEquals(listOf(start), settledAt)
     }
 
@@ -94,7 +90,7 @@ internal class SettleTrackerTest {
     fun `reschedule is a no-op when nothing is active`() {
         settle.reschedule()
         assertFalse(scheduler.scheduled)
-        assertEquals(0, scheduler.scheduleCount)
+        assertEquals(0, scheduler.scheduledTaskCount)
     }
 
     @Test

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsWindowCallbackTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsWindowCallbackTest.kt
@@ -33,7 +33,7 @@ internal class VitalsWindowCallbackTest {
                 return true
             }
         }
-        callback = VitalsWindowCallback(delegate, args.logger, focalCallbacks)
+        callback = VitalsWindowCallback(delegate, focalCallbacks)
     }
 
     @Test

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/fake/FakeVitalsScheduler.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/fake/FakeVitalsScheduler.kt
@@ -1,33 +1,39 @@
 package io.embrace.android.embracesdk.internal.vitals.fake
 
+import android.os.SystemClock
 import io.embrace.android.embracesdk.internal.vitals.VitalsScheduler
+import java.util.IdentityHashMap
 
 /**
- * Records what was scheduled and lets the test run the pending settle check. Ignores the delay (the test
- * drives time via [org.robolectric.shadows.ShadowSystemClock], and the tracker decides settle-vs-reschedule by reading the clock).
+ * Records what was scheduled and lets the test run the pending settle check.
  */
 internal class FakeVitalsScheduler : VitalsScheduler {
-    private var pending: Runnable? = null
-    var scheduleCount = 0
-    var lastDelayMs = -1L
-    val scheduled: Boolean get() = pending != null
+    private val schedules = IdentityHashMap<Runnable, Long>()
+    val scheduled: Boolean get() = schedules.isNotEmpty()
+    val scheduledTaskCount: Int get() = schedules.size
 
     override fun post(action: Runnable) = action.run()
 
     override fun scheduleSettle(delayMs: Long, action: Runnable) {
-        scheduleCount++
-        lastDelayMs = delayMs
-        pending = action
+        schedules[action] = SystemClock.uptimeMillis() + delayMs
     }
 
     override fun cancelSettle(action: Runnable) {
-        if (pending === action) {
-            pending = null
+        schedules.remove(action)
+    }
+
+    fun runPending() {
+        val tasks = schedules.keys.toList()
+        schedules.clear()
+
+        tasks.forEach { action ->
+            action.run()
         }
     }
 
-    /**
-     * Runs the pending settle check, as the scheduler would once the delay elapses.
-     */
-    fun runPending() = pending?.run() ?: Unit
+    fun runDue(time: Long = SystemClock.uptimeMillis()) {
+        val tasks = schedules.filter { (_, scheduledTime) -> scheduledTime <= time }.map { it.key }
+        tasks.forEach { schedules.remove(it) }
+        tasks.forEach { it.run() }
+    }
 }

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTrackerTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTrackerTest.kt
@@ -2,8 +2,8 @@ package io.embrace.android.embracesdk.internal.vitals.screenload
 
 import android.os.SystemClock
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.vitals.fake.FakeVitalsScheduler
-import io.embrace.android.embracesdk.internal.vitals.millisToNanos
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -45,6 +45,9 @@ internal class ScreenLoadTrackerTest {
         assertEquals("home", result.screenName)
         assertEquals(ScreenLoadOutcome.SETTLED, result.outcome)
         assertEquals(30L, result.durationMs)
+        assertEquals("navigation started at t=10, 10ms after the tap", 10L, result.navStartDelayMs)
+        assertEquals("navigation start at t=10, navigation end at t=20", 10L, result.navDurationMs)
+        assertEquals("first frame at t=30, 10ms after navigation end (t=20)", 10L, result.firstFrameDurationMs)
         assertEquals(start, result.startTimeMs)
     }
 
@@ -61,6 +64,9 @@ internal class ScreenLoadTrackerTest {
         assertEquals("detail", result.screenName)
         assertEquals(ScreenLoadOutcome.SETTLED, result.outcome)
         assertEquals(15L, result.durationMs)
+        assertEquals("no preceding tap, so no delay before the navigation start", 0L, result.navStartDelayMs)
+        assertEquals(15L, result.navDurationMs)
+        assertEquals("no frame arrived before the settle", 0L, result.firstFrameDurationMs)
     }
 
     @Test
@@ -75,6 +81,9 @@ internal class ScreenLoadTrackerTest {
         val result = emitted.single()
         assertEquals(ScreenLoadOutcome.USER_INTERRUPTED, result.outcome)
         assertEquals(50L, result.durationMs)
+        assertEquals(0L, result.navStartDelayMs)
+        assertEquals("navigation ended at t=0, before the interrupting tap", 0L, result.navDurationMs)
+        assertEquals("no frame arrived before the interrupting tap", 0L, result.firstFrameDurationMs)
     }
 
     @Test
@@ -93,6 +102,9 @@ internal class ScreenLoadTrackerTest {
         val first = emitted.single()
         assertEquals("a", first.screenName)
         assertEquals("a ends at its last frame (t=30), not the interrupting navigation (t=70)", 30L, first.durationMs)
+        assertEquals(0L, first.navStartDelayMs)
+        assertEquals("a's navigation started at t=0 and ended at t=20", 20L, first.navDurationMs)
+        assertEquals("a's last frame (t=30) was 10ms after its navigation end (t=20)", 10L, first.firstFrameDurationMs)
         assertEquals(ScreenLoadOutcome.NAVIGATION_INTERRUPTED, first.outcome)
 
         // b settles normally as its own load, anchored at its navigation start.
@@ -103,6 +115,9 @@ internal class ScreenLoadTrackerTest {
         val second = emitted.last()
         assertEquals("b", second.screenName)
         assertEquals(0L, second.durationMs)
+        assertEquals(0L, second.navStartDelayMs)
+        assertEquals(0L, second.navDurationMs)
+        assertEquals("b settled with no frame ever rendered", 0L, second.firstFrameDurationMs)
         assertEquals(ScreenLoadOutcome.SETTLED, second.outcome)
         assertEquals(2, emitted.size)
     }
@@ -127,6 +142,9 @@ internal class ScreenLoadTrackerTest {
         assertEquals(ScreenLoadOutcome.TIMED_OUT, result.outcome)
         assertEquals("anim", result.screenName)
         assertEquals("ends at the first frame after navigation end (t=50)", 50L, result.durationMs)
+        assertEquals(0L, result.navStartDelayMs)
+        assertEquals("navigation ended at t=0", 0L, result.navDurationMs)
+        assertEquals("first frame at t=50, 50ms after navigation end (t=0)", 50L, result.firstFrameDurationMs)
     }
 
     @Test
@@ -152,6 +170,9 @@ internal class ScreenLoadTrackerTest {
         val result = emitted.single()
         assertEquals(ScreenLoadOutcome.SETTLED, result.outcome)
         assertEquals("ends at the focus gain (t=60), not the last content frame (t=10)", 60L, result.durationMs)
+        assertEquals(0L, result.navStartDelayMs)
+        assertEquals("navigation ended at t=0, well before the settle", 0L, result.navDurationMs)
+        assertEquals("first (and only) content frame at t=10, unaffected by the later focus gain", 10L, result.firstFrameDurationMs)
     }
 
     @Test

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTrackerTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTrackerTest.kt
@@ -1,0 +1,205 @@
+package io.embrace.android.embracesdk.internal.vitals.screenload
+
+import android.os.SystemClock
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.internal.vitals.fake.FakeVitalsScheduler
+import io.embrace.android.embracesdk.internal.vitals.millisToNanos
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.shadows.ShadowSystemClock
+import java.time.Duration
+
+@RunWith(AndroidJUnit4::class)
+internal class ScreenLoadTrackerTest {
+
+    private val scheduler = FakeVitalsScheduler()
+    private val emitted = mutableListOf<ScreenLoadResult>()
+
+    // Wall clock tracks uptime so a load's reported start time can be asserted against [start].
+    private val tracker = ScreenLoadTracker(
+        scheduler = scheduler,
+        clock = { SystemClock.uptimeMillis() },
+        emit = emitted::add,
+        idleThresholdMs = IDLE,
+        timeoutMs = TIMEOUT,
+    )
+
+    @Test
+    fun `a tap, navigation, and quiet destination is a settled screen load`() {
+        val start = SystemClock.uptimeMillis()
+        tracker.onTap() // t=0
+        advance(10)
+        tracker.onNavigationStart("home")
+        advance(10)
+        tracker.onNavigationEnd("home") // t=20, settling
+        advance(10)
+        frameNow() // last frame at t=30
+
+        // quiet for the idle threshold -> settles at the last frame
+        advance(IDLE)
+        scheduler.runDue()
+
+        val result = emitted.single()
+        assertEquals("home", result.screenName)
+        assertEquals(ScreenLoadOutcome.SETTLED, result.outcome)
+        assertEquals(30L, result.durationMs)
+        assertEquals(start, result.startTimeMs)
+    }
+
+    @Test
+    fun `a touchless navigation start opens the load anchored at the navigation`() {
+        tracker.onNavigationStart("detail") // t=0, no preceding tap
+        advance(15)
+        tracker.onNavigationEnd("detail") // t=15, settling
+
+        advance(IDLE)
+        scheduler.runDue()
+
+        val result = emitted.single()
+        assertEquals("detail", result.screenName)
+        assertEquals(ScreenLoadOutcome.SETTLED, result.outcome)
+        assertEquals(15L, result.durationMs)
+    }
+
+    @Test
+    fun `a tap while settling ends the load as user-interrupted at that tap`() {
+        tracker.onTap()
+        tracker.onNavigationStart("home")
+        tracker.onNavigationEnd("home") // settling
+        advance(50)
+
+        tracker.onTap() // user taps the still-settling destination at t=50
+
+        val result = emitted.single()
+        assertEquals(ScreenLoadOutcome.USER_INTERRUPTED, result.outcome)
+        assertEquals(50L, result.durationMs)
+    }
+
+    @Test
+    fun `a navigation while settling ends the in-flight load as navigation-interrupted and opens a new one`() {
+        tracker.onTap() // t=0
+        tracker.onNavigationStart("a")
+        advance(20)
+        tracker.onNavigationEnd("a") // a is settling
+        advance(10)
+        frameNow() // a's last frame at t=30
+
+        // A new navigation interrupts a's settle at t=70, well after its last frame.
+        advance(40)
+        tracker.onNavigationStart("b") // t=70
+
+        val first = emitted.single()
+        assertEquals("a", first.screenName)
+        assertEquals("a ends at its last frame (t=30), not the interrupting navigation (t=70)", 30L, first.durationMs)
+        assertEquals(ScreenLoadOutcome.NAVIGATION_INTERRUPTED, first.outcome)
+
+        // b settles normally as its own load, anchored at its navigation start.
+        tracker.onNavigationEnd("b")
+        advance(IDLE)
+        scheduler.runDue()
+
+        val second = emitted.last()
+        assertEquals("b", second.screenName)
+        assertEquals(0L, second.durationMs)
+        assertEquals(ScreenLoadOutcome.SETTLED, second.outcome)
+        assertEquals(2, emitted.size)
+    }
+
+    @Test
+    fun `a destination that never goes quiet times out at the first frame after navigation end`() {
+        tracker.onTap()
+        tracker.onNavigationStart("anim")
+        tracker.onNavigationEnd("anim") // t=0, settling
+
+        // Continuously animating: a frame every 50ms (under the idle threshold) so the settle never fires,
+        // until the timeout elapses.
+        repeat(20) {
+            if (emitted.isEmpty()) {
+                advance(50)
+                frameNow()
+                scheduler.runDue()
+            }
+        }
+
+        val result = emitted.single()
+        assertEquals(ScreenLoadOutcome.TIMED_OUT, result.outcome)
+        assertEquals("anim", result.screenName)
+        assertEquals("ends at the first frame after navigation end (t=50)", 50L, result.durationMs)
+    }
+
+    @Test
+    fun `window focus extends the settle past the last content frame`() {
+        tracker.onTap()
+        tracker.onNavigationStart("home")
+        tracker.onNavigationEnd("home") // t=0, settling
+        advance(10)
+        frameNow() // last content frame at t=10
+
+        advance(50)
+        tracker.onWindowFocused() // t=60: open animation finished
+
+        // Would have settled at t=110 (last frame + idle) ending at t=10 without the focus signal.
+        advance(50) // t=110
+        scheduler.runDue()
+        assertTrue("focus pushed the baseline out, so it has not settled yet", emitted.isEmpty())
+
+        // settles the idle threshold after the focus instead
+        advance(50) // t=160
+        scheduler.runDue()
+
+        val result = emitted.single()
+        assertEquals(ScreenLoadOutcome.SETTLED, result.outcome)
+        assertEquals("ends at the focus gain (t=60), not the last content frame (t=10)", 60L, result.durationMs)
+    }
+
+    @Test
+    fun `a blank navigation-end name does not clobber a known screen name`() {
+        tracker.onTap()
+        tracker.onNavigationStart("home")
+        tracker.onNavigationEnd()
+
+        advance(IDLE)
+        scheduler.runDue()
+
+        assertEquals("home", emitted.single().screenName)
+    }
+
+    @Test
+    fun `a timeout before navigation end is an incomplete sequence and emits nothing`() {
+        tracker.onTap()
+        tracker.onNavigationStart("home") // confirmed, but no navigation end -> settle never armed
+
+        advance(TIMEOUT)
+        scheduler.runDue()
+
+        assertTrue(emitted.isEmpty())
+    }
+
+    @Test
+    fun `an interrupt while settling abandons the load, emitting nothing`() {
+        tracker.onTap()
+        tracker.onNavigationStart("home")
+        tracker.onNavigationEnd("home") // settling
+        frameNow()
+
+        tracker.onInterrupt()
+
+        advance(IDLE)
+        scheduler.runDue()
+        assertTrue(emitted.isEmpty())
+    }
+
+    private fun advance(millis: Long) = ShadowSystemClock.advanceBy(Duration.ofMillis(millis))
+
+    /**
+     * A frame whose vsync is the current instant.
+     */
+    private fun frameNow() = tracker.onFrame(SystemClock.uptimeMillis().millisToNanos())
+
+    private companion object {
+        const val IDLE = 100L
+        const val TIMEOUT = 500L
+    }
+}

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTrackerTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTrackerTest.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.internal.vitals.smoothness
 
 import android.os.SystemClock
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.vitals.fake.FakeVitalsScheduler
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/cache/CachedConfiguration.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/cache/CachedConfiguration.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.internal.serialization.BinaryVersion
 import kotlinx.serialization.Serializable
 
 @Serializable
-@BinaryVersion(-4156899519244063313)
+@BinaryVersion(8502092995539121495)
 data class CachedConfiguration(
     val deviceId: String,
     val etag: String?,


### PR DESCRIPTION
## Goal

Track screen load timing and settled by `SettleTracker`

<!-- Describe how this change has been tested -->