### PR TITLE
Optimize span implementation

### DIFF
--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImpl.kt
@@ -16,7 +16,6 @@ import io.embrace.android.embracesdk.internal.payload.Link
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.internal.telemetry.AppliedLimitType
 import io.embrace.android.embracesdk.internal.telemetry.TelemetryService
-import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.android.embracesdk.internal.utils.truncatedStacktraceText
 import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
@@ -107,8 +106,8 @@ private class EmbraceSpanImpl(
 
     private val systemEvents = ConcurrentLinkedQueue<EmbraceSpanEvent>()
     private val customEvents = ConcurrentLinkedQueue<EmbraceSpanEvent>()
-    private val systemAttributes = ConcurrentHashMap<String, String>().apply {
-        putAll(otelSpanStartArgs.embraceAttributes.associate { it.key to it.value })
+    private val systemAttributes = ConcurrentHashMap<String, String>(otelSpanStartArgs.embraceAttributes.size).apply {
+        otelSpanStartArgs.embraceAttributes.forEach { put(it.key, it.value) }
     }
     private val customAttributes = ConcurrentHashMap<String, String>()
     private val systemLinks = ConcurrentLinkedQueue<EmbraceLinkData>()
@@ -138,78 +137,70 @@ private class EmbraceSpanImpl(
         get() = startedSpan.get()?.isRecording() == true
 
     override fun start(startTimeMs: Long?): Boolean {
-        EmbTrace.trace("span-start") {
-            if (spanStarted()) {
+        if (spanStarted()) {
+            return false
+        }
+
+        val attemptedStartTimeMs =
+            (startTimeMs?.normalizeTimestampAsMillis() ?: spanStartTimeMs)?.takeIf { it > 0 }
+                ?: openTelemetryClock.now().nanosToMillis()
+
+        synchronized(startedSpan) {
+            val args = startArgs ?: return false
+            val newSpan = args.startSpan(attemptedStartTimeMs)
+            if (newSpan.isRecording()) {
+                startedSpan.set(newSpan)
+                startArgs = null
+            } else {
                 return false
             }
 
-            val attemptedStartTimeMs =
-                (startTimeMs?.normalizeTimestampAsMillis() ?: spanStartTimeMs)?.takeIf { it > 0 }
-                    ?: openTelemetryClock.now().nanosToMillis()
+            spanRepository.trackStartedEmbraceSpan(this)
+            newSpan.setName(spanName)
 
-            synchronized(startedSpan) {
-                val args = startArgs ?: return false
-                val newSpan = EmbTrace.trace("otel-span-start") {
-                    args.startSpan(attemptedStartTimeMs)
-                }
-                if (newSpan.isRecording()) {
-                    startedSpan.set(newSpan)
-                    startArgs = null
-                } else {
-                    return false
-                }
-
-                spanRepository.trackStartedEmbraceSpan(this)
-                newSpan.setName(spanName)
-
-                spanStartTimeMs = attemptedStartTimeMs
-                spanRepository.notifySpanUpdate()
-            }
-
-            return true
+            spanStartTimeMs = attemptedStartTimeMs
+            spanRepository.notifySpanUpdate()
         }
+
+        return true
     }
 
     override fun stop(errorCode: ErrorCode?, endTimeMs: Long?): Boolean {
-        EmbTrace.trace("span-stop") {
+        if (!isRecording) {
+            return false
+        }
+        var successful = false
+        val attemptedEndTimeMs = endTimeMs?.normalizeTimestampAsMillis() ?: openTelemetryClock.now().nanosToMillis()
+
+        synchronized(startedSpan) {
             if (!isRecording) {
                 return false
             }
-            var successful = false
-            val attemptedEndTimeMs = endTimeMs?.normalizeTimestampAsMillis() ?: openTelemetryClock.now().nanosToMillis()
 
-            synchronized(startedSpan) {
-                if (!isRecording) {
-                    return false
+            startedSpan.get()?.let { spanToStop ->
+                spanId?.let { stopCallback?.invoke(it) }
+                if (errorCode != null) {
+                    status = StatusData.Error(null)
+                    spanToStop.setEmbraceAttribute(errorCode.toEmbraceErrorCode())
+                } else if (status is StatusData.Error) {
+                    spanToStop.setEmbraceAttribute(ErrorCodeAttribute.Failure)
                 }
 
-                startedSpan.get()?.let { spanToStop ->
-                    spanId?.let { stopCallback?.invoke(it) }
-                    if (errorCode != null) {
-                        status = StatusData.Error(null)
-                        spanToStop.setEmbraceAttribute(errorCode.toEmbraceErrorCode())
-                    } else if (status is StatusData.Error) {
-                        spanToStop.setEmbraceAttribute(ErrorCodeAttribute.Failure)
-                    }
+                populateAttributes(spanToStop)
+                populateEvents(spanToStop)
+                populateLinks(spanToStop)
 
-                    populateAttributes(spanToStop)
-                    populateEvents(spanToStop)
-                    populateLinks(spanToStop)
+                spanToStop.end(attemptedEndTimeMs.millisToNanos())
 
-                    EmbTrace.trace("otel-span-end") {
-                        spanToStop.end(attemptedEndTimeMs.millisToNanos())
-                    }
-
-                    successful = !isRecording
-                    if (successful) {
-                        spanEndTimeMs = attemptedEndTimeMs
-                        spanRepository.notifySpanUpdate()
-                    }
+                successful = !isRecording
+                if (successful) {
+                    spanEndTimeMs = attemptedEndTimeMs
+                    spanRepository.notifySpanUpdate()
                 }
             }
-
-            return successful
         }
+
+        return successful
     }
 
     private fun ErrorCode.toEmbraceErrorCode(): ErrorCodeAttribute = when (this) {

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImpl.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.internal.otel.spans
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.otel.sdk.DataValidator
-import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.android.embracesdk.spans.AutoTerminationMode
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
@@ -43,39 +42,35 @@ class SpanServiceImpl(
         private: Boolean,
         autoTerminationMode: AutoTerminationMode,
     ): EmbraceSdkSpan {
-        EmbTrace.trace("span-create") {
-            return if (name.isNotBlank() && canStartNewSpan(parent, internal)) {
-                embraceSpanFactory.create(
-                    OtelSpanStartArgs(
-                        name = dataValidator.truncateName(name, internal),
-                        type = type,
-                        internal = internal,
-                        private = private,
-                        tracer = tracer,
-                        autoTerminationMode = autoTerminationMode,
-                        parentCtx = (parent as? EmbraceSdkSpan)?.createContext(openTelemetry),
-                        openTelemetry = openTelemetry,
-                    ),
-                )
-            } else {
-                NoopEmbraceSdkSpan
-            }
+        return if (name.isNotBlank() && canStartNewSpan(parent, internal)) {
+            embraceSpanFactory.create(
+                OtelSpanStartArgs(
+                    name = dataValidator.truncateName(name, internal),
+                    type = type,
+                    internal = internal,
+                    private = private,
+                    tracer = tracer,
+                    autoTerminationMode = autoTerminationMode,
+                    parentCtx = (parent as? EmbraceSdkSpan)?.createContext(openTelemetry),
+                    openTelemetry = openTelemetry,
+                ),
+            )
+        } else {
+            NoopEmbraceSdkSpan
         }
     }
 
     override fun createSpan(otelSpanStartArgs: OtelSpanStartArgs): EmbraceSdkSpan {
-        EmbTrace.trace("span-create") {
-            return if (
-                otelSpanStartArgs.initialSpanName.isNotBlank() &&
-                canStartNewSpan(
-                    otelSpanStartArgs.parentContext.getEmbraceSpan(openTelemetry),
-                    otelSpanStartArgs.internal,
-                )
-            ) {
-                embraceSpanFactory.create(otelSpanStartArgs)
-            } else {
-                NoopEmbraceSdkSpan
-            }
+        return if (
+            otelSpanStartArgs.initialSpanName.isNotBlank() &&
+            canStartNewSpan(
+                otelSpanStartArgs.parentContext.getEmbraceSpan(openTelemetry),
+                otelSpanStartArgs.internal,
+            )
+        ) {
+            embraceSpanFactory.create(otelSpanStartArgs)
+        } else {
+            NoopEmbraceSdkSpan
         }
     }
 
@@ -135,40 +130,38 @@ class SpanServiceImpl(
         events: List<EmbraceSpanEvent>,
         errorCode: ErrorCode?,
     ): Boolean {
-        EmbTrace.trace("span-completed") {
-            if (startTimeMs > endTimeMs) {
-                return false
-            }
-
-            val validName = dataValidator.truncateName(name, internal)
-            val validEvents = dataValidator.truncateEvents(events, internal)
-            val validAttributes = dataValidator.truncateAttributes(attributes, internal)
-
-            if (canStartNewSpan(parent, internal)) {
-                val newSpan = embraceSpanFactory.create(
-                    OtelSpanStartArgs(
-                        name = validName,
-                        type = type,
-                        internal = internal,
-                        private = private,
-                        tracer = tracer,
-                        parentCtx = (parent as? EmbraceSdkSpan)?.createContext(openTelemetry),
-                        openTelemetry = openTelemetry,
-                    ),
-                )
-                if (newSpan.start(startTimeMs)) {
-                    validAttributes.forEach {
-                        newSpan.addAttribute(it.key, it.value)
-                    }
-                    validEvents.forEach {
-                        newSpan.addEvent(it.name, it.timestampNanos.nanosToMillis(), it.attributes)
-                    }
-                    return newSpan.stop(errorCode, endTimeMs)
-                }
-            }
-
+        if (startTimeMs > endTimeMs) {
             return false
         }
+
+        val validName = dataValidator.truncateName(name, internal)
+        val validEvents = dataValidator.truncateEvents(events, internal)
+        val validAttributes = dataValidator.truncateAttributes(attributes, internal)
+
+        if (canStartNewSpan(parent, internal)) {
+            val newSpan = embraceSpanFactory.create(
+                OtelSpanStartArgs(
+                    name = validName,
+                    type = type,
+                    internal = internal,
+                    private = private,
+                    tracer = tracer,
+                    parentCtx = (parent as? EmbraceSdkSpan)?.createContext(openTelemetry),
+                    openTelemetry = openTelemetry,
+                ),
+            )
+            if (newSpan.start(startTimeMs)) {
+                validAttributes.forEach {
+                    newSpan.addAttribute(it.key, it.value)
+                }
+                validEvents.forEach {
+                    newSpan.addEvent(it.name, it.timestampNanos.nanosToMillis(), it.attributes)
+                }
+                return newSpan.stop(errorCode, endTimeMs)
+            }
+        }
+
+        return false
     }
 
     override fun getSpan(spanId: String): EmbraceSpan? = spanRepository.getEmbraceSpan(spanId = spanId)


### PR DESCRIPTION
## Goal

Optimizes allocations when creating spans by removing one map allocation, and removing `EmbTrace` calls on the hot path that instantiated string keys.
