### PR TITLE
Close OkHttp response body

### DIFF
--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionService.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionService.kt
@@ -64,12 +64,14 @@ class OkHttpRequestExecutionService(
             null
         }
 
-        return getResult(
-            endpoint = envelopeType.endpoint,
-            responseCode = httpCallResponse?.code,
-            headersProvider = { httpCallResponse?.headers?.toMap() ?: emptyMap() },
-            executionError = executionError,
-        ).apply {
+        return httpCallResponse.use { response ->
+            getResult(
+                endpoint = envelopeType.endpoint,
+                responseCode = response?.code,
+                headersProvider = { response?.headers?.toMap() ?: emptyMap() },
+                executionError = executionError,
+            )
+        }.apply {
             deliveryTracer?.onHttpCallEnded(this, envelopeType, payloadType)
         }
     }

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionServiceTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionServiceTest.kt
@@ -191,6 +191,45 @@ class OkHttpRequestExecutionServiceTest {
     }
 
     @Test
+    fun `connection is released back to the pool and reused across requests`() {
+        val server = MockWebServer().apply {
+            protocols = listOf(Protocol.HTTP_1_1)
+            start()
+        }
+        val client = OkHttpClient()
+            .newBuilder()
+            .protocols(listOf(Protocol.HTTP_1_1))
+            .build()
+        val service = OkHttpRequestExecutionService(
+            okHttpClient = lazyOf(client),
+            coreBaseUrl = server.url("").toString(),
+            lazyDeviceId = lazy { testDeviceId },
+            appId = testAppId,
+            embraceVersionName = testEmbraceVersionName,
+            logger = logger,
+        )
+        try {
+            repeat(2) {
+                server.enqueue(MockResponse().setResponseCode(200).setBody("response body"))
+            }
+
+            repeat(2) {
+                service.attemptHttpRequest(
+                    payloadStream = { testPostBody.byteInputStream() },
+                    envelopeType = SupportedEnvelopeType.SESSION,
+                    payloadType = PayloadType.SESSION.value,
+                )
+            }
+
+            // second request reuses the pooled connection (the first request closed its response)
+            assertEquals(0, server.takeRequest().sequenceNumber)
+            assertTrue(server.takeRequest().sequenceNumber > 0)
+        } finally {
+            server.shutdown()
+        }
+    }
+
+    @Test
     fun `headers are sent correctly`() {
         // given a server that returns a 200 response
         server.enqueue(MockResponse().setResponseCode(200))


### PR DESCRIPTION
## Goal

Closes the OkHttp response body when sending payloads to Embrace.

## Testing

Added unit tests