### PR TITLE
Only rename attribute if new one is semconv

### DIFF
--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImplTest.kt
@@ -14,7 +14,6 @@ internal class EnvelopeResourceSourceImplTest {
     private val legacyKeys = listOf(
         "app_ecosystem_id",
         "app_version",
-        "environment",
         "build_id",
         "device_architecture",
         "device_manufacturer",
@@ -53,7 +52,7 @@ internal class EnvelopeResourceSourceImplTest {
         assertEquals(10000000L, attrs.getValue("disk_total_capacity").longValue)
         assertEquals("1920x1080", attrs.getValue("screen_resolution").stringValue)
         assertEquals(8, attrs.getValue("num_cores").intValue)
-        assertEquals("prod", attrs.getValue("emb.app.environment").stringValue)
+        assertEquals("prod", attrs.getValue("environment").stringValue)
 
         // legacy bespoke keys are gone, replaced by their canonical semconv keys
         legacyKeys.forEach {

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImpl.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImpl.kt
@@ -52,9 +52,7 @@ class EnvelopeResourceSourceImpl(
                 put(key, EnvelopeResourceValue.of(value))
             }
 
-            embraceInternalAttributes.forEach { (legacyKey, value) ->
-                put(PROPOSED_SEM_CONV_ATTRIBUTES[legacyKey] ?: legacyKey, value)
-            }
+            putAll(embraceInternalAttributes)
         }
 
         return EnvelopeResource(consolidatedAttributes)
@@ -80,15 +78,5 @@ class EnvelopeResourceSourceImpl(
         if (value != null) {
             put(key, EnvelopeResourceValue.of(value))
         }
-    }
-
-    private companion object {
-
-        /**
-         * Legacy internal Embrace attributes that should become OTel semantic conventions, but have not been accepted yet.
-         */
-        private val PROPOSED_SEM_CONV_ATTRIBUTES = mapOf(
-            "environment" to "emb.app.environment",
-        )
     }
 }

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImpl.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImpl.kt
@@ -54,9 +54,7 @@ class EnvelopeResourceSourceImpl(
                 put(key, EnvelopeResourceValue.of(value))
             }
 
-            embraceInternalAttributes.forEach { (legacyKey, value) ->
-                put(PROPOSED_SEM_CONV_ATTRIBUTES[legacyKey] ?: legacyKey, value)
-            }
+            putAll(embraceInternalAttributes)
         }
 
         return EnvelopeResource(consolidatedAttributes)
@@ -82,15 +80,5 @@ class EnvelopeResourceSourceImpl(
         if (value != null) {
             put(key, EnvelopeResourceValue.of(value))
         }
-    }
-
-    private companion object {
-
-        /**
-         * Legacy internal Embrace attributes that should become OTel semantic conventions, but have not been accepted yet.
-         */
-        private val PROPOSED_SEM_CONV_ATTRIBUTES = mapOf(
-            "environment" to "emb.app.environment",
-        )
     }
 }

--- a/embrace-android-payload/src/test/kotlin/io/embrace/android/embracesdk/internal/serialization/EnvelopeResourceSerializerTest.kt
+++ b/embrace-android-payload/src/test/kotlin/io/embrace/android/embracesdk/internal/serialization/EnvelopeResourceSerializerTest.kt
@@ -16,7 +16,7 @@ internal class EnvelopeResourceSerializerTest {
             "service.name" to EnvelopeResourceValue.of("io.embrace.test"),
             "app_framework" to EnvelopeResourceValue.of(AppFramework.NATIVE.value.toLong()),
             "app.build_id" to EnvelopeResourceValue.of("abc123"),
-            "emb.app.environment" to EnvelopeResourceValue.of("prod"),
+            "environment" to EnvelopeResourceValue.of("prod"),
             "host.arch" to EnvelopeResourceValue.of("arm64-v8a"),
             "os.version" to EnvelopeResourceValue.of("13"),
             "jailbroken" to EnvelopeResourceValue.of(false),

--- a/embrace-android-payload/src/test/resources/envelope_resource_full.json
+++ b/embrace-android-payload/src/test/resources/envelope_resource_full.json
@@ -3,7 +3,7 @@
   "service.name": "io.embrace.test",
   "app_framework": 1,
   "app.build_id": "abc123",
-  "emb.app.environment": "prod",
+  "environment": "prod",
   "host.arch": "arm64-v8a",
   "os.version": "13",
   "jailbroken": false,

--- a/embrace-android-sdk/src/test/resources/v2_session_expected.json
+++ b/embrace-android-sdk/src/test/resources/v2_session_expected.json
@@ -36,7 +36,7 @@
     "disk_total_capacity": "__EMBRACE_TEST_IGNORE__",
     "screen_resolution": "__EMBRACE_TEST_IGNORE__",
     "num_cores": "__EMBRACE_TEST_IGNORE__",
-    "emb.app.environment": "dev"
+    "environment": "dev"
   },
   "type": "spans",
   "version": "0.1.0"

--- a/embrace-test-common/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEnvelopeFixtures.kt
+++ b/embrace-test-common/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEnvelopeFixtures.kt
@@ -48,7 +48,7 @@ val fakeEnvelopeResource = EnvelopeResource(
         "disk_total_capacity" to EnvelopeResourceValue.of(FakeDeviceInfoValues.DISK_TOTAL_CAPACITY),
         "screen_resolution" to EnvelopeResourceValue.of(FakeDeviceInfoValues.SCREEN_RESOLUTION),
         "num_cores" to EnvelopeResourceValue.of(FakeDeviceInfoValues.NUMBER_OF_CORES.toLong()),
-        "emb.app.environment" to EnvelopeResourceValue.of("prod"),
+        "environment" to EnvelopeResourceValue.of("prod"),
     ),
 )
 


### PR DESCRIPTION
Only rename attributes that are in the semantic convention. For the ones like environment where we want to propose one, only change it when it's accepted.
