### PR TITLE
Release ANR interval references

### DIFF
--- a/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadBlockageSampler.kt
+++ b/embrace-android-instrumentation-anr/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadBlockageSampler.kt
@@ -56,6 +56,9 @@ class ThreadBlockageSampler(
                                 samples = sampler.getThreadBlockageSamples(),
                             ),
                         )
+                        // clear least valuable sample immediately so that stored intervals never
+                        // retain samples unnecessarily
+                        clearLeastValuableSamples(intervals)
                     }
                     currentBlockage.set(null)
                 }
@@ -64,32 +67,20 @@ class ThreadBlockageSampler(
     }
 
     /**
-     * Retrieves thread blockage intervals for the current session
+     * Retrieves thread blockage intervals for the current session.
      */
     fun getThreadBlockageIntervals(): List<ThreadBlockageInterval> {
+        val results = intervalSink.get().toMutableList()
         val blockage = currentBlockage.get()
-        var results = intervalSink.get().toMutableList()
 
-        if (blockage != null) {
-            if (currentBlockage.get() === blockage) {
-                results.add(
-                    ThreadBlockageInterval(
-                        startTime = blockage.startTime,
-                        lastKnownTime = clock.now(),
-                        samples = blockage.sampler.getThreadBlockageSamples(),
-                    ),
-                )
-            } else {
-                results = intervalSink.get().toMutableList()
-            }
-        }
-
-        while (reachedIntervalCaptureLimit(results)) {
-            findLeastValuableIntervalWithSamples(results)?.let { entry ->
-                val index = results.indexOf(entry)
-                results.remove(entry)
-                results.add(index, entry.clearSamples())
-            }
+        if (blockage != null && currentBlockage.get() === blockage) {
+            results.add(
+                ThreadBlockageInterval(
+                    startTime = blockage.startTime,
+                    lastKnownTime = clock.now(),
+                    samples = blockage.sampler.getThreadBlockageSamples(),
+                ),
+            )
         }
         return results
     }
@@ -122,6 +113,18 @@ class ThreadBlockageSampler(
                     else -> CODE_DEFAULT
                 },
             )
+        }
+    }
+
+    /**
+     * Clears samples from the least valuable interval in [intervals] (in place) while the number of
+     * intervals-with-samples exceeds [maxIntervalsPerSession]. This bounds retained samples at
+     * insertion time..
+     */
+    private fun clearLeastValuableSamples(intervals: MutableList<ThreadBlockageInterval>) {
+        while (reachedIntervalCaptureLimit(intervals)) {
+            val entry = findLeastValuableIntervalWithSamples(intervals) ?: return
+            intervals[intervals.indexOf(entry)] = entry.clearSamples()
         }
     }
 

--- a/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadBlockageSamplerTest.kt
+++ b/embrace-android-instrumentation-anr/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/thread/blockage/ThreadBlockageSamplerTest.kt
@@ -425,6 +425,25 @@ internal class ThreadBlockageSamplerTest {
         )
     }
 
+    @Test
+    fun `stored samples are bounded at insertion time, not read time`() {
+        repeat(20) { sampler.createThreadBlockageInterval(clock, 1000L + it) }
+
+        // assert reads are stable
+        val first = sampler.getThreadBlockageIntervals()
+        val second = sampler.getThreadBlockageIntervals()
+
+        assertEquals(20, first.size)
+        assertEquals(
+            behavior.getMaxIntervalsPerSession(),
+            first.count { it.samples != null },
+        )
+        assertEquals(
+            first.map { it.samples?.size },
+            second.map { it.samples?.size },
+        )
+    }
+
     private fun ThreadBlockageSampler.createThreadBlockageInterval(clock: FakeClock, duration: Long) {
         onThreadBlockageEvent(BLOCKED, clock.now())
         onThreadBlockageEvent(BLOCKED_INTERVAL, clock.now())


### PR DESCRIPTION
## Goal

Releases ANR interval references by clearing the least valuable sample whenever the max interval limit is exceeded. This means we should only retain 5 intervals with stacktraces rather than 100, and also avoid unnecessary allocations in `getThreadBlockageIntervals()`.

## Testing

Relied on existing unit tests.
