### PR TITLE
Memoise session link attributes

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImpl.kt
@@ -95,11 +95,12 @@ internal class CurrentSessionPartSpanImpl(
     override fun getId(): String = sessionPartState?.sessionPartId ?: ""
 
     override fun spanStopCallback(spanId: String) {
-        val currentSessionPartSpan = sessionPartState?.span
+        val state = sessionPartState
+        val currentSessionPartSpan = state?.span
         val spanToStop = spanRepository.getSpan(spanId)
 
         if (currentSessionPartSpan != spanToStop) {
-            val linkAttrs = currentSessionPartSpan?.partLinkAttrs() ?: emptyMap()
+            val linkAttrs = state?.cachedPartLinkAttrs() ?: emptyMap()
             spanToStop?.spanContext?.let { spanToStopContext ->
                 if (currentSessionPartSpan != null) {
                     currentSessionPartSpan.addSystemLink(
@@ -226,7 +227,23 @@ internal class CurrentSessionPartSpanImpl(
         val traceCount: AtomicInteger = AtomicInteger(0)
         val internalTraceCount: AtomicInteger = AtomicInteger(0)
 
+        /**
+         * Memoized link attributes for this session part. Only set once the user session attributes have been populated on the
+         * span, after which the attributes referenced by [partLinkAttrs] no longer change for the lifetime of the part.
+         */
+        @Volatile
+        var linkAttrs: Map<String, String>? = null
+
         val isReady: Boolean get() = span.isRecording
+    }
+
+    private fun SessionPartState.cachedPartLinkAttrs(): Map<String, String> {
+        linkAttrs?.let { return it }
+        val attrs = span.partLinkAttrs()
+        if (attrs.containsKey(EmbSessionAttributes.EMB_USER_SESSION_ID)) {
+            linkAttrs = attrs
+        }
+        return attrs
     }
 
     /**

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImplTests.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImplTests.kt
@@ -589,6 +589,66 @@ internal class CurrentSessionPartSpanImplTests {
     }
 
     @Test
+    fun `span stop callback link attrs pick up user session id set after an earlier span stop`() {
+        val sessionPartSpan = checkNotNull(spanRepository.getActiveSpans().single())
+        val sessionPartId = currentSessionPartSpan.getId()
+
+        val earlySpan = spanService.startSpan("early").apply {
+            stop()
+        }
+        val earlyLink = checkNotNull(checkNotNull(earlySpan.snapshot()).links).single()
+        earlyLink.validateSystemLink(
+            linkedSpan = checkNotNull(sessionPartSpan.snapshot()),
+            type = LinkType.EndSessionPart,
+            expectedAttributes = mapOf(EmbSessionAttributes.EMB_SESSION_PART_ID to sessionPartId),
+        )
+        assertTrue(
+            checkNotNull(earlyLink.attributes).none {
+                it.key == EmbSessionAttributes.EMB_USER_SESSION_ID || it.key == SessionAttributes.SESSION_ID
+            },
+        )
+
+        val userSessionId = "user-session-uuid"
+        sessionPartSpan.setSystemAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID, userSessionId)
+
+        val lateSpan = spanService.startSpan("late").apply {
+            stop()
+        }
+        checkNotNull(checkNotNull(lateSpan.snapshot()).links).single().validateSystemLink(
+            linkedSpan = checkNotNull(sessionPartSpan.snapshot()),
+            type = LinkType.EndSessionPart,
+            expectedAttributes = mapOf(
+                EmbSessionAttributes.EMB_SESSION_PART_ID to sessionPartId,
+                EmbSessionAttributes.EMB_USER_SESSION_ID to userSessionId,
+                SessionAttributes.SESSION_ID to userSessionId,
+            ),
+        )
+    }
+
+    @Test
+    fun `span stop callback link attrs are identical for consecutive stops after user session id is set`() {
+        val sessionPartSpan = checkNotNull(spanRepository.getActiveSpans().single())
+        val userSessionId = "user-session-uuid"
+        sessionPartSpan.setSystemAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID, userSessionId)
+        val expectedPartLinkAttrs = mapOf(
+            EmbSessionAttributes.EMB_SESSION_PART_ID to currentSessionPartSpan.getId(),
+            EmbSessionAttributes.EMB_USER_SESSION_ID to userSessionId,
+            SessionAttributes.SESSION_ID to userSessionId,
+        )
+
+        repeat(2) { count ->
+            val span = spanService.startSpan("test-$count").apply {
+                stop()
+            }
+            checkNotNull(checkNotNull(span.snapshot()).links).single().validateSystemLink(
+                linkedSpan = checkNotNull(sessionPartSpan.snapshot()),
+                type = LinkType.EndSessionPart,
+                expectedAttributes = expectedPartLinkAttrs,
+            )
+        }
+    }
+
+    @Test
     fun `session ending will not create span link to its own session part span`() {
         val sessionPartSpan = checkNotNull(spanRepository.getActiveSpans().single())
         currentSessionPartSpan.endSession(startNewSession = true)


### PR DESCRIPTION
## Goal

Memoises the session ID attributes for added as links to each span so that allocations are marginally reduced.

## Testing

Added unit tests.
