### PR TITLE
Use app.build_id semantic convention in envelope resource

### DIFF
--- a/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeInstrumentedConfig.kt
+++ b/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeInstrumentedConfig.kt
@@ -22,6 +22,7 @@ data class FakeInstrumentedConfig(
         appId = "abcde",
         versionName = "2.5.1",
         packageName = "com.fake.package",
+        buildId = "fakeBuildId",
     ),
     override val redaction: RedactionConfig = FakeRedactionConfig(base.redaction),
     override val symbols: Base64SharedObjectFilesMap =

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
@@ -51,6 +51,7 @@ class OpenTelemetryModuleImpl(
             sdkVersion = BuildConfig.VERSION_NAME,
             appVersion = initModule.instrumentedConfig.project.getVersionName() ?: "UNKNOWN",
             packageName = initModule.instrumentedConfig.project.getPackageName() ?: "UNKNOWN",
+            buildId = initModule.instrumentedConfig.project.getBuildId() ?: "UNKNOWN",
             systemInfo = initModule.systemInfo,
             uuidSource = initModule.uuidSource,
             sessionIdsProvider = { storedSessionIdsProvider },

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
@@ -56,6 +56,7 @@ class OpenTelemetryModuleImpl(
             sdkVersion = BuildConfig.VERSION_NAME,
             appVersion = initModule.instrumentedConfig.project.getVersionName() ?: "UNKNOWN",
             packageName = initModule.instrumentedConfig.project.getPackageName() ?: "UNKNOWN",
+            buildId = initModule.instrumentedConfig.project.getBuildId() ?: "UNKNOWN",
             systemInfo = initModule.systemInfo,
             uuidSource = initModule.uuidSource,
             sessionIdsProvider = { storedSessionIdsProvider },

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImplTest.kt
@@ -11,29 +11,41 @@ import org.junit.Test
 
 internal class EnvelopeResourceSourceImplTest {
 
+    private val legacyKeys = listOf(
+        "app_ecosystem_id",
+        "app_version",
+        "environment",
+        "build_id",
+        "device_architecture",
+        "device_manufacturer",
+        "device_model",
+        "os_code",
+        "os_type",
+        "os_name",
+        "os_version",
+        "sdk_version",
+    )
+
     @Test
     fun `getEnvelopeResource merges the OTel resource with Embrace internal attributes`() {
         val source = createSource(
             otelResourceAttributes = mapOf(
                 ServiceAttributes.SERVICE_VERSION to "2.5.1",
                 "my.custom.one" to "1",
-                "build_id" to "should-be-ignored",
+                "build_type" to "should-be-ignored",
             ),
         )
         val attrs = source.getEnvelopeResource().attributes
 
         assertEquals("2.5.1", attrs.getValue(ServiceAttributes.SERVICE_VERSION).stringValue)
         assertEquals("1", attrs.getValue("my.custom.one").stringValue)
-        assertEquals("fakeBuildId", attrs.getValue("build_id").stringValue)
+        assertEquals("fakeBuildType", attrs.getValue("build_type").stringValue)
         assertEquals("prod", attrs.getValue("emb.app.environment").stringValue)
 
         // legacy bespoke keys are gone, replaced by their canonical semconv keys
-        assertFalse(attrs.containsKey("app_version"))
-        assertFalse(attrs.containsKey("app_ecosystem_id"))
-        assertFalse(attrs.containsKey("environment"))
-        assertFalse(attrs.containsKey("sdk_version"))
-        assertFalse(attrs.containsKey("device_manufacturer"))
-        assertFalse(attrs.containsKey("device_model"))
+        legacyKeys.forEach {
+            assertFalse("'$it' should not exist in the envelope resource", attrs.containsKey(it))
+        }
     }
 
     @Test

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImpl.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImpl.kt
@@ -25,7 +25,6 @@ class EnvelopeResourceSourceImpl(
         // Custom envelope resource keys that are internal to Embrace and do not match attributes defined in OTel semantic conventions
         val embraceInternalAttributes = buildMap {
             putValue("app_framework", configService.appFramework.value)
-            putValue("build_id", buildInfo.buildId)
             putValue("build_type", buildInfo.buildType)
             putValue("build_flavor", buildInfo.buildFlavor)
             putValue("bundle_version", buildInfo.versionCode)

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
@@ -15,6 +15,7 @@ import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.logging.export.LogRecordExporter
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.opentelemetry.kotlin.semconv.AndroidAttributes
+import io.opentelemetry.kotlin.semconv.AppAttributes
 import io.opentelemetry.kotlin.semconv.DeviceAttributes
 import io.opentelemetry.kotlin.semconv.HostAttributes
 import io.opentelemetry.kotlin.semconv.OsAttributes
@@ -30,6 +31,7 @@ class OtelSdkConfig(
     val sdkVersion: String,
     val appVersion: String,
     val packageName: String,
+    val buildId: String,
     private val systemInfo: SystemInfo,
     private val uuidSource: UuidSource,
     private val sessionIdsProvider: () -> SessionIdsProvider? = { null },
@@ -79,6 +81,7 @@ class OtelSdkConfig(
     private val embraceResourceAttributes: Map<String, String> = LinkedHashMap<String, String>().apply {
         put(ServiceAttributes.SERVICE_NAME, packageName)
         put(ServiceAttributes.SERVICE_VERSION, appVersion)
+        put(AppAttributes.APP_BUILD_ID, buildId)
         put(OsAttributes.OS_NAME, systemInfo.osName)
         put(OsAttributes.OS_VERSION, systemInfo.osVersion)
         put(OsAttributes.OS_TYPE, systemInfo.osType)

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
@@ -15,6 +15,7 @@ import io.opentelemetry.kotlin.attributes.AttributesMutator
 import io.opentelemetry.kotlin.logging.export.LogRecordExporter
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.opentelemetry.kotlin.semconv.AndroidAttributes
+import io.opentelemetry.kotlin.semconv.AppAttributes
 import io.opentelemetry.kotlin.semconv.DeviceAttributes
 import io.opentelemetry.kotlin.semconv.HostAttributes
 import io.opentelemetry.kotlin.semconv.OsAttributes
@@ -30,6 +31,7 @@ class OtelSdkConfig(
     val sdkVersion: String,
     val appVersion: String,
     val packageName: String,
+    val buildId: String,
     private val systemInfo: SystemInfo,
     private val uuidSource: UuidSource,
     private val sessionIdsProvider: () -> SessionIdsProvider? = { null },
@@ -75,6 +77,7 @@ class OtelSdkConfig(
     private val embraceResourceAttributes: Map<String, String> = LinkedHashMap<String, String>().apply {
         put(ServiceAttributes.SERVICE_NAME, packageName)
         put(ServiceAttributes.SERVICE_VERSION, appVersion)
+        put(AppAttributes.APP_BUILD_ID, buildId)
         put(OsAttributes.OS_NAME, systemInfo.osName)
         put(OsAttributes.OS_VERSION, systemInfo.osVersion)
         put(OsAttributes.OS_TYPE, systemInfo.osType)

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfigTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfigTest.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.otel.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
 import io.opentelemetry.kotlin.semconv.AndroidAttributes
+import io.opentelemetry.kotlin.semconv.AppAttributes
 import io.opentelemetry.kotlin.semconv.DeviceAttributes
 import io.opentelemetry.kotlin.semconv.HostAttributes
 import io.opentelemetry.kotlin.semconv.OsAttributes
@@ -37,6 +38,7 @@ internal class OtelSdkConfigTest {
             sdkVersion = "1.0",
             appVersion = "2.5.1",
             packageName = "com.test.app",
+            buildId = "fake-build-id",
             systemInfo = systemInfo,
             uuidSource = TestUuidSource(),
         )
@@ -45,6 +47,7 @@ internal class OtelSdkConfigTest {
         val expected = mapOf(
             ServiceAttributes.SERVICE_NAME to configuration.packageName,
             ServiceAttributes.SERVICE_VERSION to configuration.appVersion,
+            AppAttributes.APP_BUILD_ID to configuration.buildId,
             TelemetryAttributes.TELEMETRY_DISTRO_NAME to configuration.sdkName,
             TelemetryAttributes.TELEMETRY_DISTRO_VERSION to configuration.sdkVersion,
             OsAttributes.OS_NAME to systemInfo.osName,
@@ -133,6 +136,7 @@ internal class OtelSdkConfigTest {
         sdkVersion = "1.0",
         appVersion = "2.5.1",
         packageName = "com.test.app",
+        buildId = "fake-build-id",
         systemInfo = SystemInfo(),
         resourceAttributeOverrideEnabled = { resourceAttributeOverrideEnabled },
     )

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfigTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfigTest.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.otel.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
 import io.opentelemetry.kotlin.semconv.AndroidAttributes
+import io.opentelemetry.kotlin.semconv.AppAttributes
 import io.opentelemetry.kotlin.semconv.DeviceAttributes
 import io.opentelemetry.kotlin.semconv.HostAttributes
 import io.opentelemetry.kotlin.semconv.OsAttributes
@@ -37,6 +38,7 @@ internal class OtelSdkConfigTest {
             sdkVersion = "1.0",
             appVersion = "2.5.1",
             packageName = "com.test.app",
+            buildId = "fake-build-id",
             systemInfo = systemInfo,
             uuidSource = TestUuidSource(),
         )
@@ -45,6 +47,7 @@ internal class OtelSdkConfigTest {
         val expected = mapOf(
             ServiceAttributes.SERVICE_NAME to configuration.packageName,
             ServiceAttributes.SERVICE_VERSION to configuration.appVersion,
+            AppAttributes.APP_BUILD_ID to configuration.buildId,
             TelemetryAttributes.TELEMETRY_DISTRO_NAME to configuration.sdkName,
             TelemetryAttributes.TELEMETRY_DISTRO_VERSION to configuration.sdkVersion,
             OsAttributes.OS_NAME to systemInfo.osName,
@@ -133,6 +136,7 @@ internal class OtelSdkConfigTest {
         sdkVersion = "1.0",
         appVersion = "2.5.1",
         packageName = "com.test.app",
+        buildId = "fake-build-id",
         systemInfo = SystemInfo(),
         uuidSource = TestUuidSource(),
         resourceAttributeOverrideEnabled = { resourceAttributeOverrideEnabled },

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OpenTelemetrySdkTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OpenTelemetrySdkTest.kt
@@ -154,6 +154,7 @@ internal class OpenTelemetrySdkTest {
             sdkVersion = "1.0",
             appVersion = "2.5.1",
             packageName = "com.test.app",
+            buildId = "fake-build-id",
             systemInfo = systemInfo,
             uuidSource = TestUuidSource(),
         )

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
@@ -846,6 +846,7 @@ internal class SpanServiceImplTest {
             sdkVersion = "1.0",
             appVersion = "1.0.0",
             packageName = "com.test.app",
+            buildId = "fake-build-id",
             systemInfo = SystemInfo(),
             uuidSource = TestUuidSource(),
             sessionIdsProvider = { FakeSessionIdsProvider(userSessionId = "fake-session-id") },

--- a/embrace-android-payload/src/test/kotlin/io/embrace/android/embracesdk/internal/serialization/EnvelopeResourceSerializerTest.kt
+++ b/embrace-android-payload/src/test/kotlin/io/embrace/android/embracesdk/internal/serialization/EnvelopeResourceSerializerTest.kt
@@ -15,7 +15,7 @@ internal class EnvelopeResourceSerializerTest {
             "service.version" to EnvelopeResourceValue.of("1.0.0"),
             "service.name" to EnvelopeResourceValue.of("io.embrace.test"),
             "app_framework" to EnvelopeResourceValue.of(AppFramework.NATIVE.value.toLong()),
-            "build_id" to EnvelopeResourceValue.of("abc123"),
+            "app.build_id" to EnvelopeResourceValue.of("abc123"),
             "emb.app.environment" to EnvelopeResourceValue.of("prod"),
             "host.arch" to EnvelopeResourceValue.of("arm64-v8a"),
             "os.version" to EnvelopeResourceValue.of("13"),

--- a/embrace-android-payload/src/test/resources/envelope_resource_full.json
+++ b/embrace-android-payload/src/test/resources/envelope_resource_full.json
@@ -2,7 +2,7 @@
   "service.version": "1.0.0",
   "service.name": "io.embrace.test",
   "app_framework": 1,
-  "build_id": "abc123",
+  "app.build_id": "abc123",
   "emb.app.environment": "prod",
   "host.arch": "arm64-v8a",
   "os.version": "13",

--- a/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-log-record.json
+++ b/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-log-record.json
@@ -19,6 +19,7 @@
     "instrumentationScopeName": "external-logger",
     "resourceAttributes": {
       "android.os.api_level": "35",
+      "app.build_id": "fakeBuildId",
       "device.manufacturer": "Fake Manufacturer",
       "device.model.identifier": "Phake Phone Phive",
       "device.model.name": "Phake Phone Phive",
@@ -55,6 +56,7 @@
     "instrumentationScopeName": "external-logger",
     "resourceAttributes": {
       "android.os.api_level": "35",
+      "app.build_id": "fakeBuildId",
       "device.manufacturer": "Fake Manufacturer",
       "device.model.identifier": "Phake Phone Phive",
       "device.model.name": "Phake Phone Phive",
@@ -92,6 +94,7 @@
     "instrumentationScopeName": "external-logger",
     "resourceAttributes": {
       "android.os.api_level": "35",
+      "app.build_id": "fakeBuildId",
       "device.manufacturer": "Fake Manufacturer",
       "device.model.identifier": "Phake Phone Phive",
       "device.model.name": "Phake Phone Phive",

--- a/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-log-span-context.json
+++ b/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-log-span-context.json
@@ -20,6 +20,7 @@
     "instrumentationScopeName": "external-logger",
     "resourceAttributes": {
       "android.os.api_level": "35",
+      "app.build_id": "fakeBuildId",
       "device.manufacturer": "Fake Manufacturer",
       "device.model.identifier": "Phake Phone Phive",
       "device.model.name": "Phake Phone Phive",
@@ -54,6 +55,7 @@
     "instrumentationScopeName": "external-logger",
     "resourceAttributes": {
       "android.os.api_level": "35",
+      "app.build_id": "fakeBuildId",
       "device.manufacturer": "Fake Manufacturer",
       "device.model.identifier": "Phake Phone Phive",
       "device.model.name": "Phake Phone Phive",

--- a/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-log.json
+++ b/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-log.json
@@ -21,6 +21,7 @@
     "instrumentationScopeName": "embrace-android-sdk",
     "resourceAttributes": {
       "android.os.api_level": "35",
+      "app.build_id": "fakeBuildId",
       "device.manufacturer": "Fake Manufacturer",
       "device.model.identifier": "Phake Phone Phive",
       "device.model.name": "Phake Phone Phive",

--- a/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-span-attributes.json
+++ b/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-span-attributes.json
@@ -43,6 +43,7 @@
     "instrumentationScopeName": "external-tracer",
     "resourceAttributes": {
       "android.os.api_level": "35",
+      "app.build_id": "fakeBuildId",
       "device.manufacturer": "Fake Manufacturer",
       "device.model.identifier": "Phake Phone Phive",
       "device.model.name": "Phake Phone Phive",

--- a/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-span-events.json
+++ b/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-span-events.json
@@ -58,6 +58,7 @@
     "instrumentationScopeName": "external-tracer",
     "resourceAttributes": {
       "android.os.api_level": "35",
+      "app.build_id": "fakeBuildId",
       "device.manufacturer": "Fake Manufacturer",
       "device.model.identifier": "Phake Phone Phive",
       "device.model.name": "Phake Phone Phive",

--- a/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-span-relationships.json
+++ b/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-span-relationships.json
@@ -32,6 +32,7 @@
     "instrumentationScopeName": "external-tracer",
     "resourceAttributes": {
       "android.os.api_level": "35",
+      "app.build_id": "fakeBuildId",
       "device.manufacturer": "Fake Manufacturer",
       "device.model.identifier": "Phake Phone Phive",
       "device.model.name": "Phake Phone Phive",
@@ -79,6 +80,7 @@
     "instrumentationScopeName": "external-tracer",
     "resourceAttributes": {
       "android.os.api_level": "35",
+      "app.build_id": "fakeBuildId",
       "device.manufacturer": "Fake Manufacturer",
       "device.model.identifier": "Phake Phone Phive",
       "device.model.name": "Phake Phone Phive",
@@ -136,6 +138,7 @@
     "instrumentationScopeName": "external-tracer",
     "resourceAttributes": {
       "android.os.api_level": "35",
+      "app.build_id": "fakeBuildId",
       "device.manufacturer": "Fake Manufacturer",
       "device.model.identifier": "Phake Phone Phive",
       "device.model.name": "Phake Phone Phive",

--- a/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-trace.json
+++ b/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-trace.json
@@ -39,6 +39,7 @@
     "instrumentationScopeName": "embrace-android-sdk",
     "resourceAttributes": {
       "android.os.api_level": "35",
+      "app.build_id": "fakeBuildId",
       "device.manufacturer": "Fake Manufacturer",
       "device.model.identifier": "Phake Phone Phive",
       "device.model.name": "Phake Phone Phive",

--- a/embrace-android-sdk/src/test/resources/v2_session_expected.json
+++ b/embrace-android-sdk/src/test/resources/v2_session_expected.json
@@ -15,6 +15,7 @@
   "resource": {
     "service.name": "com.fake.package",
     "service.version": "2.5.1",
+    "app.build_id": "fakeBuildId",
     "os.name": "android",
     "os.type": "linux",
     "os.version": "__EMBRACE_TEST_IGNORE__",
@@ -27,7 +28,6 @@
     "telemetry.distro.name": "embrace-android-sdk",
     "telemetry.distro.version": "__EMBRACE_TEST_IGNORE__",
     "app_framework": 1,
-    "build_id": "fakeBuildId",
     "build_type": "fakeBuildType",
     "build_flavor": "fakeBuildFlavor",
     "bundle_version": "99",

--- a/embrace-test-common/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogFixtures.kt
+++ b/embrace-test-common/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogFixtures.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResourceValue
 import io.embrace.android.embracesdk.internal.payload.LogPayload
+import io.opentelemetry.kotlin.semconv.AppAttributes
 import io.opentelemetry.kotlin.semconv.DeviceAttributes
 import io.opentelemetry.kotlin.semconv.OsAttributes
 import io.opentelemetry.kotlin.semconv.ServiceAttributes
@@ -28,7 +29,7 @@ val fakeEnvelopeResource = EnvelopeResource(
         DeviceAttributes.DEVICE_MODEL_IDENTIFIER to EnvelopeResourceValue.of("Pixel 5"),
         DeviceAttributes.DEVICE_MODEL_NAME to EnvelopeResourceValue.of("Pixel 5"),
         "app_framework" to EnvelopeResourceValue.of(AppFramework.NATIVE.value.toLong()),
-        "build_id" to EnvelopeResourceValue.of("555"),
+        AppAttributes.APP_BUILD_ID to EnvelopeResourceValue.of("555"),
     ),
 )
 

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
@@ -4,13 +4,13 @@ import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.config.behavior.OtelBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehavior
 import io.embrace.android.embracesdk.internal.injection.OpenTelemetryModule
-import io.embrace.android.embracesdk.internal.session.id.SessionIdsProvider
 import io.embrace.android.embracesdk.internal.otel.config.OtelSdkConfig
 import io.embrace.android.embracesdk.internal.otel.logs.LogSink
 import io.embrace.android.embracesdk.internal.otel.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.otel.sdk.OtelSdkWrapper
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsProvider
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionPartSpan
 import io.embrace.android.embracesdk.spans.TracingApi
 
@@ -32,6 +32,7 @@ class FakeOpenTelemetryModule(
             sdkVersion = sdkVersion,
             appVersion = "1.0.0",
             packageName = "com.test.app",
+            buildId = "fake-build-id",
             systemInfo = systemInfo,
             uuidSource = TestUuidSource(),
         )

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
@@ -5,13 +5,13 @@ import io.embrace.android.embracesdk.internal.config.behavior.BreadcrumbBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.OtelBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehavior
 import io.embrace.android.embracesdk.internal.injection.OpenTelemetryModule
-import io.embrace.android.embracesdk.internal.session.id.SessionIdsProvider
 import io.embrace.android.embracesdk.internal.otel.config.OtelSdkConfig
 import io.embrace.android.embracesdk.internal.otel.logs.LogSink
 import io.embrace.android.embracesdk.internal.otel.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.otel.sdk.OtelSdkWrapper
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsProvider
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionPartSpan
 import io.embrace.android.embracesdk.spans.TracingApi
 
@@ -33,6 +33,7 @@ class FakeOpenTelemetryModule(
             sdkVersion = sdkVersion,
             appVersion = "1.0.0",
             packageName = "com.test.app",
+            buildId = "fake-build-id",
             systemInfo = systemInfo,
             uuidSource = TestUuidSource(),
         )


### PR DESCRIPTION
Replace `build_id` with the semantic convention-approved `app.build_id` when denoting the unique ID for the build that generated the app binary.