### PR TITLE
Bump opentelemetry-kotlin to 0.6.0

### DIFF
--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeReadWriteLogRecord.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeReadWriteLogRecord.kt
@@ -19,4 +19,5 @@ class FakeReadWriteLogRecord(
     override var timestamp: Long? = null,
     override var spanContext: SpanContext = FakeSpanContext(),
     override val attributes: Map<String, Any> = attributeContainer.attributes,
+    override val droppedAttributesCount: Int = 0,
 ) : ReadWriteLogRecord, AttributesMutator by attributeContainer

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeReadWriteSpan.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeReadWriteSpan.kt
@@ -21,6 +21,9 @@ class FakeReadWriteSpan(
     override val instrumentationScopeInfo: InstrumentationScopeInfo
         get() = throw UnsupportedOperationException()
     override val links: List<SpanLinkData> = emptyList()
+    override val droppedEventsCount: Int = 0
+    override val droppedLinksCount: Int = 0
+    override val droppedAttributesCount: Int = 0
     override val resource: Resource
         get() = throw UnsupportedOperationException()
 

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTracer.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeTracer.kt
@@ -8,6 +8,8 @@ import io.opentelemetry.kotlin.tracing.SpanCreationAction
 
 class FakeTracer : Tracer {
 
+    override fun enabled(): Boolean = true
+
     override fun startSpan(
         name: String,
         parentContext: Context?,

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracer.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracer.kt
@@ -24,6 +24,8 @@ class EmbTracer(
     private val useKotlinSdk: Boolean,
 ) : Tracer {
 
+    override fun enabled(): Boolean = impl.enabled()
+
     override fun startSpan(
         name: String,
         parentContext: Context?,

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/payload/SpanMapperTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/payload/SpanMapperTest.kt
@@ -104,6 +104,7 @@ internal class SpanMapperTest {
                 override val name: String = "test-event"
                 override val timestamp: Long = START_TIME_NANOS + 1_000_000L
                 override val attributes: Map<String, Any> = mapOf("event-key" to "event-value")
+                override val droppedAttributesCount: Int = 0
             },
         ),
         links = listOf(
@@ -111,6 +112,7 @@ internal class SpanMapperTest {
                 override val spanContext: SpanContext =
                     TestSpanContext(traceId = "032df1b0b1c1e0cbc0bd8b342a2a1f26", spanId = "b5a2c5c5b6b6f2f1")
                 override val attributes: Map<String, Any> = mapOf("link-key" to "link-value")
+                override val droppedAttributesCount: Int = 0
             },
         ),
     )
@@ -140,6 +142,9 @@ internal class SpanMapperTest {
     ) : SpanData {
         override val spanKind: SpanKind = SpanKind.INTERNAL
         override val hasEnded: Boolean = endTimestamp != null
+        override val droppedEventsCount: Int = 0
+        override val droppedLinksCount: Int = 0
+        override val droppedAttributesCount: Int = 0
         override val resource: Resource
             get() = throw UnsupportedOperationException()
         override val instrumentationScopeInfo: InstrumentationScopeInfo

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ openTelemetryCore = "1.64.0"
 moshi = "1.15.2" # only used by the Gradle-plugin
 lifecycle = "2.7.0" # version pinned to 2.7.0 because of AGP bug
 annotation = "1.10.0"
-otelKotlin = "0.5.0"
+otelKotlin = "0.6.0"
 # Pinned to 1.10.x: 1.11.0+ requires kotlin-stdlib 2.2.20, which breaks our minimum supported Kotlin (2.0.21).
 kotlinxCoroutines = "1.10.2"
 kotlinxSerialization = "1.8.1"


### PR DESCRIPTION
## Goal

Bumps opentelemetry-kotlin to 0.6.0. This won't pass CI until 0.6.0 has released.
