### PR TITLE
Reduce allocations in log/span export

### DIFF
--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/DefaultLogRecordExporter.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/DefaultLogRecordExporter.kt
@@ -21,17 +21,18 @@ internal class DefaultLogRecordExporter(
         if (!exportCheck()) {
             return OperationResultCode.Success
         }
+        val exportable = if (externalExporters.isEmpty()) {
+            emptyList()
+        } else {
+            telemetry.filterNot { it.attributes.containsKey(PrivateSpan.key) }
+        }
         var result = logSink.storeLogs(telemetry.map(ReadableLogRecord::toEmbracePayload))
 
-        EmbTrace.trace("otel-external-export") {
-            if (externalExporters.isNotEmpty() && result == StoreDataResult.SUCCESS) {
+        if (externalExporters.isNotEmpty() && result == StoreDataResult.SUCCESS) {
+            EmbTrace.trace("otel-external-export") {
                 externalExporters.forEach { exporter ->
                     try {
-                        exporter.export(
-                            telemetry.filterNot {
-                                it.attributes.containsKey(PrivateSpan.key)
-                            },
-                        )
+                        exporter.export(exportable)
                     } catch (ignored: Throwable) {
                         result = StoreDataResult.FAILURE
                     }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/DefaultSpanExporter.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/DefaultSpanExporter.kt
@@ -21,16 +21,17 @@ internal class DefaultSpanExporter(
         if (!exportCheck()) {
             return OperationResultCode.Success
         }
+        val exportable = if (externalExporters.isEmpty()) {
+            emptyList()
+        } else {
+            telemetry.filterNot { it.attributes.containsKey(PrivateSpan.key) }
+        }
         var result = spanSink.storeCompletedSpans(telemetry.map(SpanData::toEmbracePayload))
         if (externalExporters.isNotEmpty() && result == StoreDataResult.SUCCESS) {
             EmbTrace.trace("otel-external-export") {
                 externalExporters.forEach { exporter ->
                     try {
-                        exporter.export(
-                            telemetry.filterNot {
-                                it.attributes.containsKey(PrivateSpan.key)
-                            },
-                        )
+                        exporter.export(exportable)
                     } catch (ignored: Throwable) {
                         result = StoreDataResult.FAILURE
                     }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/DefaultSpanExporterTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/DefaultSpanExporterTest.kt
@@ -1,0 +1,62 @@
+package io.embrace.android.embracesdk.internal.otel.spans
+
+import io.embrace.android.embracesdk.fakes.FakeReadWriteSpan
+import io.embrace.android.embracesdk.fakes.FakeSpan
+import io.embrace.android.embracesdk.fakes.FakeSpanExporter
+import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.tracing.data.SpanData
+import io.opentelemetry.kotlin.tracing.export.SpanExporter
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+internal class DefaultSpanExporterTest {
+
+    private fun span(name: String, vararg attrs: Pair<String, String>): SpanData =
+        FakeReadWriteSpan(FakeSpan(name = name).apply { this.attrs.putAll(attrs) })
+
+    @Test
+    fun `export() should store spans in SpanSink`() {
+        val spanSink: SpanSink = SpanSinkImpl()
+        val exporter = DefaultSpanExporter(spanSink, emptyList()) { true }
+
+        runBlocking { exporter.export(listOf(span("public-span"))) }
+
+        assertFalse(spanSink.completedSpans().isEmpty())
+    }
+
+    @Test
+    fun `private spans should be filtered out from external exporters but still stored internally`() {
+        val spanSink: SpanSink = SpanSinkImpl()
+        val externalExporter = FakeSpanExporter()
+        val exporter = DefaultSpanExporter(spanSink, listOf(externalExporter)) { true }
+
+        val publicSpan = span("public-span")
+        val privateSpan = span("private-span", PrivateSpan.key to PrivateSpan.value)
+
+        runBlocking { exporter.export(listOf(publicSpan, privateSpan)) }
+
+        assertEquals(2, spanSink.completedSpans().size)
+        assertEquals(1, externalExporter.exportedSpans.size)
+        assertEquals("public-span", externalExporter.exportedSpans.first().name)
+    }
+
+    @Test
+    fun `export() returns failure when an external exporter throws`() {
+        val spanSink: SpanSink = SpanSinkImpl()
+        val throwingExporter = object : SpanExporter {
+            override suspend fun export(telemetry: List<SpanData>): OperationResultCode =
+                throw RuntimeException("boom")
+
+            override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+            override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+        }
+        val exporter = DefaultSpanExporter(spanSink, listOf(throwingExporter)) { true }
+
+        val result = runBlocking { exporter.export(listOf(span("public-span"))) }
+
+        assertEquals(OperationResultCode.Failure, result)
+    }
+}


### PR DESCRIPTION
## Goal

Reduces allocations in log/span export by filtering out private spans first, and avoiding another instantiation of attributes for each span/log record.
