### PR TITLE
Update sdk to use common Embrace federated semconv registry

### DIFF
--- a/embrace-android-semconv/src/main/semconv/manifest.yaml
+++ b/embrace-android-semconv/src/main/semconv/manifest.yaml
@@ -1,0 +1,8 @@
+name: embrace-android
+description: Embrace Android SDK semantic conventions.
+schema_url: https://embrace.io/schemas/embrace-android/0.1.0
+dependencies:
+  - name: otel
+    registry_path: https://github.com/open-telemetry/semantic-conventions@v1.43.0[model]
+  - name: embrace
+    registry_path: https://github.com/embrace-io/embrace-semconv@v0.1.0[model]


### PR DESCRIPTION
Create new definition for Android semconv repo that makes it a federated one with dependencies on the core OTel and Embrace registries