### PR TITLE
Set new distro name to the repo name

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
@@ -47,7 +47,7 @@ class OpenTelemetryModuleImpl(
         OtelSdkConfig(
             spanRepository = spanRepository,
             logSink = logSink,
-            sdkName = BuildConfig.LIBRARY_PACKAGE_NAME,
+            sdkName = "embrace-android-sdk",
             sdkVersion = BuildConfig.VERSION_NAME,
             appVersion = initModule.instrumentedConfig.project.getVersionName() ?: "UNKNOWN",
             packageName = initModule.instrumentedConfig.project.getPackageName() ?: "UNKNOWN",

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
@@ -52,7 +52,7 @@ class OpenTelemetryModuleImpl(
         OtelSdkConfig(
             spanRepository = spanRepository,
             logSink = logSink,
-            sdkName = BuildConfig.LIBRARY_PACKAGE_NAME,
+            sdkName = "embrace-android-sdk",
             sdkVersion = BuildConfig.VERSION_NAME,
             appVersion = initModule.instrumentedConfig.project.getVersionName() ?: "UNKNOWN",
             packageName = initModule.instrumentedConfig.project.getPackageName() ?: "UNKNOWN",

--- a/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-log-record.json
+++ b/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-log-record.json
@@ -28,7 +28,7 @@
       "os.version": "99.0.0",
       "service.name": "com.fake.package",
       "service.version": "2.5.1",
-      "telemetry.distro.name": "io.embrace.android.embracesdk.core",
+      "telemetry.distro.name": "embrace-android-sdk",
       "telemetry.distro.version": "__EMBRACE_TEST_IGNORE__"
     }
   },
@@ -63,7 +63,7 @@
       "os.version": "99.0.0",
       "service.name": "com.fake.package",
       "service.version": "2.5.1",
-      "telemetry.distro.name": "io.embrace.android.embracesdk.core",
+      "telemetry.distro.name": "embrace-android-sdk",
       "telemetry.distro.version": "__EMBRACE_TEST_IGNORE__"
     }
   },
@@ -99,7 +99,7 @@
       "os.version": "99.0.0",
       "service.name": "com.fake.package",
       "service.version": "2.5.1",
-      "telemetry.distro.name": "io.embrace.android.embracesdk.core",
+      "telemetry.distro.name": "embrace-android-sdk",
       "telemetry.distro.version": "__EMBRACE_TEST_IGNORE__"
     }
   }

--- a/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-log-span-context.json
+++ b/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-log-span-context.json
@@ -29,7 +29,7 @@
       "os.version": "99.0.0",
       "service.name": "com.fake.package",
       "service.version": "2.5.1",
-      "telemetry.distro.name": "io.embrace.android.embracesdk.core",
+      "telemetry.distro.name": "embrace-android-sdk",
       "telemetry.distro.version": "__EMBRACE_TEST_IGNORE__"
     }
   },
@@ -62,7 +62,7 @@
       "os.version": "99.0.0",
       "service.name": "com.fake.package",
       "service.version": "2.5.1",
-      "telemetry.distro.name": "io.embrace.android.embracesdk.core",
+      "telemetry.distro.name": "embrace-android-sdk",
       "telemetry.distro.version": "__EMBRACE_TEST_IGNORE__"
     }
   }

--- a/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-log.json
+++ b/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-log.json
@@ -18,7 +18,7 @@
       "my-attribute": "my-value",
       "session.id": "__EMBRACE_TEST_IGNORE__"
     },
-    "instrumentationScopeName": "io.embrace.android.embracesdk.core",
+    "instrumentationScopeName": "embrace-android-sdk",
     "resourceAttributes": {
       "android.os.api_level": "35",
       "device.manufacturer": "Fake Manufacturer",
@@ -30,7 +30,7 @@
       "os.version": "99.0.0",
       "service.name": "com.fake.package",
       "service.version": "2.5.1",
-      "telemetry.distro.name": "io.embrace.android.embracesdk.core",
+      "telemetry.distro.name": "embrace-android-sdk",
       "telemetry.distro.version": "__EMBRACE_TEST_IGNORE__"
     }
   }

--- a/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-span-attributes.json
+++ b/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-span-attributes.json
@@ -52,7 +52,7 @@
       "os.version": "99.0.0",
       "service.name": "com.fake.package",
       "service.version": "2.5.1",
-      "telemetry.distro.name": "io.embrace.android.embracesdk.core",
+      "telemetry.distro.name": "embrace-android-sdk",
       "telemetry.distro.version": "__EMBRACE_TEST_IGNORE__"
     }
   }

--- a/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-span-events.json
+++ b/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-span-events.json
@@ -67,7 +67,7 @@
       "os.version": "99.0.0",
       "service.name": "com.fake.package",
       "service.version": "2.5.1",
-      "telemetry.distro.name": "io.embrace.android.embracesdk.core",
+      "telemetry.distro.name": "embrace-android-sdk",
       "telemetry.distro.version": "__EMBRACE_TEST_IGNORE__"
     }
   }

--- a/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-span-relationships.json
+++ b/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-span-relationships.json
@@ -41,7 +41,7 @@
       "os.version": "99.0.0",
       "service.name": "com.fake.package",
       "service.version": "2.5.1",
-      "telemetry.distro.name": "io.embrace.android.embracesdk.core",
+      "telemetry.distro.name": "embrace-android-sdk",
       "telemetry.distro.version": "__EMBRACE_TEST_IGNORE__"
     }
   },
@@ -87,7 +87,7 @@
       "os.version": "99.0.0",
       "service.name": "com.fake.package",
       "service.version": "2.5.1",
-      "telemetry.distro.name": "io.embrace.android.embracesdk.core",
+      "telemetry.distro.name": "embrace-android-sdk",
       "telemetry.distro.version": "__EMBRACE_TEST_IGNORE__"
     }
   },
@@ -143,7 +143,7 @@
       "os.version": "99.0.0",
       "service.name": "com.fake.package",
       "service.version": "2.5.1",
-      "telemetry.distro.name": "io.embrace.android.embracesdk.core",
+      "telemetry.distro.name": "embrace-android-sdk",
       "telemetry.distro.version": "__EMBRACE_TEST_IGNORE__"
     }
   }

--- a/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-trace.json
+++ b/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-trace.json
@@ -36,7 +36,7 @@
         }
       }
     ],
-    "instrumentationScopeName": "io.embrace.android.embracesdk.core",
+    "instrumentationScopeName": "embrace-android-sdk",
     "resourceAttributes": {
       "android.os.api_level": "35",
       "device.manufacturer": "Fake Manufacturer",
@@ -48,7 +48,7 @@
       "os.version": "99.0.0",
       "service.name": "com.fake.package",
       "service.version": "2.5.1",
-      "telemetry.distro.name": "io.embrace.android.embracesdk.core",
+      "telemetry.distro.name": "embrace-android-sdk",
       "telemetry.distro.version": "__EMBRACE_TEST_IGNORE__"
     }
   }

--- a/embrace-android-sdk/src/integrationTest/resources/system-low-power-export.json
+++ b/embrace-android-sdk/src/integrationTest/resources/system-low-power-export.json
@@ -12,6 +12,6 @@
     },
     "totalRecordedEvents": "0",
     "events": [],
-    "instrumentationScopeName": "io.embrace.android.embracesdk.core"
+    "instrumentationScopeName": "embrace-android-sdk"
   }
 ]

--- a/embrace-android-sdk/src/integrationTest/resources/ux-view-export.json
+++ b/embrace-android-sdk/src/integrationTest/resources/ux-view-export.json
@@ -13,6 +13,6 @@
     },
     "totalRecordedEvents": "0",
     "events": [],
-    "instrumentationScopeName": "io.embrace.android.embracesdk.core"
+    "instrumentationScopeName": "embrace-android-sdk"
   }
 ]

--- a/embrace-android-sdk/src/test/resources/v2_session_expected.json
+++ b/embrace-android-sdk/src/test/resources/v2_session_expected.json
@@ -23,7 +23,7 @@
     "device.manufacturer": "Fake Manufacturer",
     "device.model.identifier": "Phake Phone Phive",
     "device.model.name": "Phake Phone Phive",
-    "telemetry.distro.name": "io.embrace.android.embracesdk.core",
+    "telemetry.distro.name": "embrace-android-sdk",
     "telemetry.distro.version": "__EMBRACE_TEST_IGNORE__",
     "app_framework": 1,
     "build_id": "fakeBuildId",


### PR DESCRIPTION
Use the Github repo name for the name of the distro in the OTel resource and in the instrumentation scope returned in Tracers and Loggers. Basically, we are giving the SDK a name that can be consistent across SDKs