### PR TITLE
Cleanup temp files in storage directory

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/DisableSdkFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/DisableSdkFeatureTest.kt
@@ -26,8 +26,14 @@ internal class DisableSdkFeatureTest {
         private const val LOG_1 = "${TEST_PREFIX}1"
         private const val LOG_2 = "${TEST_PREFIX}2"
         private const val LOG_3 = "${TEST_PREFIX}3"
+        // nest the sentinel inside a subdirectory: the payload storage dirs now sweep loose
+        // files with unparseable names on startup, but leave subdirectories alone. This still
+        // verifies that disable() recursively deletes the storage directories.
+        private const val TEST_SUBDIR_NAME = "emb_test_dir"
         private const val TEST_FILE_NAME = "test_file"
         private const val DUMMY_CONTENT = "Hello, world!"
+
+        private fun File.sentinelFile(): File = File(File(this, TEST_SUBDIR_NAME), TEST_FILE_NAME)
     }
 
     @Rule
@@ -53,12 +59,15 @@ internal class DisableSdkFeatureTest {
                 getEmbLogger().throwOnInternalError = false
                 // create some dummy values in embrace directories to see if they get deleted
                 embraceDirs.forEach {
-                    File(it, TEST_FILE_NAME).writeText(DUMMY_CONTENT)
+                    it.sentinelFile().apply {
+                        parentFile?.mkdirs()
+                        writeText(DUMMY_CONTENT)
+                    }
                 }
             },
             testCaseAction = {
                 embraceDirs.forEach {
-                    assertEquals(DUMMY_CONTENT, File(it, TEST_FILE_NAME).readText())
+                    assertEquals(DUMMY_CONTENT, it.sentinelFile().readText())
                 }
                 recordSession {
                     embrace.startSpan(SPAN_1).stop()
@@ -80,7 +89,7 @@ internal class DisableSdkFeatureTest {
                     desiredValueSupplier = { true },
                     dataProvider = {
                         embraceDirs.all {
-                            !File(it, TEST_FILE_NAME).exists()
+                            !it.sentinelFile().exists()
                         }
                     },
                     condition = { true },
@@ -131,7 +140,7 @@ internal class DisableSdkFeatureTest {
                     desiredValueSupplier = { true },
                     dataProvider = {
                         embraceDirs.all {
-                            !File(it, TEST_FILE_NAME).exists()
+                            !it.sentinelFile().exists()
                         }
                     },
                     condition = { true },

--- a/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImpl.kt
+++ b/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImpl.kt
@@ -35,8 +35,13 @@ class FileStorageServiceImpl(
     private val storedFiles: CopyOnWriteArraySet<StoredTelemetryMetadata> by lazy {
         val result = runCatching { payloadDir.listFiles() }.getOrNull()
         val files = result?.toList() ?: emptyList()
-        val metadata = files.mapNotNull {
-            StoredTelemetryMetadata.fromFilename(it.name).getOrNull()
+        val metadata = files.mapNotNull { file ->
+            val parsed = StoredTelemetryMetadata.fromFilename(file.name).getOrNull()
+            if (parsed == null) {
+                // delete files that can't be parsed (e.g. leftover .tmp files from killed processes)
+                runCatching { file.delete() }
+            }
+            parsed
         }
         CopyOnWriteArraySet(metadata)
     }
@@ -63,16 +68,23 @@ class FileStorageServiceImpl(
 
         // write to a temporary file then rename it, to avoid sending incomplete files
         // to the backend (i.e. where the process terminates or there isn't any disk space).
-        val tmpFile = File.createTempFile(metadata.filename, ".tmp")
-        tmpFile.outputStream().buffered().use { stream ->
-            action(stream)
-        }
+        // create temp file inside payloadDir so any orphans
+        // are co-located with payloads and swept on next startup
+        val tmpFile = File.createTempFile(metadata.filename, ".tmp", payloadDir)
+        try {
+            tmpFile.outputStream().buffered().use { stream ->
+                action(stream)
+            }
 
-        // move the complete file to its final location.
-        val dst = metadata.asFile()
-        dst.parentFile?.mkdirs()
-        if (tmpFile.renameTo(dst)) {
-            storedFiles.add(metadata)
+            // move the complete file to its final location.
+            val dst = metadata.asFile()
+            dst.parentFile?.mkdirs()
+            if (tmpFile.renameTo(dst)) {
+                storedFiles.add(metadata)
+            }
+        } finally {
+            // clean up the temp file on any failure
+            tmpFile.delete()
         }
     }
 

--- a/embrace-android-telemetry-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImplTest.kt
+++ b/embrace-android-telemetry-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImplTest.kt
@@ -9,11 +9,13 @@ import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType
 import io.embrace.android.embracesdk.internal.worker.PriorityWorker
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.io.File
+import java.io.IOException
 import java.nio.file.Files
 
 class FileStorageServiceImplTest {
@@ -152,6 +154,38 @@ class FileStorageServiceImplTest {
         // verify that the payload is gone and the callback is fired even if the actual file delete didn't happen
         assertEquals(0, service.getStoredPayloads().size)
         assertTrue(callbackFired)
+    }
+
+    @Test
+    fun `temp file is cleaned up when write fails`() {
+        service.store(fakeSessionStoredTelemetryMetadata) {
+            throw IOException("disk full")
+        }
+
+        // no orphaned temp file remains and nothing was indexed
+        assertTrue(outputDir.listFiles()?.none { it.name.endsWith(".tmp") } ?: true)
+        assertEquals(0, service.getStoredPayloads().size)
+    }
+
+    @Test
+    fun `unparseable files are swept when building the index`() {
+        // simulate a payload written by a format this version can't parse
+        val bogus = File(outputDir, "not-a-valid-name").apply { writeText("x") }
+        // simulate a leftover temp file from a process killed mid-write
+        val orphanTmp = File(outputDir, "leftover.tmp").apply { writeText("x") }
+
+        val freshService = FileStorageServiceImpl(
+            lazy { outputDir },
+            PriorityWorker(executor),
+            logger,
+            clock,
+            maxAgeMs = MAX_AGE_MS,
+        )
+
+        // trigger the lazy index init
+        assertEquals(0, freshService.getStoredPayloads().size)
+        assertFalse(bogus.exists())
+        assertFalse(orphanTmp.exists())
     }
 
     private fun storeDummyFile(metadata: StoredTelemetryMetadata) {


### PR DESCRIPTION
## Goal

Cleans up temporary files that may be hanging around in the storage directory, along with removing files whose names are malformed.

## Testing

Added unit tests.
