### PR TITLE
Avoid duplicating Window.Callback registrations

### DIFF
--- a/embrace-android-instrumentation-compose-tap/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/ComposeActivityListener.kt
+++ b/embrace-android-instrumentation-compose-tap/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/ComposeActivityListener.kt
@@ -6,24 +6,29 @@ import android.os.Bundle
 import android.view.GestureDetector
 import android.view.Window
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
+import java.util.WeakHashMap
 
 internal class ComposeActivityListener(
     private val logger: InternalLogger,
     private val dataSource: ComposeTapDataSource,
 ) : ActivityLifecycleCallbacks {
 
+    private val windowCallbacks = WeakHashMap<Window, EmbraceWindowCallback>()
+
     override fun onActivityResumed(activity: Activity) {
         try {
             // Set EmbraceWindowCallback to install Embrace Gesture Listener to capture onClick events
             val window: Window = activity.window
-            if (window.callback == null || window.callback !is EmbraceWindowCallback) {
+            if (!windowCallbacks.containsKey(window)) {
                 val gestureListener = EmbraceGestureListener(activity, logger, dataSource)
                 val gestureDetectorCompat = GestureDetector(activity, gestureListener)
-                window.callback = EmbraceWindowCallback(
+                val callback = EmbraceWindowCallback(
                     window.callback,
                     gestureDetectorCompat,
                     logger,
                 )
+                window.callback = callback
+                windowCallbacks[window] = callback
             }
         } catch (e: Throwable) {
             logger.logError("Failed to register gesture listener", e)

--- a/embrace-android-instrumentation-compose-tap/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/ComposeActivityListenerTest.kt
+++ b/embrace-android-instrumentation-compose-tap/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/ComposeActivityListenerTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.instrumentation.compose.tap
 
 import android.app.Activity
 import android.app.Application
+import android.view.Window
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
@@ -48,6 +49,23 @@ internal class ComposeActivityListenerTest {
         val secondCallback = activity.window.callback
 
         assertSame(firstCallback, secondCallback)
+        assertTrue(args.logger.errorMessages.isEmpty())
+    }
+
+    @Test
+    fun `onActivityResumed does not re-wrap when a foreign callback sits on top`() {
+        val activity = buildActivity(Activity::class.java).setup().get()
+
+        // First resume installs our wrapper.
+        listener.onActivityResumed(activity)
+        // Another SDK (or vitals) then wraps our callback, so ours is no longer outermost.
+        val foreign: Window.Callback = object : Window.Callback by activity.window.callback {}
+        activity.window.callback = foreign
+
+        // A later resume must not add a second EmbraceWindowCallback layer.
+        listener.onActivityResumed(activity)
+
+        assertSame(foreign, activity.window.callback)
         assertTrue(args.logger.errorMessages.isEmpty())
     }
 }

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsActivityListener.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsActivityListener.kt
@@ -25,6 +25,8 @@ internal class VitalsActivityListener(
 
     private val frameListeners = WeakHashMap<Window, VitalsFrameMetricsListener>()
 
+    private val interactionCallbacks = WeakHashMap<Window, VitalsWindowCallback>()
+
     override fun onActivityCreated(activity: Activity, bundle: Bundle?) {
         // captured first so the navigation-start timestamp reflects this event, not the delay until it's processed
         val eventTime = SystemClock.uptimeMillis()
@@ -59,12 +61,15 @@ internal class VitalsActivityListener(
     }
 
     private fun installInteractionCallback(window: Window) {
-        if (window.callback !is VitalsWindowCallback) {
-            window.callback = VitalsWindowCallback(
-                delegate = window.callback,
-                focalCallbacks = focalCallbacks,
-            )
+        if (interactionCallbacks.containsKey(window)) {
+            return
         }
+        val callback = VitalsWindowCallback(
+            delegate = window.callback,
+            focalCallbacks = focalCallbacks,
+        )
+        window.callback = callback
+        interactionCallbacks[window] = callback
     }
 
     private fun installFrameMetricsListener(window: Window) {

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsActivityListenerTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsActivityListenerTest.kt
@@ -6,6 +6,7 @@ import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
 import android.view.FrameMetrics
+import android.view.Window
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
@@ -61,6 +62,22 @@ internal class VitalsActivityListenerTest {
         listener.onActivityResumed(activity)
 
         assertSame(firstCallback, activity.window.callback)
+    }
+
+    @Test
+    fun `onActivityResumed does not re-wrap when a foreign callback sits on top`() {
+        val activity = buildActivity(Activity::class.java).setup().get()
+
+        // First resume installs our wrapper.
+        listener.onActivityResumed(activity)
+        // Another SDK (or compose-tap) then wraps our callback, so ours is no longer outermost.
+        val foreign: Window.Callback = object : Window.Callback by activity.window.callback {}
+        activity.window.callback = foreign
+
+        // A later resume must not add a second VitalsWindowCallback layer.
+        listener.onActivityResumed(activity)
+
+        assertSame(foreign, activity.window.callback)
     }
 
     @Test


### PR DESCRIPTION
## Goal
Avoid duplicating and leaking `Window.Callback`s in the callback chain.

## Changes
Track whether the `Window.Callback` for Compose Tap, and Vitals instrumentation has already been registered by keeping a weak-reference to the `Window`.

## Testing
Added new unit tests