### PR TITLE
[DNM] Experiment state delivered in envelope metadata

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/ExperimentTrackingService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/ExperimentTrackingService.kt
@@ -43,6 +43,12 @@ interface ExperimentTrackingService {
      * Returns the serialized experiment records, or null if nothing is tracked.
      */
     fun getRecords(): String?
+
+    /**
+     * Registers a listener invoked BEFORE each mutation of the experiment state becomes visible,
+     * so that in-flight telemetry batches can be cut while the old state still applies.
+     */
+    fun addChangeListener(listener: () -> Unit)
 }
 
 /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/ExperimentTrackingServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/ExperimentTrackingServiceImpl.kt
@@ -9,6 +9,7 @@ internal class ExperimentTrackingServiceImpl(
 
     private val lock = Any()
     private val records = mutableListOf<ExperimentRecord>()
+    private var listener: (() -> Unit)? = null
 
     override fun trackExperiments(experiments: List<TrackedExperimentData>): Boolean =
         trackRecords(
@@ -48,8 +49,17 @@ internal class ExperimentTrackingServiceImpl(
         serializeRecords()
     }
 
+    override fun addChangeListener(listener: () -> Unit) {
+        this.listener = listener
+    }
+
     private fun trackRecords(newRecords: List<ExperimentRecord>, requestedCount: Int): Boolean {
         synchronized(lock) {
+            // flush-then-mutate: cut the in-flight log batch under the OLD state before the new
+            // records become visible. Safe to re-enter this monitor from the same thread (the
+            // flush resolves envelope metadata via getRecords()); the built envelope captures
+            // the old records string.
+            listener?.invoke()
             var allAccepted = newRecords.size == requestedCount
             val trackedKeys = records.mapTo(mutableSetOf()) { it.key() }
             newRecords.forEach { record ->
@@ -67,6 +77,7 @@ internal class ExperimentTrackingServiceImpl(
 
     private fun untrackRecords(type: ExperimentRecordType, ids: List<String>, endTimeMs: Long): Boolean {
         synchronized(lock) {
+            listener?.invoke()
             var allAccepted = true
             ids.forEach { id ->
                 val key = "${type.code}:$id"

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
@@ -132,7 +132,10 @@ class PayloadSourceModuleImpl(
 
     private val metadataSource by singleton {
         EmbTrace.trace("metadata-source") {
-            EnvelopeMetadataSourceImpl { essentialServiceModule.userService.getUserInfo() }
+            EnvelopeMetadataSourceImpl(
+                userInfoProvider = { essentialServiceModule.userService.getUserInfo() },
+                experimentsProvider = { essentialServiceModule.experimentTrackingService.getRecords() },
+            )
         }
     }
 

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/metadata/EnvelopeMetadataSourceImpl.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/metadata/EnvelopeMetadataSourceImpl.kt
@@ -7,6 +7,7 @@ import java.util.TimeZone
 
 class EnvelopeMetadataSourceImpl(
     private val userInfoProvider: () -> UserInfo,
+    private val experimentsProvider: () -> String? = { null },
 ) : EnvelopeMetadataSource {
 
     override fun getEnvelopeMetadata(): EnvelopeMetadata {
@@ -19,6 +20,7 @@ class EnvelopeMetadataSourceImpl(
             personas = userInfo.personas ?: emptySet(),
             timezoneDescription = TimeZone.getDefault().id,
             locale = Locale.getDefault().language + "_" + Locale.getDefault().country,
+            experiments = experimentsProvider(),
         )
     }
 }

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeMetadata.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeMetadata.kt
@@ -26,4 +26,7 @@ data class EnvelopeMetadata(
 
     @SerialName("locale")
     val locale: String? = null,
+
+    @SerialName("experiments")
+    val experiments: String? = null,
 )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ExperimentPayloadGoldenFileTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ExperimentPayloadGoldenFileTest.kt
@@ -1,0 +1,85 @@
+package io.embrace.android.embracesdk.testcases.features
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.experiments.TrackedExperiment
+import io.embrace.android.embracesdk.assertions.getSessionPartId
+import io.embrace.android.embracesdk.assertions.getUserSessionId
+import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
+import io.embrace.android.embracesdk.testframework.assertions.Placeholder
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Captures what the experiment state looks like in the payloads that carry it, so that the
+ * delivery mechanism's effect on the payload shape is visible in the golden files.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class ExperimentPayloadGoldenFileTest {
+
+    @Rule
+    @JvmField
+    val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule()
+
+    @Test
+    fun `session part payload with experiment state matches golden file`() {
+        testRule.runTest(
+            preSdkStartAction = {
+                declareExperiments()
+            },
+            testCaseAction = {
+                recordSession()
+            },
+            assertAction = {
+                val envelope = getSingleSessionEnvelope()
+                validatePayloadAgainstGoldenFile(
+                    payload = envelope,
+                    goldenFileName = "experiment_session.json",
+                    placeholders = mapOf(
+                        Placeholder.USER_SESSION_ID to envelope.getUserSessionId(),
+                        Placeholder.SESSION_PART_ID to envelope.getSessionPartId(),
+                    ),
+                )
+            },
+        )
+    }
+
+    @Test
+    fun `log batch payload with experiment state matches golden file`() {
+        testRule.runTest(
+            preSdkStartAction = {
+                declareExperiments()
+            },
+            testCaseAction = {
+                recordSession {
+                    repeat(5) {
+                        embrace.logInfo("experiment log message ${it + 1}")
+                    }
+                }
+            },
+            assertAction = {
+                val session = getSingleSessionEnvelope()
+                validatePayloadAgainstGoldenFile(
+                    payload = getSingleLogEnvelope(),
+                    goldenFileName = "experiment_log_batch.json",
+                    placeholders = mapOf(
+                        Placeholder.USER_SESSION_ID to session.getUserSessionId(),
+                        Placeholder.SESSION_PART_ID to session.getSessionPartId(),
+                    ),
+                )
+            },
+        )
+    }
+
+    private fun io.embrace.android.embracesdk.testframework.actions.EmbracePreSdkStartInterface.declareExperiments() {
+        embrace.trackExperiment(
+            TrackedExperiment("checkout-flow", "variant-a", BUCKETED_AT_1_MS),
+            TrackedExperiment("new-onboarding", "control", BUCKETED_AT_2_MS),
+        )
+    }
+
+    private companion object {
+        private const val BUCKETED_AT_1_MS = 1691000000000L
+        private const val BUCKETED_AT_2_MS = 1691000100000L
+    }
+}

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ExperimentTrackingTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ExperimentTrackingTest.kt
@@ -1,0 +1,102 @@
+package io.embrace.android.embracesdk.testcases.features
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.experiments.TrackedExperiment
+import io.embrace.android.embracesdk.experiments.TrackedFeatureFlag
+import io.embrace.android.embracesdk.assertions.findSessionPartSpan
+import io.embrace.android.embracesdk.assertions.getLogOfType
+import io.embrace.android.embracesdk.assertions.toMap
+import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.capture.experiment.EMB_EXPERIMENTS_ATTRIBUTE_KEY
+import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class ExperimentTrackingTest {
+
+    @Rule
+    @JvmField
+    val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule()
+
+    private var preStartBucketTimeMs: Long = 0
+    private var secondBucketTimeMs: Long = 0
+    private var flagTrackTimeMs: Long = 0
+    private var experimentEndTimeMs: Long = 0
+
+    @Test
+    fun `experiment state is attached as envelope metadata in the happy path`() {
+        testRule.runTest(
+            preSdkStartAction = {
+                preStartBucketTimeMs = clock.now()
+                assertTrue(
+                    embrace.trackExperiment(
+                        TrackedExperiment("exp1", "variantA", preStartBucketTimeMs),
+                    ),
+                )
+            },
+            testCaseAction = {
+                recordSession {
+                    secondBucketTimeMs = clock.now()
+                    assertTrue(
+                        embrace.trackExperiment(
+                            TrackedExperiment("exp2", "variantB", secondBucketTimeMs),
+                        ),
+                    )
+                    flagTrackTimeMs = clock.now()
+                    assertTrue(embrace.trackFeatureFlag(TrackedFeatureFlag("flag1", flagTrackTimeMs)))
+                    embrace.logInfo("test message")
+                    experimentEndTimeMs = clock.now()
+                    assertTrue(embrace.untrackExperiment("exp1", endTimeMs = experimentEndTimeMs))
+                }
+                recordSession()
+            },
+            assertAction = {
+                val sessions = getSessionEnvelopes(2)
+
+                // the first session envelope's metadata carries the full state as of session end:
+                // untracking closed exp1's record in place, adding its end time
+                assertEquals(
+                    "e:exp1:variantA:$preStartBucketTimeMs:$experimentEndTimeMs;" +
+                        "e:exp2:variantB:$secondBucketTimeMs;" +
+                        "f:flag1::$flagTrackTimeMs",
+                    sessions[0].metadata?.experiments,
+                )
+
+                // records persist for the entire process (they only age out when a new process
+                // starts without re-tracking), so the second session envelope carries the same
+                // state, including exp1's closed record
+                assertEquals(
+                    "e:exp1:variantA:$preStartBucketTimeMs:$experimentEndTimeMs;" +
+                        "e:exp2:variantB:$secondBucketTimeMs;" +
+                        "f:flag1::$flagTrackTimeMs",
+                    sessions[1].metadata?.experiments,
+                )
+
+                // untrackExperiment cut the in-flight log batch BEFORE mutating the state, so the
+                // log's envelope metadata reflects the state at log time: both experiments and
+                // the feature flag tracked, no end time on exp1 yet
+                val logEnvelope = getSingleLogEnvelope()
+                assertEquals(
+                    "e:exp1:variantA:$preStartBucketTimeMs;" +
+                        "e:exp2:variantB:$secondBucketTimeMs;" +
+                        "f:flag1::$flagTrackTimeMs",
+                    logEnvelope.metadata?.experiments,
+                )
+
+                // the state lives at the envelope level only: neither the session part span nor
+                // the log carries a per-record attribute
+                assertNull(
+                    checkNotNull(sessions[0].findSessionPartSpan().attributes)
+                        .toMap()[EMB_EXPERIMENTS_ATTRIBUTE_KEY],
+                )
+                val log = logEnvelope.getLogOfType(EmbType.System.Log)
+                assertNull(checkNotNull(log.attributes).toMap()[EMB_EXPERIMENTS_ATTRIBUTE_KEY])
+            },
+        )
+    }
+}

--- a/embrace-android-sdk/src/integrationTest/resources/experiment_log_batch.json
+++ b/embrace-android-sdk/src/integrationTest/resources/experiment_log_batch.json
@@ -1,0 +1,122 @@
+{
+  "resource": {
+    "app_version": "2.5.1",
+    "app_framework": 1,
+    "build_id": "fakeBuildId",
+    "app_ecosystem_id": "com.fake.package",
+    "build_type": "fakeBuildType",
+    "build_flavor": "fakeBuildFlavor",
+    "environment": "dev",
+    "bundle_version": "99",
+    "sdk_version": "__EMBRACE_TEST_IGNORE__",
+    "sdk_simple_version": 53,
+    "device_manufacturer": "__EMBRACE_TEST_IGNORE__",
+    "device_model": "__EMBRACE_TEST_IGNORE__",
+    "device_architecture": "__EMBRACE_TEST_IGNORE__",
+    "jailbroken": "__EMBRACE_TEST_IGNORE__",
+    "disk_total_capacity": "__EMBRACE_TEST_IGNORE__",
+    "os_type": "linux",
+    "os_name": "android",
+    "os_version": "__EMBRACE_TEST_IGNORE__",
+    "os_code": "__EMBRACE_TEST_IGNORE__",
+    "screen_resolution": "__EMBRACE_TEST_IGNORE__",
+    "num_cores": "__EMBRACE_TEST_IGNORE__"
+  },
+  "metadata": {
+    "personas": "__EMBRACE_TEST_IGNORE__",
+    "timezone_description": "__EMBRACE_TEST_IGNORE__",
+    "locale": "__EMBRACE_TEST_IGNORE__",
+    "experiments": "__EMBRACE_TEST_IGNORE__"
+  },
+  "version": "0.1.0",
+  "type": "logs",
+  "data": {
+    "logs": [
+      {
+        "time_unix_nano": 169220160030000000,
+        "severity_number": 9,
+        "severity_text": "INFO",
+        "body": "experiment log message 1",
+        "attributes": [
+          { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+          { "key": "emb.state", "value": "foreground" },
+          { "key": "emb.state.network", "value": "unverified" },
+          { "key": "emb.state.screen-automatic", "value": "android.app.Activity" },
+          { "key": "emb.state.test", "value": "UNKNOWN" },
+          { "key": "emb.type", "value": "sys.log" },
+          { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+          { "key": "log.record.uid", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+        ]
+      },
+      {
+        "time_unix_nano": 169220160030000000,
+        "severity_number": 9,
+        "severity_text": "INFO",
+        "body": "experiment log message 2",
+        "attributes": [
+          { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+          { "key": "emb.state", "value": "foreground" },
+          { "key": "emb.state.network", "value": "unverified" },
+          { "key": "emb.state.screen-automatic", "value": "android.app.Activity" },
+          { "key": "emb.state.test", "value": "UNKNOWN" },
+          { "key": "emb.type", "value": "sys.log" },
+          { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+          { "key": "log.record.uid", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+        ]
+      },
+      {
+        "time_unix_nano": 169220160030000000,
+        "severity_number": 9,
+        "severity_text": "INFO",
+        "body": "experiment log message 3",
+        "attributes": [
+          { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+          { "key": "emb.state", "value": "foreground" },
+          { "key": "emb.state.network", "value": "unverified" },
+          { "key": "emb.state.screen-automatic", "value": "android.app.Activity" },
+          { "key": "emb.state.test", "value": "UNKNOWN" },
+          { "key": "emb.type", "value": "sys.log" },
+          { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+          { "key": "log.record.uid", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+        ]
+      },
+      {
+        "time_unix_nano": 169220160030000000,
+        "severity_number": 9,
+        "severity_text": "INFO",
+        "body": "experiment log message 4",
+        "attributes": [
+          { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+          { "key": "emb.state", "value": "foreground" },
+          { "key": "emb.state.network", "value": "unverified" },
+          { "key": "emb.state.screen-automatic", "value": "android.app.Activity" },
+          { "key": "emb.state.test", "value": "UNKNOWN" },
+          { "key": "emb.type", "value": "sys.log" },
+          { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+          { "key": "log.record.uid", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+        ]
+      },
+      {
+        "time_unix_nano": 169220160030000000,
+        "severity_number": 9,
+        "severity_text": "INFO",
+        "body": "experiment log message 5",
+        "attributes": [
+          { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+          { "key": "emb.state", "value": "foreground" },
+          { "key": "emb.state.network", "value": "unverified" },
+          { "key": "emb.state.screen-automatic", "value": "android.app.Activity" },
+          { "key": "emb.state.test", "value": "UNKNOWN" },
+          { "key": "emb.type", "value": "sys.log" },
+          { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+          { "key": "log.record.uid", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+        ]
+      }
+    ]
+  }
+}

--- a/embrace-android-sdk/src/integrationTest/resources/experiment_session.json
+++ b/embrace-android-sdk/src/integrationTest/resources/experiment_session.json
@@ -1,0 +1,514 @@
+{
+  "resource": {
+    "app_version": "2.5.1",
+    "app_framework": 1,
+    "build_id": "fakeBuildId",
+    "app_ecosystem_id": "com.fake.package",
+    "build_type": "fakeBuildType",
+    "build_flavor": "fakeBuildFlavor",
+    "environment": "dev",
+    "bundle_version": "99",
+    "sdk_version": "__EMBRACE_TEST_IGNORE__",
+    "sdk_simple_version": 53,
+    "device_manufacturer": "__EMBRACE_TEST_IGNORE__",
+    "device_model": "__EMBRACE_TEST_IGNORE__",
+    "device_architecture": "__EMBRACE_TEST_IGNORE__",
+    "jailbroken": "__EMBRACE_TEST_IGNORE__",
+    "disk_total_capacity": "__EMBRACE_TEST_IGNORE__",
+    "os_type": "linux",
+    "os_name": "android",
+    "os_version": "__EMBRACE_TEST_IGNORE__",
+    "os_code": "__EMBRACE_TEST_IGNORE__",
+    "screen_resolution": "__EMBRACE_TEST_IGNORE__",
+    "num_cores": "__EMBRACE_TEST_IGNORE__"
+  },
+  "metadata": {
+    "personas": "__EMBRACE_TEST_IGNORE__",
+    "timezone_description": "__EMBRACE_TEST_IGNORE__",
+    "locale": "__EMBRACE_TEST_IGNORE__",
+    "experiments": "__EMBRACE_TEST_IGNORE__"
+  },
+  "version": "0.1.0",
+  "type": "spans",
+  "data": {
+    "spans": [
+      {
+        "trace_id": "__EMBRACE_TEST_IGNORE__",
+        "span_id": "__EMBRACE_TEST_IGNORE__",
+        "parent_span_id": "0000000000000000",
+        "name": "emb-sdk-init",
+        "start_time_unix_nano": 169220160000000000,
+        "end_time_unix_nano": 169220160000000000,
+        "status": "Unset",
+        "events": [],
+        "attributes": [
+          { "key": "emb.private", "value": "true" },
+          { "key": "emb.private.sequence_id", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.process_identifier", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.session_part_id", "value": "" },
+          { "key": "emb.type", "value": "perf" },
+          { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+          { "key": "ended-in-foreground", "value": "false" },
+          { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+          { "key": "thread-name", "value": "SDK 35 Main Thread" }
+        ],
+        "links": [
+          {
+            "span_id": "__EMBRACE_TEST_IGNORE__",
+            "trace_id": "__EMBRACE_TEST_IGNORE__",
+            "attributes": [
+              { "key": "emb.link_type", "value": "END_SESSION_PART" },
+              { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" }
+            ],
+            "is_remote": false
+          }
+        ]
+      },
+      {
+        "trace_id": "__EMBRACE_TEST_IGNORE__",
+        "span_id": "__EMBRACE_TEST_IGNORE__",
+        "parent_span_id": "0000000000000000",
+        "name": "emb-screen-view",
+        "start_time_unix_nano": 169220160010000000,
+        "end_time_unix_nano": 169220200131000000,
+        "status": "Unset",
+        "events": [],
+        "attributes": [
+          { "key": "emb.private.sequence_id", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.process_identifier", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+          { "key": "emb.type", "value": "ux.view" },
+          { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+          { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+          { "key": "view.name", "value": "android.app.Activity" }
+        ],
+        "links": [
+          {
+            "span_id": "__EMBRACE_TEST_IGNORE__",
+            "trace_id": "__EMBRACE_TEST_IGNORE__",
+            "attributes": [
+              { "key": "emb.link_type", "value": "END_SESSION_PART" },
+              { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+              { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+              { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+            ],
+            "is_remote": false
+          }
+        ]
+      },
+      {
+        "trace_id": "__EMBRACE_TEST_IGNORE__",
+        "span_id": "__EMBRACE_TEST_IGNORE__",
+        "parent_span_id": "0000000000000000",
+        "name": "emb-app-startup-cold",
+        "start_time_unix_nano": 169220159900000000,
+        "end_time_unix_nano": 169220200131000000,
+        "status": "Error",
+        "events": [],
+        "attributes": [
+          { "key": "emb.error_code", "value": "user_abandon" },
+          { "key": "emb.private.sequence_id", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.process_identifier", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.session_part_id", "value": "" },
+          { "key": "emb.startup_activity", "value": "android.app.Activity" },
+          { "key": "emb.type", "value": "perf" },
+          { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+          { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+        ],
+        "links": [
+          {
+            "span_id": "__EMBRACE_TEST_IGNORE__",
+            "trace_id": "__EMBRACE_TEST_IGNORE__",
+            "attributes": [
+              { "key": "emb.link_type", "value": "END_SESSION_PART" },
+              { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+              { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+              { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+            ],
+            "is_remote": false
+          }
+        ]
+      },
+      {
+        "trace_id": "__EMBRACE_TEST_IGNORE__",
+        "span_id": "__EMBRACE_TEST_IGNORE__",
+        "parent_span_id": "__EMBRACE_TEST_IGNORE__",
+        "name": "emb-embrace-init",
+        "start_time_unix_nano": 169220160000000000,
+        "end_time_unix_nano": 169220160000000000,
+        "status": "Unset",
+        "events": [],
+        "attributes": [
+          { "key": "emb.private.sequence_id", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.process_identifier", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+          { "key": "emb.type", "value": "perf" },
+          { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+          { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+        ],
+        "links": [
+          {
+            "span_id": "__EMBRACE_TEST_IGNORE__",
+            "trace_id": "__EMBRACE_TEST_IGNORE__",
+            "attributes": [
+              { "key": "emb.link_type", "value": "END_SESSION_PART" },
+              { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+              { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+              { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+            ],
+            "is_remote": false
+          }
+        ]
+      },
+      {
+        "trace_id": "__EMBRACE_TEST_IGNORE__",
+        "span_id": "__EMBRACE_TEST_IGNORE__",
+        "parent_span_id": "__EMBRACE_TEST_IGNORE__",
+        "name": "emb-activity-init-delay",
+        "start_time_unix_nano": 169220160000000000,
+        "end_time_unix_nano": 169220160000000000,
+        "status": "Unset",
+        "events": [],
+        "attributes": [
+          { "key": "emb.private.sequence_id", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.process_identifier", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+          { "key": "emb.type", "value": "perf" },
+          { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+          { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+        ],
+        "links": [
+          {
+            "span_id": "__EMBRACE_TEST_IGNORE__",
+            "trace_id": "__EMBRACE_TEST_IGNORE__",
+            "attributes": [
+              { "key": "emb.link_type", "value": "END_SESSION_PART" },
+              { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+              { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+              { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+            ],
+            "is_remote": false
+          }
+        ]
+      },
+      {
+        "trace_id": "__EMBRACE_TEST_IGNORE__",
+        "span_id": "__EMBRACE_TEST_IGNORE__",
+        "parent_span_id": "__EMBRACE_TEST_IGNORE__",
+        "name": "emb-activity-init",
+        "start_time_unix_nano": 169220160000000000,
+        "end_time_unix_nano": 169220160010000000,
+        "status": "Unset",
+        "events": [],
+        "attributes": [
+          { "key": "emb.private.sequence_id", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.process_identifier", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+          { "key": "emb.type", "value": "perf" },
+          { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+          { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+        ],
+        "links": [
+          {
+            "span_id": "__EMBRACE_TEST_IGNORE__",
+            "trace_id": "__EMBRACE_TEST_IGNORE__",
+            "attributes": [
+              { "key": "emb.link_type", "value": "END_SESSION_PART" },
+              { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+              { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+              { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+            ],
+            "is_remote": false
+          }
+        ]
+      },
+      {
+        "trace_id": "__EMBRACE_TEST_IGNORE__",
+        "span_id": "__EMBRACE_TEST_IGNORE__",
+        "parent_span_id": "0000000000000000",
+        "name": "emb-state-test",
+        "start_time_unix_nano": 169220160010000000,
+        "end_time_unix_nano": 169220200131000000,
+        "status": "Unset",
+        "events": [],
+        "attributes": [
+          { "key": "emb.private.sequence_id", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.process_identifier", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+          { "key": "emb.state.initial_value", "value": "UNKNOWN" },
+          { "key": "emb.type", "value": "state" },
+          { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+          { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+        ],
+        "links": [
+          {
+            "span_id": "__EMBRACE_TEST_IGNORE__",
+            "trace_id": "__EMBRACE_TEST_IGNORE__",
+            "attributes": [
+              { "key": "emb.link_type", "value": "END_SESSION_PART" },
+              { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+              { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+              { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+            ],
+            "is_remote": false
+          }
+        ]
+      },
+      {
+        "trace_id": "__EMBRACE_TEST_IGNORE__",
+        "span_id": "__EMBRACE_TEST_IGNORE__",
+        "parent_span_id": "0000000000000000",
+        "name": "emb-state-screen-automatic",
+        "start_time_unix_nano": 169220160010000000,
+        "end_time_unix_nano": 169220200131000000,
+        "status": "Unset",
+        "events": [
+          {
+            "name": "transition",
+            "time_unix_nano": 169220160010000000,
+            "attributes": [
+              { "key": "emb.state.new_value", "value": "android.app.Activity" }
+            ]
+          },
+          {
+            "name": "transition",
+            "time_unix_nano": 169220200131000000,
+            "attributes": [
+              { "key": "emb.state.new_value", "value": "Backgrounded" }
+            ]
+          }
+        ],
+        "attributes": [
+          { "key": "emb.private.sequence_id", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.process_identifier", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+          { "key": "emb.state.initial_value", "value": "Initializing" },
+          { "key": "emb.state.transition_count", "value": "2" },
+          { "key": "emb.type", "value": "state" },
+          { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+          { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+        ],
+        "links": [
+          {
+            "span_id": "__EMBRACE_TEST_IGNORE__",
+            "trace_id": "__EMBRACE_TEST_IGNORE__",
+            "attributes": [
+              { "key": "emb.link_type", "value": "END_SESSION_PART" },
+              { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+              { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+              { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+            ],
+            "is_remote": false
+          }
+        ]
+      },
+      {
+        "trace_id": "__EMBRACE_TEST_IGNORE__",
+        "span_id": "__EMBRACE_TEST_IGNORE__",
+        "parent_span_id": "0000000000000000",
+        "name": "emb-state-network",
+        "start_time_unix_nano": 169220160010000000,
+        "end_time_unix_nano": 169220200131000000,
+        "status": "Unset",
+        "events": [],
+        "attributes": [
+          { "key": "emb.private.sequence_id", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.process_identifier", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+          { "key": "emb.state.initial_value", "value": "unverified" },
+          { "key": "emb.state.not_in_session", "value": "1" },
+          { "key": "emb.type", "value": "state" },
+          { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+          { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+        ],
+        "links": [
+          {
+            "span_id": "__EMBRACE_TEST_IGNORE__",
+            "trace_id": "__EMBRACE_TEST_IGNORE__",
+            "attributes": [
+              { "key": "emb.link_type", "value": "END_SESSION_PART" },
+              { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+              { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+              { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+            ],
+            "is_remote": false
+          }
+        ]
+      },
+      {
+        "trace_id": "__EMBRACE_TEST_IGNORE__",
+        "span_id": "__EMBRACE_TEST_IGNORE__",
+        "parent_span_id": "0000000000000000",
+        "name": "emb-session",
+        "start_time_unix_nano": 169220160000000000,
+        "end_time_unix_nano": 169220200131000000,
+        "status": "Unset",
+        "events": [],
+        "attributes": [
+          { "key": "emb.clean_exit", "value": "true" },
+          { "key": "emb.clock_gnss_drift", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.clock_network_drift", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.cold_start", "value": "true" },
+          { "key": "emb.disk_free_bytes", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.error_log_count", "value": "0" },
+          { "key": "emb.heartbeat_time_unix_nano", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.is_emulator", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.kotlin_on_classpath", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.okhttp3", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.okhttp3_on_classpath", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.private.sequence_id", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.process_identifier", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.session_end_type", "value": "state" },
+          { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+          { "key": "emb.session_part_number", "value": "1" },
+          { "key": "emb.session_start_type", "value": "state" },
+          { "key": "emb.startup_duration", "value": "__EMBRACE_TEST_IGNORE__" },
+          { "key": "emb.state", "value": "foreground" },
+          { "key": "emb.terminated", "value": "false" },
+          { "key": "emb.type", "value": "ux.session" },
+          { "key": "emb.usage.track_experiment", "value": "1" },
+          { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+          { "key": "emb.user_session_inactivity_timeout_seconds", "value": "1800" },
+          { "key": "emb.user_session_max_duration_seconds", "value": "43200" },
+          { "key": "emb.user_session_number", "value": "1" },
+          { "key": "emb.user_session_part_index", "value": "1" },
+          { "key": "emb.user_session_start_ts", "value": "169220160000" },
+          { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+        ],
+        "links": [
+          {
+            "span_id": "__EMBRACE_TEST_IGNORE__",
+            "trace_id": "__EMBRACE_TEST_IGNORE__",
+            "attributes": [
+              { "key": "emb.link_type", "value": "ENDED_IN" },
+              { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" }
+            ],
+            "is_remote": false
+          },
+          {
+            "span_id": "__EMBRACE_TEST_IGNORE__",
+            "trace_id": "__EMBRACE_TEST_IGNORE__",
+            "attributes": [
+              { "key": "emb.link_type", "value": "ENDED_IN" },
+              { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+              { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+              { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+            ],
+            "is_remote": false
+          },
+          {
+            "span_id": "__EMBRACE_TEST_IGNORE__",
+            "trace_id": "__EMBRACE_TEST_IGNORE__",
+            "attributes": [
+              { "key": "emb.link_type", "value": "ENDED_IN" },
+              { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+              { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+              { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+            ],
+            "is_remote": false
+          },
+          {
+            "span_id": "__EMBRACE_TEST_IGNORE__",
+            "trace_id": "__EMBRACE_TEST_IGNORE__",
+            "attributes": [
+              { "key": "emb.link_type", "value": "ENDED_IN" },
+              { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+              { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+              { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+            ],
+            "is_remote": false
+          },
+          {
+            "span_id": "__EMBRACE_TEST_IGNORE__",
+            "trace_id": "__EMBRACE_TEST_IGNORE__",
+            "attributes": [
+              { "key": "emb.link_type", "value": "ENDED_IN" },
+              { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+              { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+              { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+            ],
+            "is_remote": false
+          },
+          {
+            "span_id": "__EMBRACE_TEST_IGNORE__",
+            "trace_id": "__EMBRACE_TEST_IGNORE__",
+            "attributes": [
+              { "key": "emb.link_type", "value": "ENDED_IN" },
+              { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+              { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+              { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+            ],
+            "is_remote": false
+          },
+          {
+            "span_id": "__EMBRACE_TEST_IGNORE__",
+            "trace_id": "__EMBRACE_TEST_IGNORE__",
+            "attributes": [
+              { "key": "emb.link_type", "value": "ENDED_IN" },
+              { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+              { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+              { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+            ],
+            "is_remote": false
+          },
+          {
+            "span_id": "__EMBRACE_TEST_IGNORE__",
+            "trace_id": "__EMBRACE_TEST_IGNORE__",
+            "attributes": [
+              { "key": "emb.link_type", "value": "STATE" },
+              { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+              { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+              { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+            ],
+            "is_remote": false
+          },
+          {
+            "span_id": "__EMBRACE_TEST_IGNORE__",
+            "trace_id": "__EMBRACE_TEST_IGNORE__",
+            "attributes": [
+              { "key": "emb.link_type", "value": "ENDED_IN" },
+              { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+              { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+              { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+            ],
+            "is_remote": false
+          },
+          {
+            "span_id": "__EMBRACE_TEST_IGNORE__",
+            "trace_id": "__EMBRACE_TEST_IGNORE__",
+            "attributes": [
+              { "key": "emb.link_type", "value": "STATE" },
+              { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+              { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+              { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+            ],
+            "is_remote": false
+          },
+          {
+            "span_id": "__EMBRACE_TEST_IGNORE__",
+            "trace_id": "__EMBRACE_TEST_IGNORE__",
+            "attributes": [
+              { "key": "emb.link_type", "value": "ENDED_IN" },
+              { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+              { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+              { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+            ],
+            "is_remote": false
+          },
+          {
+            "span_id": "__EMBRACE_TEST_IGNORE__",
+            "trace_id": "__EMBRACE_TEST_IGNORE__",
+            "attributes": [
+              { "key": "emb.link_type", "value": "STATE" },
+              { "key": "emb.session_part_id", "value": "__EMBRACE_TEST_SESSION_PART_ID__" },
+              { "key": "emb.user_session_id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" },
+              { "key": "session.id", "value": "__EMBRACE_TEST_USER_SESSION_ID__" }
+            ],
+            "is_remote": false
+          }
+        ]
+      }
+    ],
+    "span_snapshots": "__EMBRACE_TEST_IGNORE__"
+  }
+}

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
@@ -45,6 +45,14 @@ internal fun ModuleGraph.postInit() {
         logModule.logOrchestrator.onLogsAdded()
     }
 
+    // Cut the in-flight log batch whenever the experiment state changes, so that every log in a
+    // batch shares the same envelope-level experiment metadata. flush() is a no-op on an empty
+    // sink, so bulk launch-time declarations before any logs cost nothing.
+    // TODO(EMBR-xxxx): reevaluate coalescing if per-call batch cuts prove wasteful
+    essentialServiceModule.experimentTrackingService.addChangeListener {
+        logModule.logOrchestrator.flush(false)
+    }
+
     essentialServiceModule.telemetryDestination.sessionUpdateAction =
         userSessionOrchestrationModule.sessionOrchestrator::onSessionDataUpdate
     essentialServiceModule.telemetryDestination.currentStatesProvider =

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeExperimentTrackingService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeExperimentTrackingService.kt
@@ -33,4 +33,7 @@ class FakeExperimentTrackingService : ExperimentTrackingService {
     }
 
     override fun getRecords(): String? = fakeRecords
+
+    override fun addChangeListener(listener: () -> Unit) {
+    }
 }


### PR DESCRIPTION
Prototype for experiments API impl to store the experiment records as an attribute on metadata object in the payload envelope - similar to Persona.   
  
Demo only - not to be merged