### PR TITLE
Close payload file when delivering

### DIFF
--- a/embrace-android-delivery-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadStorageService.kt
+++ b/embrace-android-delivery-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadStorageService.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
 import io.embrace.android.embracesdk.internal.worker.PriorityWorker
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.FilterInputStream
 import java.io.IOException
 import java.io.InputStream
 import java.util.Collections
@@ -36,6 +37,12 @@ class FakePayloadStorageService(
 
     val storeCount = AtomicInteger(0)
     val deleteCount = AtomicInteger(0)
+
+    /**
+     * Number of streams returned by [loadPayloadAsStream] that have since been closed.
+     * Lets tests verify that callers close the payload stream they were handed.
+     */
+    val closedStreamCount = AtomicInteger(0)
     var failStorage: Boolean = false
 
     override fun store(metadata: StoredTelemetryMetadata, action: SerializationAction) {
@@ -56,7 +63,12 @@ class FakePayloadStorageService(
     override fun loadPayloadAsStream(metadata: StoredTelemetryMetadata): InputStream? {
         return try {
             cachedPayloads[metadata]?.let { bytes ->
-                ByteArrayInputStream(bytes)
+                object : FilterInputStream(ByteArrayInputStream(bytes)) {
+                    override fun close() {
+                        closedStreamCount.incrementAndGet()
+                        super.close()
+                    }
+                }
             }
         } catch (t: Throwable) {
             null

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionService.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionService.kt
@@ -132,6 +132,13 @@ class OkHttpRequestExecutionService(
     ) : RequestBody() {
         override fun contentType() = mediaType
 
+        /**
+         * The payload stream can only be read once, so signal to OkHttp that it must not
+         * replay the body (e.g. on a redirect/auth challenge). Replaying would send a truncated
+         * payload.
+         */
+        override fun isOneShot(): Boolean = true
+
         override fun writeTo(sink: BufferedSink) {
             payloadStream().source().buffer().use { source ->
                 sink.writeAll(source)

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImpl.kt
@@ -163,9 +163,9 @@ class SchedulingServiceImpl(
                 ExecutionResult.NetworkNotReady
             } else {
                 try {
-                    payload.toStream()?.run {
+                    payload.toStream()?.use { stream ->
                         executionService.attemptHttpRequest(
-                            payloadStream = { this },
+                            payloadStream = { stream },
                             envelopeType = payload.envelopeType,
                             payloadType = payload.payloadTypesHeader,
                         )

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionServiceTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/OkHttpRequestExecutionServiceTest.kt
@@ -215,6 +215,12 @@ class OkHttpRequestExecutionServiceTest {
     }
 
     @Test
+    fun `request body is one-shot`() {
+        val body = OkHttpRequestExecutionService.ApiRequestBody { testPostBody.byteInputStream() }
+        assertTrue(body.isOneShot())
+    }
+
+    @Test
     fun `payload type header is sent correctly`() {
         // given a server that returns a 200 response
         server.enqueue(MockResponse().setResponseCode(200))

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImplTest.kt
@@ -271,6 +271,23 @@ internal class SchedulingServiceImplTest {
     }
 
     @Test
+    fun `payload stream is closed when the request fails before the body is read`() {
+        // simulate failure before payload body consumption
+        logger.throwOnInternalError = false
+        executionService.exceptionOnExecution = RuntimeException("die")
+        waitForResurrectionAndDeliveryAttempt(2)
+        assertEquals(0, executionService.sendAttempts())
+        assertEquals(2, storageService.closedStreamCount.get())
+    }
+
+    @Test
+    fun `payload stream is closed after a successful delivery`() {
+        waitForResurrectionAndDeliveryAttempt(2)
+        assertEquals(2, executionService.sendAttempts())
+        assertTrue(storageService.closedStreamCount.get() >= 2)
+    }
+
+    @Test
     fun `connection failure blocks further delivery attempts`() {
         blockConnection()
         waitForResurrectionAndDeliveryAttempt(2)


### PR DESCRIPTION
## Goal

Alters the scheduling service so the file is closed after a request has finished, preventing a resource leak.

## Testing

Added unit tests.
