### PR TITLE
Fixed a time mismatch in the screen-load vital

### DIFF
--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/ActivityNavigationSource.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/ActivityNavigationSource.kt
@@ -15,12 +15,12 @@ internal class ActivityNavigationSource(
      * A newly created Activity is a forward navigation start. [recreated] (a config change or process-death restore) rebuilds the same
      * screen,
      */
-    fun onActivityCreated(screenName: String, recreated: Boolean) {
+    fun onActivityCreated(screenName: String, recreated: Boolean, eventTime: Long) {
         val skip = skipNextCreate || recreated
         skipNextCreate = false
 
         if (!skip) {
-            callbacks.onNavigationStart(screenName)
+            callbacks.onNavigationStart(screenName, eventTime)
         }
     }
 

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/ActivityNavigationSource.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/ActivityNavigationSource.kt
@@ -24,7 +24,7 @@ internal class ActivityNavigationSource(
         }
     }
 
-    fun onActivityResumed(screenName: String) {
-        callbacks.onNavigationEnd(screenName)
+    fun onActivityResumed(screenName: String, eventTime: Long) {
+        callbacks.onNavigationEnd(screenName, eventTime)
     }
 }

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/FocalInteractionCallbacks.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/FocalInteractionCallbacks.kt
@@ -46,9 +46,10 @@ internal interface FocalInteractionCallbacks {
     fun onTap(eventTime: Long)
 
     /**
-     * A navigation began towards [screenName] (if known) — confirms a possible screen load.
+     * A navigation began towards [screenName] (if known) — confirms a possible screen load. The [eventTime] is the
+     * [android.os.SystemClock.uptimeMillis] that the event occurred.
      */
-    fun onNavigationStart(screenName: String?)
+    fun onNavigationStart(screenName: String?, eventTime: Long)
 
     /**
      * A navigation reached [screenName] (if known) — arms the settle that ends the screen load. The [eventTime] is the

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/FocalInteractionCallbacks.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/FocalInteractionCallbacks.kt
@@ -51,9 +51,10 @@ internal interface FocalInteractionCallbacks {
     fun onNavigationStart(screenName: String?)
 
     /**
-     * A navigation reached [screenName] (if known) — arms the settle that ends the screen load.
+     * A navigation reached [screenName] (if known) — arms the settle that ends the screen load. The [eventTime] is the
+     * [android.os.SystemClock.uptimeMillis] that the event occurred.
      */
-    fun onNavigationEnd(screenName: String?)
+    fun onNavigationEnd(screenName: String?, eventTime: Long)
 
     /**
      * The window gained input focus: the open transition finished, extending an in-flight screen load past

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsActivityListener.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsActivityListener.kt
@@ -26,9 +26,11 @@ internal class VitalsActivityListener(
     private val frameListeners = WeakHashMap<Window, VitalsFrameMetricsListener>()
 
     override fun onActivityCreated(activity: Activity, bundle: Bundle?) {
+        // captured first so the navigation-start timestamp reflects this event, not the delay until it's processed
+        val eventTime = SystemClock.uptimeMillis()
         try {
             // a non-null bundle means the Activity is being recreated (config change / restore), not navigated to
-            navSource.onActivityCreated(activity.localClassName, recreated = bundle != null)
+            navSource.onActivityCreated(activity.localClassName, recreated = bundle != null, eventTime = eventTime)
         } catch (_: Throwable) {
         }
     }

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsActivityListener.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsActivityListener.kt
@@ -5,6 +5,7 @@ import android.app.Application.ActivityLifecycleCallbacks
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
+import android.os.SystemClock
 import android.view.Window
 import androidx.annotation.RequiresApi
 import java.util.WeakHashMap
@@ -33,13 +34,15 @@ internal class VitalsActivityListener(
     }
 
     override fun onActivityResumed(activity: Activity) {
+        // captured first so the navigation-end timestamp reflects this event, not the delay until it's processed
+        val eventTime = SystemClock.uptimeMillis()
         try {
             val window = activity.window ?: return
             installInteractionCallback(window)
             installFrameMetricsListener(window)
             focalCallbacks.onScreenStart()
             // a resumed Activity is the navigation end onto its screen
-            navSource.onActivityResumed(activity.localClassName)
+            navSource.onActivityResumed(activity.localClassName, eventTime)
         } catch (_: Throwable) {
         }
     }

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTracker.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTracker.kt
@@ -100,10 +100,11 @@ internal class ScreenLoadTracker(
 
     /**
      * Signal the end of a navigation, recording that the destination has been reached (updating the screen name if [screenName] is not
-     * `null`).
+     * `null`). The [eventTime] can be specified relative to [uptimeMillis] to accurately anchor the navigation end to the underlying
+     * event (e.g. the Activity resume), rather than to whenever this call happens to run.
      */
     @WorkerThread
-    fun onNavigationEnd(screenName: String? = null) {
+    fun onNavigationEnd(screenName: String? = null, eventTime: Long = uptimeMillis()) {
         if (state != State.CONFIRMED && state != State.SETTLING) {
             return
         }
@@ -112,15 +113,14 @@ internal class ScreenLoadTracker(
             this.screenName = it
         }
 
-        val now = uptimeMillis()
         if (state == State.CONFIRMED) {
             // the screen load can now be considered "settling"
             state = State.SETTLING
-            navEndMs = now
+            navEndMs = eventTime
             firstFrameAfterNavEndMs = 0L
         }
 
-        settle.notifyActivity(now)
+        settle.notifyActivity(eventTime)
     }
 
     /** A frame on the destination pushes the settle baseline out while it keeps rendering. */

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTracker.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTracker.kt
@@ -68,21 +68,22 @@ internal class ScreenLoadTracker(
 
     /**
      * Signal a navigation start, which confirms a real screen load (typically including the time since [onTap]). If the destination
-     * [screenName] is known here it should be specified as non-`null`.
+     * [screenName] is known here it should be specified as non-`null`. The [eventTime] can be specified relative to [uptimeMillis] to
+     * accurately anchor the navigation start to the underlying event (e.g. the Activity creation), rather than to whenever this call
+     * happens to run.
      */
     @WorkerThread
-    fun onNavigationStart(screenName: String? = null) {
+    fun onNavigationStart(screenName: String? = null, eventTime: Long = uptimeMillis()) {
         when (state) {
-            State.IDLE -> openLoad()
+            State.IDLE -> openLoad(eventTime)
             State.CANDIDATE -> {
-                val now = uptimeMillis()
-                if (now <= startUptimeMs + NAVIGATION_TIMEOUT_MS) {
+                if (eventTime <= startUptimeMs + NAVIGATION_TIMEOUT_MS) {
                     state = State.CONFIRMED
-                    navStartMs = now
+                    navStartMs = eventTime
                 } else {
                     // the previous "tap" event is too far in the past to be considered part of the screen load
                     // so we move the "start time" to now
-                    openLoad()
+                    openLoad(eventTime)
                 }
             }
 
@@ -90,7 +91,7 @@ internal class ScreenLoadTracker(
             State.SETTLING -> {
                 // flush the current screen load before we start another one
                 complete(endMs = settle.lastActivityMs, outcome = ScreenLoadOutcome.NAVIGATION_INTERRUPTED)
-                openLoad()
+                openLoad(eventTime)
             }
         }
 
@@ -182,12 +183,14 @@ internal class ScreenLoadTracker(
         complete(endMs = endMs, outcome = ScreenLoadOutcome.TIMED_OUT)
     }
 
-    private fun openLoad() {
+    private fun openLoad(eventTime: Long = uptimeMillis()) {
         state = State.CONFIRMED
         screenName = ""
-        startUptimeMs = uptimeMillis()
+        startUptimeMs = eventTime
         navStartMs = startUptimeMs
-        startWallMs = clock.now()
+
+        val startUptimeDelta = uptimeMillis() - startUptimeMs
+        startWallMs = clock.now() - startUptimeDelta
         scheduleTimeout()
     }
 

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTracker.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTracker.kt
@@ -111,8 +111,8 @@ internal class FocalMomentTracker(
         scheduler.post { screenLoadTracker.onNavigationStart(screenName) }
 
     @MainThread
-    override fun onNavigationEnd(screenName: String?) =
-        scheduler.post { screenLoadTracker.onNavigationEnd(screenName) }
+    override fun onNavigationEnd(screenName: String?, eventTime: Long) =
+        scheduler.post { screenLoadTracker.onNavigationEnd(screenName, eventTime) }
 
     @MainThread
     override fun onWindowFocused() =

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTracker.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTracker.kt
@@ -107,8 +107,8 @@ internal class FocalMomentTracker(
     override fun onTap(eventTime: Long) = scheduler.post { screenLoadTracker.onTap(eventTime) }
 
     @MainThread
-    override fun onNavigationStart(screenName: String?) =
-        scheduler.post { screenLoadTracker.onNavigationStart(screenName) }
+    override fun onNavigationStart(screenName: String?, eventTime: Long) =
+        scheduler.post { screenLoadTracker.onNavigationStart(screenName, eventTime) }
 
     @MainThread
     override fun onNavigationEnd(screenName: String?, eventTime: Long) =

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/ActivityNavigationSourceTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/ActivityNavigationSourceTest.kt
@@ -27,7 +27,7 @@ internal class ActivityNavigationSourceTest {
 
     @Test
     fun `an Activity resume reports a navigation end`() {
-        source.onActivityResumed("Detail")
+        source.onActivityResumed("Detail", eventTime = 100L)
 
         assertEquals(listOf<String?>("Detail"), callbacks.navigationEnds)
     }

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/ActivityNavigationSourceTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/ActivityNavigationSourceTest.kt
@@ -11,44 +11,44 @@ internal class ActivityNavigationSourceTest {
 
     @Test
     fun `the cold-start Activity is skipped`() {
-        source.onActivityCreated("Home", recreated = false)
+        source.onActivityCreated("Home", recreated = false, eventTime = 0L)
 
         assertTrue("cold start is measured by the startup vital, not screen-load", callbacks.navigationStarts.isEmpty())
     }
 
     @Test
     fun `subsequent Activity creations report a navigation start`() {
-        source.onActivityCreated("Home", recreated = false) // cold start, skipped
-        source.onActivityCreated("Detail", recreated = false)
-        source.onActivityCreated("Settings", recreated = false)
+        source.onActivityCreated("Home", recreated = false, eventTime = 0L) // cold start, skipped
+        source.onActivityCreated("Detail", recreated = false, eventTime = 10L)
+        source.onActivityCreated("Settings", recreated = false, eventTime = 20L)
 
-        assertEquals(listOf<String?>("Detail", "Settings"), callbacks.navigationStarts)
+        assertEquals(listOf("Detail" to 10L, "Settings" to 20L), callbacks.navigationStarts)
     }
 
     @Test
     fun `an Activity resume reports a navigation end`() {
         source.onActivityResumed("Detail", eventTime = 100L)
 
-        assertEquals(listOf<String?>("Detail"), callbacks.navigationEnds)
+        assertEquals(listOf("Detail" to 100L), callbacks.navigationEnds)
     }
 
     @Test
     fun `a recreated Activity does not report a navigation start`() {
-        source.onActivityCreated("Home", recreated = false) // cold start, skipped
-        source.onActivityCreated("Detail", recreated = false) // reported
+        source.onActivityCreated("Home", recreated = false, eventTime = 0L) // cold start, skipped
+        source.onActivityCreated("Detail", recreated = false, eventTime = 10L) // reported
 
         // The same screen rebuilt (rotation, process-death restore) is not a forward navigation.
-        source.onActivityCreated("Detail", recreated = true)
-        source.onActivityCreated("Settings", recreated = false) // genuine in-app navigation, reported
+        source.onActivityCreated("Detail", recreated = true, eventTime = 20L)
+        source.onActivityCreated("Settings", recreated = false, eventTime = 30L) // genuine in-app navigation, reported
 
-        assertEquals(listOf<String?>("Detail", "Settings"), callbacks.navigationStarts)
+        assertEquals(listOf("Detail" to 10L, "Settings" to 30L), callbacks.navigationStarts)
     }
 
     @Test
     fun `a cold start restored from saved state is skipped without eating the next navigation`() {
-        source.onActivityCreated("Home", recreated = true) // cold start from process-death restore, skipped
-        source.onActivityCreated("Detail", recreated = false) // first genuine navigation, reported
+        source.onActivityCreated("Home", recreated = true, eventTime = 0L) // cold start from process-death restore, skipped
+        source.onActivityCreated("Detail", recreated = false, eventTime = 10L) // first genuine navigation, reported
 
-        assertEquals(listOf<String?>("Detail"), callbacks.navigationStarts)
+        assertEquals(listOf("Detail" to 10L), callbacks.navigationStarts)
     }
 }

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/FakeFocalInteractionCallbacks.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/FakeFocalInteractionCallbacks.kt
@@ -21,7 +21,7 @@ internal class FakeFocalInteractionCallbacks : FocalInteractionCallbacks {
     override fun onInteractionEnd() { interactionEndCount++ }
     override fun onTap(eventTime: Long) { tapCount++ }
     override fun onNavigationStart(screenName: String?) { navigationStarts += screenName }
-    override fun onNavigationEnd(screenName: String?) { navigationEnds += screenName }
+    override fun onNavigationEnd(screenName: String?, eventTime: Long) { navigationEnds += screenName }
     override fun onWindowFocused() { windowFocusedCount++ }
     override fun onAppBackgrounded() { appBackgroundedCount++ }
 }

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/FakeFocalInteractionCallbacks.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/FakeFocalInteractionCallbacks.kt
@@ -10,8 +10,8 @@ internal class FakeFocalInteractionCallbacks : FocalInteractionCallbacks {
     var tapCount = 0
     var windowFocusedCount = 0
     var appBackgroundedCount = 0
-    val navigationStarts = mutableListOf<String?>()
-    val navigationEnds = mutableListOf<String?>()
+    val navigationStarts = mutableListOf<Pair<String?, Long>>()
+    val navigationEnds = mutableListOf<Pair<String?, Long>>()
 
     override fun onFrame(vsyncNanos: Long, frameDispatchNanos: Long, jankNanos: Long) {}
     override fun onScreenStart() { screenStartCount++ }
@@ -20,8 +20,8 @@ internal class FakeFocalInteractionCallbacks : FocalInteractionCallbacks {
     override fun onInteractionMove() { interactionMoveCount++ }
     override fun onInteractionEnd() { interactionEndCount++ }
     override fun onTap(eventTime: Long) { tapCount++ }
-    override fun onNavigationStart(screenName: String?) { navigationStarts += screenName }
-    override fun onNavigationEnd(screenName: String?, eventTime: Long) { navigationEnds += screenName }
+    override fun onNavigationStart(screenName: String?, eventTime: Long) { navigationStarts += screenName to eventTime }
+    override fun onNavigationEnd(screenName: String?, eventTime: Long) { navigationEnds += screenName to eventTime }
     override fun onWindowFocused() { windowFocusedCount++ }
     override fun onAppBackgrounded() { appBackgroundedCount++ }
 }

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsActivityListenerTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsActivityListenerTest.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.app.Application
 import android.os.Handler
 import android.os.Looper
+import android.os.SystemClock
 import android.view.FrameMetrics
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -76,9 +77,10 @@ internal class VitalsActivityListenerTest {
     fun `onActivityResumed reports a navigation end for the destination`() {
         val activity = buildActivity(Activity::class.java).setup().get()
 
+        val eventTime = SystemClock.uptimeMillis()
         listener.onActivityResumed(activity)
 
-        assertEquals(listOf<String?>(activity.localClassName), focalCallbacks.navigationEnds)
+        assertEquals(listOf(activity.localClassName to eventTime), focalCallbacks.navigationEnds)
     }
 
     @Test
@@ -88,7 +90,8 @@ internal class VitalsActivityListenerTest {
         listener.onActivityCreated(activity, null) // cold start: skipped
         assertTrue(focalCallbacks.navigationStarts.isEmpty())
 
+        val eventTime = SystemClock.uptimeMillis()
         listener.onActivityCreated(activity, null) // a subsequent (forward) navigation
-        assertEquals(listOf<String?>(activity.localClassName), focalCallbacks.navigationStarts)
+        assertEquals(listOf(activity.localClassName to eventTime), focalCallbacks.navigationStarts)
     }
 }

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTrackerTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTrackerTest.kt
@@ -53,6 +53,28 @@ internal class ScreenLoadTrackerTest {
     }
 
     @Test
+    fun `navigation end anchors to the passed event time, not the delay until it is dispatched`() {
+        tracker.onTap() // t=0
+        tracker.onNavigationStart("home")
+        val trueResumeTime = SystemClock.uptimeMillis() // the Activity actually resumed at t=0
+        advance(9) // the hop onto the worker thread lags 9ms behind the real event
+        tracker.onNavigationEnd("home", trueResumeTime) // runs "now" (t=9), but anchored to the true event time (t=0)
+        // the destination's first frame rendered at the true event time, its FrameMetrics delivered late
+        tracker.onFrame(trueResumeTime.millisToNanos())
+
+        advance(IDLE)
+        scheduler.runDue()
+
+        val result = emitted.single()
+        assertEquals("navigation end anchored to its true event time (t=0), not the delayed dispatch (t=9)", 0L, result.navDurationMs)
+        assertEquals(
+            "first frame at the same instant as the true navigation end is a zero duration, not a negative one",
+            0L,
+            result.firstFrameDurationMs,
+        )
+    }
+
+    @Test
     fun `a touchless navigation start opens the load anchored at the navigation`() {
         tracker.onNavigationStart("detail") // t=0, no preceding tap
         advance(15)


### PR DESCRIPTION
## Goal
Fix a timing bug in the screen load vital where the time of the event should have been captured before posting the events to the vitals handler thread.

This corrects the timing so that events are always compared relative to when they actually happened (or at least when the `main` thread received them) instead of when the vitals thread received the event.

## Testing
Updated the unit tests to cover these cases.
