### PR TITLE
Impose a vitals-specific span limit

### DIFF
--- a/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeVitalsBehavior.kt
+++ b/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeVitalsBehavior.kt
@@ -10,6 +10,7 @@ class FakeVitalsBehavior(
     var screenLoadTimeoutMsImpl: Long = 30_000L,
     var screenLoadNavTimeoutMsImpl: Long = 500L,
     var smoothnessFrameTraceEnabledImpl: Boolean = false,
+    var spanLimitImpl: Int = 250,
 ) : VitalsBehavior {
 
     override fun getSmoothnessIdleThresholdMs(): Long = smoothnessIdleThresholdMsImpl
@@ -19,4 +20,5 @@ class FakeVitalsBehavior(
     override fun getScreenLoadTimeoutMs(): Long = screenLoadTimeoutMsImpl
     override fun getScreenLoadNavTimeoutMs(): Long = screenLoadNavTimeoutMsImpl
     override fun isSmoothnessFrameTraceEnabled(): Boolean = smoothnessFrameTraceEnabledImpl
+    override fun getSpanLimit(): Int = spanLimitImpl
 }

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/VitalsBehavior.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/VitalsBehavior.kt
@@ -37,4 +37,11 @@ interface VitalsBehavior {
      * as a diagnostic aid while smoothness thresholds are being tuned.
      */
     fun isSmoothnessFrameTraceEnabled(): Boolean
+
+    /**
+     * The maximum number of vitals spans (smoothness and screen-load combined) that may be emitted per session
+     * part. Vitals emits a span per user gesture and per navigation, so this caps the share of the session's
+     * span budget that the feature can consume.
+     */
+    fun getSpanLimit(): Int
 }

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/VitalsBehaviorImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/VitalsBehaviorImpl.kt
@@ -18,6 +18,7 @@ class VitalsBehaviorImpl(
         private const val DEFAULT_SCREEN_LOAD_TIMEOUT_MS = 30_000L
         private const val DEFAULT_SCREEN_LOAD_NAV_TIMEOUT_MS = 500L
         private const val DEFAULT_SMOOTHNESS_FRAME_TRACE_ENABLED = false
+        private const val DEFAULT_SPAN_LIMIT = 250
     }
 
     private val remote = remote?.vitalsRemoteConfig
@@ -43,4 +44,7 @@ class VitalsBehaviorImpl(
     override fun isSmoothnessFrameTraceEnabled(): Boolean =
         thresholdCheck.isBehaviorEnabled(remote?.smoothnessFrameTracePctEnabled)
             ?: DEFAULT_SMOOTHNESS_FRAME_TRACE_ENABLED
+
+    override fun getSpanLimit(): Int =
+        remote?.spanLimit ?: DEFAULT_SPAN_LIMIT
 }

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/VitalsBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/VitalsBehaviorImplTest.kt
@@ -18,6 +18,7 @@ internal class VitalsBehaviorImplTest {
         screenLoadTimeoutMs = 45_000,
         screenLoadNavTimeoutMs = 750,
         smoothnessFrameTracePctEnabled = 100f,
+        spanLimit = 25,
     )
 
     @Test
@@ -30,6 +31,7 @@ internal class VitalsBehaviorImplTest {
             assertEquals(30_000L, getScreenLoadTimeoutMs())
             assertEquals(500L, getScreenLoadNavTimeoutMs())
             assertFalse(isSmoothnessFrameTraceEnabled())
+            assertEquals(250, getSpanLimit())
         }
     }
 
@@ -43,6 +45,7 @@ internal class VitalsBehaviorImplTest {
             assertEquals(45_000L, getScreenLoadTimeoutMs())
             assertEquals(750L, getScreenLoadNavTimeoutMs())
             assertTrue(isSmoothnessFrameTraceEnabled())
+            assertEquals(25, getSpanLimit())
         }
     }
 }

--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsDataSource.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsDataSource.kt
@@ -7,7 +7,7 @@ import android.view.Display
 import androidx.annotation.RequiresApi
 import io.embrace.android.embracesdk.internal.arch.InstrumentationArgs
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceImpl
-import io.embrace.android.embracesdk.internal.arch.limits.NoopLimitStrategy
+import io.embrace.android.embracesdk.internal.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.arch.state.AppStateListener
@@ -28,7 +28,9 @@ internal class VitalsDataSource(
     private val args: InstrumentationArgs,
 ) : DataSourceImpl(
     args = args,
-    limitStrategy = NoopLimitStrategy,
+    // Vitals emits a span per gesture and per navigation, so it needs a ceiling: an unlimited source would
+    // exhaust the session's shared internal-span budget and starve other instrumentation. Reset per session part.
+    limitStrategy = UpToLimitStrategy(args.configService.vitalsBehavior::getSpanLimit),
     instrumentationName = "vitals_data_source",
 ) {
 

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsDataSourceTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/VitalsDataSourceTest.kt
@@ -1,0 +1,79 @@
+package io.embrace.android.embracesdk.internal.vitals
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
+import io.embrace.android.embracesdk.fakes.FakeTelemetryService
+import io.embrace.android.embracesdk.fakes.behavior.FakeVitalsBehavior
+import io.embrace.android.embracesdk.internal.telemetry.AppliedLimitType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class VitalsDataSourceTest {
+
+    private val telemetryService = FakeTelemetryService()
+
+    private fun createDataSource(spanLimit: Int): Pair<VitalsDataSource, FakeInstrumentationArgs> {
+        val application: Application = ApplicationProvider.getApplicationContext()
+        val args = FakeInstrumentationArgs(application, telemetryService = telemetryService)
+        args.configService.vitalsBehavior = FakeVitalsBehavior(spanLimitImpl = spanLimit)
+        return VitalsDataSource(args) to args
+    }
+
+    /**
+     * Emits [count] spans through the data source's limit strategy — the same path the smoothness and
+     * screen-load results take.
+     */
+    private fun VitalsDataSource.emit(count: Int) {
+        repeat(count) {
+            captureTelemetry {
+                recordCompletedSpan(name = "smoothness", startTimeMs = 0L, endTimeMs = 1L)
+            }
+        }
+    }
+
+    @Test
+    fun `spans are emitted up to the configured limit and then dropped`() {
+        val (dataSource, args) = createDataSource(spanLimit = 3)
+
+        dataSource.emit(5)
+
+        assertEquals(3, args.destination.completedSpans().size)
+    }
+
+    @Test
+    fun `the limit is shared across both vitals span types`() {
+        val (dataSource, args) = createDataSource(spanLimit = 250)
+
+        dataSource.emit(400)
+
+        assertEquals(250, args.destination.completedSpans().size)
+    }
+
+    @Test
+    fun `the limit resets on a session part change`() {
+        val (dataSource, args) = createDataSource(spanLimit = 3)
+        dataSource.emit(5)
+
+        dataSource.resetDataCaptureLimits()
+        dataSource.emit(5)
+
+        assertEquals(6, args.destination.completedSpans().size)
+    }
+
+    @Test
+    fun `a dropped span is tracked as an applied limit`() {
+        val (dataSource, args) = createDataSource(spanLimit = 1)
+
+        dataSource.emit(3)
+
+        assertEquals(1, args.destination.completedSpans().size)
+        assertEquals(
+            List(2) { "vitals_data_source" to AppliedLimitType.DROP },
+            telemetryService.appliedLimits,
+        )
+    }
+}

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/cache/CachedConfiguration.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/cache/CachedConfiguration.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.internal.serialization.BinaryVersion
 import kotlinx.serialization.Serializable
 
 @Serializable
-@BinaryVersion(-2074456697392943244)
+@BinaryVersion(5194059233251419536)
 data class CachedConfiguration(
     val deviceId: String,
     val etag: String?,

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/VitalsRemoteConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/VitalsRemoteConfig.kt
@@ -29,4 +29,7 @@ data class VitalsRemoteConfig(
 
     @SerialName("smoothness_frame_trace_pct_enabled")
     val smoothnessFrameTracePctEnabled: Float? = null,
+
+    @SerialName("span_limit")
+    val spanLimit: Int? = null,
 )


### PR DESCRIPTION
## Goal
Limit the number of vital spans that can be generated. Default of 250 per session part, with a RemoteConfig override.

## Testing
New unit test coverage
