### PR TITLE
Remove cyclic refs in `WeakHashMap<Window, *>`

### DIFF
--- a/embrace-android-instrumentation-compose-tap/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/ComposeActivityListener.kt
+++ b/embrace-android-instrumentation-compose-tap/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/compose/tap/ComposeActivityListener.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.GestureDetector
 import android.view.Window
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
+import java.util.Collections
 import java.util.WeakHashMap
 
 internal class ComposeActivityListener(
@@ -13,22 +14,23 @@ internal class ComposeActivityListener(
     private val dataSource: ComposeTapDataSource,
 ) : ActivityLifecycleCallbacks {
 
-    private val windowCallbacks = WeakHashMap<Window, EmbraceWindowCallback>()
+    /**
+     * Windows that already have an [EmbraceWindowCallback] installed so that we don't attempt to double-install our `Callback` delegate.
+     */
+    private val windowCallbacks: MutableSet<Window> = Collections.newSetFromMap(WeakHashMap())
 
     override fun onActivityResumed(activity: Activity) {
         try {
             // Set EmbraceWindowCallback to install Embrace Gesture Listener to capture onClick events
             val window: Window = activity.window
-            if (!windowCallbacks.containsKey(window)) {
+            if (windowCallbacks.add(window)) {
                 val gestureListener = EmbraceGestureListener(activity, logger, dataSource)
                 val gestureDetectorCompat = GestureDetector(activity, gestureListener)
-                val callback = EmbraceWindowCallback(
+                window.callback = EmbraceWindowCallback(
                     window.callback,
                     gestureDetectorCompat,
                     logger,
                 )
-                window.callback = callback
-                windowCallbacks[window] = callback
             }
         } catch (e: Throwable) {
             logger.logError("Failed to register gesture listener", e)

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsActivityListener.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsActivityListener.kt
@@ -8,6 +8,7 @@ import android.os.Handler
 import android.os.SystemClock
 import android.view.Window
 import androidx.annotation.RequiresApi
+import java.util.Collections
 import java.util.WeakHashMap
 
 /**
@@ -25,7 +26,10 @@ internal class VitalsActivityListener(
 
     private val frameListeners = WeakHashMap<Window, VitalsFrameMetricsListener>()
 
-    private val interactionCallbacks = WeakHashMap<Window, VitalsWindowCallback>()
+    /**
+     * Windows that already have a [VitalsWindowCallback] installed so that we don't attempt to double-install our `Callback` delegate.
+     */
+    private val interactionCallbacks: MutableSet<Window> = Collections.newSetFromMap(WeakHashMap())
 
     override fun onActivityCreated(activity: Activity, bundle: Bundle?) {
         // captured first so the navigation-start timestamp reflects this event, not the delay until it's processed
@@ -61,15 +65,13 @@ internal class VitalsActivityListener(
     }
 
     private fun installInteractionCallback(window: Window) {
-        if (interactionCallbacks.containsKey(window)) {
+        if (!interactionCallbacks.add(window)) {
             return
         }
-        val callback = VitalsWindowCallback(
+        window.callback = VitalsWindowCallback(
             delegate = window.callback,
             focalCallbacks = focalCallbacks,
         )
-        window.callback = callback
-        interactionCallbacks[window] = callback
     }
 
     private fun installFrameMetricsListener(window: Window) {


### PR DESCRIPTION
## Goal
Replace the `WeakHashMap<Window, *>` in Vitals & Compose instrumentation with a weak hash set since the maps were only used as markers. This way `Window` references cannot be cyclic through these maps as they no longer have a right-hand-side reference.

## Testing
Tested with example app and debugger