### PR TITLE
Report whether the running device appears to use eMMC

### DIFF
--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeDevice.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeDevice.kt
@@ -8,6 +8,7 @@ class FakeDevice(
     override var screenResolution: String = "1920x1080",
     override val numberOfCores: Int = 8,
     override val internalStorageTotalCapacity: Lazy<Long> = lazy { 10000000L },
+    override val usesEmmcStorage: Boolean? = true,
     override val systemInfo: SystemInfo = SystemInfo().copy(
         deviceManufacturer = "Samsung",
         deviceModel = "Galaxy S10",

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImplTest.kt
@@ -73,5 +73,6 @@ internal class EnvelopeResourceSourceImplTest {
         assertEquals("26", envelope.osCode)
         assertEquals("1920x1080", envelope.screenResolution)
         assertEquals(8, envelope.numCores)
+        assertEquals(true, envelope.usesEmmcStorage)
     }
 }

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/Device.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/Device.kt
@@ -39,4 +39,11 @@ interface Device {
      * @return the total free capacity of the internal storage of the device in bytes
      */
     val internalStorageTotalCapacity: Lazy<Long>
+
+    /**
+     * Whether the device appears to use an eMMC module for its primary storage.
+     *
+     * @return true/false, null if unkown/inconclusive
+     */
+    val usesEmmcStorage: Boolean?
 }

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/DeviceImpl.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/DeviceImpl.kt
@@ -22,6 +22,8 @@ class DeviceImpl(
 ) : Device {
     override var isJailbroken: Boolean? = false
     override var screenResolution: String = ""
+    override var usesEmmcStorage: Boolean? = null
+
     private val jailbreakLocations: List<String> = listOf(
         "/sbin/",
         "/system/bin/",
@@ -36,6 +38,13 @@ class DeviceImpl(
     init {
         asyncRetrieveIsJailbroken()
         asyncRetrieveScreenResolution()
+        asyncRetrieveUsesEmmcStorage()
+    }
+
+    private fun asyncRetrieveUsesEmmcStorage() {
+        backgroundWorker.submit {
+            usesEmmcStorage = detectUsesEmmcStorage()
+        }
     }
 
     private fun asyncRetrieveScreenResolution() {

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImpl.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImpl.kt
@@ -48,6 +48,7 @@ class EnvelopeResourceSourceImpl(
             osCode = device.systemInfo.androidOsApiLevel,
             screenResolution = device.screenResolution,
             numCores = device.numberOfCores,
+            usesEmmcStorage = device.usesEmmcStorage,
             extras = extras.toMap(),
         )
     }

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/StorageTypeDetector.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/StorageTypeDetector.kt
@@ -1,0 +1,50 @@
+package io.embrace.android.embracesdk.internal.envelope.resource
+
+import java.io.File
+
+/**
+ * Infers whether the device uses an eMMC module for its primary storage by inspecting the names of
+ * the block device nodes that the kernel exposes under [BLOCK_DEVICE_DIR].
+ *
+ * eMMC modules appear as `mmcblkN` nodes, but so do removable SD/TF cards, so an MMC node on its own
+ * isn't conclusive. Devices with faster primary storage expose it as a SCSI/UFS (`sdX`), NVMe
+ * (`nvmeXnY`), virtio (`vdX`) or raw NAND (`mtdblockN`) node instead, so if one of those is present
+ * then the MMC node is assumed to be a removable card rather than the primary storage.
+ *
+ * @return true if the only primary storage device present is an MMC one, false if some other primary
+ * storage device is present, and null if no conclusion can be drawn - either because the directory
+ * couldn't be listed, or because it contained nothing recognisable as a primary storage device.
+ */
+internal fun detectUsesEmmcStorage(blockDeviceDir: File = File(BLOCK_DEVICE_DIR)): Boolean? =
+    runCatching {
+        val names = blockDeviceDir.list() ?: return@runCatching null
+        var mmc = false
+        var otherPrimary = false
+
+        names.forEach { name ->
+            when {
+                MMC_DEVICE.matches(name) -> mmc = true
+                OTHER_PRIMARY_DEVICE.matches(name) -> otherPrimary = true
+            }
+        }
+
+        when {
+            mmc && !otherPrimary -> true
+            mmc || otherPrimary -> false
+            else -> null
+        }
+    }.getOrNull()
+
+private const val BLOCK_DEVICE_DIR = "/dev/block"
+
+/**
+ * An MMC device, or one of its partitions: `mmcblk0`, `mmcblk0p1`, `mmcblk0boot0`, `mmcblk0rpmb`.
+ */
+private val MMC_DEVICE = Regex("""mmcblk\d+.*""")
+
+/**
+ * A non-MMC device that could plausibly hold the primary storage, or one of its partitions. The
+ * letter counts are bounded so that names which merely start with the same prefix (`sdcard`) don't
+ * get misread as a device node.
+ */
+private val OTHER_PRIMARY_DEVICE = Regex("""(sd|vd)[a-z]{1,2}\d*|nvme\d+n\d+.*|mtdblock\d+""")

--- a/embrace-android-envelope/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/StorageTypeDetectorTest.kt
+++ b/embrace-android-envelope/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/StorageTypeDetectorTest.kt
@@ -1,0 +1,100 @@
+package io.embrace.android.embracesdk.internal.envelope.resource
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+internal class StorageTypeDetectorTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    @Test
+    fun `emmc partitions and nothing else is detected as emmc`() {
+        assertTrue(
+            checkNotNull(
+                detect(
+                    "mmcblk0",
+                    "mmcblk0p1",
+                    "mmcblk0p2",
+                    "mmcblk0boot0",
+                    "mmcblk0boot1",
+                    "mmcblk0rpmb",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `non storage nodes are ignored`() {
+        assertTrue(
+            checkNotNull(
+                detect(
+                    "mmcblk0",
+                    "dm-0",
+                    "loop0",
+                    "zram0",
+                    "ram0",
+                    "by-name",
+                    "bootdevice",
+                    "sdcard",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `mmc alongside ufs is not detected as emmc`() {
+        assertFalse(checkNotNull(detect("mmcblk1", "mmcblk1p1", "sda", "sda1", "sdb")))
+    }
+
+    @Test
+    fun `mmc alongside nvme is not detected as emmc`() {
+        assertFalse(checkNotNull(detect("mmcblk1", "nvme0n1", "nvme0n1p1")))
+    }
+
+    @Test
+    fun `mmc alongside a virtual disk is not detected as emmc`() {
+        assertFalse(checkNotNull(detect("mmcblk0", "vda", "vdb", "vdc1")))
+    }
+
+    @Test
+    fun `mmc alongside raw nand is not detected as emmc`() {
+        assertFalse(checkNotNull(detect("mmcblk0", "mtdblock0", "mtdblock1")))
+    }
+
+    @Test
+    fun `ufs with no mmc is not detected as emmc`() {
+        assertFalse(checkNotNull(detect("sda", "sda1", "dm-0")))
+    }
+
+    @Test
+    fun `no recognisable storage device yields no result`() {
+        assertNull(detect("dm-0", "loop0", "zram0", "by-name"))
+    }
+
+    @Test
+    fun `empty directory yields no result`() {
+        assertNull(detect())
+    }
+
+    @Test
+    fun `missing directory yields no result`() {
+        assertNull(detectUsesEmmcStorage(File(tempFolder.root, "does-not-exist")))
+    }
+
+    @Test
+    fun `a file in place of the directory yields no result`() {
+        assertNull(detectUsesEmmcStorage(tempFolder.newFile("block")))
+    }
+
+    private fun detect(vararg deviceNames: String): Boolean? {
+        val dir = tempFolder.newFolder()
+        deviceNames.forEach { File(dir, it).createNewFile() }
+        return detectUsesEmmcStorage(dir)
+    }
+}

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeResource.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeResource.kt
@@ -64,6 +64,7 @@ import kotlinx.serialization.Serializable
  * @param osCode (Android) The OS version code. Previous name: d.oc
  * @param screenResolution The screen resolution. Previous name: d.sr
  * @param numCores (Android) The number of CPU cores the device has. Previous name: d.nc
+ * @param usesEmmcStorage (Android) Whether the device appears to use an eMMC module for its primary storage.
  */
 
 @Serializable(with = EnvelopeResourceSerializer::class)
@@ -153,6 +154,9 @@ data class EnvelopeResource(
 
     /* (Android) The number of CPU cores the device has. Previous name: d.nc */
     val numCores: Int? = null,
+
+    /* (Android) Whether the device appears to use an eMMC module for its primary storage. */
+    val usesEmmcStorage: Boolean? = null,
 
     val extras: Map<String, String> = emptyMap(),
 )

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/serialization/EnvelopeResourceSerializer.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/serialization/EnvelopeResourceSerializer.kt
@@ -24,11 +24,11 @@ import kotlinx.serialization.json.put
  * Serializer for [EnvelopeResource] that flattens [EnvelopeResource.extras] into the JSON object
  * alongside the known fields.
  *
- * On write, the 27 known fields are emitted in declaration order (nulls omitted), followed by the
+ * On write, the 28 known fields are emitted in declaration order (nulls omitted), followed by the
  * [EnvelopeResource.extras] entries as additional top-level keys (insertion order preserved).
  * [EnvelopeResource.appFramework] is encoded as its integer [AppFramework.value].
  *
- * On read, the 27 known keys are extracted and any remaining (non-null) key is folded back into
+ * On read, the 28 known keys are extracted and any remaining (non-null) key is folded back into
  * [EnvelopeResource.extras] as a stringified value. An unknown `app_framework` integer decodes to
  * null via [AppFramework.fromInt].
  */
@@ -68,6 +68,7 @@ internal object EnvelopeResourceSerializer : KSerializer<EnvelopeResource> {
             putIfPresent(KEY_OS_CODE, value.osCode)
             putIfPresent(KEY_SCREEN_RESOLUTION, value.screenResolution)
             putIfPresent(KEY_NUM_CORES, value.numCores)
+            putIfPresent(KEY_USES_EMMC_STORAGE, value.usesEmmcStorage)
             value.extras.forEach { (key, entry) -> put(key, entry) }
         }
         jsonEncoder.encodeJsonElement(obj)
@@ -114,6 +115,7 @@ internal object EnvelopeResourceSerializer : KSerializer<EnvelopeResource> {
             osCode = obj.string(KEY_OS_CODE),
             screenResolution = obj.string(KEY_SCREEN_RESOLUTION),
             numCores = obj.int(KEY_NUM_CORES),
+            usesEmmcStorage = obj.boolean(KEY_USES_EMMC_STORAGE),
             extras = extras,
         )
     }
@@ -169,6 +171,7 @@ internal object EnvelopeResourceSerializer : KSerializer<EnvelopeResource> {
     private const val KEY_OS_CODE = "os_code"
     private const val KEY_SCREEN_RESOLUTION = "screen_resolution"
     private const val KEY_NUM_CORES = "num_cores"
+    private const val KEY_USES_EMMC_STORAGE = "uses_emmc_storage"
 
     private val KNOWN_KEYS = setOf(
         KEY_APP_VERSION,
@@ -198,5 +201,6 @@ internal object EnvelopeResourceSerializer : KSerializer<EnvelopeResource> {
         KEY_OS_CODE,
         KEY_SCREEN_RESOLUTION,
         KEY_NUM_CORES,
+        KEY_USES_EMMC_STORAGE,
     )
 }

--- a/embrace-android-payload/src/test/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeResourceAdapterTest.kt
+++ b/embrace-android-payload/src/test/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeResourceAdapterTest.kt
@@ -41,6 +41,7 @@ internal class EnvelopeResourceAdapterTest {
         osCode = "33",
         screenResolution = "1080x2400",
         numCores = 8,
+        usesEmmcStorage = true,
         extras = mapOf(
             "foo" to "bar",
         ),
@@ -124,6 +125,7 @@ internal class EnvelopeResourceAdapterTest {
         assertEquals(expected.osCode, observed.osCode)
         assertEquals(expected.screenResolution, observed.screenResolution)
         assertEquals(expected.numCores, observed.numCores)
+        assertEquals(expected.usesEmmcStorage, observed.usesEmmcStorage)
         assertEquals(expected.extras, observed.extras)
     }
 }

--- a/embrace-android-payload/src/test/kotlin/io/embrace/android/embracesdk/internal/serialization/EnvelopeResourceSerializerTest.kt
+++ b/embrace-android-payload/src/test/kotlin/io/embrace/android/embracesdk/internal/serialization/EnvelopeResourceSerializerTest.kt
@@ -36,6 +36,7 @@ internal class EnvelopeResourceSerializerTest {
         osCode = "33",
         screenResolution = "1080x2400",
         numCores = 8,
+        usesEmmcStorage = true,
         extras = mapOf("foo" to "bar"),
     )
 
@@ -49,7 +50,8 @@ internal class EnvelopeResourceSerializerTest {
                 """"hosted_sdk_version":"1.0.0","unity_build_id":"unity-123","device_manufacturer":"Google",""" +
                 """"device_model":"Pixel 6","device_architecture":"arm64-v8a","jailbroken":false,""" +
                 """"disk_total_capacity":64000000000,"os_type":"android","os_name":"android","os_version":"13",""" +
-                """"os_code":"33","screen_resolution":"1080x2400","num_cores":8,"foo":"bar"}"""
+                """"os_code":"33","screen_resolution":"1080x2400","num_cores":8,"uses_emmc_storage":true,""" +
+                """"foo":"bar"}"""
         assertEquals(expected, embraceJson.encodeToString(EnvelopeResourceSerializer, fullResource))
     }
 

--- a/embrace-android-payload/src/test/resources/envelope_resource_full.json
+++ b/embrace-android-payload/src/test/resources/envelope_resource_full.json
@@ -26,5 +26,6 @@
   "os_code": "33",
   "screen_resolution": "1080x2400",
   "num_cores": 8,
+  "uses_emmc_storage": true,
   "foo": "bar"
 }


### PR DESCRIPTION
## Goal
Attempt to report whether a device appears to have an eMMC module (instead of UFS) as its primary storage.

Detection is a best-effort based on the block device names when they are accessible to the app. When no detection was possible then `null` is reported (and the resource attribute is omitted entirely) rather than report a false-positive. The detection also checks for the existence of "normal" flash storage to differentiate between eMMC as primary storage, and the existence of a TF card for secondary storage.

## Testing
New unit tests for the logic, along with manual testing of the logic across a range of real devices and Android versions.