### PR TITLE
Avoid leaking view span references

### DIFF
--- a/embrace-android-instrumentation-view/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/view/ViewDataSource.kt
+++ b/embrace-android-instrumentation-view/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/view/ViewDataSource.kt
@@ -25,6 +25,9 @@ class ViewDataSource(
 
     private val viewSpans: LinkedHashMap<String, SpanToken> = LinkedHashMap()
 
+    internal val trackedViewCount: Int
+        get() = synchronized(viewSpans) { viewSpans.size }
+
     override fun onDataCaptureEnabled() {
         application.registerActivityLifecycleCallbacks(this)
     }
@@ -78,9 +81,8 @@ class ViewDataSource(
      */
     fun onViewClose() {
         synchronized(viewSpans) {
-            viewSpans.forEach { (_, span) ->
-                span.stop()
-            }
+            viewSpans.values.forEach { it.stop() }
+            viewSpans.clear()
         }
     }
 

--- a/embrace-android-instrumentation-view/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/view/ViewDataSourceTest.kt
+++ b/embrace-android-instrumentation-view/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/view/ViewDataSourceTest.kt
@@ -154,6 +154,43 @@ internal class ViewDataSourceTest {
     }
 
     @Test
+    fun `onViewClose stops all spans and clears tracking`() {
+        dataSource.startView("a")
+        dataSource.startView("b")
+
+        dataSource.onViewClose()
+
+        val spans = args.destination.createdSpans
+        assertEquals(2, spans.size)
+        assertTrue(spans.none { it.isRecording() })
+        assertEquals(0, dataSource.trackedViewCount)
+    }
+
+    @Test
+    fun `repeated dynamic startView then onViewClose does not retain entries`() {
+        repeat(100) { dataSource.startView("view_$it") }
+        assertEquals(100, dataSource.trackedViewCount)
+
+        dataSource.onViewClose()
+
+        assertEquals(0, dataSource.trackedViewCount)
+    }
+
+    @Test
+    fun `changeView after onViewClose does not resurrect a stale view`() {
+        dataSource.startView("stale")
+        dataSource.onViewClose()
+
+        dataSource.changeView("fresh")
+
+        val spans = args.destination.createdSpans
+        assertEquals(2, spans.size)
+        val freshSpan = spans.single { it.attributes[EmbViewAttributes.VIEW_NAME] == "fresh" }
+        assertTrue(freshSpan.isRecording())
+        assertEquals(1, dataSource.trackedViewCount)
+    }
+
+    @Test
     fun `concurrent startView and endView does not throw ConcurrentModificationException`() {
         val iterations = 100
         val errors = AtomicInteger(0)


### PR DESCRIPTION
## Goal

Avoids leaking view span references if a view was tracked via the manual API.

## Testing

Added unit tests
