### PR TITLE
Added frame timing data to the smoothness vital

### DIFF
--- a/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/Behavior.kt
+++ b/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/Behavior.kt
@@ -48,8 +48,9 @@ fun createThreadBlockageBehavior(
  * A [VitalsBehaviorImpl] that returns default values.
  */
 fun createVitalsBehavior(
+    thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
     remoteCfg: RemoteConfig? = null,
-): VitalsBehavior = VitalsBehaviorImpl(remoteCfg)
+): VitalsBehavior = VitalsBehaviorImpl(thresholdCheck, remoteCfg)
 
 /**
  * A [UserSessionBehaviorImpl] that returns default values.

--- a/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeVitalsBehavior.kt
+++ b/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeVitalsBehavior.kt
@@ -9,6 +9,7 @@ class FakeVitalsBehavior(
     var screenLoadIdleThresholdMsImpl: Long = 1000L,
     var screenLoadTimeoutMsImpl: Long = 30_000L,
     var screenLoadNavTimeoutMsImpl: Long = 500L,
+    var smoothnessFrameTraceEnabledImpl: Boolean = false,
 ) : VitalsBehavior {
 
     override fun getSmoothnessIdleThresholdMs(): Long = smoothnessIdleThresholdMsImpl
@@ -17,4 +18,5 @@ class FakeVitalsBehavior(
     override fun getScreenLoadIdleThresholdMs(): Long = screenLoadIdleThresholdMsImpl
     override fun getScreenLoadTimeoutMs(): Long = screenLoadTimeoutMsImpl
     override fun getScreenLoadNavTimeoutMs(): Long = screenLoadNavTimeoutMsImpl
+    override fun isSmoothnessFrameTraceEnabled(): Boolean = smoothnessFrameTraceEnabledImpl
 }

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
@@ -127,7 +127,7 @@ class ConfigServiceImpl(
     override val sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(instrumentedConfig)
     override val logMessageBehavior = LogMessageBehaviorImpl(remoteConfig)
     override val threadBlockageBehavior = ThreadBlockageBehaviorImpl(thresholdCheck, remoteConfig)
-    override val vitalsBehavior = VitalsBehaviorImpl(remoteConfig)
+    override val vitalsBehavior = VitalsBehaviorImpl(thresholdCheck, remoteConfig)
     override val sessionBehavior = UserSessionBehaviorImpl(remoteConfig)
     override val networkBehavior = NetworkBehaviorImpl(instrumentedConfig, remoteConfig)
     override val dataCaptureEventBehavior = DataCaptureEventBehaviorImpl(remoteConfig)

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/VitalsBehavior.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/VitalsBehavior.kt
@@ -31,4 +31,10 @@ interface VitalsBehavior {
      * Maximum time between a tap and the navigation start event for the two to be linked as one screen load.
      */
     fun getScreenLoadNavTimeoutMs(): Long
+
+    /**
+     * Whether this device is sampled-in to record a per-frame duration trace alongside the smoothness result,
+     * as a diagnostic aid while smoothness thresholds are being tuned.
+     */
+    fun isSmoothnessFrameTraceEnabled(): Boolean
 }

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/VitalsBehaviorImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/VitalsBehaviorImpl.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
  * Provides the behavior that the vitals (smoothness / screen-load) feature should follow.
  */
 class VitalsBehaviorImpl(
+    private val thresholdCheck: BehaviorThresholdCheck,
     remote: RemoteConfig?,
 ) : VitalsBehavior {
 
@@ -16,6 +17,7 @@ class VitalsBehaviorImpl(
         private const val DEFAULT_SCREEN_LOAD_IDLE_THRESHOLD_MS = 1000L
         private const val DEFAULT_SCREEN_LOAD_TIMEOUT_MS = 30_000L
         private const val DEFAULT_SCREEN_LOAD_NAV_TIMEOUT_MS = 500L
+        private const val DEFAULT_SMOOTHNESS_FRAME_TRACE_ENABLED = false
     }
 
     private val remote = remote?.vitalsRemoteConfig
@@ -37,4 +39,8 @@ class VitalsBehaviorImpl(
 
     override fun getScreenLoadNavTimeoutMs(): Long =
         remote?.screenLoadNavTimeoutMs ?: DEFAULT_SCREEN_LOAD_NAV_TIMEOUT_MS
+
+    override fun isSmoothnessFrameTraceEnabled(): Boolean =
+        thresholdCheck.isBehaviorEnabled(remote?.smoothnessFrameTracePctEnabled)
+            ?: DEFAULT_SMOOTHNESS_FRAME_TRACE_ENABLED
 }

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/VitalsBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/VitalsBehaviorImplTest.kt
@@ -4,6 +4,8 @@ import io.embrace.android.embracesdk.fakes.createVitalsBehavior
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.VitalsRemoteConfig
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class VitalsBehaviorImplTest {
@@ -15,6 +17,7 @@ internal class VitalsBehaviorImplTest {
         screenLoadIdleThresholdMs = 1500,
         screenLoadTimeoutMs = 45_000,
         screenLoadNavTimeoutMs = 750,
+        smoothnessFrameTracePctEnabled = 100f,
     )
 
     @Test
@@ -26,6 +29,7 @@ internal class VitalsBehaviorImplTest {
             assertEquals(1000L, getScreenLoadIdleThresholdMs())
             assertEquals(30_000L, getScreenLoadTimeoutMs())
             assertEquals(500L, getScreenLoadNavTimeoutMs())
+            assertFalse(isSmoothnessFrameTraceEnabled())
         }
     }
 
@@ -38,6 +42,7 @@ internal class VitalsBehaviorImplTest {
             assertEquals(1500L, getScreenLoadIdleThresholdMs())
             assertEquals(45_000L, getScreenLoadTimeoutMs())
             assertEquals(750L, getScreenLoadNavTimeoutMs())
+            assertTrue(isSmoothnessFrameTraceEnabled())
         }
     }
 }

--- a/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
+++ b/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
@@ -264,6 +264,7 @@ sealed class SchemaType(
         idleThresholdMs: Long,
         heldIdleThresholdMs: Long,
         jankHeuristicMultiplier: Double,
+        frameTraceBase64: String? = null,
     ) : SchemaType(
         telemetryType = EmbType.Performance.Smoothness,
         fixedObjectName = "smoothness",
@@ -275,7 +276,8 @@ sealed class SchemaType(
             EmbSmoothnessAttributes.SMOOTHNESS_IDLE_THRESHOLD_MS to idleThresholdMs.toString(),
             EmbSmoothnessAttributes.SMOOTHNESS_HELD_IDLE_THRESHOLD_MS to heldIdleThresholdMs.toString(),
             EmbSmoothnessAttributes.SMOOTHNESS_JANK_HEURISTIC_MULTIPLIER to jankHeuristicMultiplier.toString(),
-        )
+            EmbSmoothnessAttributes.SMOOTHNESS_FRAME_TRACE to frameTraceBase64,
+        ).toNonNullMap()
     }
 
     /**

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsDataSource.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsDataSource.kt
@@ -14,6 +14,7 @@ import io.embrace.android.embracesdk.internal.arch.state.AppStateListener
 import io.embrace.android.embracesdk.internal.vitals.screenload.ScreenLoadResult
 import io.embrace.android.embracesdk.internal.vitals.screenload.ScreenLoadTracker
 import io.embrace.android.embracesdk.internal.vitals.smoothness.FocalMomentTracker
+import io.embrace.android.embracesdk.internal.vitals.smoothness.FrameTraceRecorder
 import io.embrace.android.embracesdk.internal.vitals.smoothness.SmoothnessReporter
 import io.embrace.android.embracesdk.internal.vitals.smoothness.SmoothnessResult
 
@@ -94,6 +95,7 @@ internal class VitalsDataSource(
             ),
             idleThresholdMs = vitalsBehavior.getSmoothnessIdleThresholdMs(),
             heldIdleThresholdMs = vitalsBehavior.getSmoothnessHeldIdleThresholdMs(),
+            frameTraceRecorder = if (vitalsBehavior.isSmoothnessFrameTraceEnabled()) FrameTraceRecorder() else null,
         )
         focalTracker = tracker
 
@@ -136,6 +138,7 @@ internal class VitalsDataSource(
                     idleThresholdMs = result.idleThresholdMs,
                     heldIdleThresholdMs = result.heldIdleThresholdMs,
                     jankHeuristicMultiplier = result.jankHeuristicMultiplier,
+                    frameTraceBase64 = result.frameTraceBase64,
                 ).attributes(),
             )
         }

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTracker.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTracker.kt
@@ -27,6 +27,8 @@ internal class FocalMomentTracker(
     private val screenLoadTracker: ScreenLoadTracker,
     private val idleThresholdMs: Long = DEFAULT_IDLE_THRESHOLD_MS,
     private val heldIdleThresholdMs: Long = DEFAULT_HELD_IDLE_THRESHOLD_MS,
+    // Only non-null for a sampled fraction of devices; see VitalsBehavior.isSmoothnessFrameTraceEnabled.
+    private val frameTraceRecorder: FrameTraceRecorder? = null,
 ) : FocalInteractionCallbacks {
 
     // Reused hop Runnable instances (main thread -> Vitals thread); allocate them here to make certain they're off the hot path
@@ -48,14 +50,14 @@ internal class FocalMomentTracker(
     @WorkerThread
     override fun onFrame(vsyncNanos: Long, frameDispatchNanos: Long, jankNanos: Long) {
         if (capturing) {
-            recordFrame(frameDispatchNanos, jankNanos)
+            recordFrame(vsyncNanos, frameDispatchNanos, jankNanos)
             settle.notifyActivity(vsyncNanos.nanosToMillis())
         } else if (held) {
             if (vsyncNanos - bufferedEndNanos < idleThresholdMs.millisToNanos()) {
                 // Frame is contiguous with the buffered settle: resume capturing so its jank is included.
                 held = false
                 capturing = true
-                recordFrame(frameDispatchNanos, jankNanos)
+                recordFrame(vsyncNanos, frameDispatchNanos, jankNanos)
                 settle.notifyActivity(vsyncNanos.nanosToMillis())
             } else {
                 // Idle gap before this frame: emit the buffered settle and discard the orphan frame.
@@ -151,11 +153,12 @@ internal class FocalMomentTracker(
         interacting = true
         capturing = true
         reporter.onFocalMomentStart()
+        frameTraceRecorder?.onFocalMomentStart()
         settle.notifyActivity(nowMs)
     }
 
     @WorkerThread
-    private fun recordFrame(frameDispatchNanos: Long, jankNanos: Long) {
+    private fun recordFrame(vsyncNanos: Long, frameDispatchNanos: Long, jankNanos: Long) {
         // A jank frame is counted in full, so the moment must also cover the render that produced it. We
         // back-date the start to when the engine dispatched the frame's work, if that predates the
         // moment, shifting the reported start epoch by the same amount so the end stays put.
@@ -165,6 +168,7 @@ internal class FocalMomentTracker(
         }
 
         reporter.onFocalMomentFrame(jankNanos)
+        frameTraceRecorder?.onFocalMomentFrame((vsyncNanos - frameDispatchNanos).nanosToMillis())
     }
 
     /**
@@ -201,7 +205,7 @@ internal class FocalMomentTracker(
         held = false
         settle.cancel()
         val durationMs = (endNanos - focalMomentStartNanos).nanosToMillis()
-        reporter.onFocalMomentEnd(outcome, focalMomentStartEpochMs, durationMs)
+        reporter.onFocalMomentEnd(outcome, focalMomentStartEpochMs, durationMs, frameTraceRecorder?.toBase64())
     }
 
     /**

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FrameTraceRecorder.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FrameTraceRecorder.kt
@@ -1,0 +1,71 @@
+package io.embrace.android.embracesdk.internal.vitals.smoothness
+
+import android.util.Base64
+import androidx.annotation.WorkerThread
+
+/**
+ * Records a per-frame duration trace over a focal moment, as a diagnostic aid while smoothness thresholds
+ * are being tuned. Only constructed for a sampled fraction of devices (see
+ * [io.embrace.android.embracesdk.internal.config.behavior.VitalsBehavior.isSmoothnessFrameTraceEnabled]),
+ * so the buffer is pre-allocated once per instance rather than per focal moment.
+ *
+ * Each frame's total duration (whole milliseconds) is packed as an unsigned LEB128 varint into a
+ * fixed-size buffer: a typical 1-3ms frame costs a single byte, while a slow/janky frame costs more,
+ * so detail scales with what's actually interesting. Once the buffer fills, further frames in that
+ * focal moment are silently dropped rather than corrupting the encoding with a truncated varint.
+ */
+internal class FrameTraceRecorder(
+    capacityBytes: Int = DEFAULT_CAPACITY_BYTES,
+) {
+
+    private val buffer = ByteArray(capacityBytes)
+    private var writeIndex = 0
+
+    @WorkerThread
+    fun onFocalMomentStart() {
+        writeIndex = 0
+    }
+
+    @WorkerThread
+    fun onFocalMomentFrame(frameDurationMs: Long) {
+        writeVarInt(frameDurationMs.coerceAtLeast(0L))
+        return
+    }
+
+    private fun writeVarInt(value: Long) {
+        var v = value
+        var index = writeIndex
+        while (true) {
+            if (index >= buffer.size) {
+                // Not enough room to finish this varint: drop it rather than write a truncated one.
+                return
+            }
+            val septet = (v and SEPTET_MASK).toByte()
+            v = v ushr 7
+            if (v == 0L) {
+                buffer[index] = septet
+                writeIndex = index + 1
+                return
+            }
+            buffer[index] = (septet.toInt() or CONTINUATION_BIT).toByte()
+            index++
+        }
+    }
+
+    /**
+     * Base64-encodes the frames recorded since the last [onFocalMomentStart], or null if none were recorded.
+     */
+    @WorkerThread
+    fun toBase64(): String? {
+        if (writeIndex == 0) {
+            return null
+        }
+        return Base64.encodeToString(buffer, 0, writeIndex, Base64.NO_PADDING or Base64.NO_WRAP)
+    }
+
+    internal companion object {
+        const val DEFAULT_CAPACITY_BYTES = 1024
+        private const val SEPTET_MASK = 0x7FL
+        private const val CONTINUATION_BIT = 0x80
+    }
+}

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/SmoothnessReporter.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/SmoothnessReporter.kt
@@ -31,7 +31,7 @@ internal class SmoothnessReporter(
     }
 
     @WorkerThread
-    fun onFocalMomentEnd(outcome: FocalOutcome, startTimeMs: Long, durationMs: Long) {
+    fun onFocalMomentEnd(outcome: FocalOutcome, startTimeMs: Long, durationMs: Long, frameTraceBase64: String? = null) {
         if (frameCount == 0) {
             // No frames rendered: nothing to report.
             return
@@ -46,6 +46,7 @@ internal class SmoothnessReporter(
                 idleThresholdMs = idleThresholdMs,
                 heldIdleThresholdMs = heldIdleThresholdMs,
                 jankHeuristicMultiplier = jankHeuristicMultiplier,
+                frameTraceBase64 = frameTraceBase64,
             ),
         )
     }

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/SmoothnessResult.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/SmoothnessResult.kt
@@ -34,4 +34,9 @@ internal data class SmoothnessResult(
      * The grace multiplier that was applied to a frame's budget/deadline before it was considered janky.
      */
     val jankHeuristicMultiplier: Double,
+    /**
+     * Base64-encoded, varint-packed per-frame duration trace, if this device is sampled-in to record one;
+     * null otherwise.
+     */
+    val frameTraceBase64: String? = null,
 )

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTrackerTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTrackerTest.kt
@@ -54,6 +54,9 @@ internal class ScreenLoadTrackerTest {
         assertEquals(IDLE, result.idleThresholdMs)
         assertEquals(TIMEOUT, result.timeoutMs)
         assertEquals(NAV_TIMEOUT, result.navTimeoutMs)
+        assertEquals(IDLE, result.idleThresholdMs)
+        assertEquals(TIMEOUT, result.timeoutMs)
+        assertEquals(NAV_TIMEOUT, result.navTimeoutMs)
     }
 
     @Test

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTrackerTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FocalMomentTrackerTest.kt
@@ -6,6 +6,8 @@ import io.embrace.android.embracesdk.internal.vitals.fake.FakeVitalsScheduler
 import io.embrace.android.embracesdk.internal.vitals.screenload.ScreenLoadTracker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -254,6 +256,33 @@ internal class FocalMomentTrackerTest {
         tracker.onScreenStop()
 
         assertEquals(1.0, emitted.single().normalizedDroppedFrames, 0.01)
+    }
+
+    @Test
+    fun `no frame trace is attached when the device is not sampled-in`() {
+        tracker.onInteractionStart()
+        redraw(vsyncNanos = start + 16.ms)
+        tracker.onScreenStop()
+
+        assertNull(emitted.single().frameTraceBase64)
+    }
+
+    @Test
+    fun `a frame trace is attached when a FrameTraceRecorder is supplied`() {
+        val sampledInEmitted = mutableListOf<SmoothnessResult>()
+        val sampledInTracker = FocalMomentTracker(
+            scheduler = scheduler,
+            reporter = SmoothnessReporter(emit = sampledInEmitted::add),
+            clock = { 0L },
+            screenLoadTracker = ScreenLoadTracker(scheduler = scheduler, clock = { 0L }, emit = {}),
+            frameTraceRecorder = FrameTraceRecorder(),
+        )
+
+        sampledInTracker.onInteractionStart()
+        sampledInTracker.onFrame(vsyncNanos = start + 16.ms, frameDispatchNanos = start + 16.ms, jankNanos = 0L)
+        sampledInTracker.onScreenStop()
+
+        assertNotNull(sampledInEmitted.single().frameTraceBase64)
     }
 
     private fun advance(millis: Long) = ShadowSystemClock.advanceBy(Duration.ofMillis(millis))

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FrameTraceRecorderTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/FrameTraceRecorderTest.kt
@@ -1,0 +1,100 @@
+package io.embrace.android.embracesdk.internal.vitals.smoothness
+
+import android.util.Base64
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class FrameTraceRecorderTest {
+
+    @Test
+    fun `an empty focal moment reports no trace`() {
+        val recorder = FrameTraceRecorder()
+        recorder.onFocalMomentStart()
+
+        assertNull(recorder.toBase64())
+    }
+
+    @Test
+    fun `records and round-trips a mix of small and large frame durations`() {
+        val recorder = FrameTraceRecorder()
+        recorder.onFocalMomentStart()
+
+        val durations = listOf(1L, 3L, 0L, 127L, 128L, 300L, 16_384L)
+        durations.forEach(recorder::onFocalMomentFrame)
+
+        assertEquals(durations, decode(recorder.toBase64()))
+    }
+
+    @Test
+    fun `a negative duration is clamped to zero rather than corrupting the encoding`() {
+        val recorder = FrameTraceRecorder()
+        recorder.onFocalMomentStart()
+
+        recorder.onFocalMomentFrame(-5L)
+
+        assertEquals(listOf(0L), decode(recorder.toBase64()))
+    }
+
+    @Test
+    fun `frames that would overflow the buffer are dropped, not truncated`() {
+        val recorder = FrameTraceRecorder(capacityBytes = 4)
+        recorder.onFocalMomentStart()
+
+        // Each of these needs 2 bytes (>=128); the 3rd would need bytes 5-6, past the 4-byte buffer.
+        repeat(3) { recorder.onFocalMomentFrame(200L) }
+
+        // Only the first two 2-byte frames fit; the dropped one leaves no partial/corrupt bytes behind.
+        assertEquals(listOf(200L, 200L), decode(recorder.toBase64()))
+    }
+
+    @Test
+    fun `onFocalMomentStart resets the buffer for a new focal moment`() {
+        val recorder = FrameTraceRecorder()
+        recorder.onFocalMomentStart()
+        recorder.onFocalMomentFrame(50L)
+        assertEquals(listOf(50L), decode(recorder.toBase64()))
+
+        recorder.onFocalMomentStart()
+        assertNull(recorder.toBase64())
+
+        recorder.onFocalMomentFrame(2L)
+        assertEquals(listOf(2L), decode(recorder.toBase64()))
+    }
+
+    @Test
+    fun `a 1024-byte buffer stays within the internal attribute value length limit once base64-encoded`() {
+        val recorder = FrameTraceRecorder()
+        recorder.onFocalMomentStart()
+
+        // Fill with worst-case 2-byte durations so the buffer is as full as possible.
+        repeat(600) { recorder.onFocalMomentFrame(200L) }
+
+        val base64 = requireNotNull(recorder.toBase64())
+        assertTrue("base64 length was ${base64.length}", base64.length <= 2000)
+    }
+
+    /** Decodes an unsigned-LEB128-packed byte string back into its per-frame values, for test verification only. */
+    private fun decode(base64: String?): List<Long> {
+        val bytes = Base64.decode(base64, Base64.NO_PADDING or Base64.NO_WRAP)
+        val values = mutableListOf<Long>()
+        var value = 0L
+        var shift = 0
+        for (byte in bytes) {
+            val unsigned = byte.toInt() and 0xFF
+            value = value or ((unsigned.toLong() and 0x7F) shl shift)
+            if (unsigned and 0x80 == 0) {
+                values += value
+                value = 0L
+                shift = 0
+            } else {
+                shift += 7
+            }
+        }
+        return values
+    }
+}

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/SmoothnessReporterTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/smoothness/SmoothnessReporterTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.vitals.smoothness
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 internal class SmoothnessReporterTest {
@@ -63,6 +64,19 @@ internal class SmoothnessReporterTest {
         reporter.onFocalMomentEnd(FocalOutcome.SETTLED, startTimeMs = 0, durationMs = 100)
 
         assertEquals(1, emitted.size)
+    }
+
+    @Test
+    fun `frameTraceBase64 defaults to null and passes through when supplied`() {
+        reporter.onFocalMomentStart()
+        reporter.onFocalMomentFrame(jankNanos = 0)
+        reporter.onFocalMomentEnd(FocalOutcome.SETTLED, startTimeMs = 0, durationMs = 1)
+        assertNull(emitted.single().frameTraceBase64)
+
+        reporter.onFocalMomentStart()
+        reporter.onFocalMomentFrame(jankNanos = 0)
+        reporter.onFocalMomentEnd(FocalOutcome.SETTLED, startTimeMs = 0, durationMs = 1, frameTraceBase64 = "AQ==")
+        assertEquals("AQ==", emitted.last().frameTraceBase64)
     }
 
     @Test

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/cache/CachedConfiguration.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/cache/CachedConfiguration.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.internal.serialization.BinaryVersion
 import kotlinx.serialization.Serializable
 
 @Serializable
-@BinaryVersion(1393964509035760531)
+@BinaryVersion(-2074456697392943244)
 data class CachedConfiguration(
     val deviceId: String,
     val etag: String?,

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/VitalsRemoteConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/VitalsRemoteConfig.kt
@@ -26,4 +26,7 @@ data class VitalsRemoteConfig(
 
     @SerialName("screen_load_nav_timeout_ms")
     val screenLoadNavTimeoutMs: Long? = null,
+
+    @SerialName("smoothness_frame_trace_pct_enabled")
+    val smoothnessFrameTracePctEnabled: Float? = null,
 )

--- a/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSmoothnessAttributes.kt
+++ b/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSmoothnessAttributes.kt
@@ -17,6 +17,12 @@ object EmbSmoothnessAttributes {
     const val SMOOTHNESS_FRAME_COUNT: String = "smoothness.frame_count"
 
     /**
+     * Base64-encoded, varint-packed per-frame duration trace over the focal moment, for a sampled fraction of devices. Diagnostic aid while smoothness thresholds are being tuned.
+     */
+    @ExperimentalSemconv
+    const val SMOOTHNESS_FRAME_TRACE: String = "smoothness.frame_trace"
+
+    /**
      * The 'press and hold' settle threshold that was applied.
      */
     @ExperimentalSemconv

--- a/embrace-android-semconv/src/main/semconv/embrace_android.yaml
+++ b/embrace-android-semconv/src/main/semconv/embrace_android.yaml
@@ -95,6 +95,7 @@ attribute_groups:
       - ref: smoothness.idle_threshold_ms
       - ref: smoothness.held_idle_threshold_ms
       - ref: smoothness.jank_heuristic_multiplier
+      - ref: smoothness.frame_trace
 
   - id: emb.screen_load
     visibility: public
@@ -442,6 +443,11 @@ attributes:
     brief: "The grace multiplier that was applied to a frame's budget/deadline before it was considered janky."
     stability: development
     examples: [2.0, 2.5]
+  - key: smoothness.frame_trace
+    type: string
+    brief: "Base64-encoded, varint-packed per-frame duration trace over the focal moment, for a sampled fraction of devices. Diagnostic aid while smoothness thresholds are being tuned."
+    stability: development
+    examples: ["AQIDBA=="]
   - key: screen_load.outcome
     type: string
     brief: "How the screen load ended."


### PR DESCRIPTION
## Goal
Allow the capturing of per-frame timing data in smoothness vitals, gated by a secondary threshold value under the `vitals` remote config block.

The frame time is taken only as the total fame time (vsync - dispatch) in milliseconds. The value is encoded in a buffer as a varint (LEB128) encoding so most frames will only consume a single byte. The buffer is limited to 1k bytes and is allocated exactly once per process as only one focal moment can be active at a time.

## Testing
Manually tested & added unit tests.
