### PR TITLE
build(deps): bump androidx.core:core-ktx in /examples/ExampleApp

### DIFF
--- a/examples/ExampleApp/gradle/libs.versions.toml
+++ b/examples/ExampleApp/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "9.2.1"
 kotlin = "2.4.0"
-coreKtx = "1.18.0"
+coreKtx = "1.19.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"


### PR DESCRIPTION
Bumps androidx.core:core-ktx from 1.18.0 to 1.19.0.

https://github.com/embrace-io/embrace-android-sdk/pull/3446

---
updated-dependencies:
- dependency-name: androidx.core:core-ktx dependency-version: 1.19.0 dependency-type: direct:production update-type: version-update:semver-minor ...

## Goal

<!-- Describe what this change seeks to address -->

## Testing

<!-- Describe how this change has been tested -->
