### PR TITLE
Remove leaked request references

### DIFF
--- a/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/InternalNetworkApiImplTest.kt
+++ b/embrace-android-instrumentation-huc/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/huc/InternalNetworkApiImplTest.kt
@@ -84,6 +84,9 @@ internal class InternalNetworkApiImplTest {
         override fun endRequest(endData: RequestEndData) {
         }
 
+        override fun discardRequest(id: String) {
+        }
+
         override fun onDataCaptureEnabled() {
         }
 

--- a/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSource.kt
+++ b/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSource.kt
@@ -24,4 +24,10 @@ interface NetworkRequestDataSource : DataSource {
      * Stop the span that is instrumenting the network request represented by [endData].
      */
     fun endRequest(endData: RequestEndData)
+
+    /**
+     * Stop tracking the network request that [startRequest] returned [id] for,
+     * without stopping its span.
+     */
+    fun discardRequest(id: String)
 }

--- a/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceImpl.kt
+++ b/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceImpl.kt
@@ -123,6 +123,10 @@ class NetworkRequestDataSourceImpl(
         }
     }
 
+    override fun discardRequest(id: String) {
+        activeRequests.remove(id)
+    }
+
     private fun generateSchemaAttributes(request: HttpNetworkRequest): Map<String, String> = mapOf(
         UrlAttributes.URL_FULL to stripUrl(request.url),
         HttpAttributes.HTTP_REQUEST_METHOD to request.httpMethod,

--- a/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceStatefulApiTest.kt
+++ b/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceStatefulApiTest.kt
@@ -241,6 +241,24 @@ internal class NetworkRequestDataSourceStatefulApiTest {
     }
 
     @Test
+    fun `discardRequest releases tracking without stopping the span`() {
+        val id = checkNotNull(startRequest(url = "https://www.example.com/api"))
+        harness.dataSource.discardRequest(id)
+
+        val span = harness.getNetworkSpans().single()
+        assertTrue(span.isRecording())
+
+        endRequest(callId = id, url = "https://www.example.com/api")
+        assertTrue(span.isRecording())
+    }
+
+    @Test
+    fun `discardRequest with an unknown id is a no-op`() {
+        harness.dataSource.discardRequest("unknown-id")
+        assertTrue(harness.getNetworkSpans().isEmpty())
+    }
+
+    @Test
     fun `network span adopts the span represented by the traceparent as its parent if it is in the correct format`() {
         startRequest(
             url = "https://www.example.com/api",

--- a/embrace-android-instrumentation-okhttp/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpDataSource.kt
+++ b/embrace-android-instrumentation-okhttp/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpDataSource.kt
@@ -87,9 +87,9 @@ internal class OkHttpDataSource(
 
     private fun interceptApplicationRequest(chain: Interceptor.Chain, callData: CallData?): Response? {
         val request: Request = chain.request()
-        return try {
+        try {
             // we are not interested in response, just proceed
-            chain.proceed(request)
+            return chain.proceed(request)
         } catch (e: EmbraceCustomPathException) {
             val urlString = getOverriddenURLString(EmbraceOkHttpPathOverrideRequest(request), e.customPath)
             callData?.recordNetworkError(chain.call(), urlString, request, e.cause)
@@ -99,6 +99,10 @@ internal class OkHttpDataSource(
             val urlString = getOverriddenURLString(EmbraceOkHttpPathOverrideRequest(request))
             callData?.recordNetworkError(chain.call(), urlString, request, e)
             throw e
+        } finally {
+            if (callData != null && activeCalls.remove(chain.call()) != null) {
+                networkRequestDataSource?.discardRequest(callData.id)
+            }
         }
     }
 
@@ -146,54 +150,59 @@ internal class OkHttpDataSource(
         }
         val forwardNetworkSpan = configService.networkSpanForwardingBehavior.shouldForwardForDomain(host)
 
-        // Let the request execution proceed and obs
+        // Let the request execution proceed and observe the result
         val networkResponse: Response = chain.proceed(request)
 
-        // Get the size of the body from the response header if possible
-        // Failing that, try to count the bytes in the body itself
-        // If neither works, set the content length to 0
-        val contentLength: Long = getContentLengthFromHeader(networkResponse)
-            ?: getContentLengthFromBody(
-                networkResponse = networkResponse,
-                contentType = networkResponse.header(CONTENT_TYPE_HEADER_NAME, null),
-            ) ?: 0L
-
         var response: Response = networkResponse
-        val requestEndData = createRequestEndData(request, networkResponse, callData, contentLength)
+        // A response has been obtained, so instrumentation must not alter the app-visible result of the
+        // request from here on: contain any failure and always release the call's tracking entry
         try {
+            // Get the size of the body from the response header if possible
+            // Failing that, try to count the bytes in the body itself
+            // If neither works, set the content length to 0
+            val contentLength: Long = getContentLengthFromHeader(networkResponse)
+                ?: getContentLengthFromBody(
+                    networkResponse = networkResponse,
+                    contentType = networkResponse.header(CONTENT_TYPE_HEADER_NAME, null),
+                ) ?: 0L
+
+            val requestEndData = createRequestEndData(request, networkResponse, callData, contentLength)
             networkRequestDataSource?.endRequest(requestEndData)
+
+            val shouldCaptureNetworkData = networkCaptureDataSourceProvider()?.shouldCaptureNetworkBody(
+                request.url.toString(),
+                request.method,
+            ) ?: false
+            if (shouldCaptureNetworkData && networkCaptureDataSource != null) {
+                // Decompress any response body that is gzipped so it can be captured in plain text
+                if (ENCODING_GZIP.equals(
+                        networkResponse.header(CONTENT_ENCODING_HEADER_NAME, null),
+                        ignoreCase = true,
+                    ) && networkResponse.promisesBody()
+                ) {
+                    networkResponse.body?.also {
+                        response = it.decompressResponseBody(networkResponse, request)
+                    }
+                }
+
+                val networkCaptureData = getNetworkCaptureData(request, response)
+                networkCaptureDataSource?.recordNetworkRequest(
+                    requestEndData.createHttpNetworkRequest(
+                        httpMethod = request.method,
+                        w3cTraceparent = if (forwardNetworkSpan) {
+                            callData.id
+                        } else {
+                            null
+                        },
+                        networkCaptureData = networkCaptureData,
+                    ),
+                )
+            }
+        } catch (exc: Throwable) {
+            logger.trackInternalError(InternalErrorType.DataSourceDataCaptureFail, exc)
+            networkRequestDataSource?.discardRequest(callData.id)
         } finally {
             activeCalls.remove(chain.call())
-        }
-
-        val shouldCaptureNetworkData = networkCaptureDataSourceProvider()?.shouldCaptureNetworkBody(
-            request.url.toString(),
-            request.method,
-        ) ?: false
-        if (shouldCaptureNetworkData && networkCaptureDataSource != null) {
-            // Decompress any response body that is gzipped so it can be captured in plain text
-            if (ENCODING_GZIP.equals(
-                    networkResponse.header(CONTENT_ENCODING_HEADER_NAME, null),
-                    ignoreCase = true,
-                ) && networkResponse.promisesBody()
-            ) {
-                networkResponse.body?.also {
-                    response = it.decompressResponseBody(networkResponse, request)
-                }
-            }
-
-            val networkCaptureData = getNetworkCaptureData(request, response)
-            networkCaptureDataSource?.recordNetworkRequest(
-                requestEndData.createHttpNetworkRequest(
-                    httpMethod = request.method,
-                    w3cTraceparent = if (forwardNetworkSpan) {
-                        callData.id
-                    } else {
-                        null
-                    },
-                    networkCaptureData = networkCaptureData,
-                ),
-            )
         }
 
         return response

--- a/embrace-android-instrumentation-okhttp/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpDataSourceTest.kt
+++ b/embrace-android-instrumentation-okhttp/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpDataSourceTest.kt
@@ -13,7 +13,9 @@ import io.embrace.android.embracesdk.fakes.behavior.FakeTraceparentInjectionBeha
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
 import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkCaptureDataSourceImpl
+import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkRequestDataSource
 import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkRequestDataSourceImpl
+import io.embrace.android.embracesdk.internal.instrumentation.network.RequestEndData
 import io.embrace.android.embracesdk.internal.utils.NetworkUtils.getValidTraceId
 import io.embrace.android.embracesdk.okhttp3.EmbraceCustomPathException
 import io.embrace.android.embracesdk.semconv.EmbNetworkCapturedRequestAttributes
@@ -26,9 +28,11 @@ import io.opentelemetry.kotlin.semconv.UserAgentAttributes
 import okhttp3.Headers
 import okhttp3.OkHttp
 import okhttp3.OkHttpClient
+import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okio.Buffer
@@ -79,6 +83,9 @@ internal class OkHttpDataSourceTest {
     private lateinit var args: FakeInstrumentationArgs
     private lateinit var configService: FakeConfigService
     private lateinit var okHttpClient: OkHttpClient
+    private lateinit var networkRequestDataSource: RecordingNetworkRequestDataSource
+    private lateinit var applicationInterceptor: EmbraceOkHttpInterceptor
+    private lateinit var networkInterceptor: EmbraceOkHttpInterceptor
     private lateinit var getRequestBuilder: Request.Builder
     private lateinit var postRequestBuilder: Request.Builder
     private var preNetworkInterceptorBeforeRequestSupplier: (Request) -> Request =
@@ -106,7 +113,7 @@ internal class OkHttpDataSourceTest {
             configService = configService,
             clock = sdkClock,
         )
-        val networkRequestDataSource = NetworkRequestDataSourceImpl(args)
+        networkRequestDataSource = RecordingNetworkRequestDataSource(NetworkRequestDataSourceImpl(args))
         val networkCaptureDataSource = NetworkCaptureDataSourceImpl(args)
 
         configService.apply {
@@ -130,7 +137,7 @@ internal class OkHttpDataSourceTest {
             networkRequestDataSourceProvider = { networkRequestDataSource },
             networkCaptureDataSourceProvider = { networkCaptureDataSource },
         )
-        val applicationInterceptor = EmbraceOkHttpInterceptor(InterceptorType.APPLICATION) { dataSource }
+        applicationInterceptor = EmbraceOkHttpInterceptor(InterceptorType.APPLICATION) { dataSource }
         val preNetworkInterceptorTestInterceptor = TestInspectionInterceptor(
             beforeRequestSent = { request ->
                 preNetworkInterceptorBeforeRequestSupplier.invoke(
@@ -143,7 +150,7 @@ internal class OkHttpDataSourceTest {
                 )
             },
         )
-        val networkInterceptor = EmbraceOkHttpInterceptor(InterceptorType.NETWORK) { dataSource }
+        networkInterceptor = EmbraceOkHttpInterceptor(InterceptorType.NETWORK) { dataSource }
         val postNetworkInterceptorTestInterceptor = TestInspectionInterceptor(
             beforeRequestSent = { request ->
                 postNetworkInterceptorBeforeRequestSupplier.invoke(
@@ -492,6 +499,44 @@ internal class OkHttpDataSourceTest {
         }
     }
 
+    @Test
+    fun `requests that never reach the network interceptor are discarded without an app-visible failure`() {
+        val shortCircuitClient = OkHttpClient.Builder()
+            .addInterceptor(applicationInterceptor)
+            .addInterceptor { chain ->
+                Response.Builder()
+                    .request(chain.request())
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(200)
+                    .message("OK")
+                    .body("short-circuited".toResponseBody())
+                    .build()
+            }
+            .addNetworkInterceptor(networkInterceptor)
+            .build()
+
+        val response = checkNotNull(shortCircuitClient.newCall(postRequestBuilder.build()).execute())
+        assertEquals(200, response.code)
+
+        // the request's tracking references were released, but its span was never stopped
+        assertEquals(1, networkRequestDataSource.discardedIds.size)
+        assertTrue(args.destination.createdSpans.single().isRecording())
+    }
+
+    @Test
+    fun `a failure recording the end of a request does not fail the app's request`() {
+        args.logger.throwOnInternalError = false
+        networkRequestDataSource.endRequestFailure = RuntimeException("instrumentation failure")
+        server.enqueue(createBaseMockResponse().setBody(RESPONSE_BODY))
+
+        val response = runPostRequest()
+        assertEquals(200, response.code)
+
+        // the failure was contained and the request's tracking reference released
+        assertEquals(1, args.logger.internalErrorMessages.size)
+        assertEquals(1, networkRequestDataSource.discardedIds.size)
+    }
+
     private fun assertNetworkBodyNotCaptured() {
         assertTrue(args.destination.logEvents.isEmpty())
     }
@@ -681,4 +726,26 @@ internal class OkHttpDataSourceTest {
         val minClockDrift: Long,
         val maxClockDrift: Long,
     )
+}
+
+/**
+ * Delegates to a real [NetworkRequestDataSource] while recording discarded requests and optionally
+ * simulating a failure when a request ends.
+ */
+private class RecordingNetworkRequestDataSource(
+    private val delegate: NetworkRequestDataSource,
+) : NetworkRequestDataSource by delegate {
+
+    val discardedIds: MutableList<String> = mutableListOf()
+    var endRequestFailure: Throwable? = null
+
+    override fun endRequest(endData: RequestEndData) {
+        endRequestFailure?.let { throw it }
+        delegate.endRequest(endData)
+    }
+
+    override fun discardRequest(id: String) {
+        discardedIds.add(id)
+        delegate.discardRequest(id)
+    }
 }


### PR DESCRIPTION
## Goal

`NetworkRequestDataSource` keeps a reference to active requests that wasn't always closed in a collection, which leaked memory. This changeset alters it so that the reference is always removed after a request completes.

## Testing

Added unit tests.
