### PR TITLE
Reduce scheduling overhead for ScreenLoads

### DIFF
--- a/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTracker.kt
+++ b/embrace-android-instrumentation-vitals/src/main/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTracker.kt
@@ -56,15 +56,18 @@ internal class ScreenLoadTracker(
     fun onTap(eventTime: Long = uptimeMillis()) {
         if (state == State.SETTLING) {
             complete(endMs = eventTime, outcome = ScreenLoadOutcome.USER_INTERRUPTED)
+        } else {
+            // Drop a load that is still navigating - the user is no longer waiting on it - and with it its
+            // pending timeout, which would otherwise outlive it and fire against this new candidate.
+            discard()
         }
-        settle.cancel()
+
         state = State.CANDIDATE
         screenName = ""
         startUptimeMs = eventTime
 
         val startUptimeDelta = uptimeMillis() - startUptimeMs
         startWallMs = clock.now() - startUptimeDelta
-        scheduleTimeout()
     }
 
     /**
@@ -81,6 +84,8 @@ internal class ScreenLoadTracker(
                 if (eventTime <= startUptimeMs + navigationTimeoutMs) {
                     state = State.CONFIRMED
                     navStartMs = eventTime
+                    // the candidate is now a real load, so start the clock on it reporting
+                    scheduleTimeout()
                 } else {
                     // the previous "tap" event is too far in the past to be considered part of the screen load
                     // so we move the "start time" to now
@@ -213,8 +218,15 @@ internal class ScreenLoadTracker(
         emit(result)
     }
 
+    /**
+     * Arms the give-up timer. The time window runs from the load's start (the tap-up that led to it).
+     * So the deadline is anchored to [startUptimeMs] rather than to now. That allows it to be armed when a
+     * load is confirmed rather than on every tap, without moving the deadline. Clamped to the window length
+     * in case an event timestamp is skewed against the current clock.
+     */
     private fun scheduleTimeout() {
-        scheduler.scheduleSettle(timeoutMs, timeoutRunnable)
+        val delayMs = (startUptimeMs + timeoutMs - uptimeMillis()).coerceIn(0L, timeoutMs)
+        scheduler.scheduleSettle(delayMs, timeoutRunnable)
     }
 
     private fun discard() {
@@ -252,7 +264,9 @@ internal class ScreenLoadTracker(
         IDLE,
 
         /**
-         * A committed tap opened a candidate; awaiting a navigation start.
+         * A committed tap opened a candidate; awaiting a navigation start. Unlike [IDLE], the start timestamp
+         * is a valid tap-up. Inert while it waits: no timeout is armed, as [onNavigationStart] rejects a tap
+         * that is too old to belong to the navigation on time.
          */
         CANDIDATE,
 

--- a/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTrackerTest.kt
+++ b/embrace-android-instrumentation-vitals/src/test/kotlin/io/embrace/android/embracesdk/internal/vitals/screenload/ScreenLoadTrackerTest.kt
@@ -242,6 +242,57 @@ internal class ScreenLoadTrackerTest {
         assertTrue(emitted.isEmpty())
     }
 
+    @Test
+    fun `the timeout window runs from the tap, not from the navigation that confirms it`() {
+        val tap = SystemClock.uptimeMillis()
+        tracker.onTap(tap)
+        advance(NAV_TIMEOUT - 100) // the navigation confirms the candidate 400ms after the tap
+        tracker.onNavigationStart("home")
+        tracker.onNavigationEnd("home") // settling
+
+        // Continuously animating (a frame every 50ms, under the idle threshold) so the settle never fires
+        // and only the timeout can end the load.
+        advance(50)
+        frameNow()
+        scheduler.runDue() // t=450, still inside the tap's window
+        assertTrue("the tap's window has not elapsed yet", emitted.isEmpty())
+
+        advance(50)
+        frameNow()
+        scheduler.runDue() // t=500
+
+        assertEquals(ScreenLoadOutcome.TIMED_OUT, emitted.single().outcome)
+        assertEquals(
+            "timed out a full TIMEOUT after the tap; arming at the navigation would have been ${tap + 400 + TIMEOUT}",
+            tap + TIMEOUT,
+            SystemClock.uptimeMillis(),
+        )
+    }
+
+    @Test
+    fun `a tap abandons a load still navigating`() {
+        tracker.onTap()
+        tracker.onNavigationStart("first") // confirmed, so a timeout is armed for it
+
+        // A second tap replaces the candidate. The first load's timeout must not survive to discard it.
+        advance(10)
+        val secondTap = SystemClock.uptimeMillis()
+        tracker.onTap(secondTap)
+        advance(10)
+        tracker.onNavigationStart("second")
+        tracker.onNavigationEnd("second")
+        advance(10)
+        frameNow()
+
+        advance(IDLE)
+        scheduler.runDue()
+
+        val result = emitted.single()
+        assertEquals("only the second load reports", "second", result.screenName)
+        assertEquals(ScreenLoadOutcome.SETTLED, result.outcome)
+        assertEquals(secondTap, result.startTimeMs)
+    }
+
     private fun advance(millis: Long) = ShadowSystemClock.advanceBy(Duration.ofMillis(millis))
 
     /**


### PR DESCRIPTION
## Goal
Avoid scheduling a timer on every tap for ScreenLoad vitals. The tap now captures the start time, but the timer is scheduled on the navigation start event. The timeout is derived from the tap timestamp (rather than the navigation event).

## Testing
Added unit tests to ensure the ScreenLoad time remains "tap" -> "settle"