### PR TITLE
Allow more remote config over vital behaviour

### DIFF
--- a/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/Behavior.kt
+++ b/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/Behavior.kt
@@ -25,6 +25,8 @@ import io.embrace.android.embracesdk.internal.config.behavior.TraceparentInjecti
 import io.embrace.android.embracesdk.internal.config.behavior.TraceparentInjectionBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.UserSessionBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.UserSessionBehaviorImpl
+import io.embrace.android.embracesdk.internal.config.behavior.VitalsBehavior
+import io.embrace.android.embracesdk.internal.config.behavior.VitalsBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfigImpl
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 
@@ -41,6 +43,13 @@ fun createThreadBlockageBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
     remoteCfg: RemoteConfig? = null,
 ): ThreadBlockageBehavior = ThreadBlockageBehaviorImpl(thresholdCheck, remoteCfg)
+
+/**
+ * A [VitalsBehaviorImpl] that returns default values.
+ */
+fun createVitalsBehavior(
+    remoteCfg: RemoteConfig? = null,
+): VitalsBehavior = VitalsBehaviorImpl(remoteCfg)
 
 /**
  * A [UserSessionBehaviorImpl] that returns default values.

--- a/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/Behavior.kt
+++ b/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/Behavior.kt
@@ -48,8 +48,9 @@ fun createThreadBlockageBehavior(
  * A [VitalsBehaviorImpl] that returns default values.
  */
 fun createVitalsBehavior(
+    thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
     remoteCfg: RemoteConfig? = null,
-): VitalsBehavior = VitalsBehaviorImpl(remoteCfg)
+): VitalsBehavior = VitalsBehaviorImpl(thresholdCheck, remoteCfg)
 
 /**
  * A [UserSessionBehaviorImpl] that returns default values.

--- a/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
+++ b/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
@@ -19,6 +19,7 @@ import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehav
 import io.embrace.android.embracesdk.internal.config.behavior.ThreadBlockageBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.TraceparentInjectionBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.UserSessionBehavior
+import io.embrace.android.embracesdk.internal.config.behavior.VitalsBehavior
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 
 /**
@@ -35,6 +36,7 @@ class FakeConfigService(
     override var breadcrumbBehavior: BreadcrumbBehavior = FakeBreadcrumbBehavior(),
     override var logMessageBehavior: LogMessageBehavior = createLogMessageBehavior(),
     override var threadBlockageBehavior: ThreadBlockageBehavior = createThreadBlockageBehavior(),
+    override var vitalsBehavior: VitalsBehavior = createVitalsBehavior(),
     override var sessionBehavior: UserSessionBehavior = createSessionBehavior(),
     override var networkBehavior: NetworkBehavior = FakeNetworkBehavior(),
     override var dataCaptureEventBehavior: DataCaptureEventBehavior = createDataCaptureEventBehavior(),

--- a/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeVitalsBehavior.kt
+++ b/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeVitalsBehavior.kt
@@ -1,0 +1,20 @@
+package io.embrace.android.embracesdk.fakes.behavior
+
+import io.embrace.android.embracesdk.internal.config.behavior.VitalsBehavior
+
+class FakeVitalsBehavior(
+    var smoothnessIdleThresholdMsImpl: Long = 100L,
+    var smoothnessHeldIdleThresholdMsImpl: Long = 500L,
+    var jankHeuristicMultiplierImpl: Double = 2.0,
+    var screenLoadIdleThresholdMsImpl: Long = 1000L,
+    var screenLoadTimeoutMsImpl: Long = 30_000L,
+    var screenLoadNavTimeoutMsImpl: Long = 500L,
+) : VitalsBehavior {
+
+    override fun getSmoothnessIdleThresholdMs(): Long = smoothnessIdleThresholdMsImpl
+    override fun getSmoothnessHeldIdleThresholdMs(): Long = smoothnessHeldIdleThresholdMsImpl
+    override fun getJankHeuristicMultiplier(): Double = jankHeuristicMultiplierImpl
+    override fun getScreenLoadIdleThresholdMs(): Long = screenLoadIdleThresholdMsImpl
+    override fun getScreenLoadTimeoutMs(): Long = screenLoadTimeoutMsImpl
+    override fun getScreenLoadNavTimeoutMs(): Long = screenLoadNavTimeoutMsImpl
+}

--- a/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeVitalsBehavior.kt
+++ b/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeVitalsBehavior.kt
@@ -9,6 +9,7 @@ class FakeVitalsBehavior(
     var screenLoadIdleThresholdMsImpl: Long = 1000L,
     var screenLoadTimeoutMsImpl: Long = 30_000L,
     var screenLoadNavTimeoutMsImpl: Long = 500L,
+    var smoothnessFrameTraceEnabledImpl: Boolean = false,
 ) : VitalsBehavior {
 
     override fun getSmoothnessIdleThresholdMs(): Long = smoothnessIdleThresholdMsImpl
@@ -17,4 +18,5 @@ class FakeVitalsBehavior(
     override fun getScreenLoadIdleThresholdMs(): Long = screenLoadIdleThresholdMsImpl
     override fun getScreenLoadTimeoutMs(): Long = screenLoadTimeoutMsImpl
     override fun getScreenLoadNavTimeoutMs(): Long = screenLoadNavTimeoutMsImpl
+    override fun isSmoothnessFrameTraceEnabled(): Boolean = smoothnessFrameTraceEnabledImpl
 }

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigService.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigService.kt
@@ -14,6 +14,7 @@ import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehav
 import io.embrace.android.embracesdk.internal.config.behavior.ThreadBlockageBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.TraceparentInjectionBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.UserSessionBehavior
+import io.embrace.android.embracesdk.internal.config.behavior.VitalsBehavior
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 
 /**
@@ -47,6 +48,11 @@ interface ConfigService {
      * How thread blockage functionality should behave.
      */
     val threadBlockageBehavior: ThreadBlockageBehavior
+
+    /**
+     * How the vitals (smoothness / screen-load) feature's thresholds should behave.
+     */
+    val vitalsBehavior: VitalsBehavior
 
     /**
      * How sessions should behave.

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
@@ -127,7 +127,7 @@ class ConfigServiceImpl(
     override val sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(instrumentedConfig)
     override val logMessageBehavior = LogMessageBehaviorImpl(remoteConfig)
     override val threadBlockageBehavior = ThreadBlockageBehaviorImpl(thresholdCheck, remoteConfig)
-    override val vitalsBehavior = VitalsBehaviorImpl(remoteConfig)
+    override val vitalsBehavior = VitalsBehaviorImpl(thresholdCheck, remoteConfig)
     override val sessionBehavior = UserSessionBehaviorImpl(remoteConfig)
     override val networkBehavior = NetworkBehaviorImpl(instrumentedConfig, remoteConfig)
     override val dataCaptureEventBehavior = DataCaptureEventBehaviorImpl(remoteConfig)

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
@@ -15,6 +15,7 @@ import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehav
 import io.embrace.android.embracesdk.internal.config.behavior.ThreadBlockageBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.TraceparentInjectionBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.UserSessionBehaviorImpl
+import io.embrace.android.embracesdk.internal.config.behavior.VitalsBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.InstrumentedConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.config.source.CombinedRemoteConfigSource
@@ -126,6 +127,7 @@ class ConfigServiceImpl(
     override val sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(instrumentedConfig)
     override val logMessageBehavior = LogMessageBehaviorImpl(remoteConfig)
     override val threadBlockageBehavior = ThreadBlockageBehaviorImpl(thresholdCheck, remoteConfig)
+    override val vitalsBehavior = VitalsBehaviorImpl(remoteConfig)
     override val sessionBehavior = UserSessionBehaviorImpl(remoteConfig)
     override val networkBehavior = NetworkBehaviorImpl(instrumentedConfig, remoteConfig)
     override val dataCaptureEventBehavior = DataCaptureEventBehaviorImpl(remoteConfig)

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/VitalsBehavior.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/VitalsBehavior.kt
@@ -1,0 +1,34 @@
+package io.embrace.android.embracesdk.internal.config.behavior
+
+interface VitalsBehavior {
+
+    /**
+     * How long a smoothness focal moment must be idle (no redraw, no touch) before it is considered settled.
+     */
+    fun getSmoothnessIdleThresholdMs(): Long
+
+    /**
+     * The "press and hold" settle threshold used when no move event arrives within the idle threshold.
+     */
+    fun getSmoothnessHeldIdleThresholdMs(): Long
+
+    /**
+     * The grace multiplier applied to a frame's budget/deadline before it is considered janky.
+     */
+    fun getJankHeuristicMultiplier(): Double
+
+    /**
+     * How long a screen-load destination must be idle before it is considered settled.
+     */
+    fun getScreenLoadIdleThresholdMs(): Long
+
+    /**
+     * Maximum time a screen-load is allowed to run before being force-reported as timed out.
+     */
+    fun getScreenLoadTimeoutMs(): Long
+
+    /**
+     * Maximum time between a tap and the navigation start event for the two to be linked as one screen load.
+     */
+    fun getScreenLoadNavTimeoutMs(): Long
+}

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/VitalsBehavior.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/VitalsBehavior.kt
@@ -31,4 +31,10 @@ interface VitalsBehavior {
      * Maximum time between a tap and the navigation start event for the two to be linked as one screen load.
      */
     fun getScreenLoadNavTimeoutMs(): Long
+
+    /**
+     * Whether this device is sampled-in to record a per-frame duration trace alongside the smoothness result,
+     * as a diagnostic aid while smoothness thresholds are being tuned.
+     */
+    fun isSmoothnessFrameTraceEnabled(): Boolean
 }

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/VitalsBehaviorImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/VitalsBehaviorImpl.kt
@@ -1,0 +1,40 @@
+package io.embrace.android.embracesdk.internal.config.behavior
+
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+
+/**
+ * Provides the behavior that the vitals (smoothness / screen-load) feature should follow.
+ */
+class VitalsBehaviorImpl(
+    remote: RemoteConfig?,
+) : VitalsBehavior {
+
+    private companion object {
+        private const val DEFAULT_SMOOTHNESS_IDLE_THRESHOLD_MS = 100L
+        private const val DEFAULT_SMOOTHNESS_HELD_IDLE_THRESHOLD_MS = 500L
+        private const val DEFAULT_JANK_HEURISTIC_MULTIPLIER = 2.0
+        private const val DEFAULT_SCREEN_LOAD_IDLE_THRESHOLD_MS = 1000L
+        private const val DEFAULT_SCREEN_LOAD_TIMEOUT_MS = 30_000L
+        private const val DEFAULT_SCREEN_LOAD_NAV_TIMEOUT_MS = 500L
+    }
+
+    private val remote = remote?.vitalsRemoteConfig
+
+    override fun getSmoothnessIdleThresholdMs(): Long =
+        remote?.smoothnessIdleThresholdMs ?: DEFAULT_SMOOTHNESS_IDLE_THRESHOLD_MS
+
+    override fun getSmoothnessHeldIdleThresholdMs(): Long =
+        remote?.smoothnessHeldIdleThresholdMs ?: DEFAULT_SMOOTHNESS_HELD_IDLE_THRESHOLD_MS
+
+    override fun getJankHeuristicMultiplier(): Double =
+        remote?.jankHeuristicMultiplier ?: DEFAULT_JANK_HEURISTIC_MULTIPLIER
+
+    override fun getScreenLoadIdleThresholdMs(): Long =
+        remote?.screenLoadIdleThresholdMs ?: DEFAULT_SCREEN_LOAD_IDLE_THRESHOLD_MS
+
+    override fun getScreenLoadTimeoutMs(): Long =
+        remote?.screenLoadTimeoutMs ?: DEFAULT_SCREEN_LOAD_TIMEOUT_MS
+
+    override fun getScreenLoadNavTimeoutMs(): Long =
+        remote?.screenLoadNavTimeoutMs ?: DEFAULT_SCREEN_LOAD_NAV_TIMEOUT_MS
+}

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/VitalsBehaviorImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/VitalsBehaviorImpl.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
  * Provides the behavior that the vitals (smoothness / screen-load) feature should follow.
  */
 class VitalsBehaviorImpl(
+    private val thresholdCheck: BehaviorThresholdCheck,
     remote: RemoteConfig?,
 ) : VitalsBehavior {
 
@@ -16,6 +17,7 @@ class VitalsBehaviorImpl(
         private const val DEFAULT_SCREEN_LOAD_IDLE_THRESHOLD_MS = 1000L
         private const val DEFAULT_SCREEN_LOAD_TIMEOUT_MS = 30_000L
         private const val DEFAULT_SCREEN_LOAD_NAV_TIMEOUT_MS = 500L
+        private const val DEFAULT_SMOOTHNESS_FRAME_TRACE_ENABLED = false
     }
 
     private val remote = remote?.vitalsRemoteConfig
@@ -37,4 +39,8 @@ class VitalsBehaviorImpl(
 
     override fun getScreenLoadNavTimeoutMs(): Long =
         remote?.screenLoadNavTimeoutMs ?: DEFAULT_SCREEN_LOAD_NAV_TIMEOUT_MS
+
+    override fun isSmoothnessFrameTraceEnabled(): Boolean =
+        thresholdCheck.isBehaviorEnabled(remote?.smoothnessFrameTracePctEnabled)
+            ?: DEFAULT_SMOOTHNESS_FRAME_TRACE_ENABLED
 }

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/VitalsBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/VitalsBehaviorImplTest.kt
@@ -4,6 +4,8 @@ import io.embrace.android.embracesdk.fakes.createVitalsBehavior
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.VitalsRemoteConfig
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class VitalsBehaviorImplTest {
@@ -15,6 +17,7 @@ internal class VitalsBehaviorImplTest {
         screenLoadIdleThresholdMs = 1500,
         screenLoadTimeoutMs = 45_000,
         screenLoadNavTimeoutMs = 750,
+        smoothnessFrameTracePctEnabled = 100f,
     )
 
     @Test
@@ -26,6 +29,7 @@ internal class VitalsBehaviorImplTest {
             assertEquals(1000L, getScreenLoadIdleThresholdMs())
             assertEquals(30_000L, getScreenLoadTimeoutMs())
             assertEquals(500L, getScreenLoadNavTimeoutMs())
+            assertFalse(isSmoothnessFrameTraceEnabled())
         }
     }
 
@@ -38,6 +42,7 @@ internal class VitalsBehaviorImplTest {
             assertEquals(1500L, getScreenLoadIdleThresholdMs())
             assertEquals(45_000L, getScreenLoadTimeoutMs())
             assertEquals(750L, getScreenLoadNavTimeoutMs())
+            assertTrue(isSmoothnessFrameTraceEnabled())
         }
     }
 }

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/VitalsBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/VitalsBehaviorImplTest.kt
@@ -1,0 +1,43 @@
+package io.embrace.android.embracesdk.internal.config.behavior
+
+import io.embrace.android.embracesdk.fakes.createVitalsBehavior
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.config.remote.VitalsRemoteConfig
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class VitalsBehaviorImplTest {
+
+    private val remote = VitalsRemoteConfig(
+        smoothnessIdleThresholdMs = 150,
+        smoothnessHeldIdleThresholdMs = 600,
+        jankHeuristicMultiplier = 2.5,
+        screenLoadIdleThresholdMs = 1500,
+        screenLoadTimeoutMs = 45_000,
+        screenLoadNavTimeoutMs = 750,
+    )
+
+    @Test
+    fun testDefaults() {
+        with(createVitalsBehavior()) {
+            assertEquals(100L, getSmoothnessIdleThresholdMs())
+            assertEquals(500L, getSmoothnessHeldIdleThresholdMs())
+            assertEquals(2.0, getJankHeuristicMultiplier(), 0.0)
+            assertEquals(1000L, getScreenLoadIdleThresholdMs())
+            assertEquals(30_000L, getScreenLoadTimeoutMs())
+            assertEquals(500L, getScreenLoadNavTimeoutMs())
+        }
+    }
+
+    @Test
+    fun testRemote() {
+        with(createVitalsBehavior(remoteCfg = RemoteConfig(vitalsRemoteConfig = remote))) {
+            assertEquals(150L, getSmoothnessIdleThresholdMs())
+            assertEquals(600L, getSmoothnessHeldIdleThresholdMs())
+            assertEquals(2.5, getJankHeuristicMultiplier(), 0.0)
+            assertEquals(1500L, getScreenLoadIdleThresholdMs())
+            assertEquals(45_000L, getScreenLoadTimeoutMs())
+            assertEquals(750L, getScreenLoadNavTimeoutMs())
+        }
+    }
+}

--- a/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
+++ b/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
@@ -264,6 +264,7 @@ sealed class SchemaType(
         idleThresholdMs: Long,
         heldIdleThresholdMs: Long,
         jankHeuristicMultiplier: Double,
+        frameTraceBase64: String? = null,
     ) : SchemaType(
         telemetryType = EmbType.Performance.Smoothness,
         fixedObjectName = "smoothness",
@@ -275,7 +276,8 @@ sealed class SchemaType(
             EmbSmoothnessAttributes.SMOOTHNESS_IDLE_THRESHOLD_MS to idleThresholdMs.toString(),
             EmbSmoothnessAttributes.SMOOTHNESS_HELD_IDLE_THRESHOLD_MS to heldIdleThresholdMs.toString(),
             EmbSmoothnessAttributes.SMOOTHNESS_JANK_HEURISTIC_MULTIPLIER to jankHeuristicMultiplier.toString(),
-        )
+            EmbSmoothnessAttributes.SMOOTHNESS_FRAME_TRACE to frameTraceBase64,
+        ).toNonNullMap()
     }
 
     /**

--- a/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
+++ b/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
@@ -261,6 +261,9 @@ sealed class SchemaType(
         outcome: String,
         frameCount: Int,
         normalizedDroppedFrames: Double,
+        idleThresholdMs: Long,
+        heldIdleThresholdMs: Long,
+        jankHeuristicMultiplier: Double,
     ) : SchemaType(
         telemetryType = EmbType.Performance.Smoothness,
         fixedObjectName = "smoothness",
@@ -269,6 +272,9 @@ sealed class SchemaType(
             EmbSmoothnessAttributes.SMOOTHNESS_OUTCOME to outcome,
             EmbSmoothnessAttributes.SMOOTHNESS_FRAME_COUNT to frameCount.toString(),
             EmbSmoothnessAttributes.SMOOTHNESS_NORMALIZED_DROPPED_FRAMES to normalizedDroppedFrames.toString(),
+            EmbSmoothnessAttributes.SMOOTHNESS_IDLE_THRESHOLD_MS to idleThresholdMs.toString(),
+            EmbSmoothnessAttributes.SMOOTHNESS_HELD_IDLE_THRESHOLD_MS to heldIdleThresholdMs.toString(),
+            EmbSmoothnessAttributes.SMOOTHNESS_JANK_HEURISTIC_MULTIPLIER to jankHeuristicMultiplier.toString(),
         )
     }
 
@@ -282,6 +288,9 @@ sealed class SchemaType(
         navStartDelayMs: Long,
         navDurationMs: Long,
         firstFrameDurationMs: Long,
+        idleThresholdMs: Long,
+        timeoutMs: Long,
+        navTimeoutMs: Long,
     ) : SchemaType(
         telemetryType = EmbType.Performance.ScreenLoad,
         fixedObjectName = "screen-load",
@@ -292,6 +301,9 @@ sealed class SchemaType(
             EmbScreenLoadAttributes.SCREEN_LOAD_NAV_START_DELAY_MS to navStartDelayMs.toString(),
             EmbScreenLoadAttributes.SCREEN_LOAD_NAV_DURATION_MS to navDurationMs.toString(),
             EmbScreenLoadAttributes.SCREEN_LOAD_FIRST_FRAME_DURATION_MS to firstFrameDurationMs.toString(),
+            EmbScreenLoadAttributes.SCREEN_LOAD_IDLE_THRESHOLD_MS to idleThresholdMs.toString(),
+            EmbScreenLoadAttributes.SCREEN_LOAD_TIMEOUT_MS to timeoutMs.toString(),
+            EmbScreenLoadAttributes.SCREEN_LOAD_NAV_TIMEOUT_MS to navTimeoutMs.toString(),
         )
     }
 

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/FrameMetricsStrategy.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/FrameMetricsStrategy.kt
@@ -5,6 +5,8 @@ import android.os.SystemClock
 import android.view.FrameMetrics
 import androidx.annotation.RequiresApi
 import androidx.annotation.WorkerThread
+import io.embrace.android.embracesdk.internal.vitals.FrameMetricsStrategy.Companion.create
+import io.embrace.android.embracesdk.internal.vitals.smoothness.SmoothnessReporter
 
 /**
  * Extracts `(vsyncNanos, frameDispatchNanos, jankNanos)` from a [FrameMetrics]. The concrete strategy is
@@ -38,11 +40,6 @@ internal interface FrameMetricsStrategy {
 
     companion object {
         /**
-         * A frame counts as janky once it runs this many times past its deadline; matches JankStats' default.
-         */
-        const val DEFAULT_JANK_HEURISTIC_MULTIPLIER = 2.0
-
-        /**
          * Create a [FrameMetricsStrategy] with a given [refreshIntervalNanos] and [jankHeuristicMultiplier].
          *
          * @param refreshIntervalNanos nanoseconds between frames at the current refresh rate (for devices < SDK_31)
@@ -51,7 +48,7 @@ internal interface FrameMetricsStrategy {
         @RequiresApi(Build.VERSION_CODES.N)
         fun create(
             refreshIntervalNanos: Long,
-            jankHeuristicMultiplier: Double = DEFAULT_JANK_HEURISTIC_MULTIPLIER,
+            jankHeuristicMultiplier: Double = SmoothnessReporter.DEFAULT_JANK_HEURISTIC_MULTIPLIER,
         ): FrameMetricsStrategy = when {
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ->
                 Api31FrameMetricsStrategy(jankHeuristicMultiplier)

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsDataSource.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsDataSource.kt
@@ -32,7 +32,10 @@ internal class VitalsDataSource(
 ) {
 
     // Extracts per-frame jank; below API 31 the budget tracks the display's refresh interval.
-    private val frameMetricsStrategy: FrameMetricsStrategy = FrameMetricsStrategy.create(displayRefreshIntervalNanos())
+    private val frameMetricsStrategy: FrameMetricsStrategy = FrameMetricsStrategy.create(
+        refreshIntervalNanos = displayRefreshIntervalNanos(),
+        jankHeuristicMultiplier = args.configService.vitalsBehavior.getJankHeuristicMultiplier(),
+    )
 
     private val displayListener = object : DisplayManager.DisplayListener {
         override fun onDisplayChanged(displayId: Int) {
@@ -71,15 +74,26 @@ internal class VitalsDataSource(
                 ?.registerDisplayListener(displayListener, handler)
         }
 
+        val vitalsBehavior = args.configService.vitalsBehavior
         val tracker = FocalMomentTracker(
             scheduler = vitalsScheduler,
-            reporter = SmoothnessReporter(emit = ::emitSmoothnessResult),
+            reporter = SmoothnessReporter(
+                emit = ::emitSmoothnessResult,
+                idleThresholdMs = vitalsBehavior.getSmoothnessIdleThresholdMs(),
+                heldIdleThresholdMs = vitalsBehavior.getSmoothnessHeldIdleThresholdMs(),
+                jankHeuristicMultiplier = vitalsBehavior.getJankHeuristicMultiplier(),
+            ),
             clock = clock,
             screenLoadTracker = ScreenLoadTracker(
                 scheduler = vitalsScheduler,
                 clock = clock,
                 emit = ::emitScreenLoadResult,
+                idleThresholdMs = vitalsBehavior.getScreenLoadIdleThresholdMs(),
+                timeoutMs = vitalsBehavior.getScreenLoadTimeoutMs(),
+                navigationTimeoutMs = vitalsBehavior.getScreenLoadNavTimeoutMs(),
             ),
+            idleThresholdMs = vitalsBehavior.getSmoothnessIdleThresholdMs(),
+            heldIdleThresholdMs = vitalsBehavior.getSmoothnessHeldIdleThresholdMs(),
         )
         focalTracker = tracker
 
@@ -119,6 +133,9 @@ internal class VitalsDataSource(
                     outcome = result.outcome.name.lowercase(),
                     frameCount = result.frameCount,
                     normalizedDroppedFrames = result.normalizedDroppedFrames,
+                    idleThresholdMs = result.idleThresholdMs,
+                    heldIdleThresholdMs = result.heldIdleThresholdMs,
+                    jankHeuristicMultiplier = result.jankHeuristicMultiplier,
                 ).attributes(),
             )
         }
@@ -142,6 +159,9 @@ internal class VitalsDataSource(
                     navStartDelayMs = result.navStartDelayMs,
                     navDurationMs = result.navDurationMs,
                     firstFrameDurationMs = result.firstFrameDurationMs,
+                    idleThresholdMs = result.idleThresholdMs,
+                    timeoutMs = result.timeoutMs,
+                    navTimeoutMs = result.navTimeoutMs,
                 ).attributes(),
             )
         }

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsDataSource.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsDataSource.kt
@@ -14,6 +14,7 @@ import io.embrace.android.embracesdk.internal.arch.state.AppStateListener
 import io.embrace.android.embracesdk.internal.vitals.screenload.ScreenLoadResult
 import io.embrace.android.embracesdk.internal.vitals.screenload.ScreenLoadTracker
 import io.embrace.android.embracesdk.internal.vitals.smoothness.FocalMomentTracker
+import io.embrace.android.embracesdk.internal.vitals.smoothness.FrameTraceRecorder
 import io.embrace.android.embracesdk.internal.vitals.smoothness.SmoothnessReporter
 import io.embrace.android.embracesdk.internal.vitals.smoothness.SmoothnessResult
 
@@ -94,6 +95,7 @@ internal class VitalsDataSource(
             ),
             idleThresholdMs = vitalsBehavior.getSmoothnessIdleThresholdMs(),
             heldIdleThresholdMs = vitalsBehavior.getSmoothnessHeldIdleThresholdMs(),
+            frameTraceRecorder = if (vitalsBehavior.isSmoothnessFrameTraceEnabled()) FrameTraceRecorder() else null,
         )
         focalTracker = tracker
 
@@ -136,6 +138,7 @@ internal class VitalsDataSource(
                     idleThresholdMs = result.idleThresholdMs,
                     heldIdleThresholdMs = result.heldIdleThresholdMs,
                     jankHeuristicMultiplier = result.jankHeuristicMultiplier,
+                    frameTraceBase64 = result.frameTraceBase64,
                 ).attributes(),
             )
         }

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadResult.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadResult.kt
@@ -33,4 +33,16 @@ internal data class ScreenLoadResult(
      * How the load ended.
      */
     val outcome: ScreenLoadOutcome,
+    /**
+     * The idle threshold that was applied to determine when the destination screen had settled.
+     */
+    val idleThresholdMs: Long,
+    /**
+     * The maximum duration that was applied before the screen load was force-reported as timed out.
+     */
+    val timeoutMs: Long,
+    /**
+     * The maximum tap-to-navigation-start gap that was applied to link the two events into one screen load.
+     */
+    val navTimeoutMs: Long,
 )

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTracker.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTracker.kt
@@ -19,6 +19,7 @@ internal class ScreenLoadTracker(
     private val emit: (ScreenLoadResult) -> Unit,
     private val idleThresholdMs: Long = IDLE_THRESHOLD_MS,
     private val timeoutMs: Long = SETTLE_TIMEOUT_MS,
+    private val navigationTimeoutMs: Long = NAVIGATION_TIMEOUT_MS,
 ) {
     private val settle = SettleTracker(scheduler, { idleThresholdMs }, ::onSettled)
 
@@ -77,7 +78,7 @@ internal class ScreenLoadTracker(
         when (state) {
             State.IDLE -> openLoad(eventTime)
             State.CANDIDATE -> {
-                if (eventTime <= startUptimeMs + NAVIGATION_TIMEOUT_MS) {
+                if (eventTime <= startUptimeMs + navigationTimeoutMs) {
                     state = State.CONFIRMED
                     navStartMs = eventTime
                 } else {
@@ -203,6 +204,9 @@ internal class ScreenLoadTracker(
             durationMs = endMs - startUptimeMs,
             screenName = screenName,
             outcome = outcome,
+            idleThresholdMs = idleThresholdMs,
+            timeoutMs = timeoutMs,
+            navTimeoutMs = navigationTimeoutMs,
         )
 
         discard()

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTracker.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTracker.kt
@@ -27,6 +27,8 @@ internal class FocalMomentTracker(
     private val screenLoadTracker: ScreenLoadTracker,
     private val idleThresholdMs: Long = DEFAULT_IDLE_THRESHOLD_MS,
     private val heldIdleThresholdMs: Long = DEFAULT_HELD_IDLE_THRESHOLD_MS,
+    // Only non-null for a sampled fraction of devices; see VitalsBehavior.isSmoothnessFrameTraceEnabled.
+    private val frameTraceRecorder: FrameTraceRecorder? = null,
 ) : FocalInteractionCallbacks {
 
     // Reused hop Runnable instances (main thread -> Vitals thread); allocate them here to make certain they're off the hot path
@@ -48,14 +50,14 @@ internal class FocalMomentTracker(
     @WorkerThread
     override fun onFrame(vsyncNanos: Long, frameDispatchNanos: Long, jankNanos: Long) {
         if (capturing) {
-            recordFrame(frameDispatchNanos, jankNanos)
+            recordFrame(vsyncNanos, frameDispatchNanos, jankNanos)
             settle.notifyActivity(vsyncNanos.nanosToMillis())
         } else if (held) {
             if (vsyncNanos - bufferedEndNanos < idleThresholdMs.millisToNanos()) {
                 // Frame is contiguous with the buffered settle: resume capturing so its jank is included.
                 held = false
                 capturing = true
-                recordFrame(frameDispatchNanos, jankNanos)
+                recordFrame(vsyncNanos, frameDispatchNanos, jankNanos)
                 settle.notifyActivity(vsyncNanos.nanosToMillis())
             } else {
                 // Idle gap before this frame: emit the buffered settle and discard the orphan frame.
@@ -151,11 +153,12 @@ internal class FocalMomentTracker(
         interacting = true
         capturing = true
         reporter.onFocalMomentStart()
+        frameTraceRecorder?.onFocalMomentStart()
         settle.notifyActivity(nowMs)
     }
 
     @WorkerThread
-    private fun recordFrame(frameDispatchNanos: Long, jankNanos: Long) {
+    private fun recordFrame(vsyncNanos: Long, frameDispatchNanos: Long, jankNanos: Long) {
         // A jank frame is counted in full, so the moment must also cover the render that produced it. We
         // back-date the start to when the engine dispatched the frame's work, if that predates the
         // moment, shifting the reported start epoch by the same amount so the end stays put.
@@ -165,6 +168,7 @@ internal class FocalMomentTracker(
         }
 
         reporter.onFocalMomentFrame(jankNanos)
+        frameTraceRecorder?.onFocalMomentFrame((vsyncNanos - frameDispatchNanos).nanosToMillis())
     }
 
     /**
@@ -201,7 +205,7 @@ internal class FocalMomentTracker(
         held = false
         settle.cancel()
         val durationMs = (endNanos - focalMomentStartNanos).nanosToMillis()
-        reporter.onFocalMomentEnd(outcome, focalMomentStartEpochMs, durationMs)
+        reporter.onFocalMomentEnd(outcome, focalMomentStartEpochMs, durationMs, frameTraceRecorder?.toBase64())
     }
 
     /**

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTracker.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTracker.kt
@@ -25,8 +25,8 @@ internal class FocalMomentTracker(
     private val reporter: SmoothnessReporter,
     private val clock: Clock,
     private val screenLoadTracker: ScreenLoadTracker,
-    private val idleThresholdMs: Long = IDLE_THRESHOLD_MS,
-    private val heldIdleThresholdMs: Long = HELD_IDLE_THRESHOLD_MS,
+    private val idleThresholdMs: Long = DEFAULT_IDLE_THRESHOLD_MS,
+    private val heldIdleThresholdMs: Long = DEFAULT_HELD_IDLE_THRESHOLD_MS,
 ) : FocalInteractionCallbacks {
 
     // Reused hop Runnable instances (main thread -> Vitals thread); allocate them here to make certain they're off the hot path
@@ -219,13 +219,13 @@ internal class FocalMomentTracker(
 
     private fun nowNanos(): Long = nowMs().millisToNanos()
 
-    private companion object {
-        const val IDLE_THRESHOLD_MS = 100L
+    companion object {
+        const val DEFAULT_IDLE_THRESHOLD_MS = 100L
 
         /**
          * The "press and hold" threshold, if we don't get a "move" event (which we really should) within this time we consider the
          * interaction / focal moment settled.
          */
-        const val HELD_IDLE_THRESHOLD_MS = 500L
+        const val DEFAULT_HELD_IDLE_THRESHOLD_MS = 500L
     }
 }

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FrameTraceRecorder.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FrameTraceRecorder.kt
@@ -1,0 +1,71 @@
+package io.embrace.android.embracesdk.internal.vitals.smoothness
+
+import android.util.Base64
+import androidx.annotation.WorkerThread
+
+/**
+ * Records a per-frame duration trace over a focal moment, as a diagnostic aid while smoothness thresholds
+ * are being tuned. Only constructed for a sampled fraction of devices (see
+ * [io.embrace.android.embracesdk.internal.config.behavior.VitalsBehavior.isSmoothnessFrameTraceEnabled]),
+ * so the buffer is pre-allocated once per instance rather than per focal moment.
+ *
+ * Each frame's total duration (whole milliseconds) is packed as an unsigned LEB128 varint into a
+ * fixed-size buffer: a typical 1-3ms frame costs a single byte, while a slow/janky frame costs more,
+ * so detail scales with what's actually interesting. Once the buffer fills, further frames in that
+ * focal moment are silently dropped rather than corrupting the encoding with a truncated varint.
+ */
+internal class FrameTraceRecorder(
+    capacityBytes: Int = DEFAULT_CAPACITY_BYTES,
+) {
+
+    private val buffer = ByteArray(capacityBytes)
+    private var writeIndex = 0
+
+    @WorkerThread
+    fun onFocalMomentStart() {
+        writeIndex = 0
+    }
+
+    @WorkerThread
+    fun onFocalMomentFrame(frameDurationMs: Long) {
+        writeVarInt(frameDurationMs.coerceAtLeast(0L))
+        return
+    }
+
+    private fun writeVarInt(value: Long) {
+        var v = value
+        var index = writeIndex
+        while (true) {
+            if (index >= buffer.size) {
+                // Not enough room to finish this varint: drop it rather than write a truncated one.
+                return
+            }
+            val septet = (v and SEPTET_MASK).toByte()
+            v = v ushr 7
+            if (v == 0L) {
+                buffer[index] = septet
+                writeIndex = index + 1
+                return
+            }
+            buffer[index] = (septet.toInt() or CONTINUATION_BIT).toByte()
+            index++
+        }
+    }
+
+    /**
+     * Base64-encodes the frames recorded since the last [onFocalMomentStart], or null if none were recorded.
+     */
+    @WorkerThread
+    fun toBase64(): String? {
+        if (writeIndex == 0) {
+            return null
+        }
+        return Base64.encodeToString(buffer, 0, writeIndex, Base64.NO_PADDING or Base64.NO_WRAP)
+    }
+
+    internal companion object {
+        const val DEFAULT_CAPACITY_BYTES = 1024
+        private const val SEPTET_MASK = 0x7FL
+        private const val CONTINUATION_BIT = 0x80
+    }
+}

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/SmoothnessReporter.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/SmoothnessReporter.kt
@@ -31,7 +31,7 @@ internal class SmoothnessReporter(
     }
 
     @WorkerThread
-    fun onFocalMomentEnd(outcome: FocalOutcome, startTimeMs: Long, durationMs: Long) {
+    fun onFocalMomentEnd(outcome: FocalOutcome, startTimeMs: Long, durationMs: Long, frameTraceBase64: String? = null) {
         if (frameCount == 0) {
             // No frames rendered: nothing to report.
             return
@@ -46,6 +46,7 @@ internal class SmoothnessReporter(
                 idleThresholdMs = idleThresholdMs,
                 heldIdleThresholdMs = heldIdleThresholdMs,
                 jankHeuristicMultiplier = jankHeuristicMultiplier,
+                frameTraceBase64 = frameTraceBase64,
             ),
         )
     }

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/SmoothnessReporter.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/SmoothnessReporter.kt
@@ -10,6 +10,9 @@ import androidx.annotation.WorkerThread
  */
 internal class SmoothnessReporter(
     private val emit: (SmoothnessResult) -> Unit,
+    private val idleThresholdMs: Long = FocalMomentTracker.DEFAULT_IDLE_THRESHOLD_MS,
+    private val heldIdleThresholdMs: Long = FocalMomentTracker.DEFAULT_HELD_IDLE_THRESHOLD_MS,
+    private val jankHeuristicMultiplier: Double = DEFAULT_JANK_HEURISTIC_MULTIPLIER,
 ) {
 
     private var frameCount = 0
@@ -40,14 +43,22 @@ internal class SmoothnessReporter(
                 durationMs = durationMs,
                 frameCount = frameCount,
                 normalizedDroppedFrames = normalizedDroppedFrames,
+                idleThresholdMs = idleThresholdMs,
+                heldIdleThresholdMs = heldIdleThresholdMs,
+                jankHeuristicMultiplier = jankHeuristicMultiplier,
             ),
         )
     }
 
-    private companion object {
+    internal companion object {
         /**
          * A 60fps reference frame in nanoseconds; all jank is normalized to this.
          */
         private const val REFERENCE_FRAME_NANOS = 1_000_000_000.0 / 60.0
+
+        /**
+         * A frame counts as janky once it runs this many times past its deadline; matches JankStats' default.
+         */
+        const val DEFAULT_JANK_HEURISTIC_MULTIPLIER = 2.0
     }
 }

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/SmoothnessResult.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/SmoothnessResult.kt
@@ -34,4 +34,9 @@ internal data class SmoothnessResult(
      * The grace multiplier that was applied to a frame's budget/deadline before it was considered janky.
      */
     val jankHeuristicMultiplier: Double,
+    /**
+     * Base64-encoded, varint-packed per-frame duration trace, if this device is sampled-in to record one;
+     * null otherwise.
+     */
+    val frameTraceBase64: String? = null,
 )

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/SmoothnessResult.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/SmoothnessResult.kt
@@ -22,4 +22,16 @@ internal data class SmoothnessResult(
      * Total jank over the focal moment, expressed in 60fps-reference frames.
      */
     val normalizedDroppedFrames: Double,
+    /**
+     * The idle threshold that was applied to determine when the focal moment had settled.
+     */
+    val idleThresholdMs: Long,
+    /**
+     * The "press and hold" settle threshold that was applied.
+     */
+    val heldIdleThresholdMs: Long,
+    /**
+     * The grace multiplier that was applied to a frame's budget/deadline before it was considered janky.
+     */
+    val jankHeuristicMultiplier: Double,
 )

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTrackerTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTrackerTest.kt
@@ -54,6 +54,9 @@ internal class ScreenLoadTrackerTest {
         assertEquals(IDLE, result.idleThresholdMs)
         assertEquals(TIMEOUT, result.timeoutMs)
         assertEquals(NAV_TIMEOUT, result.navTimeoutMs)
+        assertEquals(IDLE, result.idleThresholdMs)
+        assertEquals(TIMEOUT, result.timeoutMs)
+        assertEquals(NAV_TIMEOUT, result.navTimeoutMs)
     }
 
     @Test

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTrackerTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTrackerTest.kt
@@ -24,6 +24,7 @@ internal class ScreenLoadTrackerTest {
         emit = emitted::add,
         idleThresholdMs = IDLE,
         timeoutMs = TIMEOUT,
+        navigationTimeoutMs = NAV_TIMEOUT,
     )
 
     @Test
@@ -50,6 +51,9 @@ internal class ScreenLoadTrackerTest {
         assertEquals("navigation start at t=10, navigation end at t=20", 10L, result.navDurationMs)
         assertEquals("first frame at t=30, 10ms after navigation end (t=20)", 10L, result.firstFrameDurationMs)
         assertEquals(start, result.startTimeMs)
+        assertEquals(IDLE, result.idleThresholdMs)
+        assertEquals(TIMEOUT, result.timeoutMs)
+        assertEquals(NAV_TIMEOUT, result.navTimeoutMs)
     }
 
     @Test
@@ -245,5 +249,6 @@ internal class ScreenLoadTrackerTest {
     private companion object {
         const val IDLE = 100L
         const val TIMEOUT = 500L
+        const val NAV_TIMEOUT = 500L
     }
 }

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTrackerTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTrackerTest.kt
@@ -6,6 +6,8 @@ import io.embrace.android.embracesdk.internal.vitals.fake.FakeVitalsScheduler
 import io.embrace.android.embracesdk.internal.vitals.screenload.ScreenLoadTracker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -254,6 +256,33 @@ internal class FocalMomentTrackerTest {
         tracker.onScreenStop()
 
         assertEquals(1.0, emitted.single().normalizedDroppedFrames, 0.01)
+    }
+
+    @Test
+    fun `no frame trace is attached when the device is not sampled-in`() {
+        tracker.onInteractionStart()
+        redraw(vsyncNanos = start + 16.ms)
+        tracker.onScreenStop()
+
+        assertNull(emitted.single().frameTraceBase64)
+    }
+
+    @Test
+    fun `a frame trace is attached when a FrameTraceRecorder is supplied`() {
+        val sampledInEmitted = mutableListOf<SmoothnessResult>()
+        val sampledInTracker = FocalMomentTracker(
+            scheduler = scheduler,
+            reporter = SmoothnessReporter(emit = sampledInEmitted::add),
+            clock = { 0L },
+            screenLoadTracker = ScreenLoadTracker(scheduler = scheduler, clock = { 0L }, emit = {}),
+            frameTraceRecorder = FrameTraceRecorder(),
+        )
+
+        sampledInTracker.onInteractionStart()
+        sampledInTracker.onFrame(vsyncNanos = start + 16.ms, frameDispatchNanos = start + 16.ms, jankNanos = 0L)
+        sampledInTracker.onScreenStop()
+
+        assertNotNull(sampledInEmitted.single().frameTraceBase64)
     }
 
     private fun advance(millis: Long) = ShadowSystemClock.advanceBy(Duration.ofMillis(millis))

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FrameTraceRecorderTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FrameTraceRecorderTest.kt
@@ -1,0 +1,100 @@
+package io.embrace.android.embracesdk.internal.vitals.smoothness
+
+import android.util.Base64
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class FrameTraceRecorderTest {
+
+    @Test
+    fun `an empty focal moment reports no trace`() {
+        val recorder = FrameTraceRecorder()
+        recorder.onFocalMomentStart()
+
+        assertNull(recorder.toBase64())
+    }
+
+    @Test
+    fun `records and round-trips a mix of small and large frame durations`() {
+        val recorder = FrameTraceRecorder()
+        recorder.onFocalMomentStart()
+
+        val durations = listOf(1L, 3L, 0L, 127L, 128L, 300L, 16_384L)
+        durations.forEach(recorder::onFocalMomentFrame)
+
+        assertEquals(durations, decode(recorder.toBase64()))
+    }
+
+    @Test
+    fun `a negative duration is clamped to zero rather than corrupting the encoding`() {
+        val recorder = FrameTraceRecorder()
+        recorder.onFocalMomentStart()
+
+        recorder.onFocalMomentFrame(-5L)
+
+        assertEquals(listOf(0L), decode(recorder.toBase64()))
+    }
+
+    @Test
+    fun `frames that would overflow the buffer are dropped, not truncated`() {
+        val recorder = FrameTraceRecorder(capacityBytes = 4)
+        recorder.onFocalMomentStart()
+
+        // Each of these needs 2 bytes (>=128); the 3rd would need bytes 5-6, past the 4-byte buffer.
+        repeat(3) { recorder.onFocalMomentFrame(200L) }
+
+        // Only the first two 2-byte frames fit; the dropped one leaves no partial/corrupt bytes behind.
+        assertEquals(listOf(200L, 200L), decode(recorder.toBase64()))
+    }
+
+    @Test
+    fun `onFocalMomentStart resets the buffer for a new focal moment`() {
+        val recorder = FrameTraceRecorder()
+        recorder.onFocalMomentStart()
+        recorder.onFocalMomentFrame(50L)
+        assertEquals(listOf(50L), decode(recorder.toBase64()))
+
+        recorder.onFocalMomentStart()
+        assertNull(recorder.toBase64())
+
+        recorder.onFocalMomentFrame(2L)
+        assertEquals(listOf(2L), decode(recorder.toBase64()))
+    }
+
+    @Test
+    fun `a 1024-byte buffer stays within the internal attribute value length limit once base64-encoded`() {
+        val recorder = FrameTraceRecorder()
+        recorder.onFocalMomentStart()
+
+        // Fill with worst-case 2-byte durations so the buffer is as full as possible.
+        repeat(600) { recorder.onFocalMomentFrame(200L) }
+
+        val base64 = requireNotNull(recorder.toBase64())
+        assertTrue("base64 length was ${base64.length}", base64.length <= 2000)
+    }
+
+    /** Decodes an unsigned-LEB128-packed byte string back into its per-frame values, for test verification only. */
+    private fun decode(base64: String?): List<Long> {
+        val bytes = Base64.decode(base64, Base64.NO_PADDING or Base64.NO_WRAP)
+        val values = mutableListOf<Long>()
+        var value = 0L
+        var shift = 0
+        for (byte in bytes) {
+            val unsigned = byte.toInt() and 0xFF
+            value = value or ((unsigned.toLong() and 0x7F) shl shift)
+            if (unsigned and 0x80 == 0) {
+                values += value
+                value = 0L
+                shift = 0
+            } else {
+                shift += 7
+            }
+        }
+        return values
+    }
+}

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/SmoothnessReporterTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/SmoothnessReporterTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.vitals.smoothness
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class SmoothnessReporterTest {
@@ -63,6 +64,19 @@ internal class SmoothnessReporterTest {
         reporter.onFocalMomentEnd(FocalOutcome.SETTLED, startTimeMs = 0, durationMs = 100)
 
         assertEquals(1, emitted.size)
+    }
+
+    @Test
+    fun `frameTraceBase64 defaults to null and passes through when supplied`() {
+        reporter.onFocalMomentStart()
+        reporter.onFocalMomentFrame(jankNanos = 0)
+        reporter.onFocalMomentEnd(FocalOutcome.SETTLED, startTimeMs = 0, durationMs = 1)
+        assertNull(emitted.single().frameTraceBase64)
+
+        reporter.onFocalMomentStart()
+        reporter.onFocalMomentFrame(jankNanos = 0)
+        reporter.onFocalMomentEnd(FocalOutcome.SETTLED, startTimeMs = 0, durationMs = 1, frameTraceBase64 = "AQ==")
+        assertEquals("AQ==", emitted.last().frameTraceBase64)
     }
 
     @Test

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/SmoothnessReporterTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/SmoothnessReporterTest.kt
@@ -6,7 +6,12 @@ import org.junit.Test
 internal class SmoothnessReporterTest {
 
     private val emitted = mutableListOf<SmoothnessResult>()
-    private val reporter = SmoothnessReporter(emit = emitted::add)
+    private val reporter = SmoothnessReporter(
+        emit = emitted::add,
+        idleThresholdMs = 150L,
+        heldIdleThresholdMs = 600L,
+        jankHeuristicMultiplier = 2.5,
+    )
 
     @Test
     fun `normalizes jank to 60fps reference frames per the SMOOTHNESS doc examples`() {
@@ -26,6 +31,9 @@ internal class SmoothnessReporterTest {
         assertEquals(1_000L, result.startTimeMs)
         assertEquals(1_100L, result.durationMs)
         assertEquals(3, result.frameCount)
+        assertEquals(150L, result.idleThresholdMs)
+        assertEquals(600L, result.heldIdleThresholdMs)
+        assertEquals(2.5, result.jankHeuristicMultiplier, 0.0)
     }
 
     @Test

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/cache/CachedConfiguration.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/cache/CachedConfiguration.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.internal.serialization.BinaryVersion
 import kotlinx.serialization.Serializable
 
 @Serializable
-@BinaryVersion(1393964509035760531)
+@BinaryVersion(-2074456697392943244)
 data class CachedConfiguration(
     val deviceId: String,
     val etag: String?,

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/cache/CachedConfiguration.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/cache/CachedConfiguration.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.internal.serialization.BinaryVersion
 import kotlinx.serialization.Serializable
 
 @Serializable
-@BinaryVersion(-4019240792695242292)
+@BinaryVersion(1393964509035760531)
 data class CachedConfiguration(
     val deviceId: String,
     val etag: String?,

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/RemoteConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/RemoteConfig.kt
@@ -135,4 +135,10 @@ data class RemoteConfig(
      */
     @SerialName("pct_screen_load_enabled")
     val pctScreenLoadEnabled: Float? = null,
+
+    /**
+     * Settings defining the thresholds used by the vitals (smoothness / screen-load) feature.
+     */
+    @SerialName("vitals")
+    val vitalsRemoteConfig: VitalsRemoteConfig? = null,
 )

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/VitalsRemoteConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/VitalsRemoteConfig.kt
@@ -1,0 +1,29 @@
+package io.embrace.android.embracesdk.internal.config.remote
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Configuration values relating to the thresholds used by the vitals (smoothness / screen-load) feature.
+ */
+@Serializable
+data class VitalsRemoteConfig(
+
+    @SerialName("smoothness_idle_threshold_ms")
+    val smoothnessIdleThresholdMs: Long? = null,
+
+    @SerialName("smoothness_held_idle_threshold_ms")
+    val smoothnessHeldIdleThresholdMs: Long? = null,
+
+    @SerialName("jank_heuristic_multiplier")
+    val jankHeuristicMultiplier: Double? = null,
+
+    @SerialName("screen_load_idle_threshold_ms")
+    val screenLoadIdleThresholdMs: Long? = null,
+
+    @SerialName("screen_load_timeout_ms")
+    val screenLoadTimeoutMs: Long? = null,
+
+    @SerialName("screen_load_nav_timeout_ms")
+    val screenLoadNavTimeoutMs: Long? = null,
+)

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/VitalsRemoteConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/VitalsRemoteConfig.kt
@@ -26,4 +26,7 @@ data class VitalsRemoteConfig(
 
     @SerialName("screen_load_nav_timeout_ms")
     val screenLoadNavTimeoutMs: Long? = null,
+
+    @SerialName("smoothness_frame_trace_pct_enabled")
+    val smoothnessFrameTracePctEnabled: Float? = null,
 )

--- a/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbScreenLoadAttributes.kt
+++ b/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbScreenLoadAttributes.kt
@@ -17,6 +17,12 @@ object EmbScreenLoadAttributes {
     const val SCREEN_LOAD_FIRST_FRAME_DURATION_MS: String = "screen_load.first_frame_duration_ms"
 
     /**
+     * The idle threshold that was applied to determine when the destination screen had settled.
+     */
+    @ExperimentalSemconv
+    const val SCREEN_LOAD_IDLE_THRESHOLD_MS: String = "screen_load.idle_threshold_ms"
+
+    /**
      * Duration from the navigation start event until the navigation end event, in milliseconds.
      */
     @ExperimentalSemconv
@@ -29,8 +35,20 @@ object EmbScreenLoadAttributes {
     const val SCREEN_LOAD_NAV_START_DELAY_MS: String = "screen_load.nav_start_delay_ms"
 
     /**
+     * The maximum tap-to-navigation-start gap that was applied to link the two events into one screen load.
+     */
+    @ExperimentalSemconv
+    const val SCREEN_LOAD_NAV_TIMEOUT_MS: String = "screen_load.nav_timeout_ms"
+
+    /**
      * How the screen load ended.
      */
     @ExperimentalSemconv
     const val SCREEN_LOAD_OUTCOME: String = "screen_load.outcome"
+
+    /**
+     * The maximum duration that was applied before the screen load was force-reported as timed out.
+     */
+    @ExperimentalSemconv
+    const val SCREEN_LOAD_TIMEOUT_MS: String = "screen_load.timeout_ms"
 }

--- a/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSmoothnessAttributes.kt
+++ b/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSmoothnessAttributes.kt
@@ -17,6 +17,12 @@ object EmbSmoothnessAttributes {
     const val SMOOTHNESS_FRAME_COUNT: String = "smoothness.frame_count"
 
     /**
+     * Base64-encoded, varint-packed per-frame duration trace over the focal moment, for a sampled fraction of devices. Diagnostic aid while smoothness thresholds are being tuned.
+     */
+    @ExperimentalSemconv
+    const val SMOOTHNESS_FRAME_TRACE: String = "smoothness.frame_trace"
+
+    /**
      * The 'press and hold' settle threshold that was applied.
      */
     @ExperimentalSemconv

--- a/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSmoothnessAttributes.kt
+++ b/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSmoothnessAttributes.kt
@@ -17,6 +17,24 @@ object EmbSmoothnessAttributes {
     const val SMOOTHNESS_FRAME_COUNT: String = "smoothness.frame_count"
 
     /**
+     * The 'press and hold' settle threshold that was applied.
+     */
+    @ExperimentalSemconv
+    const val SMOOTHNESS_HELD_IDLE_THRESHOLD_MS: String = "smoothness.held_idle_threshold_ms"
+
+    /**
+     * The idle threshold that was applied to determine when the focal moment had settled.
+     */
+    @ExperimentalSemconv
+    const val SMOOTHNESS_IDLE_THRESHOLD_MS: String = "smoothness.idle_threshold_ms"
+
+    /**
+     * The grace multiplier that was applied to a frame's budget/deadline before it was considered janky.
+     */
+    @ExperimentalSemconv
+    const val SMOOTHNESS_JANK_HEURISTIC_MULTIPLIER: String = "smoothness.jank_heuristic_multiplier"
+
+    /**
      * Total jank over the focal moment, expressed in 60fps-reference frames.
      */
     @ExperimentalSemconv

--- a/embrace-android-semconv/src/main/semconv/embrace_android.yaml
+++ b/embrace-android-semconv/src/main/semconv/embrace_android.yaml
@@ -95,6 +95,7 @@ attribute_groups:
       - ref: smoothness.idle_threshold_ms
       - ref: smoothness.held_idle_threshold_ms
       - ref: smoothness.jank_heuristic_multiplier
+      - ref: smoothness.frame_trace
 
   - id: emb.screen_load
     visibility: public
@@ -442,6 +443,11 @@ attributes:
     brief: "The grace multiplier that was applied to a frame's budget/deadline before it was considered janky."
     stability: development
     examples: [2.0, 2.5]
+  - key: smoothness.frame_trace
+    type: string
+    brief: "Base64-encoded, varint-packed per-frame duration trace over the focal moment, for a sampled fraction of devices. Diagnostic aid while smoothness thresholds are being tuned."
+    stability: development
+    examples: ["AQIDBA=="]
   - key: screen_load.outcome
     type: string
     brief: "How the screen load ended."

--- a/embrace-android-semconv/src/main/semconv/embrace_android.yaml
+++ b/embrace-android-semconv/src/main/semconv/embrace_android.yaml
@@ -92,6 +92,9 @@ attribute_groups:
       - ref: smoothness.outcome
       - ref: smoothness.frame_count
       - ref: smoothness.normalized_dropped_frames
+      - ref: smoothness.idle_threshold_ms
+      - ref: smoothness.held_idle_threshold_ms
+      - ref: smoothness.jank_heuristic_multiplier
 
   - id: emb.screen_load
     visibility: public
@@ -102,6 +105,9 @@ attribute_groups:
       - ref: screen_load.nav_start_delay_ms
       - ref: screen_load.nav_duration_ms
       - ref: screen_load.first_frame_duration_ms
+      - ref: screen_load.idle_threshold_ms
+      - ref: screen_load.timeout_ms
+      - ref: screen_load.nav_timeout_ms
 
   - id: emb.network_request
     visibility: public
@@ -421,6 +427,21 @@ attributes:
     brief: "Total jank over the focal moment, expressed in 60fps-reference frames."
     stability: development
     examples: [0.5, 2.0]
+  - key: smoothness.idle_threshold_ms
+    type: int
+    brief: "The idle threshold that was applied to determine when the focal moment had settled."
+    stability: development
+    examples: [100, 150]
+  - key: smoothness.held_idle_threshold_ms
+    type: int
+    brief: "The 'press and hold' settle threshold that was applied."
+    stability: development
+    examples: [500, 600]
+  - key: smoothness.jank_heuristic_multiplier
+    type: double
+    brief: "The grace multiplier that was applied to a frame's budget/deadline before it was considered janky."
+    stability: development
+    examples: [2.0, 2.5]
   - key: screen_load.outcome
     type: string
     brief: "How the screen load ended."
@@ -441,6 +462,21 @@ attributes:
     brief: "Duration from the navigation end event until the first frame rendered on the destination, in milliseconds."
     stability: development
     examples: [10, 100]
+  - key: screen_load.idle_threshold_ms
+    type: int
+    brief: "The idle threshold that was applied to determine when the destination screen had settled."
+    stability: development
+    examples: [1000, 1500]
+  - key: screen_load.timeout_ms
+    type: int
+    brief: "The maximum duration that was applied before the screen load was force-reported as timed out."
+    stability: development
+    examples: [30000, 45000]
+  - key: screen_load.nav_timeout_ms
+    type: int
+    brief: "The maximum tap-to-navigation-start gap that was applied to link the two events into one screen load."
+    stability: development
+    examples: [500, 750]
   - key: emb.w3c_traceparent
     type: string
     brief: "The W3C traceparent header value forwarded with the network request."


### PR DESCRIPTION
## Goal
Add remote config for the Smoothness and ScreenLoad vital experiments.

Each remotely configurable threshold and value is now reported as an attribute with each vital span to avoid any ambiguity.

The new `VitalsRemoteConfig` configuration allows us to tune:
- `smoothness_idle_threshold_ms`
- `smoothness_held_idle_threshold_ms`
- `jank_heuristic_multiplier`
- `screen_load_idle_threshold_ms`
- `screen_load_timeout_ms`
- `screen_load_nav_timeout_ms`

These are all tunable directly to avoid hard-coding experiment groups that may need code changes to update and deploy.,

## Testing
Added the new values to the existing config tests.