### PR TITLE
Release flushed span references

### DIFF
--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSinkImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSinkImpl.kt
@@ -4,11 +4,10 @@ import io.embrace.android.embracesdk.internal.otel.sdk.StoreDataResult
 import io.embrace.android.embracesdk.internal.utils.threadSafeTake
 import java.util.Queue
 import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.concurrent.atomic.AtomicReference
 
 class SpanSinkImpl : SpanSink {
     private val completedSpans: Queue<EmbraceSpanData> = ConcurrentLinkedQueue()
-    private val spansToFlush = AtomicReference<List<EmbraceSpanData>>(listOf())
+    private val flushLock = Any()
 
     override fun storeCompletedSpans(spans: List<EmbraceSpanData>): StoreDataResult {
         try {
@@ -25,10 +24,10 @@ class SpanSinkImpl : SpanSink {
     }
 
     override fun flushSpans(): List<EmbraceSpanData> {
-        synchronized(spansToFlush) {
-            spansToFlush.set(completedSpans())
-            completedSpans.removeAll(spansToFlush.get().toSet())
-            return spansToFlush.get()
+        synchronized(flushLock) {
+            val flushed = completedSpans()
+            completedSpans.removeAll(flushed.toSet())
+            return flushed
         }
     }
 }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSinkImplTests.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSinkImplTests.kt
@@ -45,6 +45,18 @@ internal class SpanSinkImplTests {
     }
 
     @Test
+    fun `flushing does not retain previously flushed spans`() {
+        spanSink.storeCompletedSpans(listOf(FakeSpanData(), FakeSpanData()).map(FakeSpanData::toEmbraceSpanData))
+        assertEquals(2, spanSink.flushSpans().size)
+
+        assertEquals(0, spanSink.flushSpans().size)
+        assertEquals(0, spanSink.completedSpans().size)
+
+        spanSink.storeCompletedSpans(listOf(FakeSpanData()).map(FakeSpanData::toEmbraceSpanData))
+        assertEquals(1, spanSink.flushSpans().size)
+    }
+
+    @Test
     fun `flushing does not block writing and does not clear the spans added before the flush determines what to flush`() {
         spanSink.storeCompletedSpans(
             listOf(


### PR DESCRIPTION
## Goal

Add a dedicated lock to `SpanSinkImpl` so it doesn't retain references for flushed spans for the previous session. 

## Testing

Added unit tests
