### PR TITLE
Improve RN bundle hashing performance

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/RnBundleIdTrackerImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/RnBundleIdTrackerImpl.kt
@@ -152,9 +152,9 @@ internal class RnBundleIdTrackerImpl(
             val hashBundle: String
             val sb = StringBuilder()
             for (b in bundleHashed) {
-                sb.append(String.format(Locale.ENGLISH, "%02x", b.toInt() and 0xff))
+                sb.append(String.format(Locale.US, "%02x", b.toInt() and 0xff))
             }
-            hashBundle = sb.toString().uppercase(Locale.ENGLISH)
+            hashBundle = sb.toString().uppercase(Locale.US)
             return hashBundle
         }
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/RnBundleIdTrackerImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/RnBundleIdTrackerImpl.kt
@@ -5,7 +5,6 @@ import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
-import java.io.ByteArrayOutputStream
 import java.io.FileInputStream
 import java.io.InputStream
 import java.security.MessageDigest
@@ -121,40 +120,36 @@ internal class RnBundleIdTrackerImpl(
                 return defaultBundleId
             }
 
-            val bundleStream: InputStream?
-
             // checks if the bundle url is an asset
-            if (bundleUrl.contains("assets")) {
+            val bundleStream = if (bundleUrl.contains("assets")) {
                 // looks for the bundle file in assets
-                bundleStream = getBundleAsset(context, bundleUrl)
+                getBundleAsset(context, bundleUrl)
             } else {
                 // looks for the bundle file from the custom path
-                bundleStream = getCustomBundleStream(bundleUrl)
+                getCustomBundleStream(bundleUrl)
             }
             if (bundleStream == null) {
                 return defaultBundleId
             }
             runCatching {
                 bundleStream.use { inputStream ->
-                    ByteArrayOutputStream().use { buffer ->
-                        var read: Int
-                        // The hash size for the MD5 algorithm is 128 bits - 16 bytes.
-                        val data = ByteArray(16)
-                        while (inputStream.read(data, 0, data.size).also { read = it } != -1) {
-                            buffer.write(data, 0, read)
-                        }
-                        return hashBundleToMd5(buffer.toByteArray())
+                    val md = MessageDigest.getInstance("MD5")
+                    var read: Int
+                    val data = ByteArray(8192)
+                    // Feed the bundle to the digest incrementally so the whole file is
+                    // never held in memory at once (RN bundles can be tens of MB).
+                    while (inputStream.read(data, 0, data.size).also { read = it } != -1) {
+                        md.update(data, 0, read)
                     }
+                    return formatMd5Digest(md.digest())
                 }
             }
             // if the hashing of the JS bundle URL fails, returns the default bundle ID
             return defaultBundleId
         }
 
-        private fun hashBundleToMd5(bundle: ByteArray): String {
+        private fun formatMd5Digest(bundleHashed: ByteArray): String {
             val hashBundle: String
-            val md = MessageDigest.getInstance("MD5")
-            val bundleHashed = md.digest(bundle)
             val sb = StringBuilder()
             for (b in bundleHashed) {
                 sb.append(String.format(Locale.ENGLISH, "%02x", b.toInt() and 0xff))

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceRnBundleIdTrackerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceRnBundleIdTrackerTest.kt
@@ -22,6 +22,7 @@ import java.io.FileInputStream
 import java.io.IOException
 import java.nio.file.Files
 import java.security.MessageDigest
+import java.util.Locale
 
 internal class EmbraceRnBundleIdTrackerTest {
 
@@ -178,8 +179,8 @@ internal class EmbraceRnBundleIdTrackerTest {
         bundleIdFile.writeBytes(contents)
 
         val expected = MessageDigest.getInstance("MD5").digest(contents)
-            .joinToString("") { String.format("%02x", it.toInt() and 0xff) }
-            .uppercase()
+            .joinToString("") { String.format(Locale.US, "%02x", it.toInt() and 0xff) }
+            .uppercase(Locale.US)
 
         val metadataService = createRnBundleIdTracker()
         metadataService.setReactNativeBundleId(bundleIdFile.absolutePath)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceRnBundleIdTrackerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceRnBundleIdTrackerTest.kt
@@ -21,6 +21,7 @@ import org.junit.Test
 import java.io.FileInputStream
 import java.io.IOException
 import java.nio.file.Files
+import java.security.MessageDigest
 
 internal class EmbraceRnBundleIdTrackerTest {
 
@@ -166,6 +167,24 @@ internal class EmbraceRnBundleIdTrackerTest {
         metadataService.setReactNativeBundleId(bundleIdFile.absolutePath)
         assertNotEquals(buildInfo.rnBundleId, metadataService.getReactNativeBundleId())
         assertEquals("D41D8CD98F00B204E9800998ECF8427E", metadataService.getReactNativeBundleId())
+    }
+
+    @Test
+    fun `test React Native bundle ID for a bundle larger than the read buffer`() {
+        // write a bundle bigger than the 8 KB read buffer so the incremental
+        // digest loop iterates more than once
+        val contents = ByteArray(20_000) { (it % 256).toByte() }
+        val bundleIdFile = Files.createTempFile("index.android.bundle", "temp").toFile()
+        bundleIdFile.writeBytes(contents)
+
+        val expected = MessageDigest.getInstance("MD5").digest(contents)
+            .joinToString("") { String.format("%02x", it.toInt() and 0xff) }
+            .uppercase()
+
+        val metadataService = createRnBundleIdTracker()
+        metadataService.setReactNativeBundleId(bundleIdFile.absolutePath)
+
+        assertEquals(expected, metadataService.getReactNativeBundleId())
     }
 
     @Test


### PR DESCRIPTION
## Goal

RN bundle IDs are hashed using MD5 to identify the source file. Android's implementation was inefficient as it loaded the entire file into memory & processed it using a small chunk size. I've addressed those problems in this changeset which should speed up RN init & also reduce the chance of OOMs if the bundle is large.

## Testing

Updated existing test coverage
