### PR TITLE
Small improvement in HTTP instrumentation overheads

### DIFF
--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/MapExtensions.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/MapExtensions.kt
@@ -8,3 +8,13 @@ package io.embrace.android.embracesdk.internal.utils
 fun <K, V> Map<K, V?>.toNonNullMap(): Map<K, V> {
     return filter { it.value != null } as Map<K, V>
 }
+
+/**
+ * Adds the given entry to the map if the value is not null. This allows a map of non-null values to
+ * be built directly from nullable sources, without allocating intermediate maps to filter them out.
+ */
+fun <K, V> MutableMap<K, V>.putIfNotNull(key: K, value: V?) {
+    if (value != null) {
+        put(key, value)
+    }
+}

--- a/embrace-android-instrumentation-huc-lite/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/HucLiteDataSource.kt
+++ b/embrace-android-instrumentation-huc-lite/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/HucLiteDataSource.kt
@@ -14,11 +14,11 @@ import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.instrumentation.network.getOverriddenURLString
+import io.embrace.android.embracesdk.internal.instrumentation.network.toStatusCodeString
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.telemetry.AppliedLimitType
 import io.embrace.android.embracesdk.internal.utils.NetworkUtils
-import io.embrace.android.embracesdk.internal.utils.toNonNullMap
 import io.opentelemetry.kotlin.semconv.ErrorAttributes
 import io.opentelemetry.kotlin.semconv.ExceptionAttributes
 import io.opentelemetry.kotlin.semconv.HttpAttributes
@@ -212,27 +212,27 @@ class HucLiteDataSource(
             url: String,
             httpMethod: String,
             responseCode: Int,
-        ): Map<String, String> = mapOf(
-            UrlAttributes.URL_FULL to url,
-            HttpAttributes.HTTP_REQUEST_METHOD to httpMethod,
-            HttpAttributes.HTTP_RESPONSE_STATUS_CODE to responseCode,
-            UserAgentAttributes.USER_AGENT_NAME to HUC_USER_AGENT_NAME,
-            UserAgentAttributes.USER_AGENT_VERSION to Build.VERSION.SDK_INT.toString(),
-        ).toNonNullMap().mapValues { it.value.toString() }
+        ): Map<String, String> = buildMap {
+            put(UrlAttributes.URL_FULL, url)
+            put(HttpAttributes.HTTP_REQUEST_METHOD, httpMethod)
+            put(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, responseCode.toStatusCodeString())
+            put(UserAgentAttributes.USER_AGENT_NAME, HUC_USER_AGENT_NAME)
+            put(UserAgentAttributes.USER_AGENT_VERSION, Build.VERSION.SDK_INT.toString())
+        }
 
         private fun incompleteRequestAttributes(
             url: String,
             httpMethod: String,
             errorType: String,
             errorMessage: String,
-        ): Map<String, String> = mapOf(
-            UrlAttributes.URL_FULL to url,
-            HttpAttributes.HTTP_REQUEST_METHOD to httpMethod,
-            ErrorAttributes.ERROR_TYPE to errorType,
-            ExceptionAttributes.EXCEPTION_MESSAGE to errorMessage,
-            UserAgentAttributes.USER_AGENT_NAME to HUC_USER_AGENT_NAME,
-            UserAgentAttributes.USER_AGENT_VERSION to Build.VERSION.SDK_INT.toString(),
-        ).toNonNullMap().mapValues { it.value }
+        ): Map<String, String> = buildMap {
+            put(UrlAttributes.URL_FULL, url)
+            put(HttpAttributes.HTTP_REQUEST_METHOD, httpMethod)
+            put(ErrorAttributes.ERROR_TYPE, errorType)
+            put(ExceptionAttributes.EXCEPTION_MESSAGE, errorMessage)
+            put(UserAgentAttributes.USER_AGENT_NAME, HUC_USER_AGENT_NAME)
+            put(UserAgentAttributes.USER_AGENT_VERSION, Build.VERSION.SDK_INT.toString())
+        }
 
         private fun getValidStartTime(): Long =
             if (startTimeMs.get() == INVALID_START_TIME) {

--- a/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceImpl.kt
+++ b/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceImpl.kt
@@ -13,7 +13,7 @@ import io.embrace.android.embracesdk.internal.utils.NetworkUtils.getDomain
 import io.embrace.android.embracesdk.internal.utils.NetworkUtils.getUrlPath
 import io.embrace.android.embracesdk.internal.utils.NetworkUtils.getValidTraceId
 import io.embrace.android.embracesdk.internal.utils.NetworkUtils.stripUrl
-import io.embrace.android.embracesdk.internal.utils.toNonNullMap
+import io.embrace.android.embracesdk.internal.utils.putIfNotNull
 import io.embrace.android.embracesdk.semconv.EmbNetworkRequestAttributes
 import io.opentelemetry.kotlin.semconv.ErrorAttributes
 import io.opentelemetry.kotlin.semconv.ExceptionAttributes
@@ -127,35 +127,37 @@ class NetworkRequestDataSourceImpl(
         activeRequests.remove(id)
     }
 
-    private fun generateSchemaAttributes(request: HttpNetworkRequest): Map<String, String> = mapOf(
-        UrlAttributes.URL_FULL to stripUrl(request.url),
-        HttpAttributes.HTTP_REQUEST_METHOD to request.httpMethod,
-        HttpAttributes.HTTP_RESPONSE_STATUS_CODE to request.statusCode,
-        HttpAttributes.HTTP_REQUEST_BODY_SIZE to request.bytesSent,
-        HttpAttributes.HTTP_RESPONSE_BODY_SIZE to request.bytesReceived,
-        ErrorAttributes.ERROR_TYPE to request.errorType,
-        ExceptionAttributes.EXCEPTION_MESSAGE to request.errorMessage,
-        EmbNetworkRequestAttributes.EMB_W3C_TRACEPARENT to request.w3cTraceparent,
-        EmbNetworkRequestAttributes.EMB_FORWARD_TELEMETRY to request.w3cTraceparent?.let { "true" },
-        EmbNetworkRequestAttributes.EMB_TRACE_ID to getValidTraceId(request.traceId),
-    ).toNonNullMap().mapValues { it.value.toString() }
+    private fun generateSchemaAttributes(request: HttpNetworkRequest): Map<String, String> = buildMap {
+        put(UrlAttributes.URL_FULL, stripUrl(request.url))
+        put(HttpAttributes.HTTP_REQUEST_METHOD, request.httpMethod)
+        putIfNotNull(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, request.statusCode?.toStatusCodeString())
+        putIfNotNull(HttpAttributes.HTTP_REQUEST_BODY_SIZE, request.bytesSent?.toString())
+        putIfNotNull(HttpAttributes.HTTP_RESPONSE_BODY_SIZE, request.bytesReceived?.toString())
+        putIfNotNull(ErrorAttributes.ERROR_TYPE, request.errorType)
+        putIfNotNull(ExceptionAttributes.EXCEPTION_MESSAGE, request.errorMessage)
+        request.w3cTraceparent?.let { traceparent ->
+            put(EmbNetworkRequestAttributes.EMB_W3C_TRACEPARENT, traceparent)
+            put(EmbNetworkRequestAttributes.EMB_FORWARD_TELEMETRY, "true")
+        }
+        putIfNotNull(EmbNetworkRequestAttributes.EMB_TRACE_ID, getValidTraceId(request.traceId))
+    }
 
-    private fun requestStartAttributes(startData: RequestStartData): Map<String, String> = mapOf(
-        UrlAttributes.URL_FULL to stripUrl(startData.url),
-        HttpAttributes.HTTP_REQUEST_METHOD to startData.httpMethod,
-    ).toNonNullMap().mapValues { it.value }
+    private fun requestStartAttributes(startData: RequestStartData): Map<String, String> = buildMap {
+        put(UrlAttributes.URL_FULL, stripUrl(startData.url))
+        put(HttpAttributes.HTTP_REQUEST_METHOD, startData.httpMethod)
+    }
 
-    private fun requestEndAttributes(endData: RequestEndData): Map<String, String> = mapOf(
-        UrlAttributes.URL_FULL to stripUrl(endData.url),
-        HttpAttributes.HTTP_RESPONSE_STATUS_CODE to endData.statusCode,
-        HttpAttributes.HTTP_REQUEST_BODY_SIZE to endData.bytesSent,
-        HttpAttributes.HTTP_RESPONSE_BODY_SIZE to endData.bytesReceived,
-        ErrorAttributes.ERROR_TYPE to endData.errorType,
-        ExceptionAttributes.EXCEPTION_MESSAGE to endData.errorMessage,
-        UserAgentAttributes.USER_AGENT_NAME to endData.userAgentName,
-        UserAgentAttributes.USER_AGENT_VERSION to endData.userAgentVersion,
-        EmbNetworkRequestAttributes.EMB_TRACE_ID to getValidTraceId(endData.traceId),
-    ).toNonNullMap().mapValues { it.value.toString() }
+    private fun requestEndAttributes(endData: RequestEndData): Map<String, String> = buildMap {
+        put(UrlAttributes.URL_FULL, stripUrl(endData.url))
+        putIfNotNull(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, endData.statusCode?.toStatusCodeString())
+        putIfNotNull(HttpAttributes.HTTP_REQUEST_BODY_SIZE, endData.bytesSent?.toString())
+        putIfNotNull(HttpAttributes.HTTP_RESPONSE_BODY_SIZE, endData.bytesReceived?.toString())
+        putIfNotNull(ErrorAttributes.ERROR_TYPE, endData.errorType)
+        putIfNotNull(ExceptionAttributes.EXCEPTION_MESSAGE, endData.errorMessage)
+        putIfNotNull(UserAgentAttributes.USER_AGENT_NAME, endData.userAgentName)
+        putIfNotNull(UserAgentAttributes.USER_AGENT_VERSION, endData.userAgentVersion)
+        putIfNotNull(EmbNetworkRequestAttributes.EMB_TRACE_ID, getValidTraceId(endData.traceId))
+    }
 
     private fun getNetworkSpanName(httpMethod: String, url: String) = "$httpMethod ${getUrlPath(stripUrl(url))}"
 
@@ -163,6 +165,27 @@ class NetworkRequestDataSourceImpl(
      * Returns the span-id of this string if it is a valid W3C traceparent, or null if it is not.
      */
     private fun String.getSpanIdFromTraceparent(): String? = SPAN_ID_FROM_TRACEPARENT_REGEX.matchEntire(this)?.groupValues?.get(1)
+
+    /**
+     * Returns an interned string for the status codes an app is most likely to see, avoiding an
+     * allocation for the common cases. Anything else falls back to [toString].
+     *
+     * Redirects are deliberately absent: HTTP clients follow them by default, so the code that gets
+     * recorded here is the one the destination returned.
+     */
+    private fun Int.toStatusCodeString(): String = when (this) {
+        200 -> "200"
+        201 -> "201"
+        204 -> "204"
+        304 -> "304"
+        400 -> "400"
+        401 -> "401"
+        403 -> "403"
+        404 -> "404"
+        500 -> "500"
+        503 -> "503"
+        else -> toString()
+    }
 
     private companion object {
         // version(2)-traceId(32)-spanId(16)-flags(2), lowercase hex per the W3C traceparent spec.

--- a/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceImpl.kt
+++ b/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkRequestDataSourceImpl.kt
@@ -166,27 +166,6 @@ class NetworkRequestDataSourceImpl(
      */
     private fun String.getSpanIdFromTraceparent(): String? = SPAN_ID_FROM_TRACEPARENT_REGEX.matchEntire(this)?.groupValues?.get(1)
 
-    /**
-     * Returns an interned string for the status codes an app is most likely to see, avoiding an
-     * allocation for the common cases. Anything else falls back to [toString].
-     *
-     * Redirects are deliberately absent: HTTP clients follow them by default, so the code that gets
-     * recorded here is the one the destination returned.
-     */
-    private fun Int.toStatusCodeString(): String = when (this) {
-        200 -> "200"
-        201 -> "201"
-        204 -> "204"
-        304 -> "304"
-        400 -> "400"
-        401 -> "401"
-        403 -> "403"
-        404 -> "404"
-        500 -> "500"
-        503 -> "503"
-        else -> toString()
-    }
-
     private companion object {
         // version(2)-traceId(32)-spanId(16)-flags(2), lowercase hex per the W3C traceparent spec.
         private val SPAN_ID_FROM_TRACEPARENT_REGEX = Regex("[0-9a-f]{2}-[0-9a-f]{32}-([0-9a-f]{16})-[0-9a-f]{2}")

--- a/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/StatusCodes.kt
+++ b/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/StatusCodes.kt
@@ -1,0 +1,22 @@
+package io.embrace.android.embracesdk.internal.instrumentation.network
+
+/**
+ * Returns an interned string for the status codes an app is most likely to see, avoiding an
+ * allocation for the common cases. Anything else falls back to [toString].
+ *
+ * Redirects are deliberately absent: HTTP clients follow them by default, so the code that gets
+ * recorded here is the one the destination returned.
+ */
+fun Int.toStatusCodeString(): String = when (this) {
+    200 -> "200"
+    201 -> "201"
+    204 -> "204"
+    304 -> "304"
+    400 -> "400"
+    401 -> "401"
+    403 -> "403"
+    404 -> "404"
+    500 -> "500"
+    503 -> "503"
+    else -> toString()
+}


### PR DESCRIPTION
## Goal
By adding a `MutableMap.putIfNotNull` extension the HTTP instrumentation modules can reasonably use `buildMap` instead of the chain of `mapOf().toNonNullMap().mapValues {}` reducing the number of allocations in the attribute map construction.

This PR also interns some of the most common HTTP status codes via a `toStatusCodeString()` function so that we don't create fresh strings for the most common status codes.

## Testing
Relied on existing tests.