### PR TITLE
build(deps): bump kotlinxSerialization from 1.8.1 to 1.10.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ annotation = "1.10.0"
 otelKotlin = "0.4.0"
 # Pinned to 1.10.x: 1.11.0+ requires kotlin-stdlib 2.2.20, which breaks our minimum supported Kotlin (2.0.21).
 kotlinxCoroutines = "1.10.2"
-kotlinxSerialization = "1.8.1"
+kotlinxSerialization = "1.10.0"
 protobuf = "4.35.1"
 profileinstaller = "1.3.1" # version pinned to 1.3.1 because of AGP bug
 okhttp = "4.12.0"


### PR DESCRIPTION
Bumps `kotlinxSerialization` from 1.8.1 to 1.10.0.

https://github.com/embrace-io/embrace-android-sdk/pull/3476

Updates `org.jetbrains.kotlinx:kotlinx-serialization-core` from 1.8.1 to 1.10.0
- [Release notes](https://github.com/Kotlin/kotlinx.serialization/releases)
- [Changelog](https://github.com/Kotlin/kotlinx.serialization/blob/master/CHANGELOG.md)
- [Commits](https://github.com/Kotlin/kotlinx.serialization/compare/v1.8.1...v1.10.0)

Updates `org.jetbrains.kotlinx:kotlinx-serialization-json` from 1.8.1 to 1.10.0
- [Release notes](https://github.com/Kotlin/kotlinx.serialization/releases)
- [Changelog](https://github.com/Kotlin/kotlinx.serialization/blob/master/CHANGELOG.md)
- [Commits](https://github.com/Kotlin/kotlinx.serialization/compare/v1.8.1...v1.10.0)

---
updated-dependencies:
- dependency-name: org.jetbrains.kotlinx:kotlinx-serialization-core dependency-version: 1.10.0 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.jetbrains.kotlinx:kotlinx-serialization-json dependency-version: 1.10.0 dependency-type: direct:production update-type: version-update:semver-minor ...

## Goal

<!-- Describe what this change seeks to address -->

## Testing

<!-- Describe how this change has been tested -->
