### PR TITLE
Bump OpenTelemetry Kotlin to 0.5.0

### DIFF
--- a/embrace-android-otel/embrace-proguard.cfg
+++ b/embrace-android-otel/embrace-proguard.cfg
@@ -10,9 +10,16 @@
 -dontwarn io.opentelemetry.api.incubator.trace.ExtendedTracer
 -dontwarn io.opentelemetry.api.incubator.metrics.ExtendedDoubleHistogram
 -dontwarn io.opentelemetry.api.incubator.metrics.ExtendedLongHistogram
+-dontwarn io.opentelemetry.api.incubator.metrics.ExtendedLongCounter
+-dontwarn io.opentelemetry.api.incubator.metrics.ExtendedLongCounterBuilder
+-dontwarn io.opentelemetry.api.incubator.metrics.ExtendedLongUpDownCounter
+-dontwarn io.opentelemetry.api.incubator.metrics.ExtendedLongUpDownCounterBuilder
+-dontwarn io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider
+-dontwarn io.opentelemetry.sdk.autoconfigure.spi.internal.ConditionalResourceProvider
 
 ## Annotations used by some dependencies (such as OTel, Protobuf and Moshi) at compile time.
 ## No need to keep them for runtime.
 -dontwarn com.google.auto.value.AutoValue
+-dontwarn com.google.auto.value.AutoValue$Builder
 -dontwarn com.google.auto.value.AutoValue$CopyAnnotations
 -dontwarn com.google.errorprone.annotations.MustBeClosed

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ openTelemetryCore = "1.63.0"
 moshi = "1.15.2" # only used by the Gradle-plugin
 lifecycle = "2.7.0" # version pinned to 2.7.0 because of AGP bug
 annotation = "1.10.0"
-otelKotlin = "0.4.0"
+otelKotlin = "0.5.0"
 # Pinned to 1.10.x: 1.11.0+ requires kotlin-stdlib 2.2.20, which breaks our minimum supported Kotlin (2.0.21).
 kotlinxCoroutines = "1.10.2"
 kotlinxSerialization = "1.8.1"


### PR DESCRIPTION
## Goal

Bumps OpenTelemetry Kotlin to 0.5.0.