### PR TITLE
Http info modifier

### DIFF
--- a/embrace-android-api/api/embrace-android-api.api
+++ b/embrace-android-api/api/embrace-android-api.api
@@ -110,8 +110,10 @@ public final class io/embrace/android/embracesdk/internal/api/LogsApi$DefaultImp
 }
 
 public abstract interface class io/embrace/android/embracesdk/internal/api/NetworkRequestApi {
+	public abstract fun addHttpRequestInfoModifier (Lio/embrace/android/embracesdk/network/http/HttpRequestInfoModifier;)V
 	public abstract fun generateW3cTraceparent ()Ljava/lang/String;
 	public abstract fun recordNetworkRequest (Lio/embrace/android/embracesdk/network/EmbraceNetworkRequest;)V
+	public abstract fun removeHttpRequestInfoModifier (Lio/embrace/android/embracesdk/network/http/HttpRequestInfoModifier;)V
 }
 
 public abstract interface class io/embrace/android/embracesdk/internal/api/OTelApi {
@@ -242,6 +244,22 @@ public final class io/embrace/android/embracesdk/network/http/HttpMethod : java/
 
 public final class io/embrace/android/embracesdk/network/http/HttpMethod$Companion {
 	public final fun fromString (Ljava/lang/String;)Lio/embrace/android/embracesdk/network/http/HttpMethod;
+}
+
+public abstract interface class io/embrace/android/embracesdk/network/http/HttpRequestInfo {
+	public abstract fun getHttpMethod ()Ljava/lang/String;
+	public abstract fun getUrl ()Ljava/lang/String;
+}
+
+public abstract interface class io/embrace/android/embracesdk/network/http/HttpRequestInfoModifier {
+	public abstract fun modifyHttpRequestInfo (Lio/embrace/android/embracesdk/network/http/MutableHttpRequestInfo;)V
+}
+
+public abstract interface class io/embrace/android/embracesdk/network/http/MutableHttpRequestInfo : io/embrace/android/embracesdk/network/http/HttpRequestInfo {
+	public abstract fun getHttpMethod ()Ljava/lang/String;
+	public abstract fun getUrl ()Ljava/lang/String;
+	public abstract fun setHttpMethod (Ljava/lang/String;)V
+	public abstract fun setUrl (Ljava/lang/String;)V
 }
 
 public final class io/embrace/android/embracesdk/spans/AutoTerminationMode : java/lang/Enum {

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/NetworkRequestApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/NetworkRequestApi.kt
@@ -21,7 +21,8 @@ public interface NetworkRequestApi {
     /**
      * Registers a [HttpRequestInfoModifier] that will be invoked to alter the HTTP request info
      * captured by network instrumentation before it is reported as telemetry. This does not modify
-     * the underlying HTTP request that is executed.
+     * the underlying HTTP request that is executed. Only requests recorded after this method returns
+     * will be modified by the given [modifier].
      */
     public fun addHttpRequestInfoModifier(modifier: HttpRequestInfoModifier)
 

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/NetworkRequestApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/NetworkRequestApi.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.api
 
 import io.embrace.android.embracesdk.annotation.InternalApi
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
+import io.embrace.android.embracesdk.network.http.HttpRequestInfoModifier
 
 /**
  * The public API that is used for capturing network requests manually
@@ -16,6 +17,19 @@ public interface NetworkRequestApi {
      * You can create an instance of [EmbraceNetworkRequest] using the factory functions.
      */
     public fun recordNetworkRequest(networkRequest: EmbraceNetworkRequest)
+
+    /**
+     * Registers a [HttpRequestInfoModifier] that will be invoked to alter the HTTP request info
+     * captured by network instrumentation before it is reported as telemetry. This does not modify
+     * the underlying HTTP request that is executed.
+     */
+    public fun addHttpRequestInfoModifier(modifier: HttpRequestInfoModifier)
+
+    /**
+     * Unregisters a [HttpRequestInfoModifier] that was previously registered via
+     * [addHttpRequestInfoModifier].
+     */
+    public fun removeHttpRequestInfoModifier(modifier: HttpRequestInfoModifier)
 
     @Deprecated("This is no longer supported")
     public fun generateW3cTraceparent(): String?

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/network/http/HttpRequestInfo.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/network/http/HttpRequestInfo.kt
@@ -10,7 +10,7 @@ public interface HttpRequestInfo {
     public val url: String
 
     /**
-     * The request's method. Must be one of the following: GET, PUT, POST, DELETE, PATCH.
+     * The request's method (`GET`, `PUT`, `POST`, `DELETE`, `PATCH`, etc.).
      */
     public val httpMethod: String
 }

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/network/http/HttpRequestInfo.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/network/http/HttpRequestInfo.kt
@@ -1,0 +1,16 @@
+package io.embrace.android.embracesdk.network.http
+
+/**
+ * Information captured about an HTTP request by instrumentation.
+ */
+public interface HttpRequestInfo {
+    /**
+     * The request's URL. Must start with http:// or https://
+     */
+    public val url: String
+
+    /**
+     * The request's method. Must be one of the following: GET, PUT, POST, DELETE, PATCH.
+     */
+    public val httpMethod: String
+}

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/network/http/HttpRequestInfoModifier.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/network/http/HttpRequestInfoModifier.kt
@@ -1,0 +1,5 @@
+package io.embrace.android.embracesdk.network.http
+
+public fun interface HttpRequestInfoModifier {
+    public fun modifyHttpRequestInfo(info: MutableHttpRequestInfo)
+}

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/network/http/MutableHttpRequestInfo.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/network/http/MutableHttpRequestInfo.kt
@@ -1,0 +1,9 @@
+package io.embrace.android.embracesdk.network.http
+
+/**
+ * Mutable `HttpRequestInfo` to be used for altering the reported HTTP request data before it is reported as telemetry.
+ */
+public interface MutableHttpRequestInfo : HttpRequestInfo {
+    override var httpMethod: String
+    override var url: String
+}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/InstrumentationArgsImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/InstrumentationArgsImpl.kt
@@ -13,6 +13,7 @@ import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.injection.WorkerThreadModule
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
+import io.embrace.android.embracesdk.internal.network.http.HttpRequestInfoModifierChain
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.session.id.SessionIdsSnapshot
 import io.embrace.android.embracesdk.internal.session.id.SessionPartTracker
@@ -50,6 +51,8 @@ internal class InstrumentationArgsImpl(
 ) : InstrumentationArgs {
 
     override val crashMarkerFile: File by lazy { crashMarkerFileProvider() }
+
+    override val httpRequestInfoModifierChain: HttpRequestInfoModifierChain = HttpRequestInfoModifierChain(logger)
 
     override fun backgroundWorker(worker: Worker.Background): BackgroundWorker = workerThreadModule.backgroundWorker(worker)
     override fun <T> priorityWorker(

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/InternalErrorType.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/InternalErrorType.kt
@@ -45,4 +45,5 @@ sealed class InternalErrorType(private val severity: Severity) {
     object ClockBackwardsShift : InternalErrorType(ERROR)
     object NavControllerTrackingFail : InternalErrorType(ERROR)
     object UserSessionCallbackFail : InternalErrorType(ERROR)
+    object HttpRequestInfoModifierFail : InternalErrorType(Severity.WARNING)
 }

--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationArgs.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationArgs.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.internal.arch.InstrumentationArgs
 import io.embrace.android.embracesdk.internal.arch.SessionPartChangeListener
 import io.embrace.android.embracesdk.internal.arch.SessionPartEndListener
 import io.embrace.android.embracesdk.internal.arch.state.AppStateTracker
+import io.embrace.android.embracesdk.internal.network.http.HttpRequestInfoModifierChain
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.session.id.SessionIdsSnapshot
 import io.embrace.android.embracesdk.internal.store.OrdinalStore
@@ -61,6 +62,8 @@ class FakeInstrumentationArgs(
     override val crashMarkerFile: File by lazy { File.createTempFile("crash_marker", "") }
 
     override val navigationTrackingService = FakeNavigationTrackingService()
+
+    override val httpRequestInfoModifierChain: HttpRequestInfoModifierChain = HttpRequestInfoModifierChain(logger)
 
     override fun registerSessionPartChangeListener(listener: SessionPartChangeListener) {
         sessionChangeListeners.add(listener)

--- a/embrace-android-instrumentation-api/build.gradle.kts
+++ b/embrace-android-instrumentation-api/build.gradle.kts
@@ -10,6 +10,7 @@ android {
 }
 
 dependencies {
+    api(project(":embrace-android-api"))
     api(project(":embrace-android-instrumentation-schema"))
     api(project(":embrace-android-infra"))
     api(project(":embrace-android-utils"))

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationArgs.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationArgs.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.internal.arch.state.AppStateTracker
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
+import io.embrace.android.embracesdk.internal.network.http.HttpRequestInfoModifierChain
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.session.id.SessionIdsSnapshot
 import io.embrace.android.embracesdk.internal.store.KeyValueStore
@@ -48,6 +49,13 @@ interface InstrumentationArgs {
      * A clock that can be used for time measurements in telemetry.
      */
     val clock: Clock
+
+    /**
+     * Holds the [io.embrace.android.embracesdk.network.http.HttpRequestInfoModifier]s registered by
+     * the consumer. Network instrumentation applies these to captured HTTP request info before it is
+     * reported as telemetry.
+     */
+    val httpRequestInfoModifierChain: HttpRequestInfoModifierChain
 
     /**
      * Service for tracking telemetry usage and limits.

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/network/http/HttpRequestInfoModifierChain.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/network/http/HttpRequestInfoModifierChain.kt
@@ -1,0 +1,49 @@
+package io.embrace.android.embracesdk.internal.network.http
+
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
+import io.embrace.android.embracesdk.network.http.HttpRequestInfo
+import io.embrace.android.embracesdk.network.http.HttpRequestInfoModifier
+import io.embrace.android.embracesdk.network.http.MutableHttpRequestInfo
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Holds the [HttpRequestInfoModifier]s registered by the consumer and applies them to the HTTP
+ * request info captured by network instrumentation before it is reported as telemetry.
+ *
+ * Registering the same modifier more than once has no additional effect.
+ */
+class HttpRequestInfoModifierChain(
+    private val logger: InternalLogger,
+) {
+    private val modifiers = CopyOnWriteArrayList<HttpRequestInfoModifier>()
+
+    // we only log a single user callback failure per process to avoid generating a flood of error reports for a faulty callback
+    private val loggedFailure = AtomicBoolean(false)
+
+    fun add(modifier: HttpRequestInfoModifier) {
+        modifiers.addIfAbsent(modifier)
+    }
+
+    fun remove(modifier: HttpRequestInfoModifier) {
+        modifiers.remove(modifier)
+    }
+
+    /**
+     * Applies every registered modifier to [info] and returns it. The same instance is returned so
+     * callers can read the possibly-modified values back off it.
+     */
+    fun apply(info: MutableHttpRequestInfo): HttpRequestInfo {
+        modifiers.forEach { modifier ->
+            try {
+                modifier.modifyHttpRequestInfo(info)
+            } catch (t: Exception) {
+                if (loggedFailure.compareAndSet(false, true)) {
+                    logger.trackInternalError(InternalErrorType.HttpRequestInfoModifierFail, t)
+                }
+            }
+        }
+        return info
+    }
+}

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/network/http/MutableHttpRequestInfoImpl.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/network/http/MutableHttpRequestInfoImpl.kt
@@ -1,0 +1,14 @@
+package io.embrace.android.embracesdk.internal.network.http
+
+import io.embrace.android.embracesdk.network.http.MutableHttpRequestInfo
+
+/**
+ * Mutable holder for the HTTP request info captured by network instrumentation. It is seeded with
+ * the values captured for a request, passed through the registered [HttpRequestInfoModifier]s, and
+ * then read back to generate telemetry. Mutating an instance does not affect the underlying HTTP
+ * request that was executed.
+ */
+class MutableHttpRequestInfoImpl(
+    override var httpMethod: String,
+    override var url: String,
+) : MutableHttpRequestInfo

--- a/embrace-android-instrumentation-api/src/test/kotlin/io/embrace/android/embracesdk/internal/network/http/HttpRequestInfoModifierChainTest.kt
+++ b/embrace-android-instrumentation-api/src/test/kotlin/io/embrace/android/embracesdk/internal/network/http/HttpRequestInfoModifierChainTest.kt
@@ -1,0 +1,102 @@
+package io.embrace.android.embracesdk.internal.network.http
+
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.network.http.HttpRequestInfoModifier
+import io.embrace.android.embracesdk.network.http.MutableHttpRequestInfo
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+internal class HttpRequestInfoModifierChainTest {
+
+    private lateinit var logger: FakeInternalLogger
+    private lateinit var chain: HttpRequestInfoModifierChain
+
+    @Before
+    fun setUp() {
+        logger = FakeInternalLogger(throwOnInternalError = false)
+        chain = HttpRequestInfoModifierChain(logger)
+    }
+
+    @Test
+    fun `no modifiers leaves the info unchanged`() {
+        val result = chain.apply(MutableHttpRequestInfoImpl(httpMethod = "GET", url = "https://example.com"))
+        assertEquals("GET", result.httpMethod)
+        assertEquals("https://example.com", result.url)
+    }
+
+    @Test
+    fun `a modifier alters the reported url and method`() {
+        chain.add {
+            it.httpMethod = "POST"
+            it.url = "https://redacted.com"
+        }
+        val result = chain.apply(MutableHttpRequestInfoImpl(httpMethod = "GET", url = "https://example.com"))
+        assertEquals("POST", result.httpMethod)
+        assertEquals("https://redacted.com", result.url)
+    }
+
+    @Test
+    fun `modifiers are applied in sequence`() {
+        chain.add { it.url = it.url + "/a" }
+        chain.add { it.url = it.url + "/b" }
+        val result = chain.apply(MutableHttpRequestInfoImpl(httpMethod = "GET", url = "https://example.com"))
+        assertEquals("https://example.com/a/b", result.url)
+    }
+
+    @Test
+    fun `registering the same modifier twice only invokes it once`() {
+        var invocations = 0
+        val modifier = HttpRequestInfoModifier { invocations++ }
+        chain.add(modifier)
+        chain.add(modifier)
+        chain.apply(MutableHttpRequestInfoImpl(httpMethod = "GET", url = "https://example.com"))
+        assertEquals(1, invocations)
+    }
+
+    @Test
+    fun `a removed modifier is no longer invoked`() {
+        var invocations = 0
+        val modifier = HttpRequestInfoModifier { invocations++ }
+        chain.add(modifier)
+        chain.remove(modifier)
+        chain.apply(MutableHttpRequestInfoImpl(httpMethod = "GET", url = "https://example.com"))
+        assertEquals(0, invocations)
+    }
+
+    @Test
+    fun `a throwing modifier is isolated, logged, and does not prevent other modifiers from running`() {
+        var ranAfter = false
+        chain.add { error("boom") }
+        chain.add {
+            it.url = "https://after.com"
+            ranAfter = true
+        }
+        val result = chain.apply(MutableHttpRequestInfoImpl(httpMethod = "GET", url = "https://example.com"))
+
+        assertEquals(true, ranAfter)
+        assertEquals("https://after.com", result.url)
+        assertEquals(1, logger.internalErrorMessages.size)
+        assertEquals(
+            InternalErrorType.HttpRequestInfoModifierFail.toString(),
+            logger.internalErrorMessages.single().msg,
+        )
+    }
+
+    @Test
+    fun `a throwing modifier is only logged once across multiple applications`() {
+        chain.add { error("boom") }
+        repeat(3) {
+            chain.apply(MutableHttpRequestInfoImpl(httpMethod = "GET", url = "https://example.com"))
+        }
+        assertEquals(1, logger.internalErrorMessages.size)
+    }
+
+    @Test
+    fun `MutableHttpRequestInfoImpl exposes the values it was constructed with`() {
+        val info: MutableHttpRequestInfo = MutableHttpRequestInfoImpl(httpMethod = "PUT", url = "https://example.com")
+        assertEquals("PUT", info.httpMethod)
+        assertEquals("https://example.com", info.url)
+    }
+}

--- a/embrace-android-instrumentation-huc-lite/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/HucLiteDataSource.kt
+++ b/embrace-android-instrumentation-huc-lite/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/HucLiteDataSource.kt
@@ -17,8 +17,11 @@ import io.embrace.android.embracesdk.internal.instrumentation.network.getOverrid
 import io.embrace.android.embracesdk.internal.instrumentation.network.toStatusCodeString
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
+import io.embrace.android.embracesdk.internal.network.http.HttpRequestInfoModifierChain
+import io.embrace.android.embracesdk.internal.network.http.MutableHttpRequestInfoImpl
 import io.embrace.android.embracesdk.internal.telemetry.AppliedLimitType
 import io.embrace.android.embracesdk.internal.utils.NetworkUtils
+import io.embrace.android.embracesdk.network.http.HttpRequestInfo
 import io.opentelemetry.kotlin.semconv.ErrorAttributes
 import io.opentelemetry.kotlin.semconv.ExceptionAttributes
 import io.opentelemetry.kotlin.semconv.HttpAttributes
@@ -78,6 +81,7 @@ class HucLiteDataSource(
                     clock = clock,
                     telemetryDestination = telemetryDestination,
                     errorHandler = ::errorHandler,
+                    httpRequestInfoModifierChain = args.httpRequestInfoModifierChain,
                 )
             }.onFailure {
                 errorHandler(it)
@@ -135,6 +139,7 @@ class HucLiteDataSource(
         val clock: Clock,
         val telemetryDestination: TelemetryDestination,
         val errorHandler: (t: Throwable) -> Unit,
+        private val httpRequestInfoModifierChain: HttpRequestInfoModifierChain,
     ) {
         private val creationTimeMs = clock.now()
         private val telemetryUrlProvider = {
@@ -159,23 +164,22 @@ class HucLiteDataSource(
             }
 
         fun completeRequest(responseCode: Int) {
-            recordRequest(telemetryUrlProvider) {
+            recordRequest { info ->
                 val endTimeMs = clock.now()
                 val errorCode = if (responseCode !in 1..<400) {
                     ErrorCodeAttribute.Failure
                 } else {
                     null
                 }
-                val method = methodProvider()
                 val networkRequestSchemaType = SchemaType.NetworkRequest(
                     completedRequestAttributes(
-                        url = telemetryUrlProvider(),
-                        httpMethod = method,
+                        url = info.url,
+                        httpMethod = info.httpMethod,
                         responseCode = responseCode,
                     ),
                 )
                 telemetryDestination.recordCompletedSpan(
-                    name = "$method ${pathProvider()}",
+                    name = "${info.httpMethod} ${pathProvider()}",
                     startTimeMs = getValidStartTime(),
                     endTimeMs = endTimeMs,
                     errorCode = errorCode,
@@ -186,19 +190,18 @@ class HucLiteDataSource(
         }
 
         fun clientError(t: Throwable) {
-            recordRequest(telemetryUrlProvider) {
+            recordRequest { info ->
                 val errorTimeMs = clock.now()
-                val method = methodProvider()
                 val networkRequestSchemaType = SchemaType.NetworkRequest(
                     incompleteRequestAttributes(
-                        url = telemetryUrlProvider(),
-                        httpMethod = method,
+                        url = info.url,
+                        httpMethod = info.httpMethod,
                         errorType = t::class.java.canonicalName ?: t::class.java.simpleName,
                         errorMessage = t.message ?: "Unexpected error",
                     ),
                 )
                 telemetryDestination.recordCompletedSpan(
-                    name = "$method ${pathProvider()}",
+                    name = "${info.httpMethod} ${pathProvider()}",
                     startTimeMs = getValidStartTime(),
                     endTimeMs = errorTimeMs,
                     errorCode = ErrorCodeAttribute.Failure,
@@ -242,14 +245,21 @@ class HucLiteDataSource(
             }
 
         private fun recordRequest(
-            urlProvider: () -> String,
-            recordingFunction: () -> Unit,
+            recordingFunction: (info: HttpRequestInfo) -> Unit,
         ) {
             runCatching {
                 if (requestRecorded.compareAndSet(false, true)) {
-                    NetworkUtils.getDomain(urlProvider())?.let { domain ->
+                    // Apply any registered modifiers so the reported url/method reflect the
+                    // consumer's changes. The underlying HTTP request is not affected.
+                    val info = httpRequestInfoModifierChain.apply(
+                        MutableHttpRequestInfoImpl(
+                            httpMethod = methodProvider(),
+                            url = telemetryUrlProvider(),
+                        ),
+                    )
+                    NetworkUtils.getDomain(info.url)?.let { domain ->
                         if (shouldRecord(domain)) {
-                            recordingFunction()
+                            recordingFunction(info)
                         } else {
                             onLimitReached()
                         }

--- a/embrace-android-instrumentation-huc-lite/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/HucLiteDataSourceTest.kt
+++ b/embrace-android-instrumentation-huc-lite/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/HucLiteDataSourceTest.kt
@@ -14,10 +14,12 @@ import io.embrace.android.embracesdk.instrumentation.huclite.DelegatingInstrumen
 import io.embrace.android.embracesdk.instrumentation.huclite.FAKE_TIME_MS
 import io.embrace.android.embracesdk.instrumentation.huclite.InstrumentedUrlStreamHandlerFactory
 import io.embrace.android.embracesdk.instrumentation.huclite.testUrl
+import io.embrace.android.embracesdk.internal.network.http.HttpRequestInfoModifierChain
 import io.embrace.android.embracesdk.internal.network.logging.EmbraceDomainCountLimiter
 import io.embrace.android.embracesdk.internal.telemetry.AppliedLimitType
 import io.mockk.every
 import io.mockk.mockk
+import io.opentelemetry.kotlin.semconv.HttpAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -68,6 +70,7 @@ class HucLiteDataSourceTest {
 
     private fun createHucLiteDataSource(
         networkBehavior: FakeNetworkBehavior = FakeNetworkBehavior(domainCountLimiter = domainCountLimiter),
+        configureModifiers: (HttpRequestInfoModifierChain) -> Unit = {},
     ): HucLiteDataSource = HucLiteDataSource(
         args = FakeInstrumentationArgs(
             application = ApplicationProvider.getApplicationContext(),
@@ -76,7 +79,7 @@ class HucLiteDataSourceTest {
             logger = fakeEmbLogger,
             clock = fakeClock,
             telemetryService = fakeTelemetryService,
-        ),
+        ).apply { configureModifiers(httpRequestInfoModifierChain) },
         streamHandlerFactoryFieldProvider = { factoryFieldRef },
         factoryInstaller = {
             factoryField = it
@@ -129,6 +132,32 @@ class HucLiteDataSourceTest {
         // 4 spans should be recorded, 1 should be dropped
         assertEquals(4, fakeTelemetryDestination.createdSpans.size)
         assertEquals("huc_network_request" to AppliedLimitType.DROP, fakeTelemetryService.appliedLimits.first())
+    }
+
+    @Test
+    fun `a registered modifier alters the reported url and method`() {
+        val ds = createHucLiteDataSource(
+            configureModifiers = { chain ->
+                chain.add {
+                    it.url = "https://redacted.burger/api"
+                    it.httpMethod = "POST"
+                }
+            },
+        )
+
+        ds.createRequestData(
+            wrappedConnection = mockedConnection,
+            clock = fakeClock,
+        )?.apply {
+            startRequest()
+            completeRequest(200)
+        }
+
+        with(fakeTelemetryDestination.createdSpans.single()) {
+            assertEquals("https://redacted.burger/api", attributes["url.full"])
+            assertEquals("POST", attributes[HttpAttributes.HTTP_REQUEST_METHOD])
+            assertTrue(name.startsWith("POST "))
+        }
     }
 
     @Test

--- a/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/FakeNetworkRequestApi.kt
+++ b/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/FakeNetworkRequestApi.kt
@@ -2,14 +2,24 @@ package io.embrace.android.embracesdk.instrumentation.huc
 
 import io.embrace.android.embracesdk.internal.api.NetworkRequestApi
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
+import io.embrace.android.embracesdk.network.http.HttpRequestInfoModifier
 
 class FakeNetworkRequestApi(
     private val traceparent: String? = null,
 ) : NetworkRequestApi {
     val requests = mutableListOf<EmbraceNetworkRequest>()
+    val httpRequestInfoModifiers = mutableListOf<HttpRequestInfoModifier>()
 
     override fun recordNetworkRequest(networkRequest: EmbraceNetworkRequest) {
         requests.add(networkRequest)
+    }
+
+    override fun addHttpRequestInfoModifier(modifier: HttpRequestInfoModifier) {
+        httpRequestInfoModifiers.add(modifier)
+    }
+
+    override fun removeHttpRequestInfoModifier(modifier: HttpRequestInfoModifier) {
+        httpRequestInfoModifiers.remove(modifier)
     }
 
     @Deprecated("This is no longer supported")

--- a/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceImpl.kt
+++ b/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceImpl.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.internal.arch.limits.NoopLimitStrategy
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
+import io.embrace.android.embracesdk.internal.network.http.MutableHttpRequestInfoImpl
 import io.embrace.android.embracesdk.internal.network.logging.DomainCountLimiter
 import io.embrace.android.embracesdk.internal.telemetry.AppliedLimitType
 import io.embrace.android.embracesdk.internal.utils.NetworkUtils.getDomain
@@ -36,17 +37,24 @@ class NetworkRequestDataSourceImpl(
     NoopLimitStrategy,
     "network_request_data_source",
 ) {
-    private val activeRequests: MutableMap<String, SpanToken> = ConcurrentHashMap()
+    private val activeRequests: MutableMap<String, ActiveRequest> = ConcurrentHashMap()
     private val domainCountLimiter: DomainCountLimiter = args.configService.networkBehavior.domainCountLimiter
+    private val httpRequestInfoModifierChain = args.httpRequestInfoModifierChain
 
     override fun recordNetworkRequest(request: HttpNetworkRequest) {
-        if (!configService.networkBehavior.isUrlEnabled(request.url)) {
+        // Apply any registered modifiers so the reported url/method reflect the consumer's changes.
+        // The underlying HTTP request is not affected.
+        val info = httpRequestInfoModifierChain.apply(MutableHttpRequestInfoImpl(request.httpMethod, request.url))
+        val url = info.url
+        val httpMethod = info.httpMethod
+
+        if (!configService.networkBehavior.isUrlEnabled(url)) {
             return
         }
 
         // Get the domain, if it can be successfully parsed. If not, don't log this call.
         val domain = getDomain(
-            stripUrl(request.url),
+            stripUrl(url),
         ) ?: return
 
         captureTelemetry(
@@ -57,7 +65,7 @@ class NetworkRequestDataSourceImpl(
                 telemetryService.trackAppliedLimit("network_request", AppliedLimitType.DROP)
             },
         ) {
-            val networkRequestSchemaType = SchemaType.NetworkRequest(generateSchemaAttributes(request))
+            val networkRequestSchemaType = SchemaType.NetworkRequest(generateSchemaAttributes(request, url, httpMethod))
             val statusCode = request.statusCode
             val errorCode = if (statusCode == null || statusCode <= 0 || statusCode >= 400) {
                 ErrorCodeAttribute.Failure
@@ -65,7 +73,7 @@ class NetworkRequestDataSourceImpl(
                 null
             }
             recordCompletedSpan(
-                name = getNetworkSpanName(request.httpMethod, request.url),
+                name = getNetworkSpanName(httpMethod, url),
                 startTimeMs = request.startTime,
                 endTimeMs = request.endTime,
                 type = EmbType.Performance.Network,
@@ -76,13 +84,19 @@ class NetworkRequestDataSourceImpl(
     }
 
     override fun startRequest(startData: RequestStartData): String? {
-        if (!configService.networkBehavior.isUrlEnabled(startData.url)) {
+        // Apply any registered modifiers so the reported url/method reflect the consumer's changes.
+        // The underlying HTTP request is not affected.
+        val info = httpRequestInfoModifierChain.apply(MutableHttpRequestInfoImpl(startData.httpMethod, startData.url))
+        val url = info.url
+        val httpMethod = info.httpMethod
+
+        if (!configService.networkBehavior.isUrlEnabled(url)) {
             return null
         }
 
         // Get the domain, if it can be successfully parsed. If not, don't log this call.
         val domain = getDomain(
-            stripUrl(startData.url),
+            stripUrl(url),
         ) ?: return null
 
         return captureTelemetry(
@@ -92,9 +106,9 @@ class NetworkRequestDataSourceImpl(
             },
         ) {
             val spanToken = destination.startSpanCapture(
-                schemaType = SchemaType.NetworkRequest(requestStartAttributes(startData)),
+                schemaType = SchemaType.NetworkRequest(requestStartAttributes(url, httpMethod)),
                 startTimeMs = startData.sdkClockStartTime,
-                name = getNetworkSpanName(startData.httpMethod, startData.url),
+                name = getNetworkSpanName(httpMethod, url),
                 parentSpanId = startData.traceparent?.getSpanIdFromTraceparent(),
             )
 
@@ -103,23 +117,31 @@ class NetworkRequestDataSourceImpl(
                     spanToken.setSystemAttribute(EmbNetworkRequestAttributes.EMB_W3C_TRACEPARENT, traceparent)
                     spanToken.setSystemAttribute(EmbNetworkRequestAttributes.EMB_FORWARD_TELEMETRY, "true")
                 }
-                activeRequests[traceparent] = spanToken
+                activeRequests[traceparent] = ActiveRequest(spanToken, httpMethod)
             }
         }
     }
 
     override fun endRequest(endData: RequestEndData) {
-        activeRequests.remove(endData.id)?.apply {
-            val statusCode = endData.statusCode
-            val errorCode = if (statusCode == null || statusCode <= 0 || statusCode >= 400) {
-                ErrorCodeAttribute.Failure
-            } else {
-                null
+        activeRequests.remove(endData.id)?.let { activeRequest ->
+            // The final url is only known when the request ends (e.g. it may be overridden during
+            // execution), so apply the modifiers again to the end url. The underlying HTTP request
+            // is not affected.
+            val modifiedUrl = httpRequestInfoModifierChain.apply(
+                MutableHttpRequestInfoImpl(activeRequest.httpMethod, endData.url),
+            ).url
+            with(activeRequest.spanToken) {
+                val statusCode = endData.statusCode
+                val errorCode = if (statusCode == null || statusCode <= 0 || statusCode >= 400) {
+                    ErrorCodeAttribute.Failure
+                } else {
+                    null
+                }
+                requestEndAttributes(endData, modifiedUrl).forEach {
+                    setSystemAttribute(it.key, it.value)
+                }
+                stop(endData.sdkClockEndTime, errorCode)
             }
-            requestEndAttributes(endData).forEach {
-                setSystemAttribute(it.key, it.value)
-            }
-            stop(endData.sdkClockEndTime, errorCode)
         }
     }
 
@@ -127,9 +149,13 @@ class NetworkRequestDataSourceImpl(
         activeRequests.remove(id)
     }
 
-    private fun generateSchemaAttributes(request: HttpNetworkRequest): Map<String, String> = buildMap {
-        put(UrlAttributes.URL_FULL, stripUrl(request.url))
-        put(HttpAttributes.HTTP_REQUEST_METHOD, request.httpMethod)
+    private fun generateSchemaAttributes(
+        request: HttpNetworkRequest,
+        url: String,
+        httpMethod: String,
+    ): Map<String, String> = buildMap {
+        put(UrlAttributes.URL_FULL, stripUrl(url))
+        put(HttpAttributes.HTTP_REQUEST_METHOD, httpMethod)
         putIfNotNull(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, request.statusCode?.toStatusCodeString())
         putIfNotNull(HttpAttributes.HTTP_REQUEST_BODY_SIZE, request.bytesSent?.toString())
         putIfNotNull(HttpAttributes.HTTP_RESPONSE_BODY_SIZE, request.bytesReceived?.toString())
@@ -142,13 +168,13 @@ class NetworkRequestDataSourceImpl(
         putIfNotNull(EmbNetworkRequestAttributes.EMB_TRACE_ID, getValidTraceId(request.traceId))
     }
 
-    private fun requestStartAttributes(startData: RequestStartData): Map<String, String> = buildMap {
-        put(UrlAttributes.URL_FULL, stripUrl(startData.url))
-        put(HttpAttributes.HTTP_REQUEST_METHOD, startData.httpMethod)
+    private fun requestStartAttributes(url: String, httpMethod: String): Map<String, String> = buildMap {
+        put(UrlAttributes.URL_FULL, stripUrl(url))
+        put(HttpAttributes.HTTP_REQUEST_METHOD, httpMethod)
     }
 
-    private fun requestEndAttributes(endData: RequestEndData): Map<String, String> = buildMap {
-        put(UrlAttributes.URL_FULL, stripUrl(endData.url))
+    private fun requestEndAttributes(endData: RequestEndData, url: String): Map<String, String> = buildMap {
+        put(UrlAttributes.URL_FULL, stripUrl(url))
         putIfNotNull(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, endData.statusCode?.toStatusCodeString())
         putIfNotNull(HttpAttributes.HTTP_REQUEST_BODY_SIZE, endData.bytesSent?.toString())
         putIfNotNull(HttpAttributes.HTTP_RESPONSE_BODY_SIZE, endData.bytesReceived?.toString())
@@ -165,6 +191,15 @@ class NetworkRequestDataSourceImpl(
      * Returns the span-id of this string if it is a valid W3C traceparent, or null if it is not.
      */
     private fun String.getSpanIdFromTraceparent(): String? = SPAN_ID_FROM_TRACEPARENT_REGEX.matchEntire(this)?.groupValues?.get(1)
+
+    /**
+     * Tracks an in-flight request span. [httpMethod] is the post-modifier method captured at request
+     * start, retained so the modifiers can be re-applied to the final url when the request ends.
+     */
+    private class ActiveRequest(
+        val spanToken: SpanToken,
+        val httpMethod: String,
+    )
 
     private companion object {
         // version(2)-traceId(32)-spanId(16)-flags(2), lowercase hex per the W3C traceparent spec.

--- a/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceStatefulApiTest.kt
+++ b/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceStatefulApiTest.kt
@@ -290,6 +290,36 @@ internal class NetworkRequestDataSourceStatefulApiTest {
         spans.forEach { assertNull(it.parent) }
     }
 
+    @Test
+    fun `a registered modifier alters the url and method of a span-based request`() {
+        harness.args.httpRequestInfoModifierChain.add {
+            it.url = "https://redacted.com/api"
+            it.httpMethod = "POST"
+        }
+        runRequest(url = "https://secret.com/api?token=abc")
+
+        with(checkNotNull(harness.getNetworkSpans().single())) {
+            assertEquals("https://redacted.com/api", attributes["url.full"])
+            assertEquals("POST", attributes[HttpAttributes.HTTP_REQUEST_METHOD])
+            assertEquals("POST /api", name)
+        }
+    }
+
+    @Test
+    fun `a modifier is applied to the final end url when it differs from the start url`() {
+        harness.args.httpRequestInfoModifierChain.add { it.url = it.url.replace("example", "redacted") }
+        runRequest(
+            url = "https://www.example.com/start",
+            endUrl = "https://www.example.com/end",
+        )
+
+        with(checkNotNull(harness.getNetworkSpans().single())) {
+            // url.full reflects the modified end url; the span name reflects the modified start url
+            assertEquals("https://www.redacted.com/end", attributes["url.full"])
+            assertEquals("GET /start", name)
+        }
+    }
+
     private fun runRequest(
         url: String,
         httpMethod: String = "GET",

--- a/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceTest.kt
+++ b/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceTest.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.telemetry.AppliedLimitType
 import io.embrace.android.embracesdk.internal.utils.NetworkUtils
 import io.embrace.android.embracesdk.internal.utils.NetworkUtils.stripUrl
+import io.opentelemetry.kotlin.semconv.HttpAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -139,6 +140,29 @@ internal class NetworkRequestDataSourceTest {
                 attributes["url.full"],
             )
         }
+    }
+
+    @Test
+    fun `a registered modifier alters the recorded url and method`() {
+        harness.args.httpRequestInfoModifierChain.add {
+            it.url = "https://redacted.com/api"
+            it.httpMethod = "POST"
+        }
+        logNetworkRequest(url = "https://secret.com/api?token=abc")
+
+        with(checkNotNull(harness.getNetworkSpans().single())) {
+            assertEquals("https://redacted.com/api", attributes["url.full"])
+            assertEquals("POST", attributes[HttpAttributes.HTTP_REQUEST_METHOD])
+            assertEquals("POST /api", name)
+        }
+    }
+
+    @Test
+    fun `the modified url is used for the domain enablement check`() {
+        harness.args.httpRequestInfoModifierChain.add { it.url = "examplecom" }
+        logNetworkRequest(url = "https://www.example.com/api")
+        // the modified url has no parseable domain, so nothing is recorded
+        assertTrue(harness.getNetworkSpans().isEmpty())
     }
 
     private fun logNetworkRequest(

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -2,6 +2,7 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public static final field INSTANCE Lio/embrace/android/embracesdk/Embrace;
 	public fun activityLoaded (Landroid/app/Activity;)V
 	public fun addBreadcrumb (Ljava/lang/String;)V
+	public fun addHttpRequestInfoModifier (Lio/embrace/android/embracesdk/network/http/HttpRequestInfoModifier;)V
 	public fun addLoadTraceAttribute (Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)V
 	public fun addLoadTraceChildSpan (Landroid/app/Activity;Ljava/lang/String;JJ)V
 	public fun addLoadTraceChildSpan (Landroid/app/Activity;Ljava/lang/String;JJLjava/util/Map;Ljava/util/List;Lio/embrace/android/embracesdk/spans/ErrorCode;)V
@@ -49,6 +50,7 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun recordCompletedSpan (Ljava/lang/String;JJLio/embrace/android/embracesdk/spans/ErrorCode;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Ljava/util/Map;Ljava/util/List;)Z
 	public fun recordNetworkRequest (Lio/embrace/android/embracesdk/network/EmbraceNetworkRequest;)V
 	public fun recordSpan (Ljava/lang/String;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Ljava/util/Map;Ljava/util/List;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun removeHttpRequestInfoModifier (Lio/embrace/android/embracesdk/network/http/HttpRequestInfoModifier;)V
 	public fun removeUserSessionListener (Lio/embrace/android/embracesdk/UserSessionListener;)V
 	public fun removeUserSessionProperty (Ljava/lang/String;)Z
 	public fun setResourceAttribute (Ljava/lang/String;Ljava/lang/String;)V

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/NetworkRequestApiTest.kt
@@ -15,6 +15,7 @@ import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.network.http.HttpMethod
+import io.embrace.android.embracesdk.network.http.HttpRequestInfoModifier
 import io.embrace.android.embracesdk.semconv.EmbNetworkCapturedRequestAttributes
 import io.embrace.android.embracesdk.semconv.EmbNetworkRequestAttributes
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
@@ -353,6 +354,127 @@ internal class NetworkRequestApiTest {
         )
     }
 
+    @Test
+    fun `a registered modifier alters the recorded network request`() {
+        testRule.runTest(
+            testCaseAction = {
+                recordSession {
+                    embrace.addHttpRequestInfoModifier { info ->
+                        info.url = MODIFIED_URL
+                        info.httpMethod = "POST"
+                    }
+                    clock.tick(5)
+                    embrace.recordNetworkRequest(
+                        EmbraceNetworkRequest.fromCompletedRequest(
+                            URL,
+                            HttpMethod.GET,
+                            START_TIME,
+                            END_TIME,
+                            BYTES_SENT,
+                            BYTES_RECEIVED,
+                            200
+                        )
+                    )
+                }
+            },
+            assertAction = {
+                validateAndReturnExpectedNetworkSpan().attributes?.assertMatches(
+                    mapOf(
+                        "url.full" to MODIFIED_URL,
+                        HttpAttributes.HTTP_REQUEST_METHOD to "POST",
+                    )
+                )
+            }
+        )
+    }
+
+    @Test
+    fun `a removed modifier no longer alters the recorded network request`() {
+        testRule.runTest(
+            testCaseAction = {
+                recordSession {
+                    val modifier = HttpRequestInfoModifier { info ->
+                        info.url = MODIFIED_URL
+                    }
+                    embrace.addHttpRequestInfoModifier(modifier)
+                    embrace.removeHttpRequestInfoModifier(modifier)
+                    clock.tick(5)
+                    embrace.recordNetworkRequest(
+                        EmbraceNetworkRequest.fromCompletedRequest(
+                            URL,
+                            HttpMethod.GET,
+                            START_TIME,
+                            END_TIME,
+                            BYTES_SENT,
+                            BYTES_RECEIVED,
+                            200
+                        )
+                    )
+                }
+            },
+            assertAction = {
+                validateAndReturnExpectedNetworkSpan().attributes?.assertMatches(
+                    mapOf("url.full" to URL)
+                )
+            }
+        )
+    }
+
+    @Test
+    fun `modifiers do not affect the captured network body payload`() {
+        testRule.runTest(
+            persistedRemoteConfig = RemoteConfig(
+                networkCaptureRules = setOf(
+                    NetworkCaptureRuleRemoteConfig(
+                        id = "test",
+                        duration = 0,
+                        method = "GET",
+                        urlRegex = "embrace.io",
+                        expiresIn = 10000,
+                        statusCodes = setOf(200),
+                    )
+                )
+            ),
+            testCaseAction = {
+                recordSession {
+                    embrace.addHttpRequestInfoModifier { info ->
+                        info.url = MODIFIED_URL
+                        info.httpMethod = "POST"
+                    }
+                    embrace.recordNetworkRequest(
+                        EmbraceNetworkRequest.fromCompletedRequest(
+                            URL,
+                            HttpMethod.GET,
+                            START_TIME,
+                            END_TIME,
+                            BYTES_SENT,
+                            BYTES_RECEIVED,
+                            200,
+                            networkCaptureData = NETWORK_CAPTURE_DATA,
+                        )
+                    )
+                }
+            },
+            assertAction = {
+                // the network span reflects the modification...
+                validateAndReturnExpectedNetworkSpan().attributes?.assertMatches(
+                    mapOf(
+                        "url.full" to MODIFIED_URL,
+                        HttpAttributes.HTTP_REQUEST_METHOD to "POST",
+                    )
+                )
+                // ...but the captured body payload retains the raw, unmodified request data.
+                val capturedLog = getSingleLogEnvelope().getLogOfType(EmbType.System.NetworkCapturedRequest)
+                checkNotNull(capturedLog.attributes).assertMatches(
+                    mapOf(
+                        EmbNetworkCapturedRequestAttributes.URL to URL,
+                        HttpAttributes.HTTP_REQUEST_METHOD to "GET",
+                    )
+                )
+            }
+        )
+    }
+
     private fun assertSingleNetworkRequestInSession(
         expectedRequest: EmbraceNetworkRequest,
         completed: Boolean = true,
@@ -434,6 +556,7 @@ internal class NetworkRequestApiTest {
 
     companion object {
         private const val URL = "https://embrace.io"
+        private const val MODIFIED_URL = "https://redacted.io"
         private const val DISABLED_URL = "https://dontlogmebro.pizza/yum"
         private const val START_TIME = 1692201601000L
         private const val END_TIME = 1692201603000L

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/NetworkRequestApiDelegate.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/NetworkRequestApiDelegate.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.internal.instrumentation.network.HttpNetwor
 import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkCaptureDataSource
 import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkRequestDataSource
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
+import io.embrace.android.embracesdk.network.http.HttpRequestInfoModifier
 
 internal class NetworkRequestApiDelegate(
     bootstrapper: ModuleInitBootstrapper,
@@ -18,6 +19,9 @@ internal class NetworkRequestApiDelegate(
     private val registry by embraceImplInject(sdkCallChecker) {
         bootstrapper.instrumentationModule.instrumentationRegistry
     }
+    private val httpRequestInfoModifierChain by embraceImplInject(sdkCallChecker) {
+        bootstrapper.instrumentationModule.instrumentationArgs.httpRequestInfoModifierChain
+    }
     private val sessionOrchestrator by embraceImplInject(sdkCallChecker) {
         bootstrapper.userSessionOrchestrationModule.sessionOrchestrator
     }
@@ -25,6 +29,18 @@ internal class NetworkRequestApiDelegate(
     override fun recordNetworkRequest(networkRequest: EmbraceNetworkRequest) {
         if (sdkCallChecker.check("record_network_request")) {
             logNetworkRequest(networkRequest)
+        }
+    }
+
+    override fun addHttpRequestInfoModifier(modifier: HttpRequestInfoModifier) {
+        if (sdkCallChecker.check("add_http_request_info_modifier")) {
+            httpRequestInfoModifierChain?.add(modifier)
+        }
+    }
+
+    override fun removeHttpRequestInfoModifier(modifier: HttpRequestInfoModifier) {
+        if (sdkCallChecker.check("remove_http_request_info_modifier")) {
+            httpRequestInfoModifierChain?.remove(modifier)
         }
     }
 


### PR DESCRIPTION
## Goal
Allow captured HTTP request info to be modified before it is recorded as telemetry. This PR only covers HTTP method and URL for now, but the implementation is open to additional changes in future.

All existing HTTP instrumentation now constructs a `MutableHttpRequestInfo` implementation and passes it to any number of registered (and shared) `HttpRequestInfoModifier`s before recording the telemetry. This allows for easy redaction of the URL being recorded.

## Testing
Introduced new integration & unit tests for the new functionality.