### PR TITLE
Avoid capturing content length in OkHttp requests with no header

### DIFF
--- a/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeNetworkBehavior.kt
+++ b/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeNetworkBehavior.kt
@@ -9,6 +9,7 @@ class FakeNetworkBehavior(
     private val captureLimit: Int = 1000,
     private val domains: Map<String, Int> = emptyMap(),
     private val captureHttpUrlConnectionRequests: Boolean = false,
+    private val okHttpResponseBodySizeCaptureEnabled: Boolean = false,
     private val hucLiteInstrumentationEnabled: Boolean = true,
     private val urlEnabled: Boolean = true,
     override val domainCountLimiter: DomainCountLimiter = FakeDomainCountLimiter(),
@@ -18,6 +19,7 @@ class FakeNetworkBehavior(
 ) : NetworkBehavior {
 
     override fun isRequestContentLengthCaptureEnabled(): Boolean = false
+    override fun isOkHttpResponseBodySizeCaptureEnabled(): Boolean = okHttpResponseBodySizeCaptureEnabled
     override fun isHttpUrlConnectionCaptureEnabled(): Boolean = captureHttpUrlConnectionRequests
     override fun isHucLiteInstrumentationEnabled(): Boolean = hucLiteInstrumentationEnabled
     override fun getLimitsByDomain(): Map<String, Int> = domains

--- a/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeEnabledFeatureConfig.kt
+++ b/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeEnabledFeatureConfig.kt
@@ -21,6 +21,7 @@ class FakeEnabledFeatureConfig(
     private val webviewQueryCapture: Boolean = base.isWebViewBreadcrumbQueryParamCaptureEnabled(),
     private val fcmPiiCapture: Boolean = base.isFcmPiiDataCaptureEnabled(),
     private val requestContentLengthCapture: Boolean = base.isRequestContentLengthCaptureEnabled(),
+    private val okHttpResponseBodySizeCapture: Boolean = base.isOkHttpResponseBodySizeCaptureEnabled(),
     private val httpUrlConnectionCapture: Boolean = base.isHttpUrlConnectionCaptureEnabled(),
     /**
      * Disable [hucLiteInstrumentation] by default so integration tests don't attempt to load this which will cause an error
@@ -51,6 +52,7 @@ class FakeEnabledFeatureConfig(
     override fun isWebViewBreadcrumbQueryParamCaptureEnabled(): Boolean = webviewQueryCapture
     override fun isFcmPiiDataCaptureEnabled(): Boolean = fcmPiiCapture
     override fun isRequestContentLengthCaptureEnabled(): Boolean = requestContentLengthCapture
+    override fun isOkHttpResponseBodySizeCaptureEnabled(): Boolean = okHttpResponseBodySizeCapture
     override fun isHttpUrlConnectionCaptureEnabled(): Boolean = httpUrlConnectionCapture
     override fun isHucLiteInstrumentationEnabled(): Boolean = hucLiteInstrumentation
     override fun isNetworkSpanForwardingEnabled(): Boolean = networkSpanForwarding

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehavior.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehavior.kt
@@ -11,6 +11,13 @@ interface NetworkBehavior {
     fun isRequestContentLengthCaptureEnabled(): Boolean
 
     /**
+     * Control whether the size of an OkHttp response body is captured when the response has no
+     * Content-Length header. Doing so requires buffering the whole body into memory, so it is
+     * disabled by default to avoid excessive heap usage on large/streaming responses.
+     */
+    fun isOkHttpResponseBodySizeCaptureEnabled(): Boolean
+
+    /**
      * Enable the native monitoring.
      */
     fun isHttpUrlConnectionCaptureEnabled(): Boolean

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehaviorImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/NetworkBehaviorImpl.kt
@@ -37,6 +37,9 @@ class NetworkBehaviorImpl(
     override fun isRequestContentLengthCaptureEnabled(): Boolean =
         local.enabledFeatures.isRequestContentLengthCaptureEnabled()
 
+    override fun isOkHttpResponseBodySizeCaptureEnabled(): Boolean =
+        local.enabledFeatures.isOkHttpResponseBodySizeCaptureEnabled()
+
     override fun isHttpUrlConnectionCaptureEnabled(): Boolean =
         local.enabledFeatures.isHttpUrlConnectionCaptureEnabled()
 

--- a/embrace-android-instrumentation-okhttp/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpDataSource.kt
+++ b/embrace-android-instrumentation-okhttp/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpDataSource.kt
@@ -157,14 +157,14 @@ internal class OkHttpDataSource(
         // A response has been obtained, so instrumentation must not alter the app-visible result of the
         // request from here on: contain any failure and always release the call's tracking entry
         try {
-            // Get the size of the body from the response header if possible
-            // Failing that, try to count the bytes in the body itself
-            // If neither works, set the content length to 0
+            // Get the size of the body from the response header if possible.
+            // Failing that, and only when explicitly opted-in, count the bytes in the body itself.
+            // Reading the body buffers it entirely into memory, so it is gated behind config to avoid
+            // excessive heap usage / OOM on large or streaming responses.
+            // If neither works, set the content length to 0.
             val contentLength: Long = getContentLengthFromHeader(networkResponse)
-                ?: getContentLengthFromBody(
-                    networkResponse = networkResponse,
-                    contentType = networkResponse.header(CONTENT_TYPE_HEADER_NAME, null),
-                ) ?: 0L
+                ?: getContentLengthFromBodyIfEnabled(networkResponse)
+                ?: 0L
 
             val requestEndData = createRequestEndData(request, networkResponse, callData, contentLength)
             networkRequestDataSource?.endRequest(requestEndData)
@@ -273,6 +273,19 @@ internal class OkHttpDataSource(
             }
         }
         return contentLength
+    }
+
+    /**
+     * Measures the response body size by reading it if enabled.
+     */
+    private fun getContentLengthFromBodyIfEnabled(networkResponse: Response): Long? {
+        if (!configService.networkBehavior.isOkHttpResponseBodySizeCaptureEnabled()) {
+            return null
+        }
+        return getContentLengthFromBody(
+            networkResponse = networkResponse,
+            contentType = networkResponse.header(CONTENT_TYPE_HEADER_NAME, null),
+        )
     }
 
     private fun getContentLengthFromBody(networkResponse: Response, contentType: String?): Long? {

--- a/embrace-android-instrumentation-okhttp/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpDataSourceTest.kt
+++ b/embrace-android-instrumentation-okhttp/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/okhttp/OkHttpDataSourceTest.kt
@@ -116,21 +116,8 @@ internal class OkHttpDataSourceTest {
         networkRequestDataSource = RecordingNetworkRequestDataSource(NetworkRequestDataSourceImpl(args))
         val networkCaptureDataSource = NetworkCaptureDataSourceImpl(args)
 
-        configService.apply {
-            networkBehavior = FakeNetworkBehavior(
-                rules = setOf(
-                    NetworkCaptureRuleRemoteConfig(
-                        id = "1",
-                        method = "POST",
-                        duration = 0,
-                        urlRegex = "^.*$",
-                        expiresIn = 60000,
-                        statusCodes = setOf(200, 500),
-                    ),
-                ),
-            )
-            networkSpanForwardingBehavior = FakeNetworkSpanForwardingBehavior()
-        }
+        configureNetworkBehavior(okHttpResponseBodySizeCaptureEnabled = false)
+        configService.networkSpanForwardingBehavior = FakeNetworkSpanForwardingBehavior()
 
         val dataSource = OkHttpDataSource(
             args = args,
@@ -183,6 +170,22 @@ internal class OkHttpDataSourceTest {
     @After
     fun teardown() {
         server.shutdown()
+    }
+
+    private fun configureNetworkBehavior(okHttpResponseBodySizeCaptureEnabled: Boolean) {
+        configService.networkBehavior = FakeNetworkBehavior(
+            okHttpResponseBodySizeCaptureEnabled = okHttpResponseBodySizeCaptureEnabled,
+            rules = setOf(
+                NetworkCaptureRuleRemoteConfig(
+                    id = "1",
+                    method = "POST",
+                    duration = 0,
+                    urlRegex = "^.*$",
+                    expiresIn = 60000,
+                    statusCodes = setOf(200, 500),
+                ),
+            ),
+        )
     }
 
     @Test
@@ -290,6 +293,7 @@ internal class OkHttpDataSourceTest {
 
     @Test
     fun `check network interceptor can handle compressed response without content-length parameter`() {
+        configureNetworkBehavior(okHttpResponseBodySizeCaptureEnabled = true)
         postNetworkInterceptorAfterResponseSupplier = ::removeContentLengthFromResponse
         preNetworkInterceptorAfterResponseSupplier = ::consumeBody
         server.enqueue(createBaseMockResponse().setGzipBody(RESPONSE_BODY))
@@ -298,10 +302,21 @@ internal class OkHttpDataSourceTest {
 
     @Test
     fun `check network interceptor can handle uncompressed response without content-length parameter`() {
+        configureNetworkBehavior(okHttpResponseBodySizeCaptureEnabled = true)
         postNetworkInterceptorAfterResponseSupplier = ::removeContentLengthFromResponse
         preNetworkInterceptorAfterResponseSupplier = ::consumeBody
         server.enqueue(createBaseMockResponse().setBody(RESPONSE_BODY))
         runAndValidatePostRequest(RESPONSE_BODY_SIZE)
+    }
+
+    @Test
+    fun `response body is not read to measure its size when capture is disabled and content-length is absent`() {
+        // Body-size capture is disabled by default, so a response without a Content-Length header must
+        // not be buffered to measure it: the size is reported as unknown (0).
+        postNetworkInterceptorAfterResponseSupplier = ::removeContentLengthFromResponse
+        preNetworkInterceptorAfterResponseSupplier = ::consumeBody
+        server.enqueue(createBaseMockResponse().setBody(RESPONSE_BODY))
+        runAndValidateGetRequest(0)
     }
 
     @Test

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
@@ -118,6 +118,16 @@ interface EnabledFeatureConfig {
     fun isRequestContentLengthCaptureEnabled(): Boolean = false
 
     /**
+     * Gates whether the size of an OkHttp response body is captured when the response has no
+     * Content-Length header. Determining the size in that case requires buffering the entire body
+     * into memory, which can cause excessive heap usage or OOM for large/streaming responses, so
+     * this is disabled by default.
+     *
+     * sdk_config.networking.capture_okhttp_response_body_size
+     */
+    fun isOkHttpResponseBodySizeCaptureEnabled(): Boolean = false
+
+    /**
      * Gates whether HttpUrlConnection network requests should be captured
      *
      * sdk_config.networking.enable_native_monitoring

--- a/embrace-config-schema.json
+++ b/embrace-config-schema.json
@@ -147,6 +147,11 @@
               "default": true,
               "type": "boolean"
             },
+            "capture_okhttp_response_body_size": {
+              "description": "Enable capture of an OkHttp response body's size when it has no Content-Length header. This buffers the whole body into memory so is disabled by default to avoid excessive heap usage on large or streaming responses.",
+              "default": false,
+              "type": "boolean"
+            },
             "disabled_url_patterns": {
               "description": "Specify one or more regular expressions to exclude network request with URLs matching one of the regular expressions from being captured.",
               "type": "array",

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/EnabledFeatureConfigInstrumentation.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/EnabledFeatureConfigInstrumentation.kt
@@ -24,6 +24,7 @@ fun createEnabledFeatureConfigInstrumentation(cfg: VariantConfig) = modelSdkConf
         boolMethod("isWebViewBreadcrumbQueryParamCaptureEnabled") { webViewConfig?.captureQueryParams }
         boolMethod("isFcmPiiDataCaptureEnabled") { captureFcmPiiData }
         boolMethod("isRequestContentLengthCaptureEnabled") { networking?.captureRequestContentLength }
+        boolMethod("isOkHttpResponseBodySizeCaptureEnabled") { networking?.captureOkHttpResponseBodySize }
         boolMethod("isHttpUrlConnectionCaptureEnabled") { networking?.enableNativeMonitoring }
         boolMethod("isHucLiteInstrumentationEnabled") { networking?.enableHucLiteInstrumentation }
         boolMethod("isNetworkSpanForwardingEnabled") { networking?.enableNetworkSpanForwarding }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/NetworkLocalConfig.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/NetworkLocalConfig.kt
@@ -22,6 +22,9 @@ data class NetworkLocalConfig(
     @Json(name = "capture_request_content_length")
     val captureRequestContentLength: Boolean? = null,
 
+    @Json(name = "capture_okhttp_response_body_size")
+    val captureOkHttpResponseBodySize: Boolean? = null,
+
     @Json(name = "disabled_url_patterns")
     val disabledUrlPatterns: List<String>? = null,
 

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/EnabledFeatureConfigInstrumentationKtTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/EnabledFeatureConfigInstrumentationKtTest.kt
@@ -44,6 +44,7 @@ class EnabledFeatureConfigInstrumentationKtTest {
         ConfigMethod("isWebViewBreadcrumbQueryParamCaptureEnabled", "()Z", true),
         ConfigMethod("isFcmPiiDataCaptureEnabled", "()Z", true),
         ConfigMethod("isRequestContentLengthCaptureEnabled", "()Z", true),
+        ConfigMethod("isOkHttpResponseBodySizeCaptureEnabled", "()Z", true),
         ConfigMethod("isHttpUrlConnectionCaptureEnabled", "()Z", true),
         ConfigMethod("isHucLiteInstrumentationEnabled", "()Z", true),
         ConfigMethod("isNetworkSpanForwardingEnabled", "()Z", true),
@@ -103,6 +104,7 @@ class EnabledFeatureConfigInstrumentationKtTest {
                         ),
                         networking = NetworkLocalConfig(
                             captureRequestContentLength = true,
+                            captureOkHttpResponseBodySize = true,
                             enableNativeMonitoring = true,
                             enableHucLiteInstrumentation = true,
                             enableNetworkSpanForwarding = true,


### PR DESCRIPTION
## Goal

Avoid capturing content length in OkHttp requests that have no explicit Content-Length header. I've created a local config flag `sdk_config.networking.capture_okhttp_response_body_size` that allows opting into this behaviour. This runs a risk of memory exhaustion for the current instrumentation & making this alteration better matches what HttpUrlConnection instrumentation does.

## Testing

Added unit tests.
