### PR TITLE
Fix R8 warning

### DIFF
--- a/embrace-android-otel/embrace-proguard.cfg
+++ b/embrace-android-otel/embrace-proguard.cfg
@@ -14,8 +14,11 @@
 -dontwarn io.opentelemetry.api.incubator.metrics.ExtendedLongCounterBuilder
 -dontwarn io.opentelemetry.api.incubator.metrics.ExtendedLongUpDownCounter
 -dontwarn io.opentelemetry.api.incubator.metrics.ExtendedLongUpDownCounterBuilder
--dontwarn io.opentelemetry.sdk.autoconfigure.spi.internal.ComponentProvider
--dontwarn io.opentelemetry.sdk.autoconfigure.spi.internal.ConditionalResourceProvider
+## The OTel autoconfigure SPI is compileOnly in opentelemetry-java, so it never ships on Android.
+## Artifacts we pull in transitively (opentelemetry-extension-trace-propagators,
+## opentelemetry-sdk-extension-incubator) declare ServiceLoader providers against it that we
+## never load
+-dontwarn io.opentelemetry.sdk.autoconfigure.spi.**
 
 ## Annotations used by some dependencies (such as OTel, Protobuf and Moshi) at compile time.
 ## No need to keep them for runtime.

--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/framework/PluginIntegrationTestRule.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/framework/PluginIntegrationTestRule.kt
@@ -225,6 +225,9 @@ class PluginIntegrationTestRule : ExternalResource() {
         args.addAll(
             listOf(
                 "--stacktrace",
+                // fixtures consume io.embrace:*:<version>-SNAPSHOT from mavenLocal. Force a refresh
+                // to avoid CI jobs picking up old artifacts
+                "--refresh-dependencies",
                 "-Dorg.gradle.daemon=false",
                 "-Dorg.gradle.parallel=true",
                 "-Dorg.gradle.caching=true",


### PR DESCRIPTION
## Goal

`opentelemetry-kotlin` 0.6.0 adds a new runtime dependency on `io.opentelemetry:opentelemetry-extension-trace-propagators`, which has classes that implement `io.opentelemetry.sdk.autoconfigure.spi.ConfigurablePropagatorProvider`.  This is causing R8 warnings when compiling, such as [this one](https://github.com/embrace-io/embrace-android-sdk/actions/runs/30540000440/job/90865197591).

This showed up as a sporadic test flake due to CI caching the mavenLocal snapshot that runs the gradle plugin integration tests. I've fixed this so that those tests always refresh dependencies to ensure they're correct.