### PR TITLE
Report the device SOC when it is available

### DIFF
--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeDevice.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeDevice.kt
@@ -9,6 +9,7 @@ class FakeDevice(
     override val numberOfCores: Int = 8,
     override val internalStorageTotalCapacity: Lazy<Long> = lazy { 10000000L },
     override val usesEmmcStorage: Boolean? = true,
+    override val socModel: String? = "SM8450",
     override val systemInfo: SystemInfo = SystemInfo().copy(
         deviceManufacturer = "Samsung",
         deviceModel = "Galaxy S10",

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImplTest.kt
@@ -74,5 +74,6 @@ internal class EnvelopeResourceSourceImplTest {
         assertEquals("1920x1080", envelope.screenResolution)
         assertEquals(8, envelope.numCores)
         assertEquals(true, envelope.usesEmmcStorage)
+        assertEquals("SM8450", envelope.deviceSocModel)
     }
 }

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/Device.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/Device.kt
@@ -46,4 +46,11 @@ interface Device {
      * @return true/false, null if unkown/inconclusive
      */
     val usesEmmcStorage: Boolean?
+
+    /**
+     * The model name of the SoC the device is built around, e.g. `SM8450`.
+     *
+     * @return the SoC model name, null if the platform doesn't report one
+     */
+    val socModel: String?
 }

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/DeviceImpl.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/DeviceImpl.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.envelope.resource
 
+import android.os.Build
 import android.os.Environment
 import android.os.StatFs
 import android.util.DisplayMetrics
@@ -124,6 +125,13 @@ class DeviceImpl(
      */
     override val internalStorageTotalCapacity: Lazy<Long> =
         lazy { StatFs(Environment.getDataDirectory().path).totalBytes }
+
+    override val socModel: String? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            Build.SOC_MODEL.trim().takeIf { it.isNotEmpty() && !it.equals(Build.UNKNOWN, ignoreCase = true) }
+        } else {
+            null
+        }
 
     private var persistedJailbroken: Boolean?
         get() = store.getBoolean(

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImpl.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImpl.kt
@@ -49,6 +49,7 @@ class EnvelopeResourceSourceImpl(
             screenResolution = device.screenResolution,
             numCores = device.numberOfCores,
             usesEmmcStorage = device.usesEmmcStorage,
+            deviceSocModel = device.socModel,
             extras = extras.toMap(),
         )
     }

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeResource.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeResource.kt
@@ -65,6 +65,7 @@ import kotlinx.serialization.Serializable
  * @param screenResolution The screen resolution. Previous name: d.sr
  * @param numCores (Android) The number of CPU cores the device has. Previous name: d.nc
  * @param usesEmmcStorage (Android) Whether the device appears to use an eMMC module for its primary storage.
+ * @param deviceSocModel (Android) The model name of the SoC the device is built around.
  */
 
 @Serializable(with = EnvelopeResourceSerializer::class)
@@ -157,6 +158,9 @@ data class EnvelopeResource(
 
     /* (Android) Whether the device appears to use an eMMC module for its primary storage. */
     val usesEmmcStorage: Boolean? = null,
+
+    /* The model name of the SoC (System on a Chip) the device is built around. */
+    val deviceSocModel: String? = null,
 
     val extras: Map<String, String> = emptyMap(),
 )

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/serialization/EnvelopeResourceSerializer.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/serialization/EnvelopeResourceSerializer.kt
@@ -24,11 +24,11 @@ import kotlinx.serialization.json.put
  * Serializer for [EnvelopeResource] that flattens [EnvelopeResource.extras] into the JSON object
  * alongside the known fields.
  *
- * On write, the 28 known fields are emitted in declaration order (nulls omitted), followed by the
+ * On write, the 29 known fields are emitted in declaration order (nulls omitted), followed by the
  * [EnvelopeResource.extras] entries as additional top-level keys (insertion order preserved).
  * [EnvelopeResource.appFramework] is encoded as its integer [AppFramework.value].
  *
- * On read, the 28 known keys are extracted and any remaining (non-null) key is folded back into
+ * On read, the 29 known keys are extracted and any remaining (non-null) key is folded back into
  * [EnvelopeResource.extras] as a stringified value. An unknown `app_framework` integer decodes to
  * null via [AppFramework.fromInt].
  */
@@ -69,6 +69,7 @@ internal object EnvelopeResourceSerializer : KSerializer<EnvelopeResource> {
             putIfPresent(KEY_SCREEN_RESOLUTION, value.screenResolution)
             putIfPresent(KEY_NUM_CORES, value.numCores)
             putIfPresent(KEY_USES_EMMC_STORAGE, value.usesEmmcStorage)
+            putIfPresent(KEY_DEVICE_SOC_MODEL, value.deviceSocModel)
             value.extras.forEach { (key, entry) -> put(key, entry) }
         }
         jsonEncoder.encodeJsonElement(obj)
@@ -116,6 +117,7 @@ internal object EnvelopeResourceSerializer : KSerializer<EnvelopeResource> {
             screenResolution = obj.string(KEY_SCREEN_RESOLUTION),
             numCores = obj.int(KEY_NUM_CORES),
             usesEmmcStorage = obj.boolean(KEY_USES_EMMC_STORAGE),
+            deviceSocModel = obj.string(KEY_DEVICE_SOC_MODEL),
             extras = extras,
         )
     }
@@ -172,6 +174,7 @@ internal object EnvelopeResourceSerializer : KSerializer<EnvelopeResource> {
     private const val KEY_SCREEN_RESOLUTION = "screen_resolution"
     private const val KEY_NUM_CORES = "num_cores"
     private const val KEY_USES_EMMC_STORAGE = "uses_emmc_storage"
+    private const val KEY_DEVICE_SOC_MODEL = "device_soc_model"
 
     private val KNOWN_KEYS = setOf(
         KEY_APP_VERSION,
@@ -202,5 +205,6 @@ internal object EnvelopeResourceSerializer : KSerializer<EnvelopeResource> {
         KEY_SCREEN_RESOLUTION,
         KEY_NUM_CORES,
         KEY_USES_EMMC_STORAGE,
+        KEY_DEVICE_SOC_MODEL,
     )
 }

--- a/embrace-android-payload/src/test/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeResourceAdapterTest.kt
+++ b/embrace-android-payload/src/test/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeResourceAdapterTest.kt
@@ -42,6 +42,7 @@ internal class EnvelopeResourceAdapterTest {
         screenResolution = "1080x2400",
         numCores = 8,
         usesEmmcStorage = true,
+        deviceSocModel = "SM8450",
         extras = mapOf(
             "foo" to "bar",
         ),
@@ -126,6 +127,7 @@ internal class EnvelopeResourceAdapterTest {
         assertEquals(expected.screenResolution, observed.screenResolution)
         assertEquals(expected.numCores, observed.numCores)
         assertEquals(expected.usesEmmcStorage, observed.usesEmmcStorage)
+        assertEquals(expected.deviceSocModel, observed.deviceSocModel)
         assertEquals(expected.extras, observed.extras)
     }
 }

--- a/embrace-android-payload/src/test/kotlin/io/embrace/android/embracesdk/internal/serialization/EnvelopeResourceSerializerTest.kt
+++ b/embrace-android-payload/src/test/kotlin/io/embrace/android/embracesdk/internal/serialization/EnvelopeResourceSerializerTest.kt
@@ -37,6 +37,7 @@ internal class EnvelopeResourceSerializerTest {
         screenResolution = "1080x2400",
         numCores = 8,
         usesEmmcStorage = true,
+        deviceSocModel = "SM8450",
         extras = mapOf("foo" to "bar"),
     )
 
@@ -51,7 +52,7 @@ internal class EnvelopeResourceSerializerTest {
                 """"device_model":"Pixel 6","device_architecture":"arm64-v8a","jailbroken":false,""" +
                 """"disk_total_capacity":64000000000,"os_type":"android","os_name":"android","os_version":"13",""" +
                 """"os_code":"33","screen_resolution":"1080x2400","num_cores":8,"uses_emmc_storage":true,""" +
-                """"foo":"bar"}"""
+                """"device_soc_model":"SM8450","foo":"bar"}"""
         assertEquals(expected, embraceJson.encodeToString(EnvelopeResourceSerializer, fullResource))
     }
 

--- a/embrace-android-payload/src/test/resources/envelope_resource_full.json
+++ b/embrace-android-payload/src/test/resources/envelope_resource_full.json
@@ -27,5 +27,6 @@
   "screen_resolution": "1080x2400",
   "num_cores": 8,
   "uses_emmc_storage": true,
+  "device_soc_model": "SM8450",
   "foo": "bar"
 }


### PR DESCRIPTION
## Goal
Report the SOC model (which is manufacturer specific) when it is available and not a known placeholder value. The SOC in the device can't always reliably be determined by the device make & model.

## Testing
Unit tested, and manually tested on real devices.