### PR TITLE
Shared MapSerializer  in SharedPrefsStore

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/SharedPrefsStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/SharedPrefsStore.kt
@@ -42,7 +42,7 @@ internal class SharedPrefsStore(
 
     override fun getStringMap(key: String): Map<String, String>? {
         val mapString = impl.getString(key, null) ?: return null
-        return serializer.fromJson(mapString, MapSerializer(String.serializer(), String.serializer()))
+        return serializer.fromJson(mapString, mapSerializer)
     }
 
     override fun edit(action: KeyValueStoreEditor.() -> Unit) {
@@ -61,5 +61,9 @@ internal class SharedPrefsStore(
         } catch (tr: Throwable) {
             -1
         }
+    }
+
+    private companion object {
+        val mapSerializer = MapSerializer(String.serializer(), String.serializer())
     }
 }


### PR DESCRIPTION
## Goal
Create a single common `MapSerializer<String, String>` used `SharedPrefsStore. getStringMap()` so that we don't allocate one for every `getStringMap()` call

## Testing
Existing tests