### PR TITLE
Correctly strip URLs that encode URLs in query string

### DIFF
--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/utils/NetworkUtilsTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/utils/NetworkUtilsTest.kt
@@ -70,6 +70,21 @@ internal class NetworkUtilsTest {
             "http://example.com/index.html#:words:some-context-for-a-(search-term)",
             "http://example.com/index.html",
         ),
+
+        // a '/' in the query or fragment must not prevent the strip
+        arrayOf(
+            "http://foo.google.com/foo?next=https://bar.google.com/baz",
+            "http://foo.google.com/foo",
+        ),
+        arrayOf("http://foo.google.com/foo?token=ab/cd+ef", "http://foo.google.com/foo"),
+        arrayOf("http://foo.google.com/foo#frag/ment", "http://foo.google.com/foo"),
+
+        // the first delimiter wins: a '?' inside a fragment is part of the fragment
+        arrayOf("http://foo.google.com/foo#bar?color=blue", "http://foo.google.com/foo"),
+
+        // no path
+        arrayOf("http://google.com?color=blue", "http://google.com"),
+        arrayOf("http://google.com#bar", "http://google.com"),
     )
 
     @Test

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/NetworkUtils.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/NetworkUtils.kt
@@ -73,21 +73,8 @@ object NetworkUtils {
      * @return the URL with the hash fragment and query string parameters removed
      */
     fun stripUrl(url: String): String {
-        val pathPos: Int = url.lastIndexOf('/')
-        val suffix: String = if (pathPos < 0) url else url.substring(pathPos)
-
-        val queryPos = suffix.indexOf('?')
-        val fragmentPos = suffix.indexOf('#')
-
-        val queryPosResult = if (queryPos < 0) Int.MAX_VALUE else queryPos
-        val fragmentPosResult = if (fragmentPos < 0) Int.MAX_VALUE else fragmentPos
-
-        val terminalPos = queryPosResult.coerceAtMost(fragmentPosResult)
-
-        return url.substring(
-            0,
-            (if (pathPos < 0) 0 else pathPos) + suffix.length.coerceAtMost(terminalPos),
-        )
+        val terminalPos = url.indexOfFirst { it == '?' || it == '#' }
+        return if (terminalPos < 0) url else url.substring(0, terminalPos)
     }
 
     fun getUrlPath(url: String?): String? = try {


### PR DESCRIPTION
## Goal
Ensure that `stripUrl` correctly removes the query string and fragment on URLs that encode path data within the fragment or URL.

## Testing
Added new tests for problematic URLs