### PR TITLE
Remove clock device-sleep edge-case

### DIFF
--- a/embrace-android-utils/src/main/kotlin/io/embrace/android/embracesdk/internal/clock/NormalizedIntervalClock.kt
+++ b/embrace-android-utils/src/main/kotlin/io/embrace/android/embracesdk/internal/clock/NormalizedIntervalClock.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
+import kotlin.math.max
 
 /**
  * A clock which uses [android.os.SystemClock.elapsedRealtime] that is normalized
@@ -23,6 +24,12 @@ class NormalizedIntervalClock(
     private val monotonicClock: () -> Long = SystemClock::elapsedRealtime,
 ) : Clock {
 
+    /**
+     * The maximum number of CAS iterations to attempt when attempting to retrieve the current time and detect drift. We scale this
+     * relative to the number of cores available on startup, this stops us locking up the CPU trying to retrieve the time.
+     */
+    private val casLimit = max(Runtime.getRuntime().availableProcessors() * 2, 8)
+
     private val baseline = wallClock() - monotonicClock()
 
     /**
@@ -32,7 +39,8 @@ class NormalizedIntervalClock(
     private val hasLoggedDrift = AtomicBoolean(false)
 
     override fun now(): Long {
-        while (true) {
+        val newTime = 0L
+        repeat(casLimit) {
             val prev = lastTime.get()
             val newTime = baseline + monotonicClock()
 
@@ -53,6 +61,8 @@ class NormalizedIntervalClock(
                 return newTime
             }
         }
+
+        return newTime
     }
 
     companion object {

--- a/embrace-android-utils/src/main/kotlin/io/embrace/android/embracesdk/internal/clock/NormalizedIntervalClock.kt
+++ b/embrace-android-utils/src/main/kotlin/io/embrace/android/embracesdk/internal/clock/NormalizedIntervalClock.kt
@@ -24,23 +24,35 @@ class NormalizedIntervalClock(
 ) : Clock {
 
     private val baseline = wallClock() - monotonicClock()
-    private val lastTime = AtomicLong(0L)
+
+    /**
+     * The lastTime that `now` was called - `Long.MIN_VALUE` as a "not yet tracked" sentinel.
+     */
+    private val lastTime = AtomicLong(Long.MIN_VALUE)
     private val hasLoggedDrift = AtomicBoolean(false)
 
     override fun now(): Long {
-        val newTime = baseline + monotonicClock()
-        val prev = lastTime.getAndSet(newTime)
-        if (prev > 0L && newTime < prev - driftThresholdMs) {
-            if (hasLoggedDrift.compareAndSet(false, true)) {
-                logger?.trackInternalError(
-                    InternalErrorType.InternalInterfaceFail,
-                    IllegalStateException(
-                        "NormalizedIntervalClock drifted back in time by more than threshold. Delivery is likely out-of-order.",
-                    ),
-                )
+        while (true) {
+            val prev = lastTime.get()
+            val newTime = baseline + monotonicClock()
+
+            if (prev != Long.MIN_VALUE && newTime < prev - driftThresholdMs) {
+                if (hasLoggedDrift.compareAndSet(false, true)) {
+                    logger?.trackInternalError(
+                        InternalErrorType.InternalInterfaceFail,
+                        IllegalStateException(
+                            "NormalizedIntervalClock drifted back in time by more than threshold. Delivery is likely out-of-order.",
+                        ),
+                    )
+                }
+            }
+
+            // never lower the high-water mark: a backwards reading is returned but not stored,
+            // otherwise repeated sub-threshold steps would walk the comparison baseline down.
+            if (newTime <= prev || lastTime.compareAndSet(prev, newTime)) {
+                return newTime
             }
         }
-        return newTime
     }
 
     companion object {

--- a/embrace-android-utils/src/test/kotlin/io/embrace/android/embracesdk/internal/clock/NormalizedIntervalClockTest.kt
+++ b/embrace-android-utils/src/test/kotlin/io/embrace/android/embracesdk/internal/clock/NormalizedIntervalClockTest.kt
@@ -23,7 +23,7 @@ internal class NormalizedIntervalClockTest {
         clock.now()
         elapsedMs += 1_000L
         clock.now()
-        assertTrue(logger.errorMessages.isEmpty())
+        assertTrue(logger.internalErrorMessages.isEmpty())
     }
 
     @Test
@@ -33,7 +33,7 @@ internal class NormalizedIntervalClockTest {
         clock.now() // record high-water mark
         elapsedMs -= 59_999L // drift back by just under 60s
         clock.now()
-        assertTrue(logger.errorMessages.isEmpty())
+        assertTrue(logger.internalErrorMessages.isEmpty())
     }
 
     @Test
@@ -65,7 +65,7 @@ internal class NormalizedIntervalClockTest {
         clock.now()
         elapsedMs -= 500L // 500ms back, under 1s threshold
         clock.now()
-        assertTrue(logger.errorMessages.isEmpty())
+        assertTrue(logger.internalErrorMessages.isEmpty())
     }
 
     @Test
@@ -97,7 +97,7 @@ internal class NormalizedIntervalClockTest {
         val clock = buildClock()
         elapsedMs = 0L // very low elapsed time
         clock.now() // no previous value, must not log
-        assertTrue(logger.errorMessages.isEmpty())
+        assertTrue(logger.internalErrorMessages.isEmpty())
     }
 
     private fun buildClock(driftThresholdMs: Long = NormalizedIntervalClock.DEFAULT_DRIFT_THRESHOLD_MS) =


### PR DESCRIPTION
## Goal
`NormalizedIntervalClock` may have been falsely reporting drift when the device slept between:
```
        val newTime = baseline + monotonicClock()
        val prev = lastTime.getAndSet(newTime) 
```

Leading a thread to calculate the drift against a stale (and raced) timestamp.

## Design
`SystemClock::elapsedRealtime` cannot go backwards by contract, but the new logic in `NormalizedIntervalClock` should reliably detect if the supplied clock source ever *did* go backwards by more than 60 seconds. This does come at a cost however, since we may now CAS loop several times on any given `now()` call (where `getAndSet` was a single exclusive-exchange on most devices).

## Testing
Fixed the existing tests to assert `internalErrorMessages` instead of `errorMessages` (which were never being logged by the `NormalizedIntervalClock`).