### PR TITLE
Allow the build info to be exported for async mapping uploads

### DIFF
--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/framework/AssertionInterface.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/framework/AssertionInterface.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.validateMappingFile
 import io.embrace.android.gradle.config.TestMatrix
 import io.embrace.android.gradle.plugin.buildreporter.BuildTelemetryRequest
 import io.embrace.android.gradle.plugin.network.EmbraceEndpoint
+import io.embrace.android.gradle.plugin.tasks.buildinfo.BuildInfoExport
 import io.embrace.android.gradle.plugin.tasks.ndk.NdkUploadHandshakeRequest
 import io.embrace.android.gradle.plugin.util.serialization.MoshiSerializer
 import okhttp3.mockwebserver.RecordedRequest
@@ -314,5 +315,21 @@ class AssertionInterface(
 
     private fun defaultAppIds(size: Int) = MutableList(size) {
         IntegrationTestDefaults.APP_ID
+    }
+
+    /**
+     * Reads and deserializes the `embrace-build-info.json` file exported for the given variant.
+     */
+    fun AssertionInterface.readBuildInfoExport(projectDir: File, variant: String): BuildInfoExport {
+        val file = projectDir.buildFile("outputs/embrace/build-info/$variant/embrace-build-info.json")
+        return MoshiSerializer().fromJson(file.readText(), BuildInfoExport::class.java)
+    }
+
+    /**
+     * Asserts that no `embrace-build-info.json` file was exported for the given variant.
+     */
+    fun AssertionInterface.verifyNoBuildInfoExported(projectDir: File, variant: String) {
+        val file = projectDir.buildFile("outputs/embrace/build-info/$variant/embrace-build-info.json")
+        assertFalse("Expected no build info file at ${file.absolutePath}", file.exists())
     }
 }

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/ExportBuildInfoTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/ExportBuildInfoTest.kt
@@ -1,0 +1,75 @@
+package io.embrace.android.gradle.integration.testcases
+
+import io.embrace.android.gradle.integration.framework.IntegrationTestDefaults
+import io.embrace.android.gradle.integration.framework.PluginIntegrationTestRule
+import io.embrace.android.gradle.integration.framework.ProjectType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class ExportBuildInfoTest {
+
+    @Rule
+    @JvmField
+    val rule: PluginIntegrationTestRule = PluginIntegrationTestRule()
+
+    @Test
+    fun `no build info exported by default`() {
+        rule.runTest(
+            fixture = "android-simple",
+            task = "assembleRelease",
+            projectType = ProjectType.ANDROID,
+            assertions = { projectDir ->
+                verifyNoBuildInfoExported(projectDir, "release")
+            },
+        )
+    }
+
+    @Test
+    fun `build info exported for release variant when enabled`() {
+        rule.runTest(
+            fixture = "android-simple",
+            task = "assembleRelease",
+            projectType = ProjectType.ANDROID,
+            additionalArgs = listOf("-Pembrace.exportBuildInfo=true"),
+            assertions = { projectDir ->
+                val buildInfo = readBuildInfoExport(projectDir, "release")
+                assertEquals(IntegrationTestDefaults.APP_ID, buildInfo.appId)
+                assertEquals(IntegrationTestDefaults.API_TOKEN, buildInfo.apiToken)
+                assertEquals("release", buildInfo.variantName)
+                assertTrue(buildInfo.buildId.isNotBlank())
+            },
+        )
+    }
+
+    @Test
+    fun `no build info exported for debug variant when enabled`() {
+        rule.runTest(
+            fixture = "android-simple",
+            task = "assembleDebug",
+            projectType = ProjectType.ANDROID,
+            additionalArgs = listOf("-Pembrace.exportBuildInfo=true"),
+            assertions = { projectDir ->
+                verifyNoBuildInfoExported(projectDir, "debug")
+            },
+        )
+    }
+
+    @Test
+    fun `build info exported for dexguard obfuscation task`() {
+        rule.runTest(
+            fixture = "android-dexguard",
+            task = "assemble",
+            projectType = ProjectType.ANDROID,
+            additionalArgs = listOf("-Pembrace.exportBuildInfo=true"),
+            assertions = { projectDir ->
+                val buildInfo = readBuildInfoExport(projectDir, "release")
+                assertEquals(IntegrationTestDefaults.APP_ID, buildInfo.appId)
+                assertEquals(IntegrationTestDefaults.API_TOKEN, buildInfo.apiToken)
+                assertEquals("release", buildInfo.variantName)
+                assertTrue(buildInfo.buildId.isNotBlank())
+            },
+        )
+    }
+}

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/ExportBuildInfoTest.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/testcases/ExportBuildInfoTest.kt
@@ -36,7 +36,6 @@ class ExportBuildInfoTest {
             assertions = { projectDir ->
                 val buildInfo = readBuildInfoExport(projectDir, "release")
                 assertEquals(IntegrationTestDefaults.APP_ID, buildInfo.appId)
-                assertEquals(IntegrationTestDefaults.API_TOKEN, buildInfo.apiToken)
                 assertEquals("release", buildInfo.variantName)
                 assertTrue(buildInfo.buildId.isNotBlank())
             },
@@ -66,7 +65,6 @@ class ExportBuildInfoTest {
             assertions = { projectDir ->
                 val buildInfo = readBuildInfoExport(projectDir, "release")
                 assertEquals(IntegrationTestDefaults.APP_ID, buildInfo.appId)
-                assertEquals(IntegrationTestDefaults.API_TOKEN, buildInfo.apiToken)
                 assertEquals("release", buildInfo.variantName)
                 assertTrue(buildInfo.buildId.isNotBlank())
             },

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/PluginBehavior.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/PluginBehavior.kt
@@ -30,6 +30,12 @@ interface PluginBehavior {
     val failBuildOnUploadErrors: Provider<Boolean>
 
     /**
+     * Whether the parameters used to upload the mapping file and NDK symbols should be exported
+     * to an `embrace-build-info.json` file, set via `embrace.exportBuildInfo`
+     */
+    val isExportBuildInfoEnabled: Boolean
+
+    /**
      * The base URL for the Embrace API, set via `embrace.baseUrl`
      */
     val baseUrl: String
@@ -72,5 +78,6 @@ const val EMBRACE_BASE_URL = "embrace.baseUrl"
 const val EMBRACE_DISABLE_COLLECT_BUILD_DATA = "embrace.disableCollectBuildData"
 const val EMBRACE_UPLOAD_IL2CPP_MAPPING_FILES = "embrace.uploadIl2CppMappingFiles"
 const val EMBRACE_DISABLE_MAPPING_FILE_UPLOAD = "embrace.disableMappingFileUpload"
+const val EMBRACE_EXPORT_BUILD_INFO = "embrace.exportBuildInfo"
 const val EMBRACE_UNITY_EXTERNAL_DEPENDENCY_MANAGER = "embrace.externalDependencyManager"
 const val DEFAULT_SYMBOL_STORE_HOST_URL = "https://dsym-store.emb-api.com"

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/PluginBehaviorImpl.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/config/PluginBehaviorImpl.kt
@@ -39,6 +39,10 @@ class PluginBehaviorImpl(
         }
     }
 
+    override val isExportBuildInfoEnabled: Boolean by lazy {
+        project.getBoolProperty(EMBRACE_EXPORT_BUILD_INFO)
+    }
+
     override val baseUrl: String by lazy {
         val prop = project.getProperty(EMBRACE_BASE_URL)
             ?: return@lazy DEFAULT_SYMBOL_STORE_HOST_URL

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/buildinfo/BuildInfoExport.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/buildinfo/BuildInfoExport.kt
@@ -1,0 +1,11 @@
+package io.embrace.android.gradle.plugin.tasks.buildinfo
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class BuildInfoExport(
+    val buildId: String,
+    val appId: String,
+    val apiToken: String,
+    val variantName: String,
+)

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/buildinfo/BuildInfoExport.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/buildinfo/BuildInfoExport.kt
@@ -6,6 +6,5 @@ import com.squareup.moshi.JsonClass
 data class BuildInfoExport(
     val buildId: String,
     val appId: String,
-    val apiToken: String,
     val variantName: String,
 )

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/buildinfo/ExportBuildInfoTask.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/buildinfo/ExportBuildInfoTask.kt
@@ -1,0 +1,61 @@
+package io.embrace.android.gradle.plugin.tasks.buildinfo
+
+import io.embrace.android.gradle.plugin.model.AndroidCompactedVariantData
+import io.embrace.android.gradle.plugin.tasks.EmbraceTask
+import io.embrace.android.gradle.plugin.util.serialization.MoshiSerializer
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import javax.inject.Inject
+
+/**
+ * Writes the parameters that would be used to upload the mapping file and NDK symbols for a
+ * variant into a JSON file, so they can be reused by external tooling.
+ */
+@DisableCachingByDefault(because = "Writes build metadata and does not benefit from caching")
+abstract class ExportBuildInfoTask @Inject constructor(
+    objectFactory: ObjectFactory,
+) : DefaultTask(), EmbraceTask {
+
+    @get:Input
+    override val variantData: Property<AndroidCompactedVariantData> =
+        objectFactory.property(AndroidCompactedVariantData::class.java)
+
+    private val serializer = MoshiSerializer()
+
+    @get:Input
+    val buildId: Property<String> = objectFactory.property(String::class.java)
+
+    @get:Input
+    val appId: Property<String> = objectFactory.property(String::class.java)
+
+    @get:Input
+    val apiToken: Property<String> = objectFactory.property(String::class.java)
+
+    @get:OutputFile
+    val outputFile: RegularFileProperty = objectFactory.fileProperty()
+
+    @TaskAction
+    fun onRun() {
+        val buildInfo = BuildInfoExport(
+            buildId = buildId.get(),
+            appId = appId.get(),
+            apiToken = apiToken.get(),
+            variantName = variantData.get().name,
+        )
+        outputFile.get().asFile.apply {
+            parentFile.mkdirs()
+            outputStream().use { serializer.toJson(buildInfo, BuildInfoExport::class.java, it) }
+        }
+    }
+
+    companion object {
+        const val NAME: String = "exportBuildInfoTaskFor"
+        const val FILE_NAME: String = "embrace-build-info.json"
+    }
+}

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/buildinfo/ExportBuildInfoTask.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/buildinfo/ExportBuildInfoTask.kt
@@ -34,9 +34,6 @@ abstract class ExportBuildInfoTask @Inject constructor(
     @get:Input
     val appId: Property<String> = objectFactory.property(String::class.java)
 
-    @get:Input
-    val apiToken: Property<String> = objectFactory.property(String::class.java)
-
     @get:OutputFile
     val outputFile: RegularFileProperty = objectFactory.fileProperty()
 
@@ -45,7 +42,6 @@ abstract class ExportBuildInfoTask @Inject constructor(
         val buildInfo = BuildInfoExport(
             buildId = buildId.get(),
             appId = appId.get(),
-            apiToken = apiToken.get(),
             variantName = variantData.get().name,
         )
         outputFile.get().asFile.apply {

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/buildinfo/ExportBuildInfoTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/buildinfo/ExportBuildInfoTaskRegistration.kt
@@ -1,0 +1,96 @@
+package io.embrace.android.gradle.plugin.tasks.buildinfo
+
+import io.embrace.android.gradle.plugin.gradle.isTaskRegistered
+import io.embrace.android.gradle.plugin.gradle.registerTask
+import io.embrace.android.gradle.plugin.gradle.tryGetTaskProvider
+import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
+import io.embrace.android.gradle.plugin.model.AndroidCompactedVariantData
+import io.embrace.android.gradle.plugin.tasks.registration.EmbraceTaskRegistration
+import io.embrace.android.gradle.plugin.tasks.registration.RegistrationParams
+import io.embrace.android.gradle.plugin.util.capitalizedString
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
+
+/**
+ * Registers a task per variant that exports the parameters that would be used to upload the
+ * mapping file and NDK symbols into an `embrace-build-info.json` file, controlled via
+ * `embrace.exportBuildInfo`.
+ */
+class ExportBuildInfoTaskRegistration : EmbraceTaskRegistration {
+
+    override fun register(params: RegistrationParams) {
+        with(params) {
+            project.afterEvaluate {
+                val tasks = fetchObfuscationTasks(project, data)
+                tasks.forEach { task ->
+                    register(
+                        project,
+                        data,
+                        task,
+                        variantConfigurationsListProperty,
+                        buildIdProvider,
+                    )
+                }
+            }
+        }
+    }
+
+    private fun register(
+        project: Project,
+        variant: AndroidCompactedVariantData,
+        anchorTask: TaskProvider<Task>,
+        variantConfigurationsListProperty: ListProperty<VariantConfig>,
+        buildIdProvider: Provider<String>,
+    ): TaskProvider<ExportBuildInfoTask> {
+        val anchorTaskWithoutVariant = anchorTask.name.replace(variant.name, "", true)
+        val exportTaskName = "${ExportBuildInfoTask.NAME}${anchorTaskWithoutVariant}OnVariant"
+        val exportTask = project.registerTask(
+            exportTaskName,
+            ExportBuildInfoTask::class.java,
+            variant,
+        ) { task ->
+            val variantConfig = variantConfigurationsListProperty.get().first { it.variantName == variant.name }
+            val embraceConfig = variantConfig.embraceConfig
+
+            task.buildId.set(buildIdProvider)
+            task.appId.set(embraceConfig?.appId.orEmpty())
+            task.apiToken.set(embraceConfig?.apiToken.orEmpty())
+
+            task.outputFile.set(
+                project.layout.buildDirectory.file(
+                    "outputs/embrace/build-info/${variant.name}/${ExportBuildInfoTask.FILE_NAME}",
+                ),
+            )
+        }
+
+        anchorTask.configure { task ->
+            task.finalizedBy(exportTask)
+        }
+        return exportTask
+    }
+
+    /**
+     * It fetches all available obfuscation tasks. In practice, a single task will be
+     * executed but multiple tasks may be registered and configured. Because of this, we are
+     * forced to return a list of tasks since we are in configuration phase.
+     */
+    private fun fetchObfuscationTasks(
+        project: Project,
+        variant: AndroidCompactedVariantData,
+    ): List<TaskProvider<Task>> {
+        val name = variant.name.capitalizedString()
+        val targetObfuscationTasks = listOf(
+            "dexguardApk$name",
+            "dexguardAab$name",
+            "minify${name}WithProguard",
+            "minify${name}WithR8",
+        )
+        val tasks = targetObfuscationTasks.filter { taskName ->
+            isTaskRegistered(project.tryGetTaskProvider(taskName))
+        }
+        return tasks.mapNotNull { project.tryGetTaskProvider(it) }
+    }
+}

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/buildinfo/ExportBuildInfoTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/buildinfo/ExportBuildInfoTaskRegistration.kt
@@ -1,17 +1,9 @@
 package io.embrace.android.gradle.plugin.tasks.buildinfo
 
-import io.embrace.android.gradle.plugin.gradle.isTaskRegistered
 import io.embrace.android.gradle.plugin.gradle.registerTask
-import io.embrace.android.gradle.plugin.gradle.tryGetTaskProvider
-import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
-import io.embrace.android.gradle.plugin.model.AndroidCompactedVariantData
-import io.embrace.android.gradle.plugin.tasks.registration.EmbraceTaskRegistration
+import io.embrace.android.gradle.plugin.tasks.registration.MappingTaskRegistration
 import io.embrace.android.gradle.plugin.tasks.registration.RegistrationParams
-import io.embrace.android.gradle.plugin.util.capitalizedString
-import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.provider.ListProperty
-import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 
 /**
@@ -19,78 +11,30 @@ import org.gradle.api.tasks.TaskProvider
  * mapping file and NDK symbols into an `embrace-build-info.json` file, controlled via
  * `embrace.exportBuildInfo`.
  */
-class ExportBuildInfoTaskRegistration : EmbraceTaskRegistration {
+class ExportBuildInfoTaskRegistration : MappingTaskRegistration() {
 
-    override fun register(params: RegistrationParams) {
-        with(params) {
-            project.afterEvaluate {
-                val tasks = fetchObfuscationTasks(project, data)
-                tasks.forEach { task ->
-                    register(
-                        project,
-                        data,
-                        task,
-                        variantConfigurationsListProperty,
-                        buildIdProvider,
-                    )
-                }
-            }
-        }
-    }
-
-    private fun register(
-        project: Project,
-        variant: AndroidCompactedVariantData,
-        anchorTask: TaskProvider<Task>,
-        variantConfigurationsListProperty: ListProperty<VariantConfig>,
-        buildIdProvider: Provider<String>,
-    ): TaskProvider<ExportBuildInfoTask> {
-        val anchorTaskWithoutVariant = anchorTask.name.replace(variant.name, "", true)
+    override fun registerForMappingTask(params: RegistrationParams, anchorTask: TaskProvider<Task>) {
+        val anchorTaskWithoutVariant = anchorTaskNameWithoutVariant(anchorTask, params.data)
         val exportTaskName = "${ExportBuildInfoTask.NAME}${anchorTaskWithoutVariant}OnVariant"
-        val exportTask = project.registerTask(
+        val exportTask = params.project.registerTask(
             exportTaskName,
             ExportBuildInfoTask::class.java,
-            variant,
+            params.data,
         ) { task ->
-            val variantConfig = variantConfigurationsListProperty.get().first { it.variantName == variant.name }
+            val variantConfig = params.variantConfigurationsListProperty.get().first { it.variantName == params.data.name }
             val embraceConfig = variantConfig.embraceConfig
 
-            task.buildId.set(buildIdProvider)
+            task.buildId.set(params.buildIdProvider)
             task.appId.set(embraceConfig?.appId.orEmpty())
             task.apiToken.set(embraceConfig?.apiToken.orEmpty())
 
             task.outputFile.set(
-                project.layout.buildDirectory.file(
-                    "outputs/embrace/build-info/${variant.name}/${ExportBuildInfoTask.FILE_NAME}",
+                params.project.layout.buildDirectory.file(
+                    "outputs/embrace/build-info/${params.data.name}/${ExportBuildInfoTask.FILE_NAME}",
                 ),
             )
         }
 
-        anchorTask.configure { task ->
-            task.finalizedBy(exportTask)
-        }
-        return exportTask
-    }
-
-    /**
-     * It fetches all available obfuscation tasks. In practice, a single task will be
-     * executed but multiple tasks may be registered and configured. Because of this, we are
-     * forced to return a list of tasks since we are in configuration phase.
-     */
-    private fun fetchObfuscationTasks(
-        project: Project,
-        variant: AndroidCompactedVariantData,
-    ): List<TaskProvider<Task>> {
-        val name = variant.name.capitalizedString()
-        val targetObfuscationTasks = listOf(
-            "dexguardApk$name",
-            "dexguardAab$name",
-            "minify${name}WithProguard",
-            "minify${name}WithR8",
-        )
-        val tasks = targetObfuscationTasks.filter { taskName ->
-            isTaskRegistered(project.tryGetTaskProvider(taskName))
-        }
-        return tasks.mapNotNull { project.tryGetTaskProvider(it) }
+        exportTask.finalizeAnchorTask(anchorTask)
     }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/buildinfo/ExportBuildInfoTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/buildinfo/ExportBuildInfoTaskRegistration.kt
@@ -26,7 +26,6 @@ class ExportBuildInfoTaskRegistration : MappingTaskRegistration() {
 
             task.buildId.set(params.buildIdProvider)
             task.appId.set(embraceConfig?.appId.orEmpty())
-            task.apiToken.set(embraceConfig?.apiToken.orEmpty())
 
             task.outputFile.set(
                 params.project.layout.buildDirectory.file(

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/r8/JvmMappingUploadTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/r8/JvmMappingUploadTaskRegistration.kt
@@ -3,29 +3,21 @@ package io.embrace.android.gradle.plugin.tasks.r8
 import com.android.build.api.artifact.SingleArtifact
 import com.android.build.api.variant.Variant
 import io.embrace.android.gradle.plugin.agp.AgpUtils.isDexguard
-import io.embrace.android.gradle.plugin.config.PluginBehavior
-import io.embrace.android.gradle.plugin.gradle.isTaskRegistered
 import io.embrace.android.gradle.plugin.gradle.registerTask
 import io.embrace.android.gradle.plugin.gradle.safeFlatMap
 import io.embrace.android.gradle.plugin.gradle.safeMap
-import io.embrace.android.gradle.plugin.gradle.tryGetTaskProvider
-import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
-import io.embrace.android.gradle.plugin.model.AndroidCompactedVariantData
 import io.embrace.android.gradle.plugin.network.EmbraceEndpoint
 import io.embrace.android.gradle.plugin.tasks.common.FileCompressionTask
 import io.embrace.android.gradle.plugin.tasks.common.MultipartUploadTask
 import io.embrace.android.gradle.plugin.tasks.common.RequestParams
-import io.embrace.android.gradle.plugin.tasks.registration.EmbraceTaskRegistration
+import io.embrace.android.gradle.plugin.tasks.registration.MappingTaskRegistration
 import io.embrace.android.gradle.plugin.tasks.registration.RegistrationParams
-import io.embrace.android.gradle.plugin.util.capitalizedString
-import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import java.io.File
 
-class JvmMappingUploadTaskRegistration : EmbraceTaskRegistration {
+class JvmMappingUploadTaskRegistration : MappingTaskRegistration() {
 
     companion object {
         private const val COMPRESS_TASK_NAME = "jvmMappingCompressionTaskFor"
@@ -33,69 +25,44 @@ class JvmMappingUploadTaskRegistration : EmbraceTaskRegistration {
         private const val FILE_NAME_MAPPING_TXT = "mapping.txt"
     }
 
-    override fun register(params: RegistrationParams) {
-        with(params) {
-            project.afterEvaluate {
-                val tasks = fetchJvmMappingTasks(project, data)
-                tasks.forEach { task ->
-                    register(
-                        project,
-                        data,
-                        task,
-                        fetchJvmMappingFile(task, variant),
-                        behavior,
-                        variantConfigurationsListProperty,
-                        buildIdProvider,
-                    )
-                }
-            }
-        }
-    }
+    override fun registerForMappingTask(params: RegistrationParams, anchorTask: TaskProvider<Task>) {
+        val anchorTaskWithoutVariant = anchorTaskNameWithoutVariant(anchorTask, params.data)
+        val mappingFile = fetchJvmMappingFile(anchorTask, params.variant)
 
-    private fun register(
-        project: Project,
-        variant: AndroidCompactedVariantData,
-        anchorTask: TaskProvider<Task>,
-        mappingFile: Provider<File>,
-        behavior: PluginBehavior,
-        variantConfigurationsListProperty: ListProperty<VariantConfig>,
-        buildIdProvider: Provider<String>,
-    ): TaskProvider<MultipartUploadTask> {
-        val anchorTaskWithoutVariant = anchorTask.name.replace(variant.name, "", true)
         val compressionTaskName = "${COMPRESS_TASK_NAME}For${anchorTaskWithoutVariant}OnVariant"
-        val compressionTask = project.registerTask(
+        val compressionTask = params.project.registerTask(
             compressionTaskName,
             FileCompressionTask::class.java,
-            variant,
+            params.data,
         ) { task: FileCompressionTask ->
             // automatically link as a task dependency
             task.originalFile.fileProvider(mappingFile)
             task.compressedFile.convention(
-                project.layout.buildDirectory.file(
-                    "outputs/embrace/mapping/compressed/${variant.name}/$anchorTaskWithoutVariant/$FILE_NAME_MAPPING_TXT",
+                params.project.layout.buildDirectory.file(
+                    "outputs/embrace/mapping/compressed/${params.data.name}/$anchorTaskWithoutVariant/$FILE_NAME_MAPPING_TXT",
                 ),
             )
         }
 
         val uploadTaskName = "${UPLOAD_TASK_NAME}For${anchorTaskWithoutVariant}OnVariant"
-        val uploadTask = project.registerTask(
+        val uploadTask = params.project.registerTask(
             uploadTaskName,
             MultipartUploadTask::class.java,
-            variant,
+            params.data,
         ) { task ->
-            val variantConfig = variantConfigurationsListProperty.get().first { it.variantName == variant.name }
+            val variantConfig = params.variantConfigurationsListProperty.get().first { it.variantName == params.data.name }
             // buildIdProvider is ValueSource-backed: Gradle re-evaluates it on every build even
             // when the configuration cache is active, ensuring a fresh build ID each time.
             task.requestParams.set(
-                buildIdProvider.map { buildId ->
+                params.buildIdProvider.map { buildId ->
                     RequestParams(
                         appId = variantConfig.embraceConfig?.appId.orEmpty(),
                         apiToken = variantConfig.embraceConfig?.apiToken.orEmpty(),
                         endpoint = EmbraceEndpoint.PROGUARD,
                         fileName = FILE_NAME_MAPPING_TXT,
                         buildId = buildId,
-                        baseUrl = behavior.baseUrl,
-                        failBuildOnUploadErrors = behavior.failBuildOnUploadErrors.get(),
+                        baseUrl = params.behavior.baseUrl,
+                        failBuildOnUploadErrors = params.behavior.failBuildOnUploadErrors.get(),
                     )
                 },
             )
@@ -107,11 +74,7 @@ class JvmMappingUploadTaskRegistration : EmbraceTaskRegistration {
             )
         }
 
-        // set us (Embrace) as a dependency of the obfuscation task
-        anchorTask.configure { task ->
-            task.finalizedBy(uploadTask)
-        }
-        return uploadTask
+        uploadTask.finalizeAnchorTask(anchorTask)
     }
 
     private fun fetchJvmMappingFile(
@@ -136,27 +99,5 @@ class JvmMappingUploadTaskRegistration : EmbraceTaskRegistration {
                 it.firstOrNull()?.asFile
             }
         }
-    }
-
-    /**
-     * It fetches all available obfuscation tasks. In practice, a single task will be
-     * executed but multiple tasks may be registered and configured. Because of this, we are
-     * forced to return a list of tasks since we are in configuration phase.
-     */
-    private fun fetchJvmMappingTasks(
-        project: Project,
-        variant: AndroidCompactedVariantData,
-    ): List<TaskProvider<Task>> {
-        val name = variant.name.capitalizedString()
-        val targetObfuscationTasks = listOf(
-            "dexguardApk$name",
-            "dexguardAab$name",
-            "minify${name}WithProguard",
-            "minify${name}WithR8",
-        )
-        val tasks = targetObfuscationTasks.filter { taskName ->
-            isTaskRegistered(project.tryGetTaskProvider(taskName))
-        }
-        return tasks.mapNotNull { project.tryGetTaskProvider(it) }
     }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/registration/MappingTaskRegistration.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/registration/MappingTaskRegistration.kt
@@ -1,0 +1,65 @@
+package io.embrace.android.gradle.plugin.tasks.registration
+
+import io.embrace.android.gradle.plugin.gradle.isTaskRegistered
+import io.embrace.android.gradle.plugin.gradle.tryGetTaskProvider
+import io.embrace.android.gradle.plugin.model.AndroidCompactedVariantData
+import io.embrace.android.gradle.plugin.util.capitalizedString
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.tasks.TaskProvider
+
+/**
+ * Abstract base class for [EmbraceTaskRegistration] implementations that register a task per
+ * mapping task, finalized by that anchor task.
+ */
+abstract class MappingTaskRegistration : EmbraceTaskRegistration {
+
+    final override fun register(params: RegistrationParams) {
+        params.project.afterEvaluate {
+            fetchMappingTasks(params.project, params.data).forEach { anchorTask ->
+                registerForMappingTask(params, anchorTask)
+            }
+        }
+    }
+
+    /**
+     * Registers the task associated with a single mapping task.
+     */
+    protected abstract fun registerForMappingTask(
+        params: RegistrationParams,
+        anchorTask: TaskProvider<Task>,
+    )
+
+    /**
+     * Strips the variant name from the anchor task's name, so it can be reused as a stable
+     * fragment when naming derived tasks.
+     */
+    protected fun anchorTaskNameWithoutVariant(
+        anchorTask: TaskProvider<Task>,
+        variant: AndroidCompactedVariantData,
+    ): String = anchorTask.name.replace(variant.name, "", true)
+
+    /**
+     * Sets us (Embrace) as a dependency of the given anchor (obfuscation) task.
+     */
+    protected fun TaskProvider<out Task>.finalizeAnchorTask(anchorTask: TaskProvider<Task>) {
+        anchorTask.configure { task -> task.finalizedBy(this@finalizeAnchorTask) }
+    }
+
+    private fun fetchMappingTasks(
+        project: Project,
+        variant: AndroidCompactedVariantData,
+    ): List<TaskProvider<Task>> {
+        val name = variant.name.capitalizedString()
+        val targetObfuscationTasks = listOf(
+            "dexguardApk$name",
+            "dexguardAab$name",
+            "minify${name}WithProguard",
+            "minify${name}WithR8",
+        )
+        val tasks = targetObfuscationTasks.filter { taskName ->
+            isTaskRegistered(project.tryGetTaskProvider(taskName))
+        }
+        return tasks.mapNotNull { project.tryGetTaskProvider(it) }
+    }
+}

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/registration/TaskRegistrar.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/tasks/registration/TaskRegistrar.kt
@@ -11,6 +11,7 @@ import io.embrace.android.gradle.plugin.dependency.installDependenciesForVariant
 import io.embrace.android.gradle.plugin.instrumentation.AsmTaskRegistration
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
 import io.embrace.android.gradle.plugin.model.AndroidCompactedVariantData
+import io.embrace.android.gradle.plugin.tasks.buildinfo.ExportBuildInfoTaskRegistration
 import io.embrace.android.gradle.plugin.tasks.il2cpp.Il2CppUploadTaskRegistration
 import io.embrace.android.gradle.plugin.tasks.ndk.NdkUploadTasksRegistration
 import io.embrace.android.gradle.plugin.tasks.r8.JvmMappingUploadTaskRegistration
@@ -68,12 +69,21 @@ class TaskRegistrar(
 
         AsmTaskRegistration().register(params)
 
-        if (shouldSkipUploadTasks(variant)) {
+        if (variant.isBuildTypeDebuggable || behavior.isPluginDisabledForVariant(variant.name)) {
+            logger.info("Skipping upload/export tasks for variant: ${variant.name}")
+            return
+        }
+
+        if (behavior.isExportBuildInfoEnabled) {
+            ExportBuildInfoTaskRegistration().register(params)
+        }
+
+        if (!shouldRegisterUploadTasks(variant, variantConfigurationsListProperty)) {
             logger.info("Skipping upload tasks for variant: ${variant.name}")
             return
-        } else {
-            registerUploadTasks(params, variant)
         }
+
+        registerUploadTasks(params, variant)
     }
 
     private fun onReactNativeVariant(variant: AndroidCompactedVariantData, ref: Variant) {


### PR DESCRIPTION
## Goal
Allow workflows where the `mapping.txt` or other symbols need to be uploaded only after post-build processing. The Gradle plugin can now be configured to export the build-id, app-id + token, and variant as a JSON file that will be usable in a standalone upload process outside of Gradle.

## Testing
New integration test added.