### PR TITLE
Use correct implicit context storage for opentelemetry-kotlin

### DIFF
--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetry.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetry.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.fakes
 
 import io.opentelemetry.kotlin.OpenTelemetry
+import io.opentelemetry.kotlin.context.ImplicitContextStorageMode
 import io.opentelemetry.kotlin.createCompatOpenTelemetry
 import io.opentelemetry.kotlin.createOpenTelemetry
 
@@ -8,7 +9,9 @@ import io.opentelemetry.kotlin.createOpenTelemetry
  * Creates a instance of [OpenTelemetry] that can be used in tests
  */
 fun fakeOpenTelemetry(useKotlinSdk: Boolean = true): OpenTelemetry = if (useKotlinSdk) {
-    createOpenTelemetry()
+    createOpenTelemetry {
+        context { storageMode = ImplicitContextStorageMode.THREAD_LOCAL }
+    }
 } else {
     createCompatOpenTelemetry()
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/OtelSdkInstance.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/OtelSdkInstance.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.internal.otel.spans.getEmbraceSpan
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.OpenTelemetry
 import io.opentelemetry.kotlin.context.Context
+import io.opentelemetry.kotlin.context.ImplicitContextStorageMode
 import io.opentelemetry.kotlin.createCompatOpenTelemetry
 import io.opentelemetry.kotlin.createOpenTelemetry
 import io.opentelemetry.kotlin.init.LoggerProviderConfigDsl
@@ -18,6 +19,9 @@ internal fun createSdkOtelInstance(
 ): OpenTelemetry {
     return if (useKotlinSdk) {
         createOpenTelemetry(clock) {
+            // opentelemetry-kotlin stores implicit context in a process-wide slot, whereas we want
+            // to match opentelemetry-java's default behavior
+            context { storageMode = ImplicitContextStorageMode.THREAD_LOCAL }
             tracerProvider { tracerProvider() }
             loggerProvider { loggerProvider() }
         }
@@ -29,10 +33,6 @@ internal fun createSdkOtelInstance(
     }
 }
 
-internal fun OpenTelemetry.getDefaultContext(useKotlinSdk: Boolean): Context? {
-    return if (useKotlinSdk) {
-        context.root().getEmbraceSpan(this)?.createContext(this)
-    } else {
-        context.implicit().getEmbraceSpan(this)?.createContext(this)
-    }
+internal fun OpenTelemetry.getDefaultContext(): Context? {
+    return context.implicit().getEmbraceSpan(this)?.createContext(this)
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracer.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracer.kt
@@ -21,7 +21,6 @@ class EmbTracer(
     private val openTelemetry: OpenTelemetry,
     private val spanService: SpanService,
     private val clock: Clock,
-    private val useKotlinSdk: Boolean,
 ) : Tracer {
 
     override fun enabled(): Boolean = impl.enabled()
@@ -39,7 +38,7 @@ class EmbTracer(
             internal = false,
             private = false,
             tracer = impl,
-            parentCtx = parentContext ?: openTelemetry.getDefaultContext(useKotlinSdk),
+            parentCtx = parentContext ?: openTelemetry.getDefaultContext(),
             openTelemetry = openTelemetry,
             spanKind = spanKind,
             startTimeMs = startTimestamp?.nanosToMillis(),

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerProvider.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerProvider.kt
@@ -16,7 +16,6 @@ class EmbTracerProvider(
     private val impl: OpenTelemetry,
     private val spanService: SpanService,
     private val clock: Clock,
-    private val useKotlinSdk: Boolean,
 ) : TracerProvider {
 
     private val tracers = ConcurrentHashMap<ApiKey, Tracer>()
@@ -53,7 +52,6 @@ class EmbTracerProvider(
             spanService = spanService,
             clock = clock,
             openTelemetry = impl,
-            useKotlinSdk = useKotlinSdk,
         )
         tracers[key] = tracer
         return tracer

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OtelSdkWrapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OtelSdkWrapper.kt
@@ -92,7 +92,7 @@ class OtelSdkWrapper(
     val openTelemetryKotlin: OpenTelemetry by lazy {
         EmbOpenTelemetry(
             impl = kotlinApi,
-            traceProviderSupplier = { EmbTracerProvider(kotlinApi, spanService, otelClock, useKotlinSdk) },
+            traceProviderSupplier = { EmbTracerProvider(kotlinApi, spanService, otelClock) },
             loggerProviderSupplier = { EmbLoggerProvider(kotlinApi, eventService) },
         )
     }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerProviderTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerProviderTest.kt
@@ -5,7 +5,6 @@ import io.embrace.android.embracesdk.fakes.FakeLoggerProvider
 import io.embrace.android.embracesdk.fakes.FakeOtelKotlinClock
 import io.embrace.android.embracesdk.fakes.FakeSpanService
 import io.embrace.android.embracesdk.fakes.FakeTracerProvider
-import io.embrace.android.embracesdk.fakes.TestConstants.TESTS_DEFAULT_USE_KOTLIN_SDK
 import io.opentelemetry.kotlin.NoopOpenTelemetry
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertSame
@@ -31,7 +30,6 @@ internal class EmbTracerProviderTest {
             impl = otel,
             spanService = spanService,
             clock = openTelemetryClock,
-            useKotlinSdk = TESTS_DEFAULT_USE_KOTLIN_SDK,
         )
     }
 

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/impl/EmbTracerTest.kt
@@ -1,23 +1,28 @@
 package io.embrace.android.embracesdk.internal.otel.impl
 
 import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.FakeOtelKotlinClock
 import io.embrace.android.embracesdk.fakes.FakeSpanService
 import io.embrace.android.embracesdk.fakes.FakeTracer
-import io.embrace.android.embracesdk.fakes.TestConstants.TESTS_DEFAULT_USE_KOTLIN_SDK
 import io.embrace.android.embracesdk.fakes.fakeOpenTelemetry
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.clock.nanosToMillis
+import io.embrace.android.embracesdk.internal.otel.spans.createContext
 import io.opentelemetry.kotlin.NoopOpenTelemetry
 import io.opentelemetry.kotlin.tracing.SpanKind
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Before
 import org.junit.Test
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 internal class EmbTracerTest {
     private val clock = FakeClock()
     private val openTelemetryClock = FakeOtelKotlinClock(clock)
+    private val openTelemetry = fakeOpenTelemetry()
 
     private lateinit var spanService: FakeSpanService
     private lateinit var sdkTracer: FakeTracer
@@ -31,8 +36,7 @@ internal class EmbTracerTest {
             impl = sdkTracer,
             spanService = spanService,
             clock = openTelemetryClock,
-            openTelemetry = fakeOpenTelemetry(),
-            useKotlinSdk = TESTS_DEFAULT_USE_KOTLIN_SDK,
+            openTelemetry = openTelemetry,
         )
     }
 
@@ -65,5 +69,31 @@ internal class EmbTracerTest {
             assertEquals(SpanKind.CLIENT, spanKind)
             assertEquals("bar", attributes["foo"])
         }
+    }
+
+    @Test
+    fun `span with no explicit parent inherits the span attached to the current thread`() {
+        val parent = FakeEmbraceSdkSpan(openTelemetry = openTelemetry)
+        val scope = parent.createContext(openTelemetry).attach()
+        try {
+            tracer.startSpan("foo").end()
+        } finally {
+            scope.detach()
+        }
+        assertSame(parent, spanService.createdSpans.single().parent)
+    }
+
+    @Test
+    fun `span with no explicit parent has no parent when nothing is attached to the current thread`() {
+        val parent = FakeEmbraceSdkSpan(openTelemetry = openTelemetry)
+        val scope = parent.createContext(openTelemetry).attach()
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            executor.submit { tracer.startSpan("foo").end() }.get(1, TimeUnit.SECONDS)
+        } finally {
+            executor.shutdown()
+            scope.detach()
+        }
+        assertNull(spanService.createdSpans.single().parent)
     }
 }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OpenTelemetrySdkTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OpenTelemetrySdkTest.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.fakes.FakeSpanService
 import io.embrace.android.embracesdk.fakes.TestUuidSource
 import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.otel.config.OtelSdkConfig
+import io.embrace.android.embracesdk.internal.otel.createSdkOtelInstance
 import io.embrace.android.embracesdk.internal.otel.logs.EventServiceImpl
 import io.embrace.android.embracesdk.internal.otel.logs.LogSink
 import io.embrace.android.embracesdk.internal.otel.logs.LogSinkImpl
@@ -19,6 +20,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 internal class OpenTelemetrySdkTest {
 
@@ -119,6 +122,31 @@ internal class OpenTelemetrySdkTest {
     fun `verify that the default StorageContext is used if Java SDK is used`() {
         sdk = createSdkWrapper { sdk.sdkLogger }
         assertEquals("default", System.getProperty("io.opentelemetry.context.contextStorageProvider"))
+    }
+
+    @Test
+    fun `implicit context is confined to the thread that attached it if Kotlin SDK is used`() {
+        val otel = createSdkOtelInstance(useKotlinSdk = true, clock = FakeOtelKotlinClock(FakeClock()))
+        val key = otel.context.createKey<String>("test-key")
+        val root = otel.context.root()
+        val attached = root.set(key, "value")
+
+        val scope = attached.attach()
+        try {
+            assertEquals("value", otel.context.implicit().get(key))
+
+            val executor = Executors.newSingleThreadExecutor()
+            try {
+                val otherThreadValue = executor.submit<String?> { otel.context.implicit().get(key) }
+                assertNull(otherThreadValue.get(1, TimeUnit.SECONDS))
+            } finally {
+                executor.shutdown()
+            }
+        } finally {
+            scope.detach()
+        }
+
+        assertNull(otel.context.implicit().get(key))
     }
 
     private fun createOtelSdkConfig(): OtelSdkConfig {


### PR DESCRIPTION
## Goal

Use thread-local context storage when opentelemetry-kotlin is used in the SDK, so that existing behavior is matched. 
