### PR TITLE
Rename SpanSink/SpanRepository functions

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPartPayloadSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPartPayloadSourceImpl.kt
@@ -34,7 +34,7 @@ internal class SessionPartPayloadSourceImpl(
         val includeSnapshots = endType != SessionPartSnapshotType.JVM_CRASH
 
         if (!endType.forceQuit && appStateTracker.getAppState() == AppState.BACKGROUND) {
-            spanRepository.autoTerminateSpans(clock.now())
+            spanRepository.autoTerminateEmbraceSpans(clock.now())
         }
 
         // Snapshots should only be included if the process is expected to last beyond the current user session
@@ -73,7 +73,7 @@ internal class SessionPartPayloadSourceImpl(
                     )
                 }
 
-                else -> spanSink.completedSpans()
+                else -> spanSink.completedOtelSpans()
                     .plus(otelPayloadMapper?.snapshotSpans() ?: emptyList())
             }
         }
@@ -82,7 +82,7 @@ internal class SessionPartPayloadSourceImpl(
 
     private fun retrieveSpanSnapshots(isCacheAttempt: Boolean) = captureDataSafely(logger) {
         // Only snapshot session part spans if we are caching an in-progress session payload
-        spanRepository.getActiveSpans()
+        spanRepository.getActiveEmbraceSpans()
             .filter { isCacheAttempt || !it.hasEmbraceAttribute(EmbType.Ux.Session) }
             .mapNotNull { it.snapshot() }
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImpl.kt
@@ -97,7 +97,7 @@ internal class CurrentSessionPartSpanImpl(
     override fun spanStopCallback(spanId: String) {
         val state = sessionPartState
         val currentSessionPartSpan = state?.span
-        val spanToStop = spanRepository.getSpan(spanId)
+        val spanToStop = spanRepository.getEmbraceSpan(spanId)
 
         if (currentSessionPartSpan != spanToStop) {
             val linkAttrs = state?.cachedPartLinkAttrs() ?: emptyMap()
@@ -151,7 +151,7 @@ internal class CurrentSessionPartSpanImpl(
                 if (appTerminationCause == null) {
                     endingSessionPartSpan.stop()
                     lastSessionPartSpan = endingSessionPartSpan
-                    spanRepository.clearCompletedSpans()
+                    spanRepository.clearCompletedEmbraceSpans()
                     sessionPartState = if (startNewSession) {
                         startSessionPartSpan(openTelemetryClock.now().nanosToMillis())
                     } else {
@@ -159,14 +159,14 @@ internal class CurrentSessionPartSpanImpl(
                     }
                 } else {
                     val crashTime = openTelemetryClock.now().nanosToMillis()
-                    spanRepository.failActiveSpans(crashTime)
+                    spanRepository.failActiveEmbraceSpans(crashTime)
                     endingSessionPartSpan.setSystemAttribute(
                         appTerminationCause.key,
                         appTerminationCause.value,
                     )
                     endingSessionPartSpan.stop(errorCode = ErrorCode.FAILURE, endTimeMs = crashTime)
                 }
-                spanSink.flushSpans()
+                spanSink.flushOtelSpans()
             } else {
                 emptyList()
             }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPartPayloadSourceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPartPayloadSourceImplTest.kt
@@ -31,15 +31,15 @@ internal class SessionPartPayloadSourceImplTest {
     @Before
     fun setUp() {
         sink = SpanSinkImpl().apply {
-            storeCompletedSpans(listOf(cacheSpan))
+            storeCompletedOtelSpans(listOf(cacheSpan))
         }
         currentSessionPartSpan = FakeCurrentSessionPartSpan().apply {
             initializeService(1000L)
         }
         activeSpan = FakeEmbraceSdkSpan.started()
         spanRepository = SpanRepository()
-        spanRepository.trackStartedSpan(checkNotNull(currentSessionPartSpan.sessionPartSpan))
-        spanRepository.trackStartedSpan(activeSpan)
+        spanRepository.trackStartedEmbraceSpan(checkNotNull(currentSessionPartSpan.sessionPartSpan))
+        spanRepository.trackStartedEmbraceSpan(activeSpan)
         impl = SessionPartPayloadSourceImpl(
             mapOf("armeabi-v7a" to "my-symbols"),
             sink,

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/PayloadFactoryBaTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/PayloadFactoryBaTest.kt
@@ -78,7 +78,7 @@ internal class PayloadFactoryBaTest {
         // there should be 1 completed span: the session part span
         checkNotNull(msg)
         assertEquals(1, msg.data.spans?.size)
-        assertEquals(0, spanSink.completedSpans().size)
+        assertEquals(0, spanSink.completedOtelSpans().size)
     }
 
     @Test
@@ -90,7 +90,7 @@ internal class PayloadFactoryBaTest {
         // there should be 1 completed span: the session part span
         checkNotNull(msg)
         assertEquals(1, msg.data.spans?.size)
-        assertEquals(0, spanSink.completedSpans().size)
+        assertEquals(0, spanSink.completedOtelSpans().size)
     }
 
     @Test
@@ -103,7 +103,7 @@ internal class PayloadFactoryBaTest {
         // there should be 1 completed span: the session part span
         checkNotNull(msg)
         assertEquals(1, msg.data.spans?.size)
-        assertEquals(0, spanSink.completedSpans().size)
+        assertEquals(0, spanSink.completedOtelSpans().size)
     }
 
     private fun createService(createInitialSession: Boolean = true): PayloadFactoryImpl {

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/PayloadFactorySessionPartTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/PayloadFactorySessionPartTest.kt
@@ -89,7 +89,7 @@ internal class PayloadFactorySessionPartTest {
     @Test
     fun `spanService that is not initialized will not result in any complete spans`() {
         initializeSessionService()
-        assertEquals(0, spanSink.completedSpans().size)
+        assertEquals(0, spanSink.completedOtelSpans().size)
     }
 
     private fun initializeSessionService() {

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionHandlerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionHandlerTest.kt
@@ -149,7 +149,7 @@ internal class UserSessionHandlerTest {
         startFakeSession()
         initializeServices()
         spanService.recordSpan("test-span") {}
-        assertEquals(1, spanSink.completedSpans().size)
+        assertEquals(1, spanSink.completedOtelSpans().size)
 
         clock.tick(15000L)
         val envelope =
@@ -162,7 +162,7 @@ internal class UserSessionHandlerTest {
             )
         val spans = checkNotNull(envelope.data.spans)
         assertEquals(2, spans.size)
-        assertEquals(0, spanSink.completedSpans().size)
+        assertEquals(0, spanSink.completedOtelSpans().size)
     }
 
     @Test
@@ -170,10 +170,10 @@ internal class UserSessionHandlerTest {
         startFakeSession()
         initializeServices()
         spanService.recordSpan("test-span") {}
-        assertEquals(1, spanSink.completedSpans().size)
+        assertEquals(1, spanSink.completedOtelSpans().size)
 
         payloadFactory.endPayloadWithCrash(AppState.FOREGROUND, clock.now(), initial, "crashId")
-        assertEquals(0, spanSink.completedSpans().size)
+        assertEquals(0, spanSink.completedOtelSpans().size)
     }
 
     private fun startFakeSession(): SessionPartToken {

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImplTests.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImplTests.kt
@@ -325,7 +325,7 @@ internal class CurrentSessionPartSpanImplTests {
                 internal = false,
             ),
         )
-        spanSink.flushSpans()
+        spanSink.flushOtelSpans()
         assertEquals(
             2,
             spanService.recordSpan(
@@ -334,7 +334,7 @@ internal class CurrentSessionPartSpanImplTests {
                 internal = false,
             ) { 2 },
         )
-        assertEquals(0, spanSink.completedSpans().size)
+        assertEquals(0, spanSink.completedOtelSpans().size)
     }
 
     @Test
@@ -409,7 +409,7 @@ internal class CurrentSessionPartSpanImplTests {
                 assertHasEmbraceAttribute(cause)
             }
 
-            assertEquals(0, module.openTelemetryModule.spanSink.completedSpans().size)
+            assertEquals(0, module.openTelemetryModule.spanSink.completedOtelSpans().size)
         }
     }
 
@@ -450,16 +450,16 @@ internal class CurrentSessionPartSpanImplTests {
             ),
         )
 
-        assertEquals(0, spanSink.completedSpans().size)
-        assertEquals(0, spanRepository.getActiveSpans().size)
+        assertEquals(0, spanSink.completedOtelSpans().size)
+        assertEquals(0, spanRepository.getActiveEmbraceSpans().size)
     }
 
     @Test
     fun `new session started after ending has correct metadata`() {
-        val originalSessionPartSpan = checkNotNull(spanRepository.getActiveSpans().single().snapshot())
+        val originalSessionPartSpan = checkNotNull(spanRepository.getActiveEmbraceSpans().single().snapshot())
         val originalSessionId = currentSessionPartSpan.getId()
         currentSessionPartSpan.endSession(startNewSession = true)
-        with(spanRepository.getActiveSpans().single()) {
+        with(spanRepository.getActiveEmbraceSpans().single()) {
             assertTrue(hasEmbraceAttribute(EmbType.Ux.Session))
             assertNotEquals(originalSessionPartSpan.spanId, spanId)
             checkNotNull(snapshot()?.links?.single()).validatePreviousSessionPartLink(originalSessionPartSpan, originalSessionId)
@@ -468,7 +468,7 @@ internal class CurrentSessionPartSpanImplTests {
 
     @Test
     fun `previous session part link includes user session and session part ids when set`() {
-        val originalSessionPartSpan = checkNotNull(spanRepository.getActiveSpans().single())
+        val originalSessionPartSpan = checkNotNull(spanRepository.getActiveEmbraceSpans().single())
         val originalUserSessionId = "previous-user-session"
         val originalSessionPartId = "previous-session-part"
         originalSessionPartSpan.setSystemAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID, originalUserSessionId)
@@ -477,7 +477,7 @@ internal class CurrentSessionPartSpanImplTests {
 
         currentSessionPartSpan.endSession(startNewSession = true)
 
-        with(spanRepository.getActiveSpans().single()) {
+        with(spanRepository.getActiveEmbraceSpans().single()) {
             checkNotNull(snapshot()?.links?.single()).validatePreviousSessionPartLink(
                 previousSessionPartSpan = originalSnapshot,
                 previousSessionPartId = originalSessionPartId,
@@ -488,9 +488,9 @@ internal class CurrentSessionPartSpanImplTests {
 
     @Test
     fun `new session will only start if told to`() {
-        assertNotNull(spanRepository.getActiveSpans().single())
+        assertNotNull(spanRepository.getActiveEmbraceSpans().single())
         currentSessionPartSpan.endSession(startNewSession = false)
-        assertTrue(spanRepository.getActiveSpans().isEmpty())
+        assertTrue(spanRepository.getActiveEmbraceSpans().isEmpty())
     }
 
     @Test
@@ -503,9 +503,9 @@ internal class CurrentSessionPartSpanImplTests {
 
     @Test
     fun `readySession will not replace existing session part span`() {
-        val originalSessionPartSpanId = spanRepository.getActiveSpans().single().spanId
+        val originalSessionPartSpanId = spanRepository.getActiveEmbraceSpans().single().spanId
         assertTrue(currentSessionPartSpan.readySession())
-        assertEquals(originalSessionPartSpanId, spanRepository.getActiveSpans().single().spanId)
+        assertEquals(originalSessionPartSpanId, spanRepository.getActiveEmbraceSpans().single().spanId)
     }
 
     @Test
@@ -533,12 +533,12 @@ internal class CurrentSessionPartSpanImplTests {
             checkNotNull(spanService.createSpan(name = "parent-span"))
         assertTrue(parentSpan.start())
         val parentSpanId = checkNotNull(parentSpan.spanId)
-        val parentSpanFromService = checkNotNull(spanRepository.getSpan(parentSpanId))
+        val parentSpanFromService = checkNotNull(spanRepository.getEmbraceSpan(parentSpanId))
         assertTrue(parentSpanFromService.stop())
         currentSessionPartSpan.endSession(startNewSession = true)
 
         // completed span not available after flush
-        assertNull(spanRepository.getSpan(parentSpanId))
+        assertNull(spanRepository.getEmbraceSpan(parentSpanId))
 
         // existing reference to completed span can still be used
         checkNotNull(
@@ -549,16 +549,16 @@ internal class CurrentSessionPartSpanImplTests {
         )
 
         // active span from before flush is still available and working
-        val activeSpanFromBeforeFlush = checkNotNull(spanRepository.getSpan(embraceSpanId))
+        val activeSpanFromBeforeFlush = checkNotNull(spanRepository.getEmbraceSpan(embraceSpanId))
         assertTrue(activeSpanFromBeforeFlush.stop())
-        val currentSpans = spanSink.completedSpans()
+        val currentSpans = spanSink.completedOtelSpans()
         assertEquals(1, currentSpans.size)
         assertEquals("emb-test-span", currentSpans[0].name)
     }
 
     @Test
     fun `span stop callback creates the correct span links`() {
-        val sessionPartSpan = checkNotNull(spanRepository.getActiveSpans().single())
+        val sessionPartSpan = checkNotNull(spanRepository.getActiveEmbraceSpans().single())
         val userSessionId = "user-session-uuid"
         val sessionPartId = "session-part-uuid"
         sessionPartSpan.setSystemAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID, userSessionId)
@@ -589,7 +589,7 @@ internal class CurrentSessionPartSpanImplTests {
 
     @Test
     fun `span stop callback link attrs pick up user session id set after an earlier span stop`() {
-        val sessionPartSpan = checkNotNull(spanRepository.getActiveSpans().single())
+        val sessionPartSpan = checkNotNull(spanRepository.getActiveEmbraceSpans().single())
         val sessionPartId = currentSessionPartSpan.getId()
 
         val earlySpan = spanService.startSpan("early").apply {
@@ -626,7 +626,7 @@ internal class CurrentSessionPartSpanImplTests {
 
     @Test
     fun `span stop callback link attrs are identical for consecutive stops after user session id is set`() {
-        val sessionPartSpan = checkNotNull(spanRepository.getActiveSpans().single())
+        val sessionPartSpan = checkNotNull(spanRepository.getActiveEmbraceSpans().single())
         val userSessionId = "user-session-uuid"
         sessionPartSpan.setSystemAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID, userSessionId)
         val expectedPartLinkAttrs = mapOf(
@@ -649,7 +649,7 @@ internal class CurrentSessionPartSpanImplTests {
 
     @Test
     fun `session ending will not create span link to its own session part span`() {
-        val sessionPartSpan = checkNotNull(spanRepository.getActiveSpans().single())
+        val sessionPartSpan = checkNotNull(spanRepository.getActiveEmbraceSpans().single())
         currentSessionPartSpan.endSession(startNewSession = true)
         val sessionPartSpanSnapshot = checkNotNull(sessionPartSpan.snapshot())
         assertEquals(0, sessionPartSpanSnapshot.links?.size)
@@ -657,7 +657,7 @@ internal class CurrentSessionPartSpanImplTests {
 
     @Test
     fun `span stop callback will not create links for untracked span`() {
-        val sessionPartSpan = checkNotNull(spanRepository.getActiveSpans().single())
+        val sessionPartSpan = checkNotNull(spanRepository.getActiveEmbraceSpans().single())
         currentSessionPartSpan.spanStopCallback(checkNotNull(FakeEmbraceSdkSpan.started().spanId))
 
         val sessionPartSpanSnapshot = checkNotNull(sessionPartSpan.snapshot())

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/TracingApiDelegateTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/TracingApiDelegateTest.kt
@@ -42,7 +42,7 @@ internal class TracingApiDelegateTest {
         spanService = initModule.openTelemetryModule.spanService
         spanService.initializeService(clock.now())
         tracer = initModule.openTelemetryModule.tracingApi
-        spanSink.flushSpans()
+        spanSink.flushOtelSpans()
     }
 
     @Test
@@ -76,13 +76,13 @@ internal class TracingApiDelegateTest {
             assertTrue(embraceSpan.start())
             assertTrue(embraceSpan.stop(errorCode))
             verifyPublicSpan(name = "test-span", errorCode = errorCode)
-            spanSink.flushSpans()
+            spanSink.flushOtelSpans()
         }
     }
 
     @Test
     fun `start a span directly`() {
-        spanSink.flushSpans()
+        spanSink.flushOtelSpans()
         val parent = checkNotNull(tracer.startSpan(name = "test-span"))
         clock.tick(20L)
         val childStartTimeMs = clock.now() - 10L
@@ -95,7 +95,7 @@ internal class TracingApiDelegateTest {
         )
         assertTrue(parent.stop())
         assertTrue(child.stop())
-        val spans = spanSink.flushSpans()
+        val spans = spanSink.flushOtelSpans()
         assertEquals(2, spans.size)
         assertEquals(childStartTimeMs, spans[1].startTimeNanos?.nanosToMillis())
     }
@@ -285,7 +285,7 @@ internal class TracingApiDelegateTest {
 
     @Test
     fun `event timestamp will be converted to millis if an inappropriate value detected`() {
-        spanSink.flushSpans()
+        spanSink.flushOtelSpans()
         val span = checkNotNull(tracer.startSpan(name = "my-span"))
         val eventTimeNanos = clock.now().millisToNanos()
         clock.tick(10L)
@@ -307,7 +307,7 @@ internal class TracingApiDelegateTest {
 
     @Test
     fun `start and stop span with nanosecond timestamp`() {
-        spanSink.flushSpans()
+        spanSink.flushOtelSpans()
         val expectedStartTimeNanos = clock.now().millisToNanos()
         val span = checkNotNull(
             tracer.startSpan(
@@ -350,7 +350,7 @@ internal class TracingApiDelegateTest {
         traceRoot: Boolean = true,
         errorCode: ErrorCode? = null,
     ): Span {
-        val currentSpans = spanSink.completedSpans()
+        val currentSpans = spanSink.completedOtelSpans()
         assertEquals(1, currentSpans.size)
         val currentSpan = currentSpans[0]
         assertEquals(name, currentSpan.name)

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/DefaultSpanExporter.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/DefaultSpanExporter.kt
@@ -26,7 +26,7 @@ internal class DefaultSpanExporter(
         } else {
             telemetry.filterNot { it.attributes.containsKey(PrivateSpan.key) }
         }
-        var result = spanSink.storeCompletedSpans(telemetry.map(SpanData::toEmbracePayload))
+        var result = spanSink.storeCompletedOtelSpans(telemetry.map(SpanData::toEmbracePayload))
         if (externalExporters.isNotEmpty() && result == StoreDataResult.SUCCESS) {
             EmbTrace.trace("otel-external-export") {
                 externalExporters.forEach { exporter ->

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImpl.kt
@@ -159,7 +159,7 @@ private class EmbraceSpanImpl(
                     return false
                 }
 
-                spanRepository.trackStartedSpan(this)
+                spanRepository.trackStartedEmbraceSpan(this)
                 newSpan.setName(spanName)
 
                 spanStartTimeMs = attemptedStartTimeMs

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanRepository.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanRepository.kt
@@ -17,7 +17,7 @@ class SpanRepository {
     /**
      * Track the [EmbraceSpan] if it has been started and it's not already tracked.
      */
-    fun trackStartedSpan(embraceSpan: EmbraceSdkSpan) {
+    fun trackStartedEmbraceSpan(embraceSpan: EmbraceSdkSpan) {
         val spanId = embraceSpan.spanId ?: return
         spans.putIfAbsent(spanId, embraceSpan)
     }
@@ -25,27 +25,27 @@ class SpanRepository {
     /**
      * Return the [EmbraceSdkSpan] with the corresponding [spanId] if it's tracked. Return null otherwise.
      */
-    fun getSpan(spanId: String): EmbraceSdkSpan? = spans[spanId]
+    fun getEmbraceSpan(spanId: String): EmbraceSdkSpan? = spans[spanId]
 
     /**
      * Get a list of active spans that are being tracked
      */
-    fun getActiveSpans(): List<EmbraceSdkSpan> {
+    fun getActiveEmbraceSpans(): List<EmbraceSdkSpan> {
         return spans.values.filter { it.isRecording }
     }
 
     /**
      * Get a list of completed spans that are being tracked.
      */
-    fun getCompletedSpans(): List<EmbraceSdkSpan> {
+    fun getCompletedEmbraceSpans(): List<EmbraceSdkSpan> {
         return spans.values.filterNot { it.isRecording }
     }
 
     /**
      * Stop the existing active spans and mark them as failed
      */
-    fun failActiveSpans(failureTimeMs: Long) {
-        getActiveSpans().filterNot { it.hasEmbraceAttribute(EmbType.Ux.Session) }.forEach { span ->
+    fun failActiveEmbraceSpans(failureTimeMs: Long) {
+        getActiveEmbraceSpans().filterNot { it.hasEmbraceAttribute(EmbType.Ux.Session) }.forEach { span ->
             span.stop(ErrorCode.FAILURE, failureTimeMs)
         }
     }
@@ -53,7 +53,7 @@ class SpanRepository {
     /**
      * Clear the completed spans this repository is tracking
      */
-    fun clearCompletedSpans() {
+    fun clearCompletedEmbraceSpans() {
         val iterator = spans.values.iterator()
         while (iterator.hasNext()) {
             val candidate = iterator.next()
@@ -80,7 +80,7 @@ class SpanRepository {
     /**
      * Automatically terminates root spans
      */
-    fun autoTerminateSpans(now: Long) {
+    fun autoTerminateEmbraceSpans(now: Long) {
         val roots = buildSpanTree()
         terminateSpansIfRequired(now, roots.filter { it.span.autoTerminationMode == AutoTerminationMode.ON_BACKGROUND })
     }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImpl.kt
@@ -171,5 +171,5 @@ class SpanServiceImpl(
         }
     }
 
-    override fun getSpan(spanId: String): EmbraceSpan? = spanRepository.getSpan(spanId = spanId)
+    override fun getSpan(spanId: String): EmbraceSpan? = spanRepository.getEmbraceSpan(spanId = spanId)
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSink.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSink.kt
@@ -12,17 +12,17 @@ interface SpanSink {
     /**
      * Stores spans that have been completed. Implementations must support concurrent invocations.
      */
-    fun storeCompletedSpans(spans: List<Span>): StoreDataResult
+    fun storeCompletedOtelSpans(spans: List<Span>): StoreDataResult
 
     /**
      * Returns the list of the currently stored completed spans.
      */
-    fun completedSpans(): List<Span>
+    fun completedOtelSpans(): List<Span>
 
     /**
      * Returns and clears the currently stored completed Spans. Implementations of this method must
      * make sure the clearing and returning is
      * atomic, i.e. spans cannot be added during this operation.
      */
-    fun flushSpans(): List<Span>
+    fun flushOtelSpans(): List<Span>
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSinkImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSinkImpl.kt
@@ -10,7 +10,7 @@ class SpanSinkImpl : SpanSink {
     private val completedSpans: Queue<Span> = ConcurrentLinkedQueue()
     private val flushLock = Any()
 
-    override fun storeCompletedSpans(spans: List<Span>): StoreDataResult {
+    override fun storeCompletedOtelSpans(spans: List<Span>): StoreDataResult {
         try {
             completedSpans += spans
         } catch (t: Throwable) {
@@ -19,9 +19,9 @@ class SpanSinkImpl : SpanSink {
         return StoreDataResult.SUCCESS
     }
 
-    override fun completedSpans(): List<Span> = completedSpans.threadSafeToList()
+    override fun completedOtelSpans(): List<Span> = completedSpans.threadSafeToList()
 
-    override fun flushSpans(): List<Span> {
+    override fun flushOtelSpans(): List<Span> {
         synchronized(flushLock) {
             val count = completedSpans.size
             val flushed = ArrayList<Span>(count)

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/DefaultSpanExporterTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/DefaultSpanExporterTest.kt
@@ -24,7 +24,7 @@ internal class DefaultSpanExporterTest {
 
         runBlocking { exporter.export(listOf(span("public-span"))) }
 
-        assertFalse(spanSink.completedSpans().isEmpty())
+        assertFalse(spanSink.completedOtelSpans().isEmpty())
     }
 
     @Test
@@ -38,7 +38,7 @@ internal class DefaultSpanExporterTest {
 
         runBlocking { exporter.export(listOf(publicSpan, privateSpan)) }
 
-        assertEquals(2, spanSink.completedSpans().size)
+        assertEquals(2, spanSink.completedOtelSpans().size)
         assertEquals(1, externalExporter.exportedSpans.size)
         assertEquals("public-span", externalExporter.exportedSpans.first().name)
     }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImplTest.kt
@@ -62,7 +62,7 @@ internal class EmbraceSpanFactoryImplTest {
             assertFalse(hasEmbraceAttribute(PrivateSpan))
             assertEquals("test", snapshot()?.name)
         }
-        assertNotNull(spanRepository.getSpan(spanId = checkNotNull(span.spanId)))
+        assertNotNull(spanRepository.getEmbraceSpan(spanId = checkNotNull(span.spanId)))
         assertTrue(updateNotified)
     }
 

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanImplTest.kt
@@ -104,8 +104,8 @@ internal class EmbraceSpanImplTest {
             assertFalse(isRecording)
             assertFalse(addEvent("eventName"))
             assertFalse(addAttribute("first", "value"))
-            assertEquals(0, spanRepository.getActiveSpans().size)
-            assertEquals(0, spanRepository.getCompletedSpans().size)
+            assertEquals(0, spanRepository.getActiveEmbraceSpans().size)
+            assertEquals(0, spanRepository.getCompletedEmbraceSpans().size)
             assertEquals(SpanKind.INTERNAL, spanKind)
             assertNull(embraceSpan.snapshot())
             assertNull(embraceSpan.asW3cTraceParent())
@@ -137,8 +137,8 @@ internal class EmbraceSpanImplTest {
                 expectedCustomAttributeCount = 1,
             )
             assertEquals("00-$traceId-$spanId-01", embraceSpan.asW3cTraceParent())
-            assertEquals(1, spanRepository.getActiveSpans().size)
-            assertEquals(0, spanRepository.getCompletedSpans().size)
+            assertEquals(1, spanRepository.getActiveEmbraceSpans().size)
+            assertEquals(0, spanRepository.getCompletedEmbraceSpans().size)
         }
         assertTrue(updateNotified)
         assertNull(stoppedSpanId)
@@ -322,8 +322,8 @@ internal class EmbraceSpanImplTest {
             assertTrue(start())
             assertTrue(stop(ErrorCode.FAILURE))
             assertFalse(stop())
-            assertEquals(0, spanRepository.getActiveSpans().size)
-            assertEquals(1, spanRepository.getCompletedSpans().size)
+            assertEquals(0, spanRepository.getActiveEmbraceSpans().size)
+            assertEquals(1, spanRepository.getCompletedEmbraceSpans().size)
         }
     }
 
@@ -625,8 +625,8 @@ internal class EmbraceSpanImplTest {
         assertFalse(isRecording)
         assertFalse(addEvent("eventName"))
         assertFalse(addAttribute("first", "value"))
-        assertEquals(0, spanRepository.getActiveSpans().size)
-        assertEquals(1, spanRepository.getCompletedSpans().size)
+        assertEquals(0, spanRepository.getActiveEmbraceSpans().size)
+        assertEquals(1, spanRepository.getCompletedEmbraceSpans().size)
         assertTrue(updateNotified)
         assertEquals(stoppedSpanId, spanId)
     }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanServiceTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanServiceTest.kt
@@ -115,12 +115,12 @@ internal class EmbraceSpanServiceTest {
         var lambdaRan = false
         spanService.recordSpan("test-span") { lambdaRan = true }
         assertTrue(lambdaRan)
-        assertEquals(2, spanSink.completedSpans().size)
+        assertEquals(2, spanSink.completedOtelSpans().size)
     }
 
     @Test
     fun `record internal completed span recording with all the fixings`() {
-        spanSink.flushSpans()
+        spanSink.flushOtelSpans()
         val expectedName = "test-span"
         val expectedStartTimeMs = clock.now().nanosToMillis()
         val expectedEndTimeMs = expectedStartTimeMs + 100L
@@ -144,7 +144,7 @@ internal class EmbraceSpanServiceTest {
         )
 
         val name = "emb-$expectedName"
-        val currentSpans = spanSink.completedSpans()
+        val currentSpans = spanSink.completedOtelSpans()
         assertEquals(1, currentSpans.size)
         val span = currentSpans[0]
 
@@ -167,7 +167,7 @@ internal class EmbraceSpanServiceTest {
         assertTrue(service.recordCompletedSpan("test-span", 10, 20))
         assertTrue(service.recordCompletedSpan("test-span", 15, 25))
         service.initializeService(clock.now().nanosToMillis())
-        assertEquals(2, spanSink.completedSpans().size)
+        assertEquals(2, spanSink.completedOtelSpans().size)
     }
 
     @Test

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanRepositoryTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanRepositoryTest.kt
@@ -23,67 +23,67 @@ internal class SpanRepositoryTest {
 
     @Test
     fun `new repository not tracking any spans`() {
-        assertEquals(0, repository.getActiveSpans().size)
-        assertEquals(0, repository.getCompletedSpans().size)
+        assertEquals(0, repository.getActiveEmbraceSpans().size)
+        assertEquals(0, repository.getCompletedEmbraceSpans().size)
     }
 
     @Test
     fun `started span tracked`() {
         val startedSpan = FakeEmbraceSdkSpan.started()
-        repository.trackStartedSpan(startedSpan)
-        assertSame(startedSpan, checkNotNull(repository.getSpan(checkNotNull(startedSpan.spanId))))
-        assertEquals(1, repository.getActiveSpans().size)
-        assertEquals(0, repository.getCompletedSpans().size)
+        repository.trackStartedEmbraceSpan(startedSpan)
+        assertSame(startedSpan, checkNotNull(repository.getEmbraceSpan(checkNotNull(startedSpan.spanId))))
+        assertEquals(1, repository.getActiveEmbraceSpans().size)
+        assertEquals(0, repository.getCompletedEmbraceSpans().size)
     }
 
     @Test
     fun `completed span tracked`() {
         val completedSpan = FakeEmbraceSdkSpan.stopped()
-        repository.trackStartedSpan(completedSpan)
-        assertSame(completedSpan, checkNotNull(repository.getSpan(checkNotNull(completedSpan.spanId))))
-        assertEquals(0, repository.getActiveSpans().size)
-        assertEquals(1, repository.getCompletedSpans().size)
+        repository.trackStartedEmbraceSpan(completedSpan)
+        assertSame(completedSpan, checkNotNull(repository.getEmbraceSpan(checkNotNull(completedSpan.spanId))))
+        assertEquals(0, repository.getActiveEmbraceSpans().size)
+        assertEquals(1, repository.getCompletedEmbraceSpans().size)
     }
 
     @Test
     fun `not started span not tracked`() {
-        repository.trackStartedSpan(FakeEmbraceSdkSpan.notStarted())
-        assertEquals(0, repository.getActiveSpans().size)
-        assertEquals(0, repository.getCompletedSpans().size)
+        repository.trackStartedEmbraceSpan(FakeEmbraceSdkSpan.notStarted())
+        assertEquals(0, repository.getActiveEmbraceSpans().size)
+        assertEquals(0, repository.getCompletedEmbraceSpans().size)
     }
 
     @Test
     fun `tracked span moved to complete only if it is actually complete`() {
         val span = FakeEmbraceSdkSpan.started()
-        repository.trackStartedSpan(span)
-        assertEquals(1, repository.getActiveSpans().size)
-        assertEquals(0, repository.getCompletedSpans().size)
+        repository.trackStartedEmbraceSpan(span)
+        assertEquals(1, repository.getActiveEmbraceSpans().size)
+        assertEquals(0, repository.getCompletedEmbraceSpans().size)
         span.stop()
-        assertEquals(0, repository.getActiveSpans().size)
-        assertEquals(1, repository.getCompletedSpans().size)
+        assertEquals(0, repository.getActiveEmbraceSpans().size)
+        assertEquals(1, repository.getCompletedEmbraceSpans().size)
     }
 
     @Test
     fun `completed span not available after clearing but existing reference still valid`() {
         val completedSpan = FakeEmbraceSdkSpan.stopped()
-        repository.trackStartedSpan(completedSpan)
-        checkNotNull(repository.getSpan(checkNotNull(completedSpan.spanId)))
-        assertEquals(1, repository.getCompletedSpans().size)
-        repository.clearCompletedSpans()
-        assertNull(repository.getSpan(checkNotNull(completedSpan.spanId)))
-        assertEquals(0, repository.getCompletedSpans().size)
+        repository.trackStartedEmbraceSpan(completedSpan)
+        checkNotNull(repository.getEmbraceSpan(checkNotNull(completedSpan.spanId)))
+        assertEquals(1, repository.getCompletedEmbraceSpans().size)
+        repository.clearCompletedEmbraceSpans()
+        assertNull(repository.getEmbraceSpan(checkNotNull(completedSpan.spanId)))
+        assertEquals(0, repository.getCompletedEmbraceSpans().size)
     }
 
     @Test
     fun `active spans become failed and complete when they are forced to fail`() {
         val startedSpan = FakeEmbraceSdkSpan.started()
-        repository.trackStartedSpan(startedSpan)
+        repository.trackStartedEmbraceSpan(startedSpan)
 
-        assertSame(startedSpan, repository.getActiveSpans().single())
+        assertSame(startedSpan, repository.getActiveEmbraceSpans().single())
         assertTrue(startedSpan.isRecording)
         assertNull(startedSpan.errorCode)
 
-        repository.failActiveSpans(100L)
+        repository.failActiveEmbraceSpans(100L)
 
         assertFalse(startedSpan.isRecording)
         assertEquals(ErrorCode.FAILURE, startedSpan.errorCode)

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
@@ -142,7 +142,7 @@ internal class SpanServiceImplTest {
         assertTrue(childSpan.stop())
         assertTrue(parentSpan.stop())
 
-        val currentSpans = spanSink.completedSpans()
+        val currentSpans = spanSink.completedOtelSpans()
         assertEquals(2, currentSpans.size)
         assertTrue(currentSpans[0].traceId == currentSpans[1].traceId)
 
@@ -176,7 +176,7 @@ internal class SpanServiceImplTest {
 
     @Test
     fun `start a span directly`() {
-        spanSink.flushSpans()
+        spanSink.flushOtelSpans()
         val parentStartTime = clock.now()
         val parent = checkNotNull(spansService.startSpan(name = "test-span", private = false))
         val childStartTimeMs = clock.now() + 10L
@@ -191,7 +191,7 @@ internal class SpanServiceImplTest {
         clock.tick(40L)
         val childSpanEndTimeMs = clock.now()
         assertTrue(child.stop())
-        with(spanSink.flushSpans().single()) {
+        with(spanSink.flushOtelSpans().single()) {
             assertEquals("emb-child-span", name)
             assertEquals(childStartTimeMs, startTimeNanos?.nanosToMillis())
             assertEquals(childSpanEndTimeMs, endTimeNanos?.nanosToMillis())
@@ -201,7 +201,7 @@ internal class SpanServiceImplTest {
         clock.tick(10)
         val parentEndTime = clock.now()
         assertTrue(parent.stop())
-        with(spanSink.flushSpans().single()) {
+        with(spanSink.flushOtelSpans().single()) {
             assertEquals("emb-test-span", name)
             assertEquals(parentStartTime, startTimeNanos?.nanosToMillis())
             assertEquals(parentEndTime, endTimeNanos?.nanosToMillis())
@@ -270,7 +270,7 @@ internal class SpanServiceImplTest {
         }
         assertTrue(parentSpan.stop())
 
-        val currentSpans = spanSink.completedSpans()
+        val currentSpans = spanSink.completedOtelSpans()
         assertEquals(2, currentSpans.size)
         assertTrue(currentSpans[0].traceId == currentSpans[1].traceId)
         assertTrue(currentSpans[0].parentSpanId == currentSpans[1].spanId)
@@ -290,7 +290,7 @@ internal class SpanServiceImplTest {
             with(verifyAndReturnSoleCompletedSpan("emb-test${errorCode.name}")) {
                 assertError(errorCode)
             }
-            spanSink.flushSpans()
+            spanSink.flushOtelSpans()
         }
     }
 
@@ -330,7 +330,7 @@ internal class SpanServiceImplTest {
 
         assertTrue(parentSpan.stop())
 
-        val currentSpans = spanSink.completedSpans()
+        val currentSpans = spanSink.completedOtelSpans()
         assertEquals(2, currentSpans.size)
         assertTrue(currentSpans[0].traceId == currentSpans[1].traceId)
         assertTrue(currentSpans[0].parentSpanId == currentSpans[1].spanId)
@@ -363,7 +363,7 @@ internal class SpanServiceImplTest {
         }
 
         assertTrue(executed)
-        assertEquals(0, spanSink.completedSpans().size)
+        assertEquals(0, spanSink.completedOtelSpans().size)
     }
 
     @Test
@@ -378,7 +378,7 @@ internal class SpanServiceImplTest {
             ),
         )
         assertNotNull(spansService.recordSpan(name = TOO_LONG_SPAN_NAME, internal = false) { 1 })
-        assertEquals(2, spanSink.completedSpans().size)
+        assertEquals(2, spanSink.completedOtelSpans().size)
         assertNotNull(spansService.createSpan(name = MAX_LENGTH_SPAN_NAME, internal = false))
         assertNotNull(spansService.recordSpan(name = MAX_LENGTH_SPAN_NAME, internal = false) { 2 })
         assertTrue(
@@ -389,7 +389,7 @@ internal class SpanServiceImplTest {
                 internal = false,
             ),
         )
-        assertEquals(4, spanSink.completedSpans().size)
+        assertEquals(4, spanSink.completedOtelSpans().size)
     }
 
     @Test
@@ -442,7 +442,7 @@ internal class SpanServiceImplTest {
                 events = maxSizeSystemEvents,
             ),
         )
-        val completedSpans = spanSink.completedSpans()
+        val completedSpans = spanSink.completedOtelSpans()
         assertEquals(6, completedSpans.size)
         assertEquals(2, completedSpans.filter { it.name?.endsWith("...") == true }.size)
     }
@@ -469,7 +469,7 @@ internal class SpanServiceImplTest {
             ),
         )
 
-        assertEquals(maxEventAttrCount, spanSink.flushSpans().single { it.name == "too many events" }.events?.size)
+        assertEquals(maxEventAttrCount, spanSink.flushOtelSpans().single { it.name == "too many events" }.events?.size)
 
         val attributesMap = mutableMapOf(
             Pair(TOO_LONG_ATTRIBUTE_KEY, "value"),
@@ -493,7 +493,7 @@ internal class SpanServiceImplTest {
             ),
         )
 
-        val completedSpans = spanSink.completedSpans()
+        val completedSpans = spanSink.completedOtelSpans()
         assertEquals(1, completedSpans.size)
         assertEquals(10, completedSpans[0].events?.size)
         assertEquals(maxEventAttrCount, completedSpans[0].events?.get(0)?.attributes?.size)
@@ -520,7 +520,7 @@ internal class SpanServiceImplTest {
             ),
         )
 
-        spanSink.flushSpans()
+        spanSink.flushOtelSpans()
 
         val maxCustomAttrCount = dataValidator.otelLimitsConfig.getMaxCustomAttributeCount()
         val attributesMap = mutableMapOf(
@@ -541,7 +541,7 @@ internal class SpanServiceImplTest {
             ),
         )
 
-        val truncatedAttributesSpan = spanSink.completedSpans().single { it.name == MAX_LENGTH_SPAN_NAME }
+        val truncatedAttributesSpan = spanSink.completedOtelSpans().single { it.name == MAX_LENGTH_SPAN_NAME }
         val attrs = checkNotNull(truncatedAttributesSpan.attributes)
         val truncatedAttrCount = attrs.filter { it.key?.startsWith("sss") == true }.size
         assertEquals(2, truncatedAttrCount)
@@ -613,7 +613,7 @@ internal class SpanServiceImplTest {
             ),
         )
 
-        assertEquals(3, spanSink.completedSpans().size)
+        assertEquals(3, spanSink.completedOtelSpans().size)
     }
 
     private fun createSpanService(dataValidator: DataValidator): SpanServiceImpl {
@@ -655,7 +655,7 @@ internal class SpanServiceImplTest {
     }
 
     private fun verifyAndReturnSoleCompletedSpan(name: String): Span {
-        val currentSpans = spanSink.completedSpans()
+        val currentSpans = spanSink.completedOtelSpans()
         assertEquals(1, currentSpans.size)
         assertEquals(name, currentSpans[0].name)
         return currentSpans[0]

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSinkImplTests.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanSinkImplTests.kt
@@ -22,35 +22,35 @@ internal class SpanSinkImplTests {
 
     @Test
     fun `verify default state`() {
-        assertEquals(0, spanSink.completedSpans().size)
-        assertEquals(0, spanSink.flushSpans().size)
-        assertEquals(StoreDataResult.SUCCESS, spanSink.storeCompletedSpans(listOf()))
+        assertEquals(0, spanSink.completedOtelSpans().size)
+        assertEquals(0, spanSink.flushOtelSpans().size)
+        assertEquals(StoreDataResult.SUCCESS, spanSink.storeCompletedOtelSpans(listOf()))
     }
 
     @Test
     fun `flushing clears completed spans`() {
-        spanSink.storeCompletedSpans(listOf(FakeSpanData(), FakeSpanData()).map(FakeSpanData::toEmbracePayload))
-        val snapshot = spanSink.completedSpans()
+        spanSink.storeCompletedOtelSpans(listOf(FakeSpanData(), FakeSpanData()).map(FakeSpanData::toEmbracePayload))
+        val snapshot = spanSink.completedOtelSpans()
         assertEquals(2, snapshot.size)
 
-        val flushedSpans = spanSink.flushSpans()
+        val flushedSpans = spanSink.flushOtelSpans()
         assertEquals(2, flushedSpans.size)
         repeat(2) {
             assertSame(snapshot[it], flushedSpans[it])
         }
-        assertEquals(0, spanSink.completedSpans().size)
+        assertEquals(0, spanSink.completedOtelSpans().size)
     }
 
     @Test
     fun `flushing does not retain previously flushed spans`() {
-        spanSink.storeCompletedSpans(listOf(FakeSpanData(), FakeSpanData()).map(FakeSpanData::toEmbracePayload))
-        assertEquals(2, spanSink.flushSpans().size)
+        spanSink.storeCompletedOtelSpans(listOf(FakeSpanData(), FakeSpanData()).map(FakeSpanData::toEmbracePayload))
+        assertEquals(2, spanSink.flushOtelSpans().size)
 
-        assertEquals(0, spanSink.flushSpans().size)
-        assertEquals(0, spanSink.completedSpans().size)
+        assertEquals(0, spanSink.flushOtelSpans().size)
+        assertEquals(0, spanSink.completedOtelSpans().size)
 
-        spanSink.storeCompletedSpans(listOf(FakeSpanData()).map(FakeSpanData::toEmbracePayload))
-        assertEquals(1, spanSink.flushSpans().size)
+        spanSink.storeCompletedOtelSpans(listOf(FakeSpanData()).map(FakeSpanData::toEmbracePayload))
+        assertEquals(1, spanSink.flushOtelSpans().size)
     }
 
     @Test
@@ -63,22 +63,22 @@ internal class SpanSinkImplTests {
         val producer = SingleThreadTestScheduledExecutor()
         producer.submit {
             repeat(totalToStore) { i ->
-                spanSink.storeCompletedSpans(listOf(FakeSpanData(name = "span$i")).map(FakeSpanData::toEmbracePayload))
+                spanSink.storeCompletedOtelSpans(listOf(FakeSpanData(name = "span$i")).map(FakeSpanData::toEmbracePayload))
             }
             storeDoneLatch.countDown()
         }
 
         // repeatedly flush on this thread while the producer is storing
         while (storeDoneLatch.count > 0L) {
-            flushed += spanSink.flushSpans()
+            flushed += spanSink.flushOtelSpans()
         }
         storeDoneLatch.await(5, TimeUnit.SECONDS)
 
         // final flush to drain anything stored after the last in-loop flush
-        flushed += spanSink.flushSpans()
+        flushed += spanSink.flushOtelSpans()
 
         // every stored span should have been flushed exactly once.
-        assertEquals(0, spanSink.completedSpans().size)
+        assertEquals(0, spanSink.completedOtelSpans().size)
         assertEquals(totalToStore, flushed.size)
         val distinctNames = flushed.mapTo(HashSet()) { it.name }
         assertEquals(totalToStore, distinctNames.size)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -169,7 +169,7 @@ internal class TracingApiTest {
                 )
                 val allSpans = getSdkInitSpanFromBackgroundActivity() +
                     checkNotNull(session.data.spans) +
-                    testRule.setup.getSpanSink().completedSpans()
+                    testRule.setup.getSpanSink().completedOtelSpans()
 
                 val spansMap = allSpans.associateBy { it.name }
                 val sessionPartSpan = checkNotNull(spansMap["emb-session"])

--- a/embrace-microbenchmark/src/androidTest/kotlin/io/embrace/android/embracesdk/benchmark/TracingApiBenchmarks.kt
+++ b/embrace-microbenchmark/src/androidTest/kotlin/io/embrace/android/embracesdk/benchmark/TracingApiBenchmarks.kt
@@ -294,13 +294,13 @@ class TracingApiBenchmarks {
 
     private fun BenchmarkRule.Scope.verifyAndCleanup() {
         runWithMeasurementDisabled {
-            assertEquals(TOTAL_SPAN_COUNT, spanSink.completedSpans().size)
+            assertEquals(TOTAL_SPAN_COUNT, spanSink.completedOtelSpans().size)
             cleanup()
         }
     }
 
     private fun cleanup(): List<Span> {
-        spanSink.flushSpans()
+        spanSink.flushOtelSpans()
         return harness.currentSessionPartSpan.endSession(true)
     }
 


### PR DESCRIPTION
## Goal

Renames functions in `SpanSink/SpanRepository` to clarify their responsibilities in preparation for combining the two.
