### PR TITLE
Add tests for parity between KMP/opentelemetry-java OpenTelemetry implementations

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/OtelExportParityTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/OtelExportParityTest.kt
@@ -1,0 +1,93 @@
+package io.embrace.android.embracesdk.testcases
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.Severity
+import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.config.remote.OtelKotlinSdkConfig
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.toStringMap
+import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Asserts that the telemetry exported for common tracing & logging operations is a 1:1 match between
+ * the opentelemetry-kotlin 'compat' implementation and the 'KMP' implementation.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class OtelExportParityTest {
+
+    @Rule
+    @JvmField
+    val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule()
+
+    @Test
+    fun `trace export matches golden file using compat implementation`() {
+        assertTraceExport(useKotlinSdk = false)
+    }
+
+    @Test
+    fun `trace export matches golden file using kmp implementation`() {
+        assertTraceExport(useKotlinSdk = true)
+    }
+
+    @Test
+    fun `log export matches golden file using compat implementation`() {
+        assertLogExport(useKotlinSdk = false)
+    }
+
+    @Test
+    fun `log export matches golden file using kmp implementation`() {
+        assertLogExport(useKotlinSdk = true)
+    }
+
+    private fun assertTraceExport(useKotlinSdk: Boolean) {
+        testRule.runTest(
+            persistedRemoteConfig = remoteConfig(useKotlinSdk),
+            testCaseAction = {
+                recordSession {
+                    embrace.startSpan(SPAN_NAME).apply {
+                        addAttribute("my-attribute", "my-value")
+                        addEvent("my-event")
+                    }.stop()
+                }
+            },
+            otelExportAssertion = {
+                assertSpansMatchParityGoldenFile(
+                    spans = awaitSpans(1) { it.name == SPAN_NAME },
+                    goldenFile = "otel-export-parity-trace.json",
+                )
+            },
+        )
+    }
+
+    private fun assertLogExport(useKotlinSdk: Boolean) {
+        testRule.runTest(
+            persistedRemoteConfig = remoteConfig(useKotlinSdk),
+            testCaseAction = {
+                recordSession {
+                    embrace.logMessage(LOG_MESSAGE, Severity.WARNING, mapOf("my-attribute" to "my-value"))
+                }
+            },
+            otelExportAssertion = {
+                assertLogsMatchParityGoldenFile(
+                    logs = awaitLogs(1) { it.attributes.toStringMap().containsKey(EmbType.System.Log.key) },
+                    goldenFile = "otel-export-parity-log.json",
+                )
+            },
+        )
+    }
+
+    /**
+     * Selects the implementation under test.
+     */
+    private fun remoteConfig(useKotlinSdk: Boolean) = RemoteConfig(
+        otelKotlinSdkConfig = OtelKotlinSdkConfig(pctEnabled = if (useKotlinSdk) 100.0f else 0.0f)
+    )
+
+    private companion object {
+        private const val SPAN_NAME = "test-span"
+        private const val LOG_MESSAGE = "test message"
+    }
+}

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceOtelExportAssertionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceOtelExportAssertionInterface.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.testframework.actions
 
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.testframework.export.ExportedSpanValidator
+import io.embrace.android.embracesdk.testframework.export.ExportedTelemetryParityValidator
 import io.embrace.android.embracesdk.testframework.export.FilteredLogExporter
 import io.embrace.android.embracesdk.testframework.export.FilteredSpanExporter
 import io.opentelemetry.kotlin.aliases.OtelJavaLogRecordData
@@ -15,6 +16,7 @@ internal class EmbraceOtelExportAssertionInterface(
     private val spanExporter: FilteredSpanExporter,
     private val logExporter: FilteredLogExporter,
     private val validator: ExportedSpanValidator = ExportedSpanValidator(),
+    private val parityValidator: ExportedTelemetryParityValidator = ExportedTelemetryParityValidator(),
 ) {
 
     fun awaitLogs(expectedCount: Int, filter: (OtelJavaLogRecordData) -> Boolean) = logExporter.awaitLogs(expectedCount, filter)
@@ -26,5 +28,21 @@ internal class EmbraceOtelExportAssertionInterface(
      */
     fun assertSpansMatchGoldenFile(spans: List<OtelJavaSpanData>, goldenFile: String) {
         validator.validate(spans, goldenFile)
+    }
+
+    /**
+     * Asserts that the provided spans match the golden file, including the resource. Used to prove
+     * that the opentelemetry-kotlin 'compat' and 'KMP' implementations export identical telemetry.
+     */
+    fun assertSpansMatchParityGoldenFile(spans: List<OtelJavaSpanData>, goldenFile: String) {
+        parityValidator.validateSpans(spans, goldenFile)
+    }
+
+    /**
+     * Asserts that the provided logs match the golden file, including the resource. Used to prove
+     * that the opentelemetry-kotlin 'compat' and 'KMP' implementations export identical telemetry.
+     */
+    fun assertLogsMatchParityGoldenFile(logs: List<OtelJavaLogRecordData>, goldenFile: String) {
+        parityValidator.validateLogs(logs, goldenFile)
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/assertions/JsonComparator.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/assertions/JsonComparator.kt
@@ -7,7 +7,7 @@ import org.json.JSONObject
  * Ignore any values with this key in the expected JSON, because the value is non-deterministic
  * between test runs.
  */
-private const val IGNORE_VALUE = "__EMBRACE_TEST_IGNORE__"
+internal const val IGNORE_VALUE = "__EMBRACE_TEST_IGNORE__"
 
 /**
  * Performs a comparison between two Json sources.

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/ExportedSpanValidator.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/ExportedSpanValidator.kt
@@ -1,47 +1,16 @@
 package io.embrace.android.embracesdk.testframework.export
 
-import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.opentelemetry.kotlin.aliases.OtelJavaSpanData
 import io.opentelemetry.kotlin.semconv.SessionAttributes
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.booleanOrNull
-import kotlinx.serialization.json.doubleOrNull
-import kotlinx.serialization.json.longOrNull
 import org.junit.Assert.assertEquals
 
 internal class ExportedSpanValidator {
 
     fun validate(spanDataList: List<OtelJavaSpanData>, goldenFile: String) {
-        val expected: List<Map<String, Any>> = readExpectedSpan(goldenFile)
+        val expected: List<Map<String, Any>> = readGoldenFile(goldenFile)
         val actual = spanDataList.map { it.representAsMap() }
         assertEquals(expected, actual)
-    }
-
-    private fun readExpectedSpan(goldenFile: String): List<Map<String, Any>> {
-        val text = ResourceReader.readResource(goldenFile).bufferedReader().use { it.readText() }
-        @Suppress("UNCHECKED_CAST")
-        return Json.parseToJsonElement(text).toAny() as List<Map<String, Any>>
-    }
-
-    /**
-     * Recursively unwrap a [JsonElement] tree into plain Kotlin types (`String`, `Long`, `Double`,
-     * `Boolean`, `Map<String, Any>`, `List<Any>`). JSON nulls are rendered as the string `"null"`
-     * to preserve `Map<String, Any>` non-nullability.
-     */
-    private fun JsonElement.toAny(): Any = when (this) {
-        JsonNull -> "null"
-        is JsonObject -> mapValues { (_, v) -> v.toAny() }
-        is JsonArray -> map { it.toAny() }
-        is JsonPrimitive -> when {
-            isString -> content
-            else -> booleanOrNull ?: longOrNull ?: doubleOrNull ?: content
-        }
     }
 
     private fun OtelJavaSpanData.representAsMap(): Map<String, Any> {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/ExportedTelemetryParityValidator.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/ExportedTelemetryParityValidator.kt
@@ -1,0 +1,119 @@
+package io.embrace.android.embracesdk.testframework.export
+
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
+import io.embrace.android.embracesdk.testframework.assertions.IGNORE_VALUE
+import io.opentelemetry.kotlin.aliases.OtelJavaAttributes
+import io.opentelemetry.kotlin.aliases.OtelJavaEventData
+import io.opentelemetry.kotlin.aliases.OtelJavaLogRecordData
+import io.opentelemetry.kotlin.aliases.OtelJavaSpanData
+import io.opentelemetry.kotlin.semconv.SessionAttributes
+import org.junit.Assert.assertEquals
+
+/**
+ * Validates exported telemetry against a golden file, for the purpose of proving that the
+ * opentelemetry-kotlin 'compat' and 'KMP' implementations export identical telemetry.
+ *
+ * Both implementations assert against the same golden file, so a 1:1 match between them is proven
+ * transitively. Only the properties in [DIVERGENT_ATTRIBUTES] and [REDACTED_ATTRIBUTES] are exempt.
+ */
+internal class ExportedTelemetryParityValidator {
+
+    fun validateSpans(spans: List<OtelJavaSpanData>, goldenFile: String) {
+        validate(spans.map { it.representAsMap() }, goldenFile)
+    }
+
+    fun validateLogs(logs: List<OtelJavaLogRecordData>, goldenFile: String) {
+        validate(logs.map { it.representAsMap() }, goldenFile)
+    }
+
+    private fun validate(actual: List<Map<String, Any>>, goldenFile: String) {
+        assertEquals(
+            "Exported telemetry did not match golden file '$goldenFile'. Observed telemetry was:\n" +
+                actual.toGoldenFileJson(),
+            readGoldenFile(goldenFile),
+            actual,
+        )
+    }
+
+    private fun OtelJavaSpanData.representAsMap(): Map<String, Any> {
+        val attrs = attributes.representAsMap()
+        return mapOf(
+            "name" to name,
+            "kind" to kind.toString(),
+            "status" to status.statusCode.toString(),
+            "startEpochNanos" to startEpochNanos.toString(),
+            "endEpochNanos" to endEpochNanos.toString(),
+            "hasEnded" to hasEnded().toString(),
+            "totalAttributeCount" to attrs.size.toString(),
+            "attributes" to attrs,
+            "totalRecordedEvents" to totalRecordedEvents.toString(),
+            "events" to events.map { it.representAsMap() },
+            "instrumentationScopeName" to instrumentationScopeInfo.name,
+            "resourceAttributes" to resource.attributes.representAsMap(),
+        )
+    }
+
+    private fun OtelJavaLogRecordData.representAsMap(): Map<String, Any> {
+        val attrs = attributes.representAsMap()
+        return mapOf(
+            "body" to bodyValue?.asString().toString(),
+            "severityNumber" to severity.severityNumber.toString(),
+            "severityText" to severityText.toString(),
+            "timestampEpochNanos" to timestampEpochNanos.toString(),
+            "observedTimestampEpochNanos" to observedTimestampEpochNanos.toString(),
+            "totalAttributeCount" to attrs.size.toString(),
+            "attributes" to attrs,
+            "instrumentationScopeName" to instrumentationScopeInfo.name,
+            "resourceAttributes" to resource.attributes.representAsMap(),
+        )
+    }
+
+    private fun OtelJavaEventData.representAsMap(): Map<String, Any> = mapOf(
+        "name" to name,
+        "epochNanos" to epochNanos.toString(),
+        "attributes" to attributes.representAsMap(),
+    )
+
+    /**
+     * Represents attributes as a sorted map of stringified values, dropping the attributes that only
+     * one implementation emits and redacting the values that are non-deterministic between runs.
+     */
+    private fun OtelJavaAttributes.representAsMap(): Map<String, String> =
+        asMap().entries
+            .map { it.key.key to it.value.toString() }
+            .filterNot { (key, _) -> key in DIVERGENT_ATTRIBUTES }
+            .associate { (key, value) ->
+                key to when (key) {
+                    in REDACTED_ATTRIBUTES -> IGNORE_VALUE
+                    else -> value
+                }
+            }
+            .toSortedMap(compareBy { it })
+
+    private companion object {
+
+        /**
+         * Attributes that are legitimately allowed to differ between the two implementations, and
+         * are therefore dropped altogether.
+         */
+        private val DIVERGENT_ATTRIBUTES = setOf(
+            "telemetry.sdk.name",
+            "telemetry.sdk.language",
+            "telemetry.sdk.version",
+        )
+
+        /**
+         * Attributes whose values are non-deterministic between test runs, regardless of which
+         * implementation is in use. The value is replaced with a placeholder rather than dropped so
+         * that the presence of the attribute is still asserted.
+         */
+        private val REDACTED_ATTRIBUTES = setOf(
+            SessionAttributes.SESSION_ID,
+            EmbSessionAttributes.EMB_USER_SESSION_ID,
+            EmbSessionAttributes.EMB_SESSION_PART_ID,
+            EmbSessionAttributes.EMB_PROCESS_IDENTIFIER,
+            EmbSessionAttributes.EMB_PRIVATE_SEQUENCE_ID,
+            "log.record.uid",
+        )
+    }
+}

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/GoldenJson.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/GoldenJson.kt
@@ -1,0 +1,58 @@
+package io.embrace.android.embracesdk.testframework.export
+
+import io.embrace.android.embracesdk.ResourceReader
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.longOrNull
+
+@OptIn(ExperimentalSerializationApi::class)
+private val prettyJson = Json {
+    prettyPrint = true
+    prettyPrintIndent = "  "
+}
+
+/**
+ * Reads a golden file that contains a JSON array of objects, each of which represents one piece of
+ * exported telemetry.
+ */
+internal fun readGoldenFile(goldenFile: String): List<Map<String, Any>> {
+    val text = ResourceReader.readResourceAsText(goldenFile)
+    @Suppress("UNCHECKED_CAST")
+    return Json.parseToJsonElement(text).toAny() as List<Map<String, Any>>
+}
+
+/**
+ * Recursively unwrap a [JsonElement] tree into plain Kotlin types (`String`, `Long`, `Double`,
+ * `Boolean`, `Map<String, Any>`, `List<Any>`). JSON nulls are rendered as the string `"null"`
+ * to preserve `Map<String, Any>` non-nullability.
+ */
+internal fun JsonElement.toAny(): Any = when (this) {
+    JsonNull -> "null"
+    is JsonObject -> mapValues { (_, v) -> v.toAny() }
+    is JsonArray -> map { it.toAny() }
+    is JsonPrimitive -> when {
+        isString -> content
+        else -> booleanOrNull ?: longOrNull ?: doubleOrNull ?: content
+    }
+}
+
+/**
+ * Renders a golden file representation as pretty-printed JSON, so that a failing assertion can print
+ * something that is directly pasteable into a golden file.
+ */
+internal fun List<Map<String, Any>>.toGoldenFileJson(): String =
+    prettyJson.encodeToString(JsonElement.serializer(), toJsonElement())
+
+private fun Any?.toJsonElement(): JsonElement = when (this) {
+    null -> JsonNull
+    is Map<*, *> -> JsonObject(entries.associate { (key, value) -> key.toString() to value.toJsonElement() })
+    is List<*> -> JsonArray(map { it.toJsonElement() })
+    else -> JsonPrimitive(toString())
+}

--- a/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-log.json
+++ b/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-log.json
@@ -1,0 +1,37 @@
+[
+  {
+    "body": "test message",
+    "severityNumber": "13",
+    "severityText": "WARNING",
+    "timestampEpochNanos": "169220160030000000",
+    "observedTimestampEpochNanos": "169220160030000000",
+    "totalAttributeCount": "10",
+    "attributes": {
+      "emb.session_part_id": "__EMBRACE_TEST_IGNORE__",
+      "emb.state": "foreground",
+      "emb.state.network": "unverified",
+      "emb.state.screen-automatic": "android.app.Activity",
+      "emb.state.test": "UNKNOWN",
+      "emb.type": "sys.log",
+      "emb.user_session_id": "__EMBRACE_TEST_IGNORE__",
+      "log.record.uid": "__EMBRACE_TEST_IGNORE__",
+      "my-attribute": "my-value",
+      "session.id": "__EMBRACE_TEST_IGNORE__"
+    },
+    "instrumentationScopeName": "io.embrace.android.embracesdk.core",
+    "resourceAttributes": {
+      "android.os.api_level": "35",
+      "device.manufacturer": "Fake Manufacturer",
+      "device.model.identifier": "Phake Phone Phive",
+      "device.model.name": "Phake Phone Phive",
+      "os.build_id": "",
+      "os.name": "android",
+      "os.type": "linux",
+      "os.version": "99.0.0",
+      "service.name": "UNKNOWN",
+      "service.version": "UNKNOWN",
+      "telemetry.distro.name": "io.embrace.android.embracesdk.core",
+      "telemetry.distro.version": "9.1.0-SNAPSHOT"
+    }
+  }
+]

--- a/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-trace.json
+++ b/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-trace.json
@@ -1,0 +1,43 @@
+[
+  {
+    "name": "test-span",
+    "kind": "INTERNAL",
+    "status": "UNSET",
+    "startEpochNanos": "169220160030000000",
+    "endEpochNanos": "169220160030000000",
+    "hasEnded": "true",
+    "totalAttributeCount": "7",
+    "attributes": {
+      "emb.private.sequence_id": "__EMBRACE_TEST_IGNORE__",
+      "emb.process_identifier": "__EMBRACE_TEST_IGNORE__",
+      "emb.session_part_id": "__EMBRACE_TEST_IGNORE__",
+      "emb.type": "perf",
+      "emb.user_session_id": "__EMBRACE_TEST_IGNORE__",
+      "my-attribute": "my-value",
+      "session.id": "__EMBRACE_TEST_IGNORE__"
+    },
+    "totalRecordedEvents": "1",
+    "events": [
+      {
+        "name": "my-event",
+        "epochNanos": "169220160030000000",
+        "attributes": {}
+      }
+    ],
+    "instrumentationScopeName": "io.embrace.android.embracesdk.core",
+    "resourceAttributes": {
+      "android.os.api_level": "35",
+      "device.manufacturer": "Fake Manufacturer",
+      "device.model.identifier": "Phake Phone Phive",
+      "device.model.name": "Phake Phone Phive",
+      "os.build_id": "",
+      "os.name": "android",
+      "os.type": "linux",
+      "os.version": "99.0.0",
+      "service.name": "UNKNOWN",
+      "service.version": "UNKNOWN",
+      "telemetry.distro.name": "io.embrace.android.embracesdk.core",
+      "telemetry.distro.version": "9.1.0-SNAPSHOT"
+    }
+  }
+]


### PR DESCRIPTION
## Goal

Add integration tests that check export parity between KMP/opentelemetry-java OpenTelemetry distributions by asserting against golden files.