### PR TITLE
Remove the use of `serializer<T>()` from init functions

### DIFF
--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
@@ -29,7 +29,6 @@ import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.payload.NativeSymbols
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
-import io.embrace.android.embracesdk.internal.serialization.fromJson
 import io.embrace.android.embracesdk.internal.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.utils.UuidSource
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
@@ -180,7 +179,7 @@ class ConfigServiceImpl(
         try {
             val encodedSymbols = instrumentedConfig.symbols.getBase64SharedObjectFilesMap() ?: return null
             val decodedSymbols: String = encodedSymbols.decodeBase64()?.utf8() ?: return null
-            return serializer.fromJson<NativeSymbols>(decodedSymbols)
+            return serializer.fromJson(decodedSymbols, NativeSymbols.serializer())
         } catch (ex: Exception) {
             logger.trackInternalError(InternalErrorType.InvalidNativeSymbols, ex)
         }

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/source/OkHttpRemoteConfigSource.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/source/OkHttpRemoteConfigSource.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.internal.config.source
 
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
-import io.embrace.android.embracesdk.internal.serialization.fromJson
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -57,7 +56,7 @@ internal class OkHttpRemoteConfigSource(
         val cfg = response.body?.source()?.use { src ->
             val gzipSource = GzipSource(src)
             gzipSource.buffer().inputStream().use { stream ->
-                serializer.fromJson<RemoteConfig>(stream)
+                serializer.fromJson(stream, RemoteConfig.serializer())
             }
         }
         ConfigHttpResponse(cfg, etag)

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/store/RemoteConfigStoreImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/store/RemoteConfigStoreImpl.kt
@@ -7,7 +7,6 @@ import io.embrace.android.embracesdk.internal.serialization.EmbraceBinary
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.serialization.decodeFromStream
 import io.embrace.android.embracesdk.internal.serialization.encodeToStream
-import io.embrace.android.embracesdk.internal.serialization.fromJson
 import io.embrace.android.embracesdk.internal.serialization.toJson
 import java.io.File
 
@@ -57,7 +56,7 @@ internal class RemoteConfigStoreImpl(
     private fun loadFromJson(): StoredConfigResponse? {
         return try {
             val cfg = configFile.inputStream().buffered().use {
-                serializer.fromJson<RemoteConfig>(it)
+                serializer.fromJson(it, RemoteConfig.serializer())
             }
             StoredConfigResponse(
                 cfg = cfg,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/SharedPrefsStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/SharedPrefsStore.kt
@@ -2,9 +2,10 @@ package io.embrace.android.embracesdk.internal.prefs
 
 import android.content.SharedPreferences
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
-import io.embrace.android.embracesdk.internal.serialization.fromJson
 import io.embrace.android.embracesdk.internal.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.store.KeyValueStoreEditor
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
 
 internal class SharedPrefsStore(
     private val impl: SharedPreferences,
@@ -41,7 +42,7 @@ internal class SharedPrefsStore(
 
     override fun getStringMap(key: String): Map<String, String>? {
         val mapString = impl.getString(key, null) ?: return null
-        return serializer.fromJson<Map<String, String>>(mapString)
+        return serializer.fromJson(mapString, MapSerializer(String.serializer(), String.serializer()))
     }
 
     override fun edit(action: KeyValueStoreEditor.() -> Unit) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
@@ -25,7 +25,6 @@ import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
-import io.embrace.android.embracesdk.internal.serialization.fromJson
 import io.embrace.android.embracesdk.internal.session.UserSessionRestoreDecision
 import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
 import io.embrace.android.embracesdk.internal.session.getUserSessionProperties
@@ -154,7 +153,7 @@ internal class PayloadResurrectionServiceImpl(
                 ?.loadDecompressedPayload()
                 ?.let { payloadStream ->
                     runCatching {
-                        serializer.fromJson<Envelope<LogPayload>>(payloadStream)
+                        serializer.fromJson(payloadStream, Envelope.serializer(LogPayload.serializer()))
                     }.getOrNull()
                 }
                 ?.also { runCatching { cacheStorageService.delete(cachedCrashEnvelopeMetadata) } }
@@ -314,7 +313,7 @@ internal class PayloadResurrectionServiceImpl(
         userSessionTerminationReason: String?,
         isBackgroundOnly: Boolean,
     ): Envelope<SessionPartPayload> {
-        val deadPart = serializer.fromJson<Envelope<SessionPartPayload>>(payloadStream)
+        val deadPart = serializer.fromJson(payloadStream, Envelope.serializer(SessionPartPayload.serializer()))
         val deadSessionPartSpan = deadPart.getSessionPartSpan()
         val sessionPartId = deadSessionPartSpan?.resolveSessionPartIdForCrashMatch()
         val appState = deadSessionPartSpan?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_STATE)

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/CachedLogEnvelopeStoreImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/CachedLogEnvelopeStoreImpl.kt
@@ -9,7 +9,6 @@ import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
-import io.embrace.android.embracesdk.internal.serialization.fromJson
 import io.embrace.android.embracesdk.internal.serialization.toJson
 import io.embrace.android.embracesdk.internal.worker.PriorityWorker
 import java.io.File
@@ -47,7 +46,7 @@ class CachedLogEnvelopeStoreImpl(
     override fun get(storedTelemetryMetadata: StoredTelemetryMetadata): Envelope<LogPayload>? =
         runCatching {
             fileStorageService.loadPayloadAsStream(storedTelemetryMetadata)?.let { inputStream ->
-                serializer.fromJson<Envelope<LogPayload>>(inputStream)
+                serializer.fromJson(inputStream, Envelope.serializer(LogPayload.serializer()))
             }
         }.getOrNull()
 

--- a/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashProcessorImpl.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashProcessorImpl.kt
@@ -9,7 +9,6 @@ import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
-import io.embrace.android.embracesdk.internal.serialization.fromJson
 import io.embrace.android.embracesdk.internal.worker.PriorityWorker
 import java.io.File
 import java.io.FileNotFoundException
@@ -53,7 +52,7 @@ internal class NativeCrashProcessorImpl(
             try {
                 val crashReport = delegate.getCrashReport(crashFile.path)
                 if (crashReport != null) {
-                    serializer.fromJson<NativeCrashData>(crashReport).apply {
+                    serializer.fromJson(crashReport, NativeCrashData.serializer()).apply {
                         this.symbols = symbolMap
                     }
                 } else {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePayloadAssertionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePayloadAssertionInterface.kt
@@ -20,7 +20,6 @@ import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
 import io.embrace.android.embracesdk.internal.payload.Span
-import io.embrace.android.embracesdk.internal.serialization.fromJson
 import io.embrace.android.embracesdk.internal.serialization.toJson
 import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
 import io.embrace.android.embracesdk.semconv.EmbAndroidAttributes
@@ -217,7 +216,7 @@ internal class EmbracePayloadAssertionInterface(
     private fun readRemoteConfigFile(file: File): RemoteConfig {
         try {
             return file.inputStream().buffered().use {
-                serializer.fromJson<RemoteConfig>(it)
+                serializer.fromJson(it, RemoteConfig.serializer())
             }
         } catch (exc: Throwable) {
             throw IllegalStateException("Failed to read remote config file.", exc)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/StoredNdkData.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/StoredNdkData.kt
@@ -19,7 +19,6 @@ import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
-import io.embrace.android.embracesdk.internal.serialization.fromJson
 import java.io.File
 
 internal data class StoredNativeCrashData(
@@ -37,8 +36,8 @@ internal data class StoredNativeCrashData(
         val outputDir = StorageLocation.NATIVE.asFile(
             logger = FakeInternalLogger(),
             rootDirSupplier = { ctx.filesDir },
-            fallbackDirSupplier = { ctx.cacheDir }
-        ) .value.apply {
+            fallbackDirSupplier = { ctx.cacheDir },
+        ).value.apply {
             mkdirs()
         }
         return File(outputDir, crashMetadata.filename)
@@ -54,8 +53,9 @@ internal fun createStoredNativeCrashData(
     envelopeResource: EnvelopeResource = fakeEnvelopeResource,
     envelopeMetadata: EnvelopeMetadata = fakeEnvelopeMetadata,
 ): StoredNativeCrashData {
-    val nativeCrashData = serializer.fromJson<NativeCrashData>(
-        ResourceReader.readResource(resourceFixtureName)
+    val nativeCrashData = serializer.fromJson(
+        ResourceReader.readResource(resourceFixtureName),
+        NativeCrashData.serializer(),
     )
     return StoredNativeCrashData(
         sessionMetadata = sessionMetadata,
@@ -80,7 +80,7 @@ internal fun createStoredNativeCrashData(
                 sessionProperties = mapOf("dead-session-prop" to "some-val"),
                 processIdentifier = sessionMetadata.processIdentifier,
                 resource = envelopeResource,
-                metadata = envelopeMetadata
+                metadata = envelopeMetadata,
             )
         } else {
             null
@@ -88,7 +88,7 @@ internal fun createStoredNativeCrashData(
         cachedCrashEnvelope = if (createCrashEnvelope) {
             fakeEmptyLogEnvelope(
                 resource = envelopeResource,
-                metadata = envelopeMetadata
+                metadata = envelopeMetadata,
             )
         } else {
             null


### PR DESCRIPTION
## Goal
Using the `reified` extension function of `PlatformSerializer.toJson` is convenient but carries a hidden reflection cost at runtime which we want to avoid. This PR changes the config related classes to create or reference the serializers directly which avoids the `Reflection.typeOf` calls.

## Testing
Relied on existing tests.