### PR TITLE
Optimize EmbTrace implementation

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -351,91 +351,89 @@ internal class SessionOrchestratorImpl(
                 return
             }
 
-            EmbTrace.start("transition-state-start")
+            EmbTrace.trace("transition-state-start") {
+                // first, disable any previous periodic caching so the job doesn't overwrite the to-be saved session
+                payloadCachingService?.stopCaching()
 
-            // first, disable any previous periodic caching so the job doesn't overwrite the to-be saved session
-            payloadCachingService?.stopCaching()
-
-            val endingSession = sessionTracker.getActiveSessionPart()
-            if (endingSession != null) {
-                sessionPartSpanAttrPopulator.populateSessionPartSpanEndAttrs(
-                    endType = transitionType.lifeEventType(state),
-                    crashId = crashId,
-                    coldStart = endingSession.isColdStart,
-                    endAttributes = transitionType.endAttributes,
-                )
-            }
-
-            // calculate new session state
-            val endAppState = transitionType.postTransitionEndState(state)
-            val newSessionPart = sessionTracker.newActiveSessionPart(
-                endSessionPartCallback = {
-                    // End the current session or background activity, if either exist.
-                    EmbTrace.trace("end-current-session") {
-                        processEndMessage(oldSessionAction?.invoke(this), transitionType)
-                    }
-                },
-                startSessionPartCallback = {
-                    // the previous session has fully ended at this point
-                    // now, we can clear the SDK state and prepare for the next session
-                    EmbTrace.trace("prepare-new-session") {
-                        boundaryDelegate.cleanupAfterSessionEnd()
-                    }
-
-                    // transition the user session before creating the new session part so that
-                    // the user session is always ready
-                    transitionUserSession(transitionType, endAppState, timestamp)
-
-                    // create the next session part span if we should, and update the SDK state to reflect the transition
-                    EmbTrace.trace("create-new-session") {
-                        newSessionAction?.invoke()
-                    }
-                },
-                postTransitionAppState = endAppState,
-            )
-
-            // update the current state of the SDK
-            state = endAppState
-
-            // update newly created session part and user session, if applicable
-            val userSession = currentUserSession()
-            if (newSessionPart != null) {
-                if (userSession != null) {
-                    // persist partIndex to handle user session restoration in new process
-                    setActiveUserSession(userSession.withPartIndex(newSessionPart.userSessionPartIndex))
-
-                    if (endAppState == AppState.FOREGROUND) {
-                        sessionTracker.setProcessStateSummary(newSessionPart.sessionPartId, userSession.userSessionId)
-                    }
+                val endingSession = sessionTracker.getActiveSessionPart()
+                if (endingSession != null) {
+                    sessionPartSpanAttrPopulator.populateSessionPartSpanEndAttrs(
+                        endType = transitionType.lifeEventType(state),
+                        crashId = crashId,
+                        coldStart = endingSession.isColdStart,
+                        endAttributes = transitionType.endAttributes,
+                    )
                 }
-                boundaryDelegate.prepareForNewSession()
-                sessionPartSpanAttrPopulator.populateSessionPartSpanStartAttrs(newSessionPart, userSession)
-                if (transitionType != TransitionType.CRASH) {
-                    // initiate periodic caching of the payload if a new session has started
-                    EmbTrace.start("initiate-periodic-caching")
-                    updatePeriodicCacheAttrs()
-                    val updateIntervalMs = lastActivityUpdateIntervalMs(userSession)
-                    payloadCachingService?.startCaching(newSessionPart, endAppState) { state, timestamp, zygote ->
-                        synchronized(lock) {
-                            if (state == AppState.FOREGROUND) {
-                                updateUserSessionActivityIfStale(
-                                    timestamp = timestamp,
-                                    updateIntervalMs = updateIntervalMs,
-                                )
-                            }
-                            updatePeriodicCacheAttrs()
-                            payloadFactory.snapshotPayload(state, timestamp, zygote)
+
+                // calculate new session state
+                val endAppState = transitionType.postTransitionEndState(state)
+                val newSessionPart = sessionTracker.newActiveSessionPart(
+                    endSessionPartCallback = {
+                        // End the current session or background activity, if either exist.
+                        EmbTrace.trace("end-current-session") {
+                            processEndMessage(oldSessionAction?.invoke(this), transitionType)
+                        }
+                    },
+                    startSessionPartCallback = {
+                        // the previous session has fully ended at this point
+                        // now, we can clear the SDK state and prepare for the next session
+                        EmbTrace.trace("prepare-new-session") {
+                            boundaryDelegate.cleanupAfterSessionEnd()
+                        }
+
+                        // transition the user session before creating the new session part so that
+                        // the user session is always ready
+                        transitionUserSession(transitionType, endAppState, timestamp)
+
+                        // create the next session part span if we should, and update the SDK state to reflect the transition
+                        EmbTrace.trace("create-new-session") {
+                            newSessionAction?.invoke()
+                        }
+                    },
+                    postTransitionAppState = endAppState,
+                )
+
+                // update the current state of the SDK
+                state = endAppState
+
+                // update newly created session part and user session, if applicable
+                val userSession = currentUserSession()
+                if (newSessionPart != null) {
+                    if (userSession != null) {
+                        // persist partIndex to handle user session restoration in new process
+                        setActiveUserSession(userSession.withPartIndex(newSessionPart.userSessionPartIndex))
+
+                        if (endAppState == AppState.FOREGROUND) {
+                            sessionTracker.setProcessStateSummary(newSessionPart.sessionPartId, userSession.userSessionId)
                         }
                     }
-                    EmbTrace.end()
+                    boundaryDelegate.prepareForNewSession()
+                    sessionPartSpanAttrPopulator.populateSessionPartSpanStartAttrs(newSessionPart, userSession)
+                    if (transitionType != TransitionType.CRASH) {
+                        // initiate periodic caching of the payload if a new session has started
+                        EmbTrace.trace("initiate-periodic-caching") {
+                            updatePeriodicCacheAttrs()
+                            val updateIntervalMs = lastActivityUpdateIntervalMs(userSession)
+                            payloadCachingService?.startCaching(newSessionPart, endAppState) { state, timestamp, zygote ->
+                                synchronized(lock) {
+                                    if (state == AppState.FOREGROUND) {
+                                        updateUserSessionActivityIfStale(
+                                            timestamp = timestamp,
+                                            updateIntervalMs = updateIntervalMs,
+                                        )
+                                    }
+                                    updatePeriodicCacheAttrs()
+                                    payloadFactory.snapshotPayload(state, timestamp, zygote)
+                                }
+                            }
+                        }
+                    }
+                } else if (transitionType == TransitionType.ON_BACKGROUND) {
+                    // if a new session hasn't been created when we background, cache an empty envelope to be used
+                    // in case a native crash needs to be sent in the future after the current process dies
+                    payloadStore?.cacheEmptyCrashEnvelope(payloadFactory.createEmptyLogEnvelope())
                 }
-            } else if (transitionType == TransitionType.ON_BACKGROUND) {
-                // if a new session hasn't been created when we background, cache an empty envelope to be used
-                // in case a native crash needs to be sent in the future after the current process dies
-                payloadStore?.cacheEmptyCrashEnvelope(payloadFactory.createEmptyLogEnvelope())
             }
-
-            EmbTrace.end()
         }
     }
 

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -46,8 +46,6 @@ import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkCap
 import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkRequestDataSource
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
-import io.embrace.android.embracesdk.internal.utils.EmbTrace.end
-import io.embrace.android.embracesdk.internal.utils.EmbTrace.start
 import io.embrace.android.embracesdk.spans.TracingApi
 import java.util.concurrent.Executors
 
@@ -108,25 +106,25 @@ internal class EmbraceImpl(
             }
             bootstrapper.postInit()
 
-            start("post-services-setup")
-            internalInterfaceModule = InternalInterfaceModuleImpl(
-                bootstrapper.initModule,
-                bootstrapper.configService,
-                bootstrapper.payloadSourceModule,
-                this,
-                bootstrapper,
-            )
+            EmbTrace.trace("post-services-setup") {
+                internalInterfaceModule = InternalInterfaceModuleImpl(
+                    bootstrapper.initModule,
+                    bootstrapper.configService,
+                    bootstrapper.payloadSourceModule,
+                    this,
+                    bootstrapper,
+                )
 
-            // not fully initialized, but the SDK shouldn't catastrophically throw after this point,
-            // so we allow external calls.
-            sdkCallChecker.started.set(true)
-            bootstrapper.registerListeners()
-            bootstrapper.loadInstrumentation()
-            initializeHucInstrumentation(bootstrapper.configService.networkBehavior)
-            bootstrapper.postLoadInstrumentation()
-            bootstrapper.triggerPayloadSend()
-            bootstrapper.markSdkInitComplete()
-            end()
+                // not fully initialized, but the SDK shouldn't catastrophically throw after this point,
+                // so we allow external calls.
+                sdkCallChecker.started.set(true)
+                bootstrapper.registerListeners()
+                bootstrapper.loadInstrumentation()
+                initializeHucInstrumentation(bootstrapper.configService.networkBehavior)
+                bootstrapper.postLoadInstrumentation()
+                bootstrapper.triggerPayloadSend()
+                bootstrapper.markSdkInitComplete()
+            }
         } catch (ignored: Throwable) {
             Log.w("Embrace", "Failed to initialize Embrace SDK", ignored)
         }

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
@@ -50,7 +50,7 @@ internal class InitializedModuleGraph(
     private val payloadSourceModuleSupplier: PayloadSourceModuleSupplier?,
 ) : ModuleGraph {
 
-    override val coreModule: CoreModule = init {
+    override val coreModule: CoreModule = init("core") {
         coreModuleSupplier?.invoke(context, initModule) ?: CoreModuleImpl(context, initModule)
     }.apply {
         EmbTrace.trace("span-service-init") {
@@ -58,7 +58,7 @@ internal class InitializedModuleGraph(
         }
     }
 
-    override val configService: ConfigService = init {
+    override val configService: ConfigService = init("config") {
         configServiceSupplier?.invoke(
             initModule,
             coreModule,
@@ -91,7 +91,7 @@ internal class InitializedModuleGraph(
         }
     }
 
-    override val essentialServiceModule: EssentialServiceModule = init {
+    override val essentialServiceModule: EssentialServiceModule = init("essential-service") {
         val lifecycleOwnerProvider: Provider<LifecycleOwner?> = { null }
         val networkConnectivityServiceProvider: Provider<NetworkConnectivityService?> = { null }
         val sessionOrchestratorProvider = { userSessionOrchestrationModule.sessionOrchestrator }
@@ -117,7 +117,7 @@ internal class InitializedModuleGraph(
         )
     }
 
-    override val storageService: StorageService = init {
+    override val storageService: StorageService = init("storage") {
         storageServiceSupplier?.invoke(initModule, coreModule, workerThreadModule)
             ?: EmbraceStorageService(
                 coreModule.context,
@@ -130,7 +130,7 @@ internal class InitializedModuleGraph(
             }
     }
 
-    override val instrumentationModule: InstrumentationModule = init {
+    override val instrumentationModule: InstrumentationModule = init("instrumentation") {
         // Forward references: break the instrumentation <-> userSessionOrchestration cycle.
         val userSessionIdsProvider = { userSessionOrchestrationModule.sessionIdsProvider.getCurrentUserSessionId() }
         val activeSessionIdsProvider = { userSessionOrchestrationModule.sessionIdsProvider.getActiveSessionIds() }
@@ -158,7 +158,7 @@ internal class InitializedModuleGraph(
         )
     }
 
-    override val featureModule: FeatureModule = init {
+    override val featureModule: FeatureModule = init("feature") {
         featureModuleSupplier?.invoke(
             instrumentationModule,
             configService,
@@ -170,7 +170,7 @@ internal class InitializedModuleGraph(
         )
     }
 
-    override val dataCaptureServiceModule: DataCaptureServiceModule = init {
+    override val dataCaptureServiceModule: DataCaptureServiceModule = init("data-capture-service") {
         val destination = instrumentationModule.instrumentationArgs.destination
         dataCaptureServiceModuleSupplier?.invoke(
             initModule.clock,
@@ -189,7 +189,7 @@ internal class InitializedModuleGraph(
         )
     }
 
-    override val deliveryModule: DeliveryModule? = init {
+    override val deliveryModule: DeliveryModule? = init("delivery") {
         if (configService.isOnlyUsingOtelExporters()) {
             null
         } else {
@@ -218,12 +218,12 @@ internal class InitializedModuleGraph(
         }
     }
 
-    override val threadBlockageService: ThreadBlockageService? = init {
+    override val threadBlockageService: ThreadBlockageService? = init("thread-blockage") {
         val args = instrumentationModule.instrumentationArgs
         threadBlockageServiceSupplier?.invoke(args) ?: createThreadBlockageService(args)
     }
 
-    override val payloadSourceModule: PayloadSourceModule = init {
+    override val payloadSourceModule: PayloadSourceModule = init("payload-source") {
         payloadSourceModuleSupplier?.invoke(
             initModule,
             coreModule,
@@ -245,7 +245,7 @@ internal class InitializedModuleGraph(
         )
     }
 
-    override val logModule: LogModule = init {
+    override val logModule: LogModule = init("log") {
         logModuleSupplier?.invoke(
             initModule,
             openTelemetryModule,
@@ -265,7 +265,7 @@ internal class InitializedModuleGraph(
         )
     }
 
-    override val userSessionOrchestrationModule: UserSessionOrchestrationModule = init {
+    override val userSessionOrchestrationModule: UserSessionOrchestrationModule = init("user-session-orchestration") {
         val startupDurationProvider = dataCaptureServiceModule.startupService::getSdkStartupDuration
         userSessionOrchestrationModuleSupplier?.invoke(
             initModule,
@@ -294,9 +294,6 @@ internal class InitializedModuleGraph(
         )
     }
 
-    private inline fun <reified T> init(supplier: () -> T): T {
-        val module = T::class
-        val name = module.simpleName?.removeSuffix("Module")?.lowercase() ?: "module"
-        return EmbTrace.trace("$name-init") { supplier() }
-    }
+    private inline fun <T> init(name: String, supplier: () -> T): T =
+        EmbTrace.trace("$name-init") { supplier() }
 }

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -65,15 +65,14 @@ internal class ModuleInitBootstrapper(
     fun init(
         context: Context,
         versionChecker: VersionChecker = BuildVersionChecker,
-    ): Boolean {
+    ): Boolean = EmbTrace.trace("modules-init") {
         try {
-            EmbTrace.start("modules-init")
             if (isInitialized()) {
-                return false
+                return@trace false
             }
             synchronized(delegate) {
                 if (isInitialized()) {
-                    return false
+                    return@trace false
                 }
                 val workerThreadModule = EmbTrace.trace("workerthread-init") {
                     workerThreadModuleSupplier?.invoke() ?: WorkerThreadModuleImpl()
@@ -98,13 +97,11 @@ internal class ModuleInitBootstrapper(
                     userSessionOrchestrationModuleSupplier,
                     payloadSourceModuleSupplier,
                 )
-                return isInitialized()
+                isInitialized()
             }
         } catch (ignored: SdkDisabledException) {
             // do nothing - avoid instantiating SDK code any more than necessary.
-            return false
-        } finally {
-            EmbTrace.end()
+            false
         }
     }
 

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
@@ -9,8 +9,6 @@ import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkSta
 import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkStatusDataSource
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
-import io.embrace.android.embracesdk.internal.utils.EmbTrace.end
-import io.embrace.android.embracesdk.internal.utils.EmbTrace.start
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
@@ -172,14 +170,14 @@ internal fun ModuleGraph.triggerPayloadSend() {
  * Mark SDK initialization as complete.
  */
 internal fun ModuleGraph.markSdkInitComplete() {
-    start("startup-tracking")
-    dataCaptureServiceModule.startupService.setSdkStartupInfo(
-        coreModule.sdkStartTime,
-        initModule.clock.now(),
-        essentialServiceModule.appStateTracker.getAppState(),
-        Thread.currentThread().name,
-    )
-    end()
+    EmbTrace.trace("startup-tracking") {
+        dataCaptureServiceModule.startupService.setSdkStartupInfo(
+            coreModule.sdkStartTime,
+            initModule.clock.now(),
+            essentialServiceModule.appStateTracker.getAppState(),
+            Thread.currentThread().name,
+        )
+    }
     val appId = configService.appId
     val startMsg = "Embrace SDK version ${BuildConfig.VERSION_NAME} started" +
         (appId?.let { " for appId = $it" } ?: " without an app ID")

--- a/embrace-android-utils/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/EmbTrace.kt
+++ b/embrace-android-utils/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/EmbTrace.kt
@@ -4,103 +4,43 @@ import android.annotation.SuppressLint
 import android.os.Build
 import android.os.Build.VERSION_CODES
 import android.os.Trace
-import androidx.annotation.ChecksSdkIntAtLeast
-import kotlin.random.Random
 
 /**
  * Shim to add custom events to system traces for API 29+. Basic alternative to using androidx.tracing that is safe to interleave.
  */
 object EmbTrace {
-    data class Instance(val name: String, val id: Int)
+
+    const val MAX_KEY_LENGTH = 127
 
     /**
-     * Start a system trace section and return an instance identifier that is required to close it.
-     * The name of the section in the logged trace will be [name] prefixed by "emb-".
-     * If the application is running on version earlier than [VERSION_CODES.Q], no trace section will be started.
-     */
-    fun startAsync(name: String): Instance? {
-        return if (enabled()) {
-            val instance = Instance("emb-$name".take(127), Random.nextInt())
-            Trace.beginAsyncSection(instance.name, instance.id)
-            instance
-        } else {
-            null
-        }
-    }
-
-    /**
-     * Close trace section identified by [instance]
-     */
-    fun endAsync(instance: Instance) {
-        if (enabled()) {
-            Trace.endAsyncSection(instance.name, instance.id)
-        }
-    }
-
-    /**
-     * Start a synchronous trace. If there is an in-progress synchronous trace, this will be nested underneath it.
+     * Create a trace section around the lambda passed in and return the result.
+     * The name of the section will be [sectionName] prefixed by "emb-" and truncated to 127 characters.
      *
-     * Note: this must be manually ended by calling [end]
+     * No section is started (and [code] is simply invoked) when running on a version earlier than
+     * [VERSION_CODES.Q] or when no system trace is currently being captured. Whether a section was
+     * opened is captured once up front, so the section stays balanced even if tracing is toggled
+     * while [code] runs.
      */
     @SuppressLint("UnclosedTrace")
-    fun start(name: String) {
-        if (enabled()) {
-            Trace.beginSection("emb-$name".take(127))
-        }
-    }
-
-    /**
-     * Stop the last-started synchronous trace.
-     */
-    fun end() {
-        if (enabled()) {
-            Trace.endSection()
-        }
-    }
-
-    /**
-     * Create a trace section around the lambda passed in and return the result.
-     * The name of the section will be [sectionName] prefixed by "emb-"
-     *
-     * Note: rethrowing the same [Throwable] that was caught is appropriate here because use of this should not change the code path.
-     */
-    @Suppress("RethrowCaughtException")
-    inline fun <T> traceAsync(sectionName: String, code: Provider<T>): T {
-        val returnValue: T
-        var instance: Instance? = null
-        try {
-            instance = startAsync(sectionName)
-            returnValue = code()
-        } catch (t: Throwable) {
-            throw t
-        } finally {
-            instance?.let { endAsync(it) }
-        }
-
-        return returnValue
-    }
-
-    /**
-     * Create a trace section around the lambda passed in and return the result.
-     * The name of the section will be [sectionName] prefixed by "emb-"
-     *
-     * Note: rethrowing the same [Throwable] that was caught is appropriate here because use of this should not change the code path.
-     */
-    @Suppress("RethrowCaughtException")
     inline fun <T> trace(sectionName: String, code: Provider<T>): T {
-        val returnValue: T
-        try {
-            start(sectionName)
-            returnValue = code()
-        } catch (t: Throwable) {
-            throw t
-        } finally {
-            end()
+        val enabled = Build.VERSION.SDK_INT >= VERSION_CODES.Q && Trace.isEnabled()
+        if (enabled) {
+            // android.os.Trace rejects section names longer than 127 chars, so only pay for the
+            // extra substring allocation when the name actually exceeds that limit.
+            val name = "emb-$sectionName"
+            Trace.beginSection(
+                when {
+                    name.length > MAX_KEY_LENGTH -> name.substring(0, MAX_KEY_LENGTH)
+                    else -> name
+                },
+            )
         }
-
-        return returnValue
+        try {
+            return code()
+        } finally {
+            if (enabled) {
+                Trace.endSection()
+            }
+        }
     }
-
-    @ChecksSdkIntAtLeast(api = VERSION_CODES.Q)
-    private fun enabled(): Boolean = Build.VERSION.SDK_INT >= VERSION_CODES.Q
 }

--- a/embrace-android-utils/src/test/kotlin/io/embrace/android/embracesdk/internal/utils/EmbTraceTest.kt
+++ b/embrace-android-utils/src/test/kotlin/io/embrace/android/embracesdk/internal/utils/EmbTraceTest.kt
@@ -2,76 +2,70 @@ package io.embrace.android.embracesdk.internal.utils
 
 import android.os.Build.VERSION_CODES
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowTrace
 
 @RunWith(AndroidJUnit4::class)
 internal class EmbTraceTest {
 
-    @Test
-    fun `check name is as expected`() {
-        var instance: EmbTrace.Instance? = null
-        try {
-            instance = checkNotNull(EmbTrace.startAsync("test 屈福特"))
-            assertEquals("emb-test 屈福特", instance.name)
-        } finally {
-            instance?.let { EmbTrace.endAsync(it) }
-        }
+    @Before
+    fun setUp() {
+        ShadowTrace.reset()
+        ShadowTrace.setEnabled(true)
+    }
+
+    @After
+    fun tearDown() {
+        ShadowTrace.reset()
     }
 
     @Test
-    fun `check long name is truncated and does not throw`() {
-        var instance: EmbTrace.Instance? = null
-        try {
-            instance = checkNotNull(EmbTrace.startAsync(longName))
-            assertEquals(127, instance.name.length)
-            assertTrue(instance.name.startsWith("emb-a"))
-        } finally {
-            instance?.let { EmbTrace.endAsync(it) }
-        }
+    fun `trace returns the value produced by the lambda`() {
+        assertEquals(2, EmbTrace.trace("test") { 1 + 1 })
     }
 
     @Test
-    fun `check long name for synchronous trace does not throw`() {
-        try {
-            EmbTrace.start(longName)
-        } finally {
-            EmbTrace.end()
-        }
+    fun `trace records a section prefixed with emb-`() {
+        EmbTrace.trace("test 屈福特") { }
+        assertEquals("emb-test 屈福特", ShadowTrace.getPreviousSections().single())
+    }
+
+    @Test
+    fun `trace truncates long section names to 127 characters`() {
+        EmbTrace.trace(longName) { }
+        val section = ShadowTrace.getPreviousSections().single()
+        assertEquals(127, section.length)
+        assertTrue(section.startsWith("emb-a"))
+    }
+
+    @Test
+    fun `trace runs the lambda but records nothing when tracing is disabled`() {
+        ShadowTrace.setEnabled(false)
+        assertEquals(2, EmbTrace.trace("test") { 1 + 1 })
+        assertTrue(ShadowTrace.getPreviousSections().isEmpty())
     }
 
     @Config(sdk = [VERSION_CODES.Q])
     @Test
-    fun `check supported API version does not throw`() {
-        recordAndVerifyAsyncTrace()
-        recordAndVerifySynchronousTrace()
+    fun `trace records a section on the minimum supported API version`() {
+        EmbTrace.trace("test") { }
+        assertEquals("emb-test", ShadowTrace.getPreviousSections().single())
     }
 
-    @Config(sdk = [VERSION_CODES.R])
+    @Config(sdk = [VERSION_CODES.P])
     @Test
-    fun `check unsupported API version does not throw`() {
-        recordAndVerifyAsyncTrace()
-        recordAndVerifySynchronousTrace()
+    fun `trace runs the lambda but records nothing below the supported API version`() {
+        assertEquals(2, EmbTrace.trace("test") { 1 + 1 })
+        assertTrue(ShadowTrace.getPreviousSections().isEmpty())
     }
 
-    private fun recordAndVerifyAsyncTrace() {
-        val returnValue = EmbTrace.traceAsync("test") {
-            1 + 1
-        }
-        assertEquals(2, returnValue)
-    }
-
-    private fun recordAndVerifySynchronousTrace() {
-        val returnValue = EmbTrace.trace("test") {
-            1 + 1
-        }
-        assertEquals(2, returnValue)
-    }
-
-    companion object {
+    private companion object {
         private val longName = "a".repeat(100) + " " + "b".repeat(100)
     }
 }


### PR DESCRIPTION
## Goal

Optimizes the EmbTrace implementation to reduce any impact it might have any performance (or correctness) of traces. I've made a few changes here:

- `EmbTrace` _must_ be called with `trace` now, as most of the other variants were unused, and led to codepaths where a trace wasn't closed which could unbalance Perfetto traces for folks consuming our SDK
- Removed inline reified fun which used reflection
- Avoided constructing a string each time the trace was invoked, in the best case
