### PR TITLE
Flatten tracing api delegate

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/TracingApiDelegate.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/TracingApiDelegate.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.spans
 
-import io.embrace.android.embracesdk.internal.clock.normalizeTimestampAsMillis
 import io.embrace.android.embracesdk.internal.otel.spans.SpanService
 import io.embrace.android.embracesdk.internal.otel.spans.toErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.otel.spans.toSpanEvent
@@ -35,7 +34,7 @@ class TracingApiDelegate(
         spanService.startSpan(
             name = name,
             parent = parent,
-            startTimeMs = startTimeMs?.normalizeTimestampAsMillis(),
+            startTimeMs = startTimeMs,
             internal = false,
             autoTerminationMode = autoTerminationMode,
         )
@@ -67,8 +66,8 @@ class TracingApiDelegate(
         events: List<EmbraceSpanEvent>,
     ): Boolean = spanService.recordCompletedSpan(
         name = name,
-        startTimeMs = startTimeMs.normalizeTimestampAsMillis(),
-        endTimeMs = endTimeMs.normalizeTimestampAsMillis(),
+        startTimeMs = startTimeMs,
+        endTimeMs = endTimeMs,
         parent = parent,
         internal = false,
         attributes = attributes,

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImpl.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.internal.arch.datasource.SpanEvent
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
+import io.embrace.android.embracesdk.internal.clock.normalizeTimestampAsMillis
 import io.embrace.android.embracesdk.internal.otel.sdk.DataValidator
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.spans.AutoTerminationMode
@@ -295,7 +296,11 @@ class SpanServiceImpl(
         events: List<SpanEvent>,
         errorCode: ErrorCodeAttribute?,
     ): Boolean {
-        if (startTimeMs > endTimeMs) {
+        // callers may supply nanosecond timestamps - normalize before validating so that the check below compares like with like
+        val validStartTimeMs = startTimeMs.normalizeTimestampAsMillis()
+        val validEndTimeMs = endTimeMs.normalizeTimestampAsMillis()
+
+        if (validStartTimeMs > validEndTimeMs) {
             return false
         }
 
@@ -315,7 +320,7 @@ class SpanServiceImpl(
                     openTelemetry = openTelemetry,
                 ),
             )
-            if (newSpan.start(startTimeMs)) {
+            if (newSpan.start(validStartTimeMs)) {
                 validAttributes.forEach {
                     newSpan.addAttribute(it.key, it.value)
                 }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
@@ -31,6 +31,7 @@ import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.arch.datasource.SpanEvent
 import io.embrace.android.embracesdk.internal.arch.datasource.SpanEventImpl
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.otel.config.OtelSdkConfig
 import io.embrace.android.embracesdk.internal.otel.logs.LogSinkImpl
@@ -309,6 +310,56 @@ internal class SpanServiceImplTest {
                 name = "test-pan",
                 startTimeMs = 500,
                 endTimeMs = 499,
+            ),
+        )
+    }
+
+    @Test
+    fun `nanosecond timestamps for a completed span are normalized to millis`() {
+        val expectedStartTimeMs = clock.now()
+        val expectedEndTimeMs = expectedStartTimeMs + 100L
+
+        assertTrue(
+            spansService.recordCompletedSpan(
+                name = "test-span",
+                startTimeMs = expectedStartTimeMs.millisToNanos(),
+                endTimeMs = expectedEndTimeMs.millisToNanos(),
+            ),
+        )
+
+        with(verifyAndReturnSoleCompletedSpan("emb-test-span")) {
+            assertEquals(expectedStartTimeMs, startTimeNanos?.nanosToMillis())
+            assertEquals(expectedEndTimeMs, endTimeNanos?.nanosToMillis())
+        }
+    }
+
+    @Test
+    fun `completed span timestamps are normalized before start and end times are validated`() {
+        val expectedStartTimeMs = clock.now()
+        val expectedEndTimeMs = expectedStartTimeMs + 100L
+
+        // mixed units: the raw values compare as start > end, but the normalized ones do not
+        assertTrue(
+            spansService.recordCompletedSpan(
+                name = "test-span",
+                startTimeMs = expectedStartTimeMs.millisToNanos(),
+                endTimeMs = expectedEndTimeMs,
+            ),
+        )
+
+        with(verifyAndReturnSoleCompletedSpan("emb-test-span")) {
+            assertEquals(expectedStartTimeMs, startTimeNanos?.nanosToMillis())
+            assertEquals(expectedEndTimeMs, endTimeNanos?.nanosToMillis())
+        }
+    }
+
+    @Test
+    fun `validate normalized start and end times for a completed span`() {
+        assertFalse(
+            spansService.recordCompletedSpan(
+                name = "test-span",
+                startTimeMs = (clock.now() + 100L).millisToNanos(),
+                endTimeMs = clock.now().millisToNanos(),
             ),
         )
     }
@@ -667,6 +718,27 @@ internal class SpanServiceImplTest {
             setOf("emb-other-span", "emb-test-span"),
             spanRepository.completedOtelSpans().map { it.name }.toSet(),
         )
+    }
+
+    @Test
+    fun `nanosecond timestamps buffered before initialization are normalized on replay`() {
+        val service = createUninitializedSpanService()
+        val expectedStartTimeMs = clock.now()
+        val expectedEndTimeMs = expectedStartTimeMs + 100L
+        assertTrue(
+            service.recordCompletedSpan(
+                name = "test-span",
+                startTimeMs = expectedStartTimeMs.millisToNanos(),
+                endTimeMs = expectedEndTimeMs.millisToNanos(),
+            ),
+        )
+
+        service.initializeService(otelClock.now().nanosToMillis())
+
+        with(verifyAndReturnSoleCompletedSpan("emb-test-span")) {
+            assertEquals(expectedStartTimeMs, startTimeNanos?.nanosToMillis())
+            assertEquals(expectedEndTimeMs, endTimeNanos?.nanosToMillis())
+        }
     }
 
     @Test


### PR DESCRIPTION
## Goal

Moves the timestamp normalization to `SpanService` from `TracingApiDelegate`.
