### PR TITLE
Reduce AEI memory usage

### DIFF
--- a/embrace-android-instrumentation-app-exit-info/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/AeiDataSourceImpl.kt
+++ b/embrace-android-instrumentation-app-exit-info/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/AeiDataSourceImpl.kt
@@ -32,7 +32,9 @@ internal class AeiDataSourceImpl(
 ) {
 
     private companion object {
-        private const val SDK_AEI_SEND_LIMIT = 64
+        // matches the default max records AOSP retains per package
+        // (config_app_exit_info_history_list_size)
+        private const val SDK_AEI_SEND_LIMIT = 16
         private const val AEI_HASH_CODES = "io.embrace.aeiHashCode"
     }
 

--- a/embrace-android-instrumentation-app-exit-info/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/ApplicationExitInfoExt.kt
+++ b/embrace-android-instrumentation-app-exit-info/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/ApplicationExitInfoExt.kt
@@ -107,7 +107,7 @@ private fun InputStream.readBytesCapped(charLimit: Int): ByteArray {
  * and truncated without ever reading the entire source into memory.
  */
 private fun Reader.readTextCapped(charLimit: Int): String {
-    val sb = StringBuilder()
+    val sb = StringBuilder(READ_BUFFER_SIZE)
     val buffer = CharArray(READ_BUFFER_SIZE)
     while (sb.length <= charLimit) {
         val count = read(buffer)

--- a/embrace-android-instrumentation-app-exit-info/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/ApplicationExitInfoExt.kt
+++ b/embrace-android-instrumentation-app-exit-info/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/ApplicationExitInfoExt.kt
@@ -7,11 +7,15 @@ import io.embrace.android.embracesdk.internal.instrumentation.aei.TraceResult.Fa
 import io.embrace.android.embracesdk.internal.instrumentation.aei.TraceResult.Success
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
 import io.embrace.android.embracesdk.internal.utils.toUTF8String
+import java.io.ByteArrayOutputStream
 import java.io.IOException
+import java.io.InputStream
+import java.io.Reader
 import java.util.regex.Pattern
 
 private val SESSION_ID_PATTERN by lazy { Pattern.compile("^[0-9a-fA-F]{32}\$").toRegex() }
 private const val SESSION_ID_LENGTH = 32
+private const val READ_BUFFER_SIZE = 8192
 
 /**
  * Constructs an [io.embrace.android.embracesdk.internal.payload.AppExitInfoData] object from an [ApplicationExitInfo] object. The trace
@@ -56,7 +60,7 @@ private fun ApplicationExitInfo.readAeiTrace(
     charLimit: Int,
 ): TraceResult? {
     return try {
-        val trace = readTraceAsString(versionChecker) ?: return null
+        val trace = readTraceAsString(versionChecker, charLimit) ?: return null
 
         when {
             trace.length > charLimit -> Success(trace.take(charLimit), "Trace was too large, sending truncated trace")
@@ -72,13 +76,47 @@ private fun ApplicationExitInfo.readAeiTrace(
 }
 
 @RequiresApi(VERSION_CODES.R)
-private fun ApplicationExitInfo.readTraceAsString(versionChecker: VersionChecker): String? {
+private fun ApplicationExitInfo.readTraceAsString(versionChecker: VersionChecker, charLimit: Int): String? {
+    val stream = traceInputStream ?: return null
     return if (isNdkProtobufFile(versionChecker)) {
-        val bytes = traceInputStream?.buffered()?.readBytes() ?: return null
-        bytes.toUTF8String()
+        stream.use { it.readBytesCapped(charLimit).toUTF8String() }
     } else {
-        traceInputStream?.bufferedReader()?.readText()
+        stream.bufferedReader().use { it.readTextCapped(charLimit) }
     }
+}
+
+/**
+ * Reads at most one buffer beyond [charLimit] bytes, so oversized traces can be detected
+ * and truncated without ever reading the entire source into memory.
+ */
+private fun InputStream.readBytesCapped(charLimit: Int): ByteArray {
+    val out = ByteArrayOutputStream(READ_BUFFER_SIZE)
+    val buffer = ByteArray(READ_BUFFER_SIZE)
+    while (out.size() <= charLimit) {
+        val count = read(buffer)
+        if (count == -1) {
+            break
+        }
+        out.write(buffer, 0, count)
+    }
+    return out.toByteArray()
+}
+
+/**
+ * Reads at most one buffer beyond [charLimit] chars, so oversized traces can be detected
+ * and truncated without ever reading the entire source into memory.
+ */
+private fun Reader.readTextCapped(charLimit: Int): String {
+    val sb = StringBuilder()
+    val buffer = CharArray(READ_BUFFER_SIZE)
+    while (sb.length <= charLimit) {
+        val count = read(buffer)
+        if (count == -1) {
+            break
+        }
+        sb.append(buffer, 0, count)
+    }
+    return sb.toString()
 }
 
 /**

--- a/embrace-android-instrumentation-app-exit-info/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/AeiDataSourceImplTest.kt
+++ b/embrace-android-instrumentation-app-exit-info/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/AeiDataSourceImplTest.kt
@@ -7,9 +7,12 @@ import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
 import io.embrace.android.embracesdk.fakes.FakeKeyValueStore
 import io.embrace.android.embracesdk.fakes.FakeOrdinalStore
 import io.embrace.android.embracesdk.fakes.behavior.FakeAppExitInfoBehavior
+import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.arch.datasource.LogSeverity
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
+import io.embrace.android.embracesdk.internal.utils.VersionChecker
 import io.embrace.android.embracesdk.semconv.EmbAeiAttributes
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.mockk.every
@@ -22,6 +25,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.io.ByteArrayInputStream
 import java.io.IOException
 
 private const val TIMESTAMP = 15000000000L
@@ -72,7 +76,7 @@ internal class AeiDataSourceImplTest {
         }
     }
 
-    private fun startApplicationExitInfoService() {
+    private fun startApplicationExitInfoService(versionChecker: VersionChecker = BuildVersionChecker) {
         args = FakeInstrumentationArgs(mockk(), configService = configService)
         applicationExitInfoService = AeiDataSourceImpl(
             args,
@@ -80,6 +84,7 @@ internal class AeiDataSourceImplTest {
             mockActivityManager,
             store,
             FakeOrdinalStore(),
+            versionChecker,
         ).apply(AeiDataSourceImpl::onDataCaptureEnabled)
     }
 
@@ -139,10 +144,10 @@ internal class AeiDataSourceImplTest {
     }
 
     @Test
-    fun `getHistoricalProcessExitInfo should truncate to 64 entries`() {
-        // given getHistoricalProcessExitReasons returns more than 64 entries
+    fun `getHistoricalProcessExitInfo should truncate to 16 entries`() {
+        // given getHistoricalProcessExitReasons returns more than 16 entries
         val entries = mutableListOf<ApplicationExitInfo>()
-        repeat(65) {
+        repeat(17) {
             entries.add(mockAppExitInfo)
         }
         every {
@@ -155,8 +160,8 @@ internal class AeiDataSourceImplTest {
 
         startApplicationExitInfoService()
 
-        // then captured data should only have 64 entries
-        assertEquals(64, args.destination.logEvents.size)
+        // then captured data should only have 16 entries
+        assertEquals(16, args.destination.logEvents.size)
     }
 
     @Test
@@ -354,6 +359,74 @@ internal class AeiDataSourceImplTest {
     }
 
     @Test
+    fun `Truncate native tombstone if it exceeds limit`() {
+        every { mockAppExitInfo.traceInputStream } returns "a".repeat(500).byteInputStream()
+        every { mockAppExitInfo.reason } returns ApplicationExitInfo.REASON_CRASH_NATIVE
+
+        configService = FakeConfigService(
+            appExitInfoBehavior = FakeAppExitInfoBehavior(enabled = true, traceMaxLimit = 100),
+            autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(ndkEnabled = true),
+        )
+        every {
+            mockActivityManager.getHistoricalProcessExitReasons(
+                any(),
+                any(),
+                any(),
+            )
+        } returns listOf(mockAppExitInfo)
+
+        startApplicationExitInfoService(versionChecker = { true })
+
+        val logEventData = args.destination.logEvents.single()
+        assertEquals("a".repeat(100), logEventData.message)
+    }
+
+    @Test
+    fun `trace stream is closed after reading a text trace`() {
+        val stream = CloseRecordingStream(TRACE.toByteArray())
+        every { mockAppExitInfo.traceInputStream } returns stream
+        every {
+            mockActivityManager.getHistoricalProcessExitReasons(
+                any(),
+                any(),
+                any(),
+            )
+        } returns listOf(mockAppExitInfo)
+
+        startApplicationExitInfoService()
+
+        assertEquals(TRACE, args.destination.logEvents.single().message)
+        assertTrue(stream.closed)
+    }
+
+    @Test
+    fun `trace stream is closed after reading a native tombstone`() {
+        val stream = CloseRecordingStream(TRACE.toByteArray())
+        every { mockAppExitInfo.traceInputStream } returns stream
+        every { mockAppExitInfo.reason } returns ApplicationExitInfo.REASON_CRASH_NATIVE
+        every {
+            mockActivityManager.getHistoricalProcessExitReasons(
+                any(),
+                any(),
+                any(),
+            )
+        } returns listOf(mockAppExitInfo)
+
+        startApplicationExitInfoService(versionChecker = { true })
+
+        assertTrue(stream.closed)
+    }
+
+    private class CloseRecordingStream(bytes: ByteArray) : ByteArrayInputStream(bytes) {
+        var closed = false
+
+        override fun close() {
+            closed = true
+            super.close()
+        }
+    }
+
+    @Test
     fun testActivityManagerException() {
         every {
             mockActivityManager.getHistoricalProcessExitReasons(
@@ -372,7 +445,7 @@ internal class AeiDataSourceImplTest {
 
     @Test
     fun `one object sent per payload`() {
-        val entries = (0..64).map { mockAppExitInfo }
+        val entries = (0..16).map { mockAppExitInfo }
         every {
             mockActivityManager.getHistoricalProcessExitReasons(
                 any(),
@@ -384,7 +457,7 @@ internal class AeiDataSourceImplTest {
         startApplicationExitInfoService()
 
         // each AEI object with a trace should be sent in a separate payload
-        assertEquals(64, args.destination.logEvents.size)
+        assertEquals(16, args.destination.logEvents.size)
     }
 
     private fun getAeiLogAttrs(): Map<String, String> {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AeiFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/AeiFeatureTest.kt
@@ -150,7 +150,7 @@ internal class AeiFeatureTest {
 
     @Test
     fun `aei limit exceeded`() {
-        val expectedSize = 64
+        val expectedSize = 16
 
         testRule.runTest(
             setupAction = {


### PR DESCRIPTION
## Goal

Reduce AEI memory usage by bounding the max trace size it can read (without affecting existing logic that records whether a trace exceeded the limit). Additionally reduces the max AEI count to AOSP's default.

## Testing

Relied on existing test coverage
