### PR TITLE
Public API for Experiments

### DIFF
--- a/embrace-android-api/api/embrace-android-api.api
+++ b/embrace-android-api/api/embrace-android-api.api
@@ -58,18 +58,15 @@ public abstract interface annotation class io/embrace/android/embracesdk/annotat
 public abstract interface annotation class io/embrace/android/embracesdk/annotation/NotTracedActivity : java/lang/annotation/Annotation {
 }
 
-public final class io/embrace/android/embracesdk/experiments/TrackedExperiment {
-	public fun <init> (Ljava/lang/String;JLjava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;JLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getId ()Ljava/lang/String;
-	public final fun getStartTimeMs ()J
-	public final fun getVariant ()Ljava/lang/String;
+public abstract interface class io/embrace/android/embracesdk/experiments/TrackedExperiment {
+	public abstract fun getId ()Ljava/lang/String;
+	public abstract fun getStartTimeMs ()J
+	public abstract fun getVariant ()Ljava/lang/String;
 }
 
-public final class io/embrace/android/embracesdk/experiments/TrackedFeatureFlag {
-	public fun <init> (Ljava/lang/String;J)V
-	public final fun getId ()Ljava/lang/String;
-	public final fun getStartTimeMs ()J
+public abstract interface class io/embrace/android/embracesdk/experiments/TrackedFeatureFlag {
+	public abstract fun getId ()Ljava/lang/String;
+	public abstract fun getStartTimeMs ()J
 }
 
 public abstract interface class io/embrace/android/embracesdk/internal/api/BreadcrumbApi {
@@ -86,10 +83,18 @@ public abstract interface class io/embrace/android/embracesdk/internal/api/Embra
 }
 
 public abstract interface class io/embrace/android/embracesdk/internal/api/ExperimentApi {
+	public abstract fun createExperiment (Ljava/lang/String;JLjava/lang/String;)Lio/embrace/android/embracesdk/experiments/TrackedExperiment;
+	public abstract fun createFeatureFlag (Ljava/lang/String;J)Lio/embrace/android/embracesdk/experiments/TrackedFeatureFlag;
 	public abstract fun trackExperiment ([Lio/embrace/android/embracesdk/experiments/TrackedExperiment;)V
 	public abstract fun trackFeatureFlag ([Lio/embrace/android/embracesdk/experiments/TrackedFeatureFlag;)V
 	public abstract fun untrackExperiment ([Ljava/lang/String;J)V
 	public abstract fun untrackFeatureFlag ([Ljava/lang/String;J)V
+}
+
+public final class io/embrace/android/embracesdk/internal/api/ExperimentApi$DefaultImpls {
+	public static fun createExperiment (Lio/embrace/android/embracesdk/internal/api/ExperimentApi;Ljava/lang/String;JLjava/lang/String;)Lio/embrace/android/embracesdk/experiments/TrackedExperiment;
+	public static synthetic fun createExperiment$default (Lio/embrace/android/embracesdk/internal/api/ExperimentApi;Ljava/lang/String;JLjava/lang/String;ILjava/lang/Object;)Lio/embrace/android/embracesdk/experiments/TrackedExperiment;
+	public static fun createFeatureFlag (Lio/embrace/android/embracesdk/internal/api/ExperimentApi;Ljava/lang/String;J)Lio/embrace/android/embracesdk/experiments/TrackedFeatureFlag;
 }
 
 public abstract interface class io/embrace/android/embracesdk/internal/api/InstrumentationApi {
@@ -152,6 +157,8 @@ public abstract interface class io/embrace/android/embracesdk/internal/api/SdkAp
 public final class io/embrace/android/embracesdk/internal/api/SdkApi$DefaultImpls {
 	public static fun addLoadTraceChildSpan (Lio/embrace/android/embracesdk/internal/api/SdkApi;Landroid/app/Activity;Ljava/lang/String;JJ)V
 	public static fun addStartupTraceChildSpan (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;JJ)V
+	public static fun createExperiment (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;JLjava/lang/String;)Lio/embrace/android/embracesdk/experiments/TrackedExperiment;
+	public static fun createFeatureFlag (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;J)Lio/embrace/android/embracesdk/experiments/TrackedFeatureFlag;
 }
 
 public abstract interface class io/embrace/android/embracesdk/internal/api/SdkStateApi {

--- a/embrace-android-api/api/embrace-android-api.api
+++ b/embrace-android-api/api/embrace-android-api.api
@@ -58,6 +58,20 @@ public abstract interface annotation class io/embrace/android/embracesdk/annotat
 public abstract interface annotation class io/embrace/android/embracesdk/annotation/NotTracedActivity : java/lang/annotation/Annotation {
 }
 
+public final class io/embrace/android/embracesdk/experiments/TrackedExperiment {
+	public fun <init> (Ljava/lang/String;JLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;JLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getId ()Ljava/lang/String;
+	public final fun getStartTimeMs ()J
+	public final fun getVariant ()Ljava/lang/String;
+}
+
+public final class io/embrace/android/embracesdk/experiments/TrackedFeatureFlag {
+	public fun <init> (Ljava/lang/String;J)V
+	public final fun getId ()Ljava/lang/String;
+	public final fun getStartTimeMs ()J
+}
+
 public abstract interface class io/embrace/android/embracesdk/internal/api/BreadcrumbApi {
 	public abstract fun addBreadcrumb (Ljava/lang/String;)V
 }
@@ -69,6 +83,13 @@ public abstract interface class io/embrace/android/embracesdk/internal/api/Embra
 	public abstract fun endView (Ljava/lang/String;)Z
 	public abstract fun start (Landroid/content/Context;)V
 	public abstract fun startView (Ljava/lang/String;)Z
+}
+
+public abstract interface class io/embrace/android/embracesdk/internal/api/ExperimentApi {
+	public abstract fun trackExperiment ([Lio/embrace/android/embracesdk/experiments/TrackedExperiment;)V
+	public abstract fun trackFeatureFlag ([Lio/embrace/android/embracesdk/experiments/TrackedFeatureFlag;)V
+	public abstract fun untrackExperiment ([Ljava/lang/String;J)V
+	public abstract fun untrackFeatureFlag ([Ljava/lang/String;J)V
 }
 
 public abstract interface class io/embrace/android/embracesdk/internal/api/InstrumentationApi {
@@ -125,7 +146,7 @@ public abstract interface class io/embrace/android/embracesdk/internal/api/OTelA
 	public abstract fun setResourceAttribute (Ljava/lang/String;Ljava/lang/String;)V
 }
 
-public abstract interface class io/embrace/android/embracesdk/internal/api/SdkApi : io/embrace/android/embracesdk/internal/api/BreadcrumbApi, io/embrace/android/embracesdk/internal/api/EmbraceAndroidApi, io/embrace/android/embracesdk/internal/api/InstrumentationApi, io/embrace/android/embracesdk/internal/api/LogsApi, io/embrace/android/embracesdk/internal/api/NetworkRequestApi, io/embrace/android/embracesdk/internal/api/OTelApi, io/embrace/android/embracesdk/internal/api/SdkStateApi, io/embrace/android/embracesdk/internal/api/UserApi, io/embrace/android/embracesdk/internal/api/UserSessionApi, io/embrace/android/embracesdk/spans/TracingApi {
+public abstract interface class io/embrace/android/embracesdk/internal/api/SdkApi : io/embrace/android/embracesdk/internal/api/BreadcrumbApi, io/embrace/android/embracesdk/internal/api/EmbraceAndroidApi, io/embrace/android/embracesdk/internal/api/ExperimentApi, io/embrace/android/embracesdk/internal/api/InstrumentationApi, io/embrace/android/embracesdk/internal/api/LogsApi, io/embrace/android/embracesdk/internal/api/NetworkRequestApi, io/embrace/android/embracesdk/internal/api/OTelApi, io/embrace/android/embracesdk/internal/api/SdkStateApi, io/embrace/android/embracesdk/internal/api/UserApi, io/embrace/android/embracesdk/internal/api/UserSessionApi, io/embrace/android/embracesdk/spans/TracingApi {
 }
 
 public final class io/embrace/android/embracesdk/internal/api/SdkApi$DefaultImpls {

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/experiments/TrackedExperiment.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/experiments/TrackedExperiment.kt
@@ -1,0 +1,22 @@
+package io.embrace.android.embracesdk.experiments
+
+/**
+ * An experiment this app instance has been bucketed into.
+ */
+public class TrackedExperiment(
+
+    /**
+     * The unique ID of the experiment.
+     */
+    public val id: String,
+
+    /**
+     * The time at which membership in this experiment began, in milliseconds since the epoch.
+     */
+    public val startTimeMs: Long,
+
+    /**
+     * Optional name of the variant in which this app instance has been bucketed into this experiment under.
+     */
+    public val variant: String? = null,
+)

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/experiments/TrackedExperiment.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/experiments/TrackedExperiment.kt
@@ -3,20 +3,26 @@ package io.embrace.android.embracesdk.experiments
 /**
  * An experiment this app instance has been bucketed into.
  */
-public class TrackedExperiment(
+public interface TrackedExperiment {
 
     /**
      * The unique ID of the experiment.
      */
-    public val id: String,
+    public val id: String
 
     /**
      * The time at which membership in this experiment began, in milliseconds since the epoch.
      */
-    public val startTimeMs: Long,
+    public val startTimeMs: Long
 
     /**
      * Optional name of the variant in which this app instance has been bucketed into this experiment under.
      */
-    public val variant: String? = null,
-)
+    public val variant: String?
+}
+
+internal class TrackedExperimentImpl(
+    override val id: String,
+    override val startTimeMs: Long,
+    override val variant: String?,
+) : TrackedExperiment

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/experiments/TrackedFeatureFlag.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/experiments/TrackedFeatureFlag.kt
@@ -1,0 +1,17 @@
+package io.embrace.android.embracesdk.experiments
+
+/**
+ * A single feature flag that has been enabled on this app instance.
+ */
+public class TrackedFeatureFlag(
+
+    /**
+     * The unique ID of the feature flag.
+     */
+    public val id: String,
+
+    /**
+     * The time at which the flag started applying to the device, in milliseconds since the epoch.
+     */
+    public val startTimeMs: Long,
+)

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/experiments/TrackedFeatureFlag.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/experiments/TrackedFeatureFlag.kt
@@ -3,15 +3,20 @@ package io.embrace.android.embracesdk.experiments
 /**
  * A single feature flag that has been enabled on this app instance.
  */
-public class TrackedFeatureFlag(
+public interface TrackedFeatureFlag {
 
     /**
      * The unique ID of the feature flag.
      */
-    public val id: String,
+    public val id: String
 
     /**
      * The time at which the flag started applying to the device, in milliseconds since the epoch.
      */
-    public val startTimeMs: Long,
-)
+    public val startTimeMs: Long
+}
+
+internal class TrackedFeatureFlagImpl(
+    override val id: String,
+    override val startTimeMs: Long,
+) : TrackedFeatureFlag

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/ExperimentApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/ExperimentApi.kt
@@ -1,0 +1,33 @@
+package io.embrace.android.embracesdk.internal.api
+
+import io.embrace.android.embracesdk.experiments.TrackedExperiment
+import io.embrace.android.embracesdk.experiments.TrackedFeatureFlag
+
+/**
+ * The public API used to track experiment and feature-flag state on a given device for the current app instance. IDs are unique across
+ * experiments and feature flags. The SDK does not persist this state, and users need to call this each time the app starts up.
+ */
+public interface ExperimentApi {
+
+    /**
+     * Tracks the given experiment memberships that this app instance has been bucketed into.
+     */
+    public fun trackExperiment(vararg experiments: TrackedExperiment)
+
+    /**
+     * Stops tracking the given experiments on this app instance at the given time. An experiment can only be untracked after it has
+     * first been tracked. Untracking an experiment that has not been tracked has no affect.
+     */
+    public fun untrackExperiment(vararg experimentIds: String, endTimeMs: Long)
+
+    /**
+     * Tracks the given enabled feature flags that apply to this app instance.
+     */
+    public fun trackFeatureFlag(vararg flags: TrackedFeatureFlag)
+
+    /**
+     * Stops tracking the given feature flag enablements on this app instance at the given time. A feature flag can only be untracked after
+     * it has first been tracked. Untracking a feature flag that has not been previously enabled has no affect.
+     */
+    public fun untrackFeatureFlag(vararg flagIds: String, endTimeMs: Long)
+}

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/ExperimentApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/ExperimentApi.kt
@@ -1,13 +1,21 @@
 package io.embrace.android.embracesdk.internal.api
 
 import io.embrace.android.embracesdk.experiments.TrackedExperiment
+import io.embrace.android.embracesdk.experiments.TrackedExperimentImpl
 import io.embrace.android.embracesdk.experiments.TrackedFeatureFlag
+import io.embrace.android.embracesdk.experiments.TrackedFeatureFlagImpl
 
 /**
  * The public API used to track experiment and feature-flag state on a given device for the current app instance. IDs are unique across
  * experiments and feature flags. The SDK does not persist this state, and users need to call this each time the app starts up.
  */
 public interface ExperimentApi {
+
+    /**
+     * Creates a [TrackedExperiment]
+     */
+    public fun createExperiment(id: String, startTimeMs: Long, variant: String? = null): TrackedExperiment =
+        TrackedExperimentImpl(id, startTimeMs, variant)
 
     /**
      * Tracks the given experiment memberships that this app instance has been bucketed into.
@@ -19,6 +27,12 @@ public interface ExperimentApi {
      * first been tracked. Untracking an experiment that has not been tracked has no affect.
      */
     public fun untrackExperiment(vararg experimentIds: String, endTimeMs: Long)
+
+    /**
+     * Creates a [TrackedFeatureFlag]
+     */
+    public fun createFeatureFlag(id: String, startTimeMs: Long): TrackedFeatureFlag =
+        TrackedFeatureFlagImpl(id, startTimeMs)
 
     /**
      * Tracks the given enabled feature flags that apply to this app instance.

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/SdkApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/SdkApi.kt
@@ -17,4 +17,5 @@ public interface SdkApi :
     SdkStateApi,
     OTelApi,
     BreadcrumbApi,
-    InstrumentationApi
+    InstrumentationApi,
+    ExperimentApi

--- a/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/Behavior.kt
+++ b/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/Behavior.kt
@@ -9,6 +9,8 @@ import io.embrace.android.embracesdk.internal.config.behavior.BackgroundActivity
 import io.embrace.android.embracesdk.internal.config.behavior.BehaviorThresholdCheck
 import io.embrace.android.embracesdk.internal.config.behavior.DataCaptureEventBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.DataCaptureEventBehaviorImpl
+import io.embrace.android.embracesdk.internal.config.behavior.ExperimentBehavior
+import io.embrace.android.embracesdk.internal.config.behavior.ExperimentBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.LogMessageBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.LogMessageBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.NetworkBehavior
@@ -58,6 +60,13 @@ fun createVitalsBehavior(
 fun createSessionBehavior(
     remoteCfg: RemoteConfig? = null,
 ): UserSessionBehavior = UserSessionBehaviorImpl(remoteCfg)
+
+/**
+ * An [ExperimentBehaviorImpl] that returns default values.
+ */
+fun createExperimentBehavior(
+    remoteCfg: RemoteConfig? = null,
+): ExperimentBehavior = ExperimentBehaviorImpl(remoteCfg)
 
 /**
  * A [NetworkBehaviorImpl] that returns default values.

--- a/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
+++ b/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.internal.config.behavior.AutoDataCaptureBeh
 import io.embrace.android.embracesdk.internal.config.behavior.BackgroundActivityBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.BreadcrumbBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.DataCaptureEventBehavior
+import io.embrace.android.embracesdk.internal.config.behavior.ExperimentBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.LogMessageBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.NetworkBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.NetworkSpanForwardingBehavior
@@ -38,6 +39,7 @@ class FakeConfigService(
     override var threadBlockageBehavior: ThreadBlockageBehavior = createThreadBlockageBehavior(),
     override var vitalsBehavior: VitalsBehavior = createVitalsBehavior(),
     override var sessionBehavior: UserSessionBehavior = createSessionBehavior(),
+    override var experimentBehavior: ExperimentBehavior = createExperimentBehavior(),
     override var networkBehavior: NetworkBehavior = FakeNetworkBehavior(),
     override var dataCaptureEventBehavior: DataCaptureEventBehavior = createDataCaptureEventBehavior(),
     override var sdkModeBehavior: SdkModeBehavior = createSdkModeBehavior(),

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigService.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigService.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.internal.config.behavior.AutoDataCaptureBeh
 import io.embrace.android.embracesdk.internal.config.behavior.BackgroundActivityBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.BreadcrumbBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.DataCaptureEventBehavior
+import io.embrace.android.embracesdk.internal.config.behavior.ExperimentBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.LogMessageBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.NetworkBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.NetworkSpanForwardingBehavior
@@ -58,6 +59,11 @@ interface ConfigService {
      * How sessions should behave.
      */
     val sessionBehavior: UserSessionBehavior
+
+    /**
+     * How the experiments tracking API should behave.
+     */
+    val experimentBehavior: ExperimentBehavior
 
     /**
      * How network call capture should behave.

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.internal.config.behavior.BackgroundActivity
 import io.embrace.android.embracesdk.internal.config.behavior.BehaviorThresholdCheck
 import io.embrace.android.embracesdk.internal.config.behavior.BreadcrumbBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.DataCaptureEventBehaviorImpl
+import io.embrace.android.embracesdk.internal.config.behavior.ExperimentBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.LogMessageBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.NetworkBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.NetworkSpanForwardingBehaviorImpl
@@ -107,6 +108,7 @@ class ConfigServiceImpl(
     override val threadBlockageBehavior = ThreadBlockageBehaviorImpl(thresholdCheck, remoteConfig)
     override val vitalsBehavior = VitalsBehaviorImpl(thresholdCheck, remoteConfig)
     override val sessionBehavior = UserSessionBehaviorImpl(remoteConfig)
+    override val experimentBehavior = ExperimentBehaviorImpl(remoteConfig)
     override val networkBehavior = NetworkBehaviorImpl(instrumentedConfig, remoteConfig)
     override val dataCaptureEventBehavior = DataCaptureEventBehaviorImpl(remoteConfig)
     override val sdkModeBehavior = SdkModeBehaviorImpl(thresholdCheck, remoteConfig)

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/ExperimentBehavior.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/ExperimentBehavior.kt
@@ -1,0 +1,22 @@
+package io.embrace.android.embracesdk.internal.config.behavior
+
+/**
+ * Configuration for the Experiments API
+ */
+interface ExperimentBehavior {
+
+    /**
+     * The combined maximum number of tracked active experiments and feature flags.
+     */
+    fun getMaxActiveCount(): Int
+
+    /**
+     * The maximum length of an ID for the experiments API.
+     */
+    fun getMaxIdLength(): Int
+
+    /**
+     * The maximum length of an experiment variant.
+     */
+    fun getMaxVariantLength(): Int
+}

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/ExperimentBehaviorImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/ExperimentBehaviorImpl.kt
@@ -1,0 +1,33 @@
+package io.embrace.android.embracesdk.internal.config.behavior
+
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import kotlin.math.min
+
+class ExperimentBehaviorImpl(
+    private val remote: RemoteConfig?,
+) : ExperimentBehavior {
+
+    override fun getMaxActiveCount(): Int = min(
+        remote?.maxExperimentCount ?: ACTIVE_COUNT_LIMIT,
+        MAX_ACTIVE_COUNT_LIMIT,
+    )
+
+    override fun getMaxIdLength(): Int = min(
+        remote?.maxExperimentIdLength ?: ID_LENGTH_LIMIT,
+        MAX_ID_LENGTH_LIMIT,
+    )
+
+    override fun getMaxVariantLength(): Int = min(
+        remote?.maxExperimentVariantLength ?: VARIANT_LENGTH_LIMIT,
+        MAX_VARIANT_LENGTH_LIMIT,
+    )
+
+    companion object {
+        const val ACTIVE_COUNT_LIMIT: Int = 500
+        const val MAX_ACTIVE_COUNT_LIMIT: Int = 5000
+        const val ID_LENGTH_LIMIT: Int = 128
+        const val MAX_ID_LENGTH_LIMIT: Int = 1024
+        const val VARIANT_LENGTH_LIMIT: Int = 128
+        const val MAX_VARIANT_LENGTH_LIMIT: Int = 1024
+    }
+}

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/ExperimentBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/ExperimentBehaviorImplTest.kt
@@ -1,0 +1,77 @@
+package io.embrace.android.embracesdk.internal.config.behavior
+
+import io.embrace.android.embracesdk.fakes.createExperimentBehavior
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class ExperimentBehaviorImplTest {
+
+    @Test
+    fun `defaults when remote config is null`() {
+        with(createExperimentBehavior()) {
+            assertEquals(500, getMaxActiveCount())
+            assertEquals(128, getMaxIdLength())
+            assertEquals(128, getMaxVariantLength())
+        }
+    }
+
+    @Test
+    fun `defaults when remote config fields are null`() {
+        with(createExperimentBehavior(remoteCfg = RemoteConfig())) {
+            assertEquals(500, getMaxActiveCount())
+            assertEquals(128, getMaxIdLength())
+            assertEquals(128, getMaxVariantLength())
+        }
+    }
+
+    @Test
+    fun `remote overrides are respected`() {
+        val cfg = RemoteConfig(
+            maxExperimentCount = 250,
+            maxExperimentIdLength = 64,
+            maxExperimentVariantLength = 32,
+        )
+        with(createExperimentBehavior(remoteCfg = cfg)) {
+            assertEquals(250, getMaxActiveCount())
+            assertEquals(64, getMaxIdLength())
+            assertEquals(32, getMaxVariantLength())
+        }
+    }
+
+    @Test
+    fun `max active count is ceilinged at 5000 when remote value exceeds it`() {
+        val cfg = RemoteConfig(maxExperimentCount = 5001)
+        assertEquals(5000, createExperimentBehavior(remoteCfg = cfg).getMaxActiveCount())
+    }
+
+    @Test
+    fun `max active count is valid at exactly 5000`() {
+        val cfg = RemoteConfig(maxExperimentCount = 5000)
+        assertEquals(5000, createExperimentBehavior(remoteCfg = cfg).getMaxActiveCount())
+    }
+
+    @Test
+    fun `id and variant lengths are capped at 1024 when remote values exceed it`() {
+        val cfg = RemoteConfig(
+            maxExperimentIdLength = 1025,
+            maxExperimentVariantLength = 1025,
+        )
+        with(createExperimentBehavior(remoteCfg = cfg)) {
+            assertEquals(1024, getMaxIdLength())
+            assertEquals(1024, getMaxVariantLength())
+        }
+    }
+
+    @Test
+    fun `id and variant lengths are valid at exactly 1024`() {
+        val cfg = RemoteConfig(
+            maxExperimentIdLength = 1024,
+            maxExperimentVariantLength = 1024,
+        )
+        with(createExperimentBehavior(remoteCfg = cfg)) {
+            assertEquals(1024, getMaxIdLength())
+            assertEquals(1024, getMaxVariantLength())
+        }
+    }
+}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/ExperimentKind.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/ExperimentKind.kt
@@ -1,0 +1,10 @@
+package io.embrace.android.embracesdk.internal.capture.experiment
+
+/**
+ * Different types of records that the Experiments API supports. Not used by the SDK to fork behavior, but instead is a classification
+ * that passes the user intent to the backend so it can route and do things differently (e.g. show them on different dashboard pages)
+ */
+internal enum class ExperimentKind(val code: String) {
+    EXPERIMENT("e"),
+    FEATURE_FLAG("f"),
+}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/ExperimentRecord.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/ExperimentRecord.kt
@@ -1,0 +1,21 @@
+package io.embrace.android.embracesdk.internal.capture.experiment
+
+/**
+ * Internal representation of an association with an experiment or feature flag
+ */
+internal data class ExperimentRecord(
+    val kind: ExperimentKind,
+    val id: String,
+    val variant: String?,
+    val startTimeMs: Long,
+    val endTimeMs: Long?,
+) {
+
+    fun serialize(): String =
+        "${kind.code}:${id.escape()}:${variant?.escape().orEmpty()}:$startTimeMs" +
+            (endTimeMs?.let { ":$it" }.orEmpty())
+
+    private fun String.escape(): String = replace("%", "%25")
+        .replace(":", "%3A")
+        .replace(";", "%3B")
+}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/ExperimentTrackingService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/ExperimentTrackingService.kt
@@ -1,0 +1,50 @@
+package io.embrace.android.embracesdk.internal.capture.experiment
+
+/**
+ * Tracks the experiment and feature-flag state declared for the current app instance. Invalid calls will be dropped silently.
+ */
+interface ExperimentTrackingService {
+
+    /**
+     * Records the given experiments and feature flags as tracked. IDs share a single namespace across kinds: the first entry
+     * tracked with a given ID persists irrespective of kind. Repeats are dropped, both in the same call and in subsequent
+     * calls, even if the kind is different.
+     */
+    fun track(data: List<TrackedData>)
+
+    /**
+     * Marks the given experiments or feature flags as no longer enabled. IDs given here must have previously been tracked.
+     * Otherwise, they are dropped.
+     */
+    fun untrack(ids: List<String>, endTimeMs: Long)
+
+    /**
+     * Returns the serialized experiment records as a blob, or null if nothing has been tracked.
+     */
+    fun getRecords(): String?
+}
+
+/**
+ * Internal representation of a single tracked experiment or feature flag.
+ */
+sealed class TrackedData {
+    abstract val id: String
+    abstract val startTimeMs: Long
+
+    /**
+     * An association with an experiment, optionally including the variant in which this app instance is bucketed into.
+     */
+    data class Experiment(
+        override val id: String,
+        override val startTimeMs: Long,
+        val variant: String?,
+    ) : TrackedData()
+
+    /**
+     * An association with an enabled feature flag.
+     */
+    data class FeatureFlag(
+        override val id: String,
+        override val startTimeMs: Long,
+    ) : TrackedData()
+}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/ExperimentTrackingServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/ExperimentTrackingServiceImpl.kt
@@ -1,0 +1,113 @@
+package io.embrace.android.embracesdk.internal.capture.experiment
+
+import io.embrace.android.embracesdk.internal.config.ConfigService
+import io.embrace.android.embracesdk.internal.telemetry.AppliedLimitType
+import io.embrace.android.embracesdk.internal.telemetry.TelemetryService
+
+internal class ExperimentTrackingServiceImpl(
+    configService: ConfigService,
+    private val telemetryService: TelemetryService,
+) : ExperimentTrackingService {
+
+    private val maxActiveCount = configService.experimentBehavior.getMaxActiveCount()
+    private val maxIdLength = configService.experimentBehavior.getMaxIdLength()
+    private val maxVariantLength = configService.experimentBehavior.getMaxVariantLength()
+
+    private val lock = Any()
+
+    private val records = LinkedHashMap<String, ExperimentRecord>()
+    private var activeCount = 0
+    private var cacheValid = false
+    private var cachedRecords: String? = null
+
+    override fun track(data: List<TrackedData>) {
+        synchronized(lock) {
+            data.forEach { entry ->
+                trackRecord(entry.toRecord())
+            }
+        }
+    }
+
+    override fun untrack(ids: List<String>, endTimeMs: Long) {
+        synchronized(lock) {
+            ids.forEach { id ->
+                untrackRecord(id, endTimeMs)
+            }
+        }
+    }
+
+    override fun getRecords(): String? = synchronized(lock) {
+        if (!cacheValid) {
+            cachedRecords = if (records.isEmpty()) {
+                null
+            } else {
+                records.values.joinToString(";") { it.serialize() }
+            }
+            cacheValid = true
+        }
+        cachedRecords
+    }
+
+    private fun trackRecord(record: ExperimentRecord) {
+        synchronized(lock) {
+            if (!isValid(record)) {
+                return
+            }
+
+            if (records.containsKey(record.id)) {
+                return
+            }
+
+            if (activeCount >= maxActiveCount) {
+                telemetryService.trackAppliedLimit("experiment", AppliedLimitType.DROP)
+                return
+            }
+            records[record.id] = record
+            activeCount++
+            cacheValid = false
+        }
+    }
+
+    private fun untrackRecord(id: String, endTimeMs: Long) {
+        synchronized(lock) {
+            val record = records[id] ?: return
+            if (record.endTimeMs == null) {
+                records[id] = record.copy(endTimeMs = endTimeMs)
+                activeCount--
+                cacheValid = false
+            }
+        }
+    }
+
+    private fun TrackedData.toRecord(): ExperimentRecord = when (this) {
+        is TrackedData.Experiment -> ExperimentRecord(
+            kind = ExperimentKind.EXPERIMENT,
+            id = id,
+            variant = variant,
+            startTimeMs = startTimeMs,
+            endTimeMs = null,
+        )
+
+        is TrackedData.FeatureFlag -> ExperimentRecord(
+            kind = ExperimentKind.FEATURE_FLAG,
+            id = id,
+            variant = null,
+            startTimeMs = startTimeMs,
+            endTimeMs = null,
+        )
+    }
+
+    private fun isValid(record: ExperimentRecord): Boolean {
+        if (record.id.isBlank()) {
+            return false
+        }
+        if (record.id.length > maxIdLength) {
+            return false
+        }
+        val variant = record.variant
+        if (variant != null && variant.length > maxVariantLength) {
+            return false
+        }
+        return true
+    }
+}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModule.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestinati
 import io.embrace.android.embracesdk.internal.arch.navigation.NavigationTrackingService
 import io.embrace.android.embracesdk.internal.arch.state.ProcessStateTracker
 import io.embrace.android.embracesdk.internal.capture.connectivity.NetworkConnectivityService
+import io.embrace.android.embracesdk.internal.capture.experiment.ExperimentTrackingService
 import io.embrace.android.embracesdk.internal.capture.session.UserSessionPropertiesService
 import io.embrace.android.embracesdk.internal.capture.user.UserService
 import io.embrace.android.embracesdk.internal.session.id.SessionIdsProvider
@@ -21,5 +22,6 @@ interface EssentialServiceModule {
     val sessionPartTracker: SessionPartTracker
     val sessionIdsProvider: SessionIdsProvider
     val userSessionPropertiesService: UserSessionPropertiesService
+    val experimentTrackingService: ExperimentTrackingService
     val telemetryDestination: TelemetryDestination
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
@@ -11,6 +11,8 @@ import io.embrace.android.embracesdk.internal.arch.state.ProcessStateTracker
 import io.embrace.android.embracesdk.internal.capture.connectivity.EmbraceNetworkConnectivityService
 import io.embrace.android.embracesdk.internal.capture.connectivity.NetworkCallbackConnectivityService
 import io.embrace.android.embracesdk.internal.capture.connectivity.NetworkConnectivityService
+import io.embrace.android.embracesdk.internal.capture.experiment.ExperimentTrackingService
+import io.embrace.android.embracesdk.internal.capture.experiment.ExperimentTrackingServiceImpl
 import io.embrace.android.embracesdk.internal.capture.session.UserSessionPropertiesService
 import io.embrace.android.embracesdk.internal.capture.session.UserSessionPropertiesServiceImpl
 import io.embrace.android.embracesdk.internal.capture.user.EmbraceUserService
@@ -112,5 +114,12 @@ class EssentialServiceModuleImpl(
                 initModule.logger,
             )
         }
+    }
+
+    override val experimentTrackingService: ExperimentTrackingService by lazy {
+        ExperimentTrackingServiceImpl(
+            configService = configService,
+            telemetryService = initModule.telemetryService,
+        )
     }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/ExperimentRecordTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/ExperimentRecordTest.kt
@@ -1,0 +1,79 @@
+package io.embrace.android.embracesdk.internal.capture.experiment
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class ExperimentRecordTest {
+
+    @Test
+    fun `serializes an open experiment with a variant`() {
+        val record = ExperimentRecord(
+            kind = ExperimentKind.EXPERIMENT,
+            id = "id",
+            variant = "variant",
+            startTimeMs = 100L,
+            endTimeMs = null,
+        )
+        assertEquals("e:id:variant:100", record.serialize())
+    }
+
+    @Test
+    fun `serializes an open variant-less experiment`() {
+        val record = ExperimentRecord(
+            kind = ExperimentKind.EXPERIMENT,
+            id = "id",
+            variant = null,
+            startTimeMs = 100L,
+            endTimeMs = null,
+        )
+        assertEquals("e:id::100", record.serialize())
+    }
+
+    @Test
+    fun `serializes an open feature flag`() {
+        val record = ExperimentRecord(
+            kind = ExperimentKind.FEATURE_FLAG,
+            id = "id",
+            variant = null,
+            startTimeMs = 100L,
+            endTimeMs = null,
+        )
+        assertEquals("f:id::100", record.serialize())
+    }
+
+    @Test
+    fun `serializes an ended record`() {
+        val record = ExperimentRecord(
+            kind = ExperimentKind.EXPERIMENT,
+            id = "id",
+            variant = "variant",
+            startTimeMs = 100L,
+            endTimeMs = 200L,
+        )
+        assertEquals("e:id:variant:100:200", record.serialize())
+    }
+
+    @Test
+    fun `percent-escapes id and variant while leaving a ampersand unchanged`() {
+        val record = ExperimentRecord(
+            kind = ExperimentKind.EXPERIMENT,
+            id = "id%:;&",
+            variant = "variant%:;&",
+            startTimeMs = 100L,
+            endTimeMs = null,
+        )
+        assertEquals("e:id%25%3A%3B&:variant%25%3A%3B&:100", record.serialize())
+    }
+
+    @Test
+    fun `escapes percent before delimiters so a pre-existing escape sequence round-trips`() {
+        val record = ExperimentRecord(
+            kind = ExperimentKind.EXPERIMENT,
+            id = "id%3A",
+            variant = null,
+            startTimeMs = 100L,
+            endTimeMs = null,
+        )
+        assertEquals("e:id%253A::100", record.serialize())
+    }
+}

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/ExperimentTrackingServiceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/ExperimentTrackingServiceImplTest.kt
@@ -1,0 +1,261 @@
+package io.embrace.android.embracesdk.internal.capture.experiment
+
+import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeTelemetryService
+import io.embrace.android.embracesdk.fakes.createExperimentBehavior
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.telemetry.AppliedLimitType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+internal class ExperimentTrackingServiceImplTest {
+
+    private lateinit var telemetryService: FakeTelemetryService
+    private lateinit var service: ExperimentTrackingService
+
+    @Before
+    fun setUp() {
+        telemetryService = FakeTelemetryService()
+        service = ExperimentTrackingServiceImpl(
+            configService = FakeConfigService(),
+            telemetryService = telemetryService,
+        )
+    }
+
+    @Test
+    fun `first track is reflected in getRecords`() {
+        service.track(
+            listOf(TrackedData.Experiment(id = "id1", variant = "v1", startTimeMs = 100L)),
+        )
+        assertEquals("e:id1:v1:100", service.getRecords())
+
+        // repeated reads without a mutation return the same cached instance
+        assertSame(service.getRecords(), service.getRecords())
+    }
+
+    @Test
+    fun `re-tracking a known id with a different variant is dropped`() {
+        service.track(
+            listOf(TrackedData.Experiment(id = "id1", variant = "v1", startTimeMs = 100L)),
+        )
+
+        val records = service.getRecords()
+        service.track(
+            listOf(TrackedData.Experiment(id = "id1", variant = "v2", startTimeMs = 200L)),
+        )
+        assertEquals("e:id1:v1:100", service.getRecords())
+
+        // the dropped call does not invalidate the cached serialization
+        assertSame(records, service.getRecords())
+    }
+
+    @Test
+    fun `untrack closes a record in place without disturbing insertion order`() {
+        service.track(
+            listOf(TrackedData.Experiment(id = "a", variant = null, startTimeMs = 100L)),
+        )
+        service.track(
+            listOf(TrackedData.Experiment(id = "b", variant = null, startTimeMs = 200L)),
+        )
+
+        assertEquals("e:a::100;e:b::200", service.getRecords())
+        service.untrack(listOf("a"), 300L)
+        assertEquals("e:a::100:300;e:b::200", service.getRecords())
+    }
+
+    @Test
+    fun `calls to untrack an id not previously tracked has no effect`() {
+        service.track(
+            listOf(TrackedData.Experiment(id = "id1", variant = null, startTimeMs = 100L)),
+        )
+
+        val records = service.getRecords()
+        service.untrack(listOf("unknown"), 200L)
+        assertEquals("e:id1::100", service.getRecords())
+
+        // the dropped call does not invalidate the cached serialization
+        assertSame(records, service.getRecords())
+    }
+
+    @Test
+    fun `untracking an already-ended experiment has no effect`() {
+        service.track(
+            listOf(TrackedData.Experiment(id = "id1", variant = null, startTimeMs = 100L)),
+        )
+        service.untrack(listOf("id1"), 200L)
+        service.untrack(listOf("id1"), 300L)
+        assertEquals("e:id1::100:200", service.getRecords())
+    }
+
+    @Test
+    fun `untrack closes a feature flag record`() {
+        service.track(
+            listOf(TrackedData.FeatureFlag(id = "flag1", startTimeMs = 100L)),
+        )
+        service.untrack(listOf("flag1"), 200L)
+        assertEquals("f:flag1::100:200", service.getRecords())
+    }
+
+    @Test
+    fun `an id tracked as an experiment cannot be re-tracked as a feature flag`() {
+        service.track(
+            listOf(TrackedData.Experiment(id = "id1", variant = null, startTimeMs = 100L)),
+        )
+        service.track(
+            listOf(TrackedData.FeatureFlag(id = "id1", startTimeMs = 150L)),
+        )
+        assertEquals("e:id1::100", service.getRecords())
+    }
+
+    @Test
+    fun `a bulk call applies all entries in order`() {
+        service.track(
+            listOf(
+                TrackedData.Experiment(id = "id1", variant = null, startTimeMs = 100L),
+                TrackedData.Experiment(id = "id2", variant = null, startTimeMs = 200L),
+                TrackedData.Experiment(id = "id3", variant = null, startTimeMs = 300L),
+            ),
+        )
+        assertEquals("e:id1::100;e:id2::200;e:id3::300", service.getRecords())
+    }
+
+    @Test
+    fun `invalid entries in a bulk call are dropped while valid entries are applied`() {
+        service.track(
+            listOf(
+                TrackedData.Experiment(id = "id1", variant = null, startTimeMs = 100L),
+                TrackedData.Experiment(id = "", variant = null, startTimeMs = 200L),
+                TrackedData.Experiment(id = "id2", variant = null, startTimeMs = 300L),
+            ),
+        )
+        assertEquals("e:id1::100;e:id2::300", service.getRecords())
+    }
+
+    @Test
+    fun `a blank id is dropped without creating a record`() {
+        service.track(
+            listOf(TrackedData.Experiment(id = "", variant = null, startTimeMs = 100L)),
+        )
+        assertNull(service.getRecords())
+    }
+
+    @Test
+    fun `an id longer than the max length is dropped silently`() {
+        val service = serviceWithRemoteConfig(RemoteConfig(maxExperimentIdLength = 5))
+        service.track(
+            listOf(TrackedData.Experiment(id = "123456", variant = null, startTimeMs = 100L)),
+        )
+        assertNull(service.getRecords())
+    }
+
+    @Test
+    fun `a variant longer than the max length is dropped silently`() {
+        val service = serviceWithRemoteConfig(RemoteConfig(maxExperimentVariantLength = 5))
+        service.track(
+            listOf(TrackedData.Experiment(id = "id1", variant = "123456", startTimeMs = 100L)),
+        )
+        assertNull(service.getRecords())
+    }
+
+    @Test
+    fun `tracking a new id is dropped once the active cap is reached`() {
+        val service = serviceWithRemoteConfig(RemoteConfig(maxExperimentCount = 2))
+        service.track(
+            listOf(
+                TrackedData.Experiment(id = "id1", variant = null, startTimeMs = 100L),
+                TrackedData.Experiment(id = "id2", variant = null, startTimeMs = 200L),
+            ),
+        )
+        service.track(
+            listOf(TrackedData.Experiment(id = "id3", variant = null, startTimeMs = 300L)),
+        )
+        assertEquals("e:id1::100;e:id2::200", service.getRecords())
+        assertEquals(listOf("experiment" to AppliedLimitType.DROP), telemetryService.appliedLimits)
+    }
+
+    @Test
+    fun `untracking an active id frees a slot for a new id`() {
+        val service = serviceWithRemoteConfig(RemoteConfig(maxExperimentCount = 2))
+        service.track(
+            listOf(
+                TrackedData.Experiment(id = "id1", variant = null, startTimeMs = 100L),
+                TrackedData.Experiment(id = "id2", variant = null, startTimeMs = 200L),
+            ),
+        )
+        service.untrack(listOf("id1"), 150L)
+        service.track(
+            listOf(TrackedData.Experiment(id = "id3", variant = null, startTimeMs = 300L)),
+        )
+        assertEquals("e:id1::100:150;e:id2::200;e:id3::300", service.getRecords())
+    }
+
+    @Test
+    fun `re-tracking a known id and untracking are never blocked by being at the cap`() {
+        val service = serviceWithRemoteConfig(RemoteConfig(maxExperimentCount = 2))
+        service.track(
+            listOf(
+                TrackedData.Experiment(id = "id1", variant = "v1", startTimeMs = 100L),
+                TrackedData.Experiment(id = "id2", variant = null, startTimeMs = 200L),
+            ),
+        )
+        // re-tracking a known id while at the cap is a no-op, not a drop
+        service.track(
+            listOf(TrackedData.Experiment(id = "id1", variant = "v2", startTimeMs = 999L)),
+        )
+        assertEquals("e:id1:v1:100;e:id2::200", service.getRecords())
+
+        // untracking while at the cap is never blocked
+        service.untrack(listOf("id1"), 300L)
+        assertEquals("e:id1:v1:100:300;e:id2::200", service.getRecords())
+        assertTrue(telemetryService.appliedLimits.none { it.first == "experiment" })
+    }
+
+    @Test
+    fun `ended records beyond the active cap remain in the serialized output`() {
+        val service = serviceWithRemoteConfig(RemoteConfig(maxExperimentCount = 1))
+        service.track(
+            listOf(TrackedData.Experiment(id = "id1", variant = null, startTimeMs = 100L)),
+        )
+        service.untrack(listOf("id1"), 150L)
+        service.track(
+            listOf(TrackedData.Experiment(id = "id2", variant = null, startTimeMs = 200L)),
+        )
+        service.untrack(listOf("id2"), 250L)
+        service.track(
+            listOf(TrackedData.Experiment(id = "id3", variant = null, startTimeMs = 300L)),
+        )
+        assertEquals(
+            "e:id1::100:150;e:id2::200:250;e:id3::300",
+            service.getRecords(),
+        )
+    }
+
+    @Test
+    fun `getRecords is null when nothing has ever been tracked`() {
+        assertNull(service.getRecords())
+    }
+
+    @Test
+    fun `serialization order follows tracking order irrespective of kind`() {
+        service.track(
+            listOf(TrackedData.Experiment(id = "id1", variant = null, startTimeMs = 100L)),
+        )
+        service.track(
+            listOf(TrackedData.FeatureFlag(id = "id2", startTimeMs = 200L)),
+        )
+        service.track(
+            listOf(TrackedData.Experiment(id = "id3", variant = null, startTimeMs = 300L)),
+        )
+        assertEquals("e:id1::100;f:id2::200;e:id3::300", service.getRecords())
+    }
+
+    private fun serviceWithRemoteConfig(remoteConfig: RemoteConfig): ExperimentTrackingService =
+        ExperimentTrackingServiceImpl(
+            configService = FakeConfigService(experimentBehavior = createExperimentBehavior(remoteConfig)),
+            telemetryService = telemetryService,
+        )
+}

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/cache/CachedConfiguration.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/cache/CachedConfiguration.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.internal.serialization.BinaryVersion
 import kotlinx.serialization.Serializable
 
 @Serializable
-@BinaryVersion(-6343163155698584460)
+@BinaryVersion(-7373599328249600804)
 data class CachedConfiguration(
     val deviceId: String,
     val etag: String?,

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/RemoteConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/RemoteConfig.kt
@@ -86,6 +86,24 @@ data class RemoteConfig(
     @SerialName("max_session_properties")
     val maxUserSessionProperties: Int? = null,
 
+    /**
+     * The combined maximum number of tracked active experiments and feature flags.
+     */
+    @SerialName("max_experiment_count")
+    val maxExperimentCount: Int? = null,
+
+    /**
+     * The maximum length of an ID for the experiments API.
+     */
+    @SerialName("max_experiment_id_length")
+    val maxExperimentIdLength: Int? = null,
+
+    /**
+     * The maximum length of an experiment variant.
+     */
+    @SerialName("max_experiment_variant_length")
+    val maxExperimentVariantLength: Int? = null,
+
     @Deprecated("Superseded by the flat nsfPctEnabled key; retained for back-compat with persisted/old payloads.")
     @SerialName("network_span_forwarding")
     val networkSpanForwardingRemoteConfig: NetworkSpanForwardingRemoteConfig? = null,

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -60,6 +60,10 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun start (Landroid/content/Context;)V
 	public fun startSpan (Ljava/lang/String;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Ljava/lang/Long;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;)Lio/embrace/android/embracesdk/spans/EmbraceSpan;
 	public fun startView (Ljava/lang/String;)Z
+	public fun trackExperiment ([Lio/embrace/android/embracesdk/experiments/TrackedExperiment;)V
+	public fun trackFeatureFlag ([Lio/embrace/android/embracesdk/experiments/TrackedFeatureFlag;)V
+	public fun untrackExperiment ([Ljava/lang/String;J)V
+	public fun untrackFeatureFlag ([Ljava/lang/String;J)V
 }
 
 public final class io/embrace/android/embracesdk/internal/instrumentation/bytecode/ApplicationInitTimeBytecodeEntrypoint {

--- a/embrace-android-sdk/api/embrace-android-sdk.api
+++ b/embrace-android-sdk/api/embrace-android-sdk.api
@@ -24,6 +24,8 @@ public final class io/embrace/android/embracesdk/Embrace : io/embrace/android/em
 	public fun clearUserIdentifier ()V
 	public fun clearUserPersona (Ljava/lang/String;)V
 	public fun clearUsername ()V
+	public fun createExperiment (Ljava/lang/String;JLjava/lang/String;)Lio/embrace/android/embracesdk/experiments/TrackedExperiment;
+	public fun createFeatureFlag (Ljava/lang/String;J)Lio/embrace/android/embracesdk/experiments/TrackedFeatureFlag;
 	public fun createSpan (Ljava/lang/String;Lio/embrace/android/embracesdk/spans/EmbraceSpan;Lio/embrace/android/embracesdk/spans/AutoTerminationMode;)Lio/embrace/android/embracesdk/spans/EmbraceSpan;
 	public fun disable ()V
 	public fun endUserSession ()V

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ExperimentTrackingFoundationTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ExperimentTrackingFoundationTest.kt
@@ -1,0 +1,76 @@
+package io.embrace.android.embracesdk.testcases.features
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.assertions.findSessionPartSpan
+import io.embrace.android.embracesdk.experiments.TrackedExperiment
+import io.embrace.android.embracesdk.experiments.TrackedFeatureFlag
+import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
+import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class ExperimentTrackingFoundationTest {
+
+    @Rule
+    @JvmField
+    val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule()
+
+    @Test
+    fun `experiment and feature flag tracking works through the public api`() {
+        var bufferedExperimentStartMs: Long = -1
+        var flagStartMs: Long = -1
+        var variantlessExperimentStartMs: Long = -1
+        var untrackEndMs: Long = -1
+
+        testRule.runTest(
+            preSdkStartAction = {
+                bufferedExperimentStartMs = clock.now()
+                embrace.trackExperiment(
+                    TrackedExperiment(
+                        id = "checkout-flow",
+                        startTimeMs = bufferedExperimentStartMs,
+                        variant = "variant-a",
+                    )
+                )
+            },
+            testCaseAction = {
+                recordSession {
+                    flagStartMs = clock.tick()
+                    embrace.trackFeatureFlag(
+                        TrackedFeatureFlag(id = "dark-mode", startTimeMs = flagStartMs)
+                    )
+
+                    variantlessExperimentStartMs = clock.tick()
+                    embrace.trackExperiment(
+                        TrackedExperiment(id = "promo", startTimeMs = variantlessExperimentStartMs)
+                    )
+
+                    untrackEndMs = clock.tick()
+                    embrace.untrackExperiment("checkout-flow", endTimeMs = untrackEndMs)
+
+                    embrace.trackExperiment(
+                        TrackedExperiment(id = "checkout-flow", startTimeMs = clock.tick(), variant = "variant-b")
+                    )
+                }
+            },
+            assertAction = {
+                val expectedRecords =
+                    "e:checkout-flow:variant-a:$bufferedExperimentStartMs:$untrackEndMs;" +
+                        "f:dark-mode::$flagStartMs;" +
+                        "e:promo::$variantlessExperimentStartMs"
+                assertEquals(
+                    expectedRecords,
+                    testRule.bootstrapper.essentialServiceModule.experimentTrackingService.getRecords()
+                )
+
+                val attrs = checkNotNull(getSingleSessionEnvelope().findSessionPartSpan().attributes)
+                assertEquals("3", attrs.findAttributeValue("emb.usage.track_experiment"))
+                assertEquals("1", attrs.findAttributeValue("emb.usage.untrack_experiment"))
+                assertEquals("1", attrs.findAttributeValue("emb.usage.track_feature_flag"))
+            }
+        )
+    }
+}

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ExperimentTrackingFoundationTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ExperimentTrackingFoundationTest.kt
@@ -2,8 +2,6 @@ package io.embrace.android.embracesdk.testcases.features
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.findSessionPartSpan
-import io.embrace.android.embracesdk.experiments.TrackedExperiment
-import io.embrace.android.embracesdk.experiments.TrackedFeatureFlag
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import org.junit.Assert.assertEquals
@@ -29,7 +27,7 @@ internal class ExperimentTrackingFoundationTest {
             preSdkStartAction = {
                 bufferedExperimentStartMs = clock.now()
                 embrace.trackExperiment(
-                    TrackedExperiment(
+                    embrace.createExperiment(
                         id = "checkout-flow",
                         startTimeMs = bufferedExperimentStartMs,
                         variant = "variant-a",
@@ -40,19 +38,19 @@ internal class ExperimentTrackingFoundationTest {
                 recordSession {
                     flagStartMs = clock.tick()
                     embrace.trackFeatureFlag(
-                        TrackedFeatureFlag(id = "dark-mode", startTimeMs = flagStartMs)
+                        embrace.createFeatureFlag(id = "dark-mode", startTimeMs = flagStartMs)
                     )
 
                     variantlessExperimentStartMs = clock.tick()
                     embrace.trackExperiment(
-                        TrackedExperiment(id = "promo", startTimeMs = variantlessExperimentStartMs)
+                        embrace.createExperiment(id = "promo", startTimeMs = variantlessExperimentStartMs)
                     )
 
                     untrackEndMs = clock.tick()
                     embrace.untrackExperiment("checkout-flow", endTimeMs = untrackEndMs)
 
                     embrace.trackExperiment(
-                        TrackedExperiment(id = "checkout-flow", startTimeMs = clock.tick(), variant = "variant-b")
+                        embrace.createExperiment(id = "checkout-flow", startTimeMs = clock.tick(), variant = "variant-b")
                     )
                 }
             },

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.internal.InternalInterfaceApi
 import io.embrace.android.embracesdk.internal.ReactNativeInternalInterface
 import io.embrace.android.embracesdk.internal.UnityInternalInterface
 import io.embrace.android.embracesdk.internal.api.BreadcrumbApi
+import io.embrace.android.embracesdk.internal.api.ExperimentApi
 import io.embrace.android.embracesdk.internal.api.InstrumentationApi
 import io.embrace.android.embracesdk.internal.api.LogsApi
 import io.embrace.android.embracesdk.internal.api.NetworkRequestApi
@@ -20,6 +21,7 @@ import io.embrace.android.embracesdk.internal.api.UserApi
 import io.embrace.android.embracesdk.internal.api.UserSessionApi
 import io.embrace.android.embracesdk.internal.api.ViewTrackingApi
 import io.embrace.android.embracesdk.internal.api.delegate.BreadcrumbApiDelegate
+import io.embrace.android.embracesdk.internal.api.delegate.ExperimentApiDelegate
 import io.embrace.android.embracesdk.internal.api.delegate.InstrumentationApiDelegate
 import io.embrace.android.embracesdk.internal.api.delegate.LogsApiDelegate
 import io.embrace.android.embracesdk.internal.api.delegate.NetworkRequestApiDelegate
@@ -77,6 +79,7 @@ internal class EmbraceImpl(
     private val breadcrumbApiDelegate: BreadcrumbApiDelegate = BreadcrumbApiDelegate(bootstrapper, sdkCallChecker),
     private val instrumentationApiDelegate: InstrumentationApiDelegate =
         InstrumentationApiDelegate(bootstrapper, sdkCallChecker),
+    private val experimentApiDelegate: ExperimentApiDelegate = ExperimentApiDelegate(bootstrapper, sdkCallChecker),
 ) : SdkApi,
     LogsApi by logsApiDelegate,
     NetworkRequestApi by networkRequestApiDelegate,
@@ -88,6 +91,7 @@ internal class EmbraceImpl(
     ViewTrackingApi by viewTrackingApiDelegate,
     BreadcrumbApi by breadcrumbApiDelegate,
     InstrumentationApi by instrumentationApiDelegate,
+    ExperimentApi by experimentApiDelegate,
     InternalInterfaceApi {
 
     init {
@@ -125,6 +129,7 @@ internal class EmbraceImpl(
                         // not fully initialized, but the SDK shouldn't catastrophically throw after this point,
                         // so we allow external calls.
                         sdkCallChecker.started.set(true)
+                        experimentApiDelegate.flushPendingCalls()
                         bootstrapper.registerListeners()
                         bootstrapper.loadInstrumentation()
                         initializeHucInstrumentation(bootstrapper.configService.networkBehavior)

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.internal.InternalInterfaceApi
 import io.embrace.android.embracesdk.internal.ReactNativeInternalInterface
 import io.embrace.android.embracesdk.internal.UnityInternalInterface
 import io.embrace.android.embracesdk.internal.api.BreadcrumbApi
+import io.embrace.android.embracesdk.internal.api.ExperimentApi
 import io.embrace.android.embracesdk.internal.api.InstrumentationApi
 import io.embrace.android.embracesdk.internal.api.LogsApi
 import io.embrace.android.embracesdk.internal.api.NetworkRequestApi
@@ -20,6 +21,7 @@ import io.embrace.android.embracesdk.internal.api.UserApi
 import io.embrace.android.embracesdk.internal.api.UserSessionApi
 import io.embrace.android.embracesdk.internal.api.ViewTrackingApi
 import io.embrace.android.embracesdk.internal.api.delegate.BreadcrumbApiDelegate
+import io.embrace.android.embracesdk.internal.api.delegate.ExperimentApiDelegate
 import io.embrace.android.embracesdk.internal.api.delegate.InstrumentationApiDelegate
 import io.embrace.android.embracesdk.internal.api.delegate.LogsApiDelegate
 import io.embrace.android.embracesdk.internal.api.delegate.NetworkRequestApiDelegate
@@ -75,6 +77,7 @@ internal class EmbraceImpl(
     private val breadcrumbApiDelegate: BreadcrumbApiDelegate = BreadcrumbApiDelegate(bootstrapper, sdkCallChecker),
     private val instrumentationApiDelegate: InstrumentationApiDelegate =
         InstrumentationApiDelegate(bootstrapper, sdkCallChecker),
+    private val experimentApiDelegate: ExperimentApiDelegate = ExperimentApiDelegate(bootstrapper, sdkCallChecker),
 ) : SdkApi,
     LogsApi by logsApiDelegate,
     NetworkRequestApi by networkRequestApiDelegate,
@@ -86,6 +89,7 @@ internal class EmbraceImpl(
     ViewTrackingApi by viewTrackingApiDelegate,
     BreadcrumbApi by breadcrumbApiDelegate,
     InstrumentationApi by instrumentationApiDelegate,
+    ExperimentApi by experimentApiDelegate,
     InternalInterfaceApi {
 
     init {
@@ -120,6 +124,7 @@ internal class EmbraceImpl(
             // not fully initialized, but the SDK shouldn't catastrophically throw after this point,
             // so we allow external calls.
             sdkCallChecker.started.set(true)
+            experimentApiDelegate.flushPendingCalls()
             bootstrapper.registerListeners()
             bootstrapper.loadInstrumentation()
             initializeHucInstrumentation(bootstrapper.configService.networkBehavior)

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExperimentApiDelegate.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExperimentApiDelegate.kt
@@ -1,0 +1,111 @@
+package io.embrace.android.embracesdk.internal.api.delegate
+
+import io.embrace.android.embracesdk.experiments.TrackedExperiment
+import io.embrace.android.embracesdk.experiments.TrackedFeatureFlag
+import io.embrace.android.embracesdk.internal.api.ExperimentApi
+import io.embrace.android.embracesdk.internal.capture.experiment.TrackedData
+import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
+import io.embrace.android.embracesdk.internal.injection.embraceImplInject
+import java.util.concurrent.ConcurrentLinkedQueue
+
+internal class ExperimentApiDelegate(
+    bootstrapper: ModuleInitBootstrapper,
+    private val sdkCallChecker: SdkCallChecker,
+) : ExperimentApi {
+
+    private val experimentTrackingService by embraceImplInject(sdkCallChecker) {
+        bootstrapper.essentialServiceModule.experimentTrackingService
+    }
+
+    private val pendingEvents = ConcurrentLinkedQueue<PendingEvent>()
+
+    override fun trackExperiment(vararg experiments: TrackedExperiment) {
+        if (!sdkCallChecker.started.get()) {
+            buffer(PendingEvent.TrackExperiments(experiments.toList()))
+        } else {
+            trackExperimentsNow(experiments.toList())
+        }
+    }
+
+    override fun untrackExperiment(vararg experimentIds: String, endTimeMs: Long) {
+        untrack("untrack_experiment", experimentIds.toList(), endTimeMs)
+    }
+
+    override fun trackFeatureFlag(vararg flags: TrackedFeatureFlag) {
+        if (!sdkCallChecker.started.get()) {
+            buffer(PendingEvent.TrackFlags(flags.toList()))
+        } else {
+            trackFeatureFlagsNow(flags.toList())
+        }
+    }
+
+    override fun untrackFeatureFlag(vararg flagIds: String, endTimeMs: Long) {
+        untrack("untrack_feature_flag", flagIds.toList(), endTimeMs)
+    }
+
+    fun flushPendingCalls() {
+        while (true) {
+            when (val event = pendingEvents.poll() ?: return) {
+                is PendingEvent.TrackExperiments -> trackExperimentsNow(event.experiments)
+                is PendingEvent.TrackFlags -> trackFeatureFlagsNow(event.flags)
+                is PendingEvent.Untrack -> untrackNow(event.action, event.ids, event.endTimeMs)
+            }
+        }
+    }
+
+    private fun untrack(action: String, ids: List<String>, endTimeMs: Long) {
+        if (!sdkCallChecker.started.get()) {
+            buffer(PendingEvent.Untrack(action, ids, endTimeMs))
+        } else {
+            untrackNow(action, ids, endTimeMs)
+        }
+    }
+
+    private fun trackExperimentsNow(experiments: List<TrackedExperiment>) {
+        if (sdkCallChecker.check("track_experiment")) {
+            experimentTrackingService?.track(experiments.map { it.toData() })
+        }
+    }
+
+    private fun trackFeatureFlagsNow(flags: List<TrackedFeatureFlag>) {
+        if (sdkCallChecker.check("track_feature_flag")) {
+            experimentTrackingService?.track(flags.map { it.toData() })
+        }
+    }
+
+    private fun untrackNow(action: String, ids: List<String>, endTimeMs: Long) {
+        if (sdkCallChecker.check(action)) {
+            experimentTrackingService?.untrack(ids, endTimeMs)
+        }
+    }
+
+    private fun buffer(event: PendingEvent) {
+        if (pendingEvents.size >= PENDING_EVENT_LIMIT) {
+            pendingEvents.poll()
+        }
+        pendingEvents.add(event)
+    }
+
+    private fun TrackedExperiment.toData(): TrackedData =
+        TrackedData.Experiment(
+            id = id,
+            startTimeMs = startTimeMs,
+            variant = variant,
+        )
+
+    private fun TrackedFeatureFlag.toData(): TrackedData =
+        TrackedData.FeatureFlag(
+            id = id,
+            startTimeMs = startTimeMs,
+        )
+
+    private sealed interface PendingEvent {
+        class TrackExperiments(val experiments: List<TrackedExperiment>) : PendingEvent
+        class TrackFlags(val flags: List<TrackedFeatureFlag>) : PendingEvent
+        class Untrack(val action: String, val ids: List<String>, val endTimeMs: Long) : PendingEvent
+    }
+
+    private companion object {
+        private const val PENDING_EVENT_LIMIT = 5000
+    }
+}

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExperimentApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExperimentApiDelegateTest.kt
@@ -37,7 +37,7 @@ internal class ExperimentApiDelegateTest {
 
         val moduleInitBootstrapper = ModuleInitBootstrapper(
             FakeInitModule(logger = initLogger),
-            essentialServiceModuleSupplier = { _, _, _, _, _, _, _, _ ->
+            essentialServiceModuleSupplier = { _, _, _, _, _, _, _, _, _ ->
                 FakeEssentialServiceModule(experimentTrackingService = fakeExperimentTrackingService)
             },
         )

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExperimentApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExperimentApiDelegateTest.kt
@@ -2,8 +2,6 @@ package io.embrace.android.embracesdk.internal.api.delegate
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.experiments.TrackedExperiment
-import io.embrace.android.embracesdk.experiments.TrackedFeatureFlag
 import io.embrace.android.embracesdk.fakes.FakeExperimentTrackingService
 import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
@@ -49,7 +47,7 @@ internal class ExperimentApiDelegateTest {
 
     @Test
     fun `trackExperiment before start buffers without recording usage or error`() {
-        delegate.trackExperiment(TrackedExperiment("exp1", 1L))
+        delegate.trackExperiment(delegate.createExperiment("exp1", 1L))
 
         assertTrue(fakeExperimentTrackingService.trackedData.isEmpty())
         assertTrue(telemetryService.apiCalls.isEmpty())
@@ -67,7 +65,7 @@ internal class ExperimentApiDelegateTest {
 
     @Test
     fun `trackFeatureFlag before start buffers without recording usage or error`() {
-        delegate.trackFeatureFlag(TrackedFeatureFlag("flag1", 1L))
+        delegate.trackFeatureFlag(delegate.createFeatureFlag("flag1", 1L))
 
         assertTrue(fakeExperimentTrackingService.trackedData.isEmpty())
         assertTrue(telemetryService.apiCalls.isEmpty())
@@ -85,8 +83,8 @@ internal class ExperimentApiDelegateTest {
 
     @Test
     fun `buffered calls flush in FIFO order`() {
-        delegate.trackExperiment(TrackedExperiment("exp1", startTimeMs = 123456789L, variant = "v1"))
-        delegate.trackFeatureFlag(TrackedFeatureFlag("flag1", startTimeMs = 987654321L))
+        delegate.trackExperiment(delegate.createExperiment("exp1", startTimeMs = 123456789L, variant = "v1"))
+        delegate.trackFeatureFlag(delegate.createFeatureFlag("flag1", startTimeMs = 987654321L))
         delegate.untrackExperiment("exp1", endTimeMs = 555555555L)
         delegate.untrackFeatureFlag("flag1", endTimeMs = 666666666L)
 
@@ -116,7 +114,7 @@ internal class ExperimentApiDelegateTest {
     @Test
     fun `oldest buffered call is dropped once the pending event limit is exceeded`() {
         repeat(PENDING_EVENT_LIMIT + 1) { i ->
-            delegate.trackExperiment(TrackedExperiment("exp-$i", i.toLong()))
+            delegate.trackExperiment(delegate.createExperiment("exp-$i", i.toLong()))
         }
 
         sdkCallChecker.started.set(true)
@@ -133,7 +131,7 @@ internal class ExperimentApiDelegateTest {
     fun `trackExperiment after SDK start calls into the internal service immediately`() {
         sdkCallChecker.started.set(true)
 
-        delegate.trackExperiment(TrackedExperiment("exp1", startTimeMs = 111L, variant = "v1"))
+        delegate.trackExperiment(delegate.createExperiment("exp1", startTimeMs = 111L, variant = "v1"))
 
         assertEquals(
             listOf(TrackedData.Experiment(id = "exp1", startTimeMs = 111L, variant = "v1")),
@@ -159,7 +157,7 @@ internal class ExperimentApiDelegateTest {
     fun `trackFeatureFlag after SDK start calls into the internal service immediately`() {
         sdkCallChecker.started.set(true)
 
-        delegate.trackFeatureFlag(TrackedFeatureFlag("flag1", startTimeMs = 333L))
+        delegate.trackFeatureFlag(delegate.createFeatureFlag("flag1", startTimeMs = 333L))
 
         assertEquals(
             listOf(TrackedData.FeatureFlag(id = "flag1", startTimeMs = 333L)),

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExperimentApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExperimentApiDelegateTest.kt
@@ -1,0 +1,206 @@
+package io.embrace.android.embracesdk.internal.api.delegate
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.experiments.TrackedExperiment
+import io.embrace.android.embracesdk.experiments.TrackedFeatureFlag
+import io.embrace.android.embracesdk.fakes.FakeExperimentTrackingService
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
+import io.embrace.android.embracesdk.fakes.FakeTelemetryService
+import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.internal.capture.experiment.TrackedData
+import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class ExperimentApiDelegateTest {
+
+    private lateinit var delegate: ExperimentApiDelegate
+    private lateinit var fakeExperimentTrackingService: FakeExperimentTrackingService
+    private lateinit var telemetryService: FakeTelemetryService
+    private lateinit var initLogger: FakeInternalLogger
+    private lateinit var checkerLogger: FakeInternalLogger
+    private lateinit var sdkCallChecker: SdkCallChecker
+
+    @Before
+    fun setUp() {
+        fakeExperimentTrackingService = FakeExperimentTrackingService()
+        telemetryService = FakeTelemetryService()
+        initLogger = FakeInternalLogger()
+        checkerLogger = FakeInternalLogger(throwOnInternalError = false)
+
+        val moduleInitBootstrapper = ModuleInitBootstrapper(
+            FakeInitModule(logger = initLogger),
+            essentialServiceModuleSupplier = { _, _, _, _, _, _, _, _ ->
+                FakeEssentialServiceModule(experimentTrackingService = fakeExperimentTrackingService)
+            },
+        )
+        moduleInitBootstrapper.init(ApplicationProvider.getApplicationContext())
+
+        sdkCallChecker = SdkCallChecker(checkerLogger, telemetryService)
+        delegate = ExperimentApiDelegate(moduleInitBootstrapper, sdkCallChecker)
+    }
+
+    @Test
+    fun `trackExperiment before start buffers without recording usage or error`() {
+        delegate.trackExperiment(TrackedExperiment("exp1", 1L))
+
+        assertTrue(fakeExperimentTrackingService.trackedData.isEmpty())
+        assertTrue(telemetryService.apiCalls.isEmpty())
+        assertTrue(checkerLogger.sdkNotInitializedMessages.isEmpty())
+    }
+
+    @Test
+    fun `untrackExperiment before start buffers without recording usage or error`() {
+        delegate.untrackExperiment("exp1", endTimeMs = 1L)
+
+        assertTrue(fakeExperimentTrackingService.untrackCalls.isEmpty())
+        assertTrue(telemetryService.apiCalls.isEmpty())
+        assertTrue(checkerLogger.sdkNotInitializedMessages.isEmpty())
+    }
+
+    @Test
+    fun `trackFeatureFlag before start buffers without recording usage or error`() {
+        delegate.trackFeatureFlag(TrackedFeatureFlag("flag1", 1L))
+
+        assertTrue(fakeExperimentTrackingService.trackedData.isEmpty())
+        assertTrue(telemetryService.apiCalls.isEmpty())
+        assertTrue(checkerLogger.sdkNotInitializedMessages.isEmpty())
+    }
+
+    @Test
+    fun `untrackFeatureFlag before start buffers without recording usage or error`() {
+        delegate.untrackFeatureFlag("flag1", endTimeMs = 1L)
+
+        assertTrue(fakeExperimentTrackingService.untrackCalls.isEmpty())
+        assertTrue(telemetryService.apiCalls.isEmpty())
+        assertTrue(checkerLogger.sdkNotInitializedMessages.isEmpty())
+    }
+
+    @Test
+    fun `buffered calls flush in FIFO order`() {
+        delegate.trackExperiment(TrackedExperiment("exp1", startTimeMs = 123456789L, variant = "v1"))
+        delegate.trackFeatureFlag(TrackedFeatureFlag("flag1", startTimeMs = 987654321L))
+        delegate.untrackExperiment("exp1", endTimeMs = 555555555L)
+        delegate.untrackFeatureFlag("flag1", endTimeMs = 666666666L)
+
+        sdkCallChecker.started.set(true)
+        delegate.flushPendingCalls()
+
+        assertEquals(
+            listOf("track_experiment", "track_feature_flag", "untrack_experiment", "untrack_feature_flag"),
+            telemetryService.apiCalls,
+        )
+        assertEquals(
+            listOf(
+                TrackedData.Experiment(id = "exp1", startTimeMs = 123456789L, variant = "v1"),
+                TrackedData.FeatureFlag(id = "flag1", startTimeMs = 987654321L),
+            ),
+            fakeExperimentTrackingService.trackedData,
+        )
+        assertEquals(
+            listOf(
+                FakeExperimentTrackingService.UntrackCall(listOf("exp1"), 555555555L),
+                FakeExperimentTrackingService.UntrackCall(listOf("flag1"), 666666666L),
+            ),
+            fakeExperimentTrackingService.untrackCalls,
+        )
+    }
+
+    @Test
+    fun `oldest buffered call is dropped once the pending event limit is exceeded`() {
+        repeat(PENDING_EVENT_LIMIT + 1) { i ->
+            delegate.trackExperiment(TrackedExperiment("exp-$i", i.toLong()))
+        }
+
+        sdkCallChecker.started.set(true)
+        delegate.flushPendingCalls()
+
+        val flushedIds = fakeExperimentTrackingService.trackedData.map { it.id }
+        assertEquals(PENDING_EVENT_LIMIT, flushedIds.size)
+        assertFalse(flushedIds.contains("exp-0"))
+        assertTrue(flushedIds.contains("exp-1"))
+        assertTrue(flushedIds.contains("exp-$PENDING_EVENT_LIMIT"))
+    }
+
+    @Test
+    fun `trackExperiment after SDK start calls into the internal service immediately`() {
+        sdkCallChecker.started.set(true)
+
+        delegate.trackExperiment(TrackedExperiment("exp1", startTimeMs = 111L, variant = "v1"))
+
+        assertEquals(
+            listOf(TrackedData.Experiment(id = "exp1", startTimeMs = 111L, variant = "v1")),
+            fakeExperimentTrackingService.trackedData,
+        )
+        assertEquals(listOf("track_experiment"), telemetryService.apiCalls)
+    }
+
+    @Test
+    fun `untrackExperiment after SDK start calls into the internal service immediately`() {
+        sdkCallChecker.started.set(true)
+
+        delegate.untrackExperiment("exp1", "exp2", endTimeMs = 222L)
+
+        assertEquals(
+            listOf(FakeExperimentTrackingService.UntrackCall(listOf("exp1", "exp2"), 222L)),
+            fakeExperimentTrackingService.untrackCalls,
+        )
+        assertEquals(listOf("untrack_experiment"), telemetryService.apiCalls)
+    }
+
+    @Test
+    fun `trackFeatureFlag after SDK start calls into the internal service immediately`() {
+        sdkCallChecker.started.set(true)
+
+        delegate.trackFeatureFlag(TrackedFeatureFlag("flag1", startTimeMs = 333L))
+
+        assertEquals(
+            listOf(TrackedData.FeatureFlag(id = "flag1", startTimeMs = 333L)),
+            fakeExperimentTrackingService.trackedData,
+        )
+        assertEquals(listOf("track_feature_flag"), telemetryService.apiCalls)
+    }
+
+    @Test
+    fun `untrackFeatureFlag after SDK start calls into the internal service immediately`() {
+        sdkCallChecker.started.set(true)
+
+        delegate.untrackFeatureFlag("flag1", endTimeMs = 444L)
+
+        assertEquals(
+            listOf(FakeExperimentTrackingService.UntrackCall(listOf("flag1"), 444L)),
+            fakeExperimentTrackingService.untrackCalls,
+        )
+        assertEquals(listOf("untrack_feature_flag"), telemetryService.apiCalls)
+    }
+
+    @Test
+    fun `empty vararg calls do not throw and leave nothing tracked`() {
+        delegate.trackExperiment()
+        delegate.untrackExperiment(endTimeMs = 0L)
+        delegate.trackFeatureFlag()
+        delegate.untrackFeatureFlag(endTimeMs = 0L)
+
+        sdkCallChecker.started.set(true)
+        delegate.flushPendingCalls()
+
+        delegate.trackExperiment()
+        delegate.untrackExperiment(endTimeMs = 0L)
+        delegate.trackFeatureFlag()
+        delegate.untrackFeatureFlag(endTimeMs = 0L)
+
+        assertTrue(fakeExperimentTrackingService.trackedData.isEmpty())
+        assertTrue(fakeExperimentTrackingService.untrackCalls.all { it.ids.isEmpty() })
+    }
+
+    private companion object {
+        private const val PENDING_EVENT_LIMIT = 5000
+    }
+}

--- a/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbCommonAttributes.kt
+++ b/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbCommonAttributes.kt
@@ -11,6 +11,12 @@ package io.embrace.android.embracesdk.semconv
 object EmbCommonAttributes {
 
     /**
+     * A blob that represents the state of all active experiments in which this app is participating in.
+     */
+    @ExperimentalSemconv
+    const val EMB_EXPERIMENTS: String = "emb.experiments"
+
+    /**
      * Set this to true when the telemetry is known to have been created through a manual instrumentation API call.
      */
     @ExperimentalSemconv

--- a/embrace-android-semconv/src/main/semconv/common.yaml
+++ b/embrace-android-semconv/src/main/semconv/common.yaml
@@ -7,9 +7,15 @@ attribute_groups:
     brief: "Embrace attributes applicable to any telemetry"
     attributes:
       - ref: emb.manual_instrumentation
+      - ref: emb.experiments
 
 attributes:
   - key: emb.manual_instrumentation
     type: boolean
     brief: "Set this to true when the telemetry is known to have been created through a manual instrumentation API call."
     stability: development
+  - key: emb.experiments
+    type: string
+    brief: "A blob that represents the state of all active experiments in which this app is participating in."
+    stability: development
+    examples: ["e:checkout-flow:variant-a:1691000000000;f:dark-mode::1691000100000;e:promo:control:1691000200000:1691000900000"]

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeExperimentTrackingService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeExperimentTrackingService.kt
@@ -1,0 +1,26 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.internal.capture.experiment.ExperimentTrackingService
+import io.embrace.android.embracesdk.internal.capture.experiment.TrackedData
+
+class FakeExperimentTrackingService : ExperimentTrackingService {
+
+    val trackedData: MutableList<TrackedData> = mutableListOf()
+    val untrackCalls: MutableList<UntrackCall> = mutableListOf()
+    var fakeRecords: String? = null
+
+    data class UntrackCall(
+        val ids: List<String>,
+        val endTimeMs: Long,
+    )
+
+    override fun track(data: List<TrackedData>) {
+        trackedData.addAll(data)
+    }
+
+    override fun untrack(ids: List<String>, endTimeMs: Long) {
+        untrackCalls.add(UntrackCall(ids, endTimeMs))
+    }
+
+    override fun getRecords(): String? = fakeRecords
+}

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeEssentialServiceModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeEssentialServiceModule.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.fakes.injection
 
+import io.embrace.android.embracesdk.fakes.FakeExperimentTrackingService
 import io.embrace.android.embracesdk.fakes.FakeProcessStateTracker
 import io.embrace.android.embracesdk.fakes.FakeNavigationTrackingService
 import io.embrace.android.embracesdk.fakes.FakeNetworkConnectivityService
@@ -26,4 +27,5 @@ class FakeEssentialServiceModule(
     override val networkConnectivityService: NetworkConnectivityService = FakeNetworkConnectivityService(),
     override val telemetryDestination: TelemetryDestination = FakeTelemetryDestination(),
     override val userSessionPropertiesService: FakeUserSessionPropertiesService = FakeUserSessionPropertiesService(),
+    override val experimentTrackingService: FakeExperimentTrackingService = FakeExperimentTrackingService(),
 ) : EssentialServiceModule


### PR DESCRIPTION
Public API that allows the tracking of experiments and feature flags, Calls before the SDK starts are buffered and the result is applied to all telemetry that the SDK logs.