### PR TITLE
Avoid two instances of I/O during SDK init

### DIFF
--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/store/RemoteConfigStoreImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/store/RemoteConfigStoreImpl.kt
@@ -12,25 +12,16 @@ import java.io.File
 
 internal class RemoteConfigStoreImpl(
     private val serializer: PlatformSerializer,
-    storageDir: File,
+    private val storageDir: File,
     private val deviceIdProvider: () -> String,
 ) : RemoteConfigStore {
 
-    init {
-        storageDir.mkdirs()
-    }
-
-    private val configFile = File(storageDir, "most_recent_response").apply {
-        createNewFile()
-    }
-
-    private val etagFile = File(storageDir, "etag").apply {
-        createNewFile()
-    }
+    private val configFile by lazy { File(storageDir, "most_recent_response") }
+    private val etagFile by lazy { File(storageDir, "etag") }
 
     // binary fast-path cache. Not created up-front: its absence is a clean cache miss that falls
     // back to [configFile]/[etagFile].
-    private val cachedConfigFile = File(storageDir, "cached_config")
+    private val cachedConfigFile by lazy { File(storageDir, "cached_config") }
 
     override fun loadResponse(): StoredConfigResponse? = loadFromCache() ?: loadFromJson()
 
@@ -60,9 +51,7 @@ internal class RemoteConfigStoreImpl(
             }
             StoredConfigResponse(
                 cfg = cfg,
-                etag = etagFile.readText().ifEmpty {
-                    null
-                },
+                etag = readEtag(),
                 deviceId = null,
             )
         } catch (_: IllegalArgumentException) {
@@ -74,8 +63,11 @@ internal class RemoteConfigStoreImpl(
         }
     }
 
+    private fun readEtag(): String? = runCatching { etagFile.readText() }.getOrNull()?.ifEmpty { null }
+
     override fun saveResponse(response: ConfigHttpResponse) {
         try {
+            storageDir.mkdirs()
             configFile.outputStream().buffered().use { stream ->
                 serializer.toJson<RemoteConfig?>(response.cfg, stream)
             }

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/store/RemoteConfigStoreImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/store/RemoteConfigStoreImplTest.kt
@@ -21,7 +21,46 @@ internal class RemoteConfigStoreImplTest {
     @Before
     fun setUp() {
         dir = Files.createTempDirectory("test").toFile()
-        store = RemoteConfigStoreImpl(TestPlatformSerializer(), dir, { deviceId })
+        store = RemoteConfigStoreImpl(TestPlatformSerializer(), dir) { deviceId }
+    }
+
+    @Test
+    fun `construction does not touch the filesystem`() {
+        val emptyDir = Files.createTempDirectory("empty").toFile()
+        RemoteConfigStoreImpl(TestPlatformSerializer(), emptyDir) { deviceId }
+
+        assertFalse(File(emptyDir, "most_recent_response").exists())
+        assertFalse(File(emptyDir, "etag").exists())
+        assertFalse(File(emptyDir, "cached_config").exists())
+    }
+
+    @Test
+    fun `storage dir is created on first save`() {
+        val nestedDir = File(dir, "nested/config")
+        assertFalse(nestedDir.exists())
+        store = RemoteConfigStoreImpl(TestPlatformSerializer(), nestedDir) { deviceId }
+        assertFalse(nestedDir.exists())
+
+        val config = RemoteConfig(50)
+        store.saveResponse(ConfigHttpResponse(config, "etag"))
+
+        val loaded = checkNotNull(store.loadResponse())
+        assertEquals(config, loaded.cfg)
+        assertEquals("etag", loaded.etag)
+    }
+
+    @Test
+    fun `config without an etag loads from the json path`() {
+        val config = RemoteConfig(50)
+        store.saveResponse(ConfigHttpResponse(config, null))
+        assertFalse(etagFile().exists())
+
+        // force the slow path: a missing binary cache is a clean miss that falls back to json.
+        cachedConfigFile().delete()
+
+        val loaded = checkNotNull(store.loadResponse())
+        assertEquals(config, loaded.cfg)
+        assertNull(loaded.etag)
     }
 
     @Test
@@ -128,7 +167,7 @@ internal class RemoteConfigStoreImplTest {
     @Test
     fun `unreadable json config is preserved as the error may be recoverable`() {
         val serializer = TestPlatformSerializer()
-        store = RemoteConfigStoreImpl(serializer, dir, { deviceId })
+        store = RemoteConfigStoreImpl(serializer, dir) { deviceId }
 
         val config = RemoteConfig(50)
         store.saveResponse(ConfigHttpResponse(config, "etag"))
@@ -152,8 +191,7 @@ internal class RemoteConfigStoreImplTest {
         store = RemoteConfigStoreImpl(
             TestPlatformSerializer(),
             dir,
-            { error("device id unavailable") },
-        )
+        ) { error("device id unavailable") }
 
         val config = RemoteConfig(50)
         store.saveResponse(ConfigHttpResponse(config, "etag"))
@@ -171,4 +209,6 @@ internal class RemoteConfigStoreImplTest {
     private fun cachedConfigFile() = File(dir, "cached_config")
 
     private fun configFile() = File(dir, "most_recent_response")
+
+    private fun etagFile() = File(dir, "etag")
 }


### PR DESCRIPTION
## Goal

Avoids two instances of I/O during SDK init by moving calls to `createNewFile` to the point where files are actually written. This exploits the fact that we now read from a cached version of config, so don't always need to create files at init (which requires unnecessary syscalls).

## Testing

Enhanced existing test file.
