### PR TITLE
Optimize span flushing

### DIFF
--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSinkImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSinkImpl.kt
@@ -1,7 +1,7 @@
 package io.embrace.android.embracesdk.internal.otel.spans
 
 import io.embrace.android.embracesdk.internal.otel.sdk.StoreDataResult
-import io.embrace.android.embracesdk.internal.utils.threadSafeTake
+import io.embrace.android.embracesdk.internal.utils.threadSafeToList
 import java.util.Queue
 import java.util.concurrent.ConcurrentLinkedQueue
 
@@ -18,15 +18,13 @@ class SpanSinkImpl : SpanSink {
         return StoreDataResult.SUCCESS
     }
 
-    override fun completedSpans(): List<EmbraceSpanData> {
-        val spansToReturn = completedSpans.size
-        return completedSpans.threadSafeTake(spansToReturn)
-    }
+    override fun completedSpans(): List<EmbraceSpanData> = completedSpans.threadSafeToList()
 
     override fun flushSpans(): List<EmbraceSpanData> {
         synchronized(flushLock) {
-            val flushed = completedSpans()
-            completedSpans.removeAll(flushed.toSet())
+            val count = completedSpans.size
+            val flushed = ArrayList<EmbraceSpanData>(count)
+            repeat(count) { completedSpans.poll()?.let(flushed::add) }
             return flushed
         }
     }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSinkImplTests.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSinkImplTests.kt
@@ -4,23 +4,19 @@ import io.embrace.android.embracesdk.concurrency.SingleThreadTestScheduledExecut
 import io.embrace.android.embracesdk.fakes.FakeSpanData
 import io.embrace.android.embracesdk.internal.otel.sdk.StoreDataResult
 import io.embrace.android.embracesdk.internal.toEmbraceSpanData
-import io.mockk.every
-import io.mockk.spyk
-import io.mockk.unmockkObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
 import org.junit.Before
 import org.junit.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
 
 internal class SpanSinkImplTests {
     private lateinit var spanSink: SpanSink
 
     @Before
     fun setup() {
-        spanSink = spyk(SpanSinkImpl())
+        spanSink = SpanSinkImpl()
     }
 
     @Test
@@ -57,51 +53,33 @@ internal class SpanSinkImplTests {
     }
 
     @Test
-    fun `flushing does not block writing and does not clear the spans added before the flush determines what to flush`() {
-        spanSink.storeCompletedSpans(
-            listOf(
-                FakeSpanData(name = "fake1"),
-                FakeSpanData(name = "fake2"),
-            ).map(FakeSpanData::toEmbraceSpanData),
-        )
-        val unblockCompletedSpansLatch = CountDownLatch(1)
-        val unblockFlushLatch = CountDownLatch(1)
-        val checkLock = CountDownLatch(1)
-        val flushedCount = AtomicInteger(-1)
+    fun `concurrent stores and flushes neither lose nor duplicate spans`() {
+        val totalToStore = 5_000
+        val storeDoneLatch = CountDownLatch(1)
+        val flushed = ArrayList<EmbraceSpanData>(totalToStore)
 
-        // Artificially block the completedSpans() - and thus flushSpans() - from completing
-        every { spanSink.completedSpans() } answers {
-            val spans = callOriginal()
-            unblockFlushLatch.countDown()
-            unblockCompletedSpansLatch.await(1, TimeUnit.SECONDS)
-            spans
+        // store spans one at a time from another thread
+        val producer = SingleThreadTestScheduledExecutor()
+        producer.submit {
+            repeat(totalToStore) { i ->
+                spanSink.storeCompletedSpans(listOf(FakeSpanData(name = "span$i")).map(FakeSpanData::toEmbraceSpanData))
+            }
+            storeDoneLatch.countDown()
         }
 
-        // Produces this order of operations:
-        // 1. thread1 flushes spanSink and is about to return 2 spans but execution is paused
-        // 2. thread2 adds a new span to spanSink and then unblocks thread1
-        // 3. thread1 will return 2 spans despite spanSink already containing the extra span added by thread2
-        // 4. thread1 will clear the two spans that it has flushed and returns, unblocking the check
-        // 5. spanSink should have 1 span in it after the flush only removing the spans that it has flushed
-
-        val thread1 = SingleThreadTestScheduledExecutor()
-        thread1.submit {
-            val flushedSpans = spanSink.flushSpans()
-            flushedCount.set(flushedSpans.size)
-            checkLock.countDown()
+        // repeatedly flush on this thread while the producer is storing
+        while (storeDoneLatch.count > 0L) {
+            flushed += spanSink.flushSpans()
         }
+        storeDoneLatch.await(5, TimeUnit.SECONDS)
 
-        unblockFlushLatch.await(1, TimeUnit.SECONDS)
-        val thread2 = SingleThreadTestScheduledExecutor()
-        thread2.submit {
-            spanSink.storeCompletedSpans(listOf(FakeSpanData(name = "fake3")).map(FakeSpanData::toEmbraceSpanData))
-            unblockCompletedSpansLatch.countDown()
-        }
+        // final flush to drain anything stored after the last in-loop flush
+        flushed += spanSink.flushSpans()
 
-        checkLock.await(1, TimeUnit.SECONDS)
-        assertEquals(2, flushedCount.get())
-
-        unmockkObject(spanSink)
-        assertEquals(1, spanSink.completedSpans().size)
+        // every stored span should have been flushed exactly once.
+        assertEquals(0, spanSink.completedSpans().size)
+        assertEquals(totalToStore, flushed.size)
+        val distinctNames = flushed.mapTo(HashSet()) { it.name }
+        assertEquals(totalToStore, distinctNames.size)
     }
 }


### PR DESCRIPTION
## Goal

Optimizes span flushing. Previously a `Set` was constructed which called `equals()` on every `EmbraceSpanData` object (and its events, links, etc) in the collection. This was chosen to deal with the demands of concurrent calls.

However, it's safe to assume that the number of completed spans will only ever grow while the flush lock is acquired. Therefore we can obtain the size of the completed spans, then poll & add elements to a new array that is returned. This avoids the potentially expensive equality checks.

## Testing

Updated unit tests.
