### PR TITLE
Close OkHttp remote config response

### DIFF
--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/source/OkHttpRemoteConfigSource.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/source/OkHttpRemoteConfigSource.kt
@@ -47,20 +47,20 @@ internal class OkHttpRemoteConfigSource(
         return request
     }
 
-    private fun processResponse(response: Response): ConfigHttpResponse? {
-        response.header("etag")?.let {
-            this.etag = it
+    private fun processResponse(response: Response): ConfigHttpResponse? = response.use {
+        response.header("etag")?.let { etagHeader ->
+            this.etag = etagHeader
         }
         if (!response.isSuccessful) {
             return null
         }
         val cfg = response.body?.source()?.use { src ->
             val gzipSource = GzipSource(src)
-            gzipSource.buffer().inputStream().use {
-                serializer.fromJson<RemoteConfig>(it)
+            gzipSource.buffer().inputStream().use { stream ->
+                serializer.fromJson<RemoteConfig>(stream)
             }
         }
-        return ConfigHttpResponse(cfg, etag)
+        ConfigHttpResponse(cfg, etag)
     }
 
     private fun prepareConfigRequestHeaders(): Map<String, String> {

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/OkHttpRemoteConfigSourceTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/OkHttpRemoteConfigSourceTest.kt
@@ -129,6 +129,26 @@ class OkHttpRemoteConfigSourceTest {
         assertConfigResponseNotDeserialized(secondCfg)
     }
 
+    @Test
+    fun `test connection reused after non-2xx response`() {
+        val etagValue = "attempt_1"
+        val (_, firstRequest) = executeRequest(
+            MockResponse().setResponseCode(200)
+                .setBody(configResponseBuffer)
+                .setHeader("etag", etagValue),
+        )
+        assertConfigRequestReceived(firstRequest)
+
+        // a 304 response body must be drained/closed so the connection returns to the
+        // pool and is reused by the next poll (sequenceNumber increments)
+        val (_, secondRequest) = executeRequest(
+            MockResponse().setResponseCode(304)
+                .setHeader("etag", etagValue),
+        )
+        assertConfigRequestReceived(secondRequest)
+        assertEquals(1, secondRequest?.sequenceNumber)
+    }
+
     private fun executeRequest(response: MockResponse?): Pair<RemoteConfig?, RecordedRequest?> {
         if (response == null) {
             return Pair(null, null)


### PR DESCRIPTION
## Goal

Closes the OkHttp remote config response regardless of status code.

## Testing

Added unit tests
