### PR TITLE
Remove session.id as span attribute

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
@@ -30,7 +30,6 @@ import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
 import io.embrace.android.embracesdk.internal.session.getUserSessionProperties
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import java.io.InputStream
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeUnit
@@ -441,13 +440,11 @@ internal class PayloadResurrectionServiceImpl(
     /**
      * Resolves the session part id used to match a native crash to this session part.
      *
-     * A current-SDK session part span always has [EmbSessionAttributes.EMB_SESSION_PART_ID] so its presence means no fallback, so we take
-     * whatever value it defines. Lacking that, it means it was created with a version of the SDK that predates user session, so we
-     * get the ID defined in [SessionAttributes.SESSION_ID]. If neither exists, this session part span is not valid, so we return null.
+     * A session part span always has [EmbSessionAttributes.EMB_SESSION_PART_ID], so we take whatever value it defines. If it does not
+     * exist, this session part span is not valid, so we return null.
      */
     private fun Span.resolveSessionPartIdForCrashMatch(): String? =
         attributes?.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID)
-            ?: attributes?.findAttributeValue(SessionAttributes.SESSION_ID)
 
     private fun StoredTelemetryMetadata.loadDecompressedPayload(): InputStream? =
         cacheStorageService.loadPayloadAsStream(this)?.let {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadata.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadata.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.internal.session
 
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 
 /**
  * Holds metadata about the user session. Creating new instances with updated attributes is only permitted to support specific
@@ -44,7 +43,6 @@ sealed interface UserSessionMetadata {
             put(EmbSessionAttributes.EMB_USER_SESSION_NUMBER, userSessionNumber)
             put(EmbSessionAttributes.EMB_USER_SESSION_MAX_DURATION_SECONDS, maxDurationSecs)
             put(EmbSessionAttributes.EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS, inactivityTimeoutSecs)
-            put(SessionAttributes.SESSION_ID, userSessionId)
             if (isBackgroundOnly == true) {
                 put(EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART, BACKGROUND_ONLY_MARKER)
             }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImpl.kt
@@ -9,7 +9,6 @@ import io.embrace.android.embracesdk.internal.session.SessionPartToken
 import io.embrace.android.embracesdk.internal.session.UserSessionMetadata
 import io.embrace.android.embracesdk.semconv.EmbAppAttributes
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import java.util.Locale
 
 internal class SessionPartSpanAttrPopulatorImpl(
@@ -41,7 +40,6 @@ internal class SessionPartSpanAttrPopulatorImpl(
             } else {
                 addSessionPartAttribute(EmbSessionAttributes.EMB_SESSION_PART_ID, "")
                 addSessionPartAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID, "")
-                addSessionPartAttribute(SessionAttributes.SESSION_ID, "")
             }
         }
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImpl.kt
@@ -24,7 +24,6 @@ import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.opentelemetry.kotlin.Clock
 import io.opentelemetry.kotlin.OpenTelemetry
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import io.opentelemetry.kotlin.tracing.Tracer
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -307,7 +306,6 @@ internal class CurrentSessionPartSpanImpl(
         }
         getSystemAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID)?.let {
             put(EmbSessionAttributes.EMB_USER_SESSION_ID, it)
-            put(SessionAttributes.SESSION_ID, it)
         }
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/schema/TelemetryAttributesTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/schema/TelemetryAttributesTest.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.internal.arch.schema
 import io.embrace.android.embracesdk.fakes.TestUuidSource
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.opentelemetry.kotlin.semconv.ExceptionAttributes
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -12,24 +11,24 @@ internal class TelemetryAttributesTest {
 
     private lateinit var customAttributes: Map<String, String>
     private lateinit var telemetryAttributes: TelemetryAttributes
-    private lateinit var otelSessionId: String
+    private lateinit var userSessionId: String
 
     @Before
     fun setup() {
         customAttributes = mapOf("custom" to "attributeValue")
-        otelSessionId = TestUuidSource().createUuid()
+        userSessionId = TestUuidSource().createUuid()
     }
 
     @Test
     fun `only schema properties`() {
         telemetryAttributes = TelemetryAttributes()
-        telemetryAttributes.setAttribute(SessionAttributes.SESSION_ID, otelSessionId)
+        telemetryAttributes.setAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID, userSessionId)
         telemetryAttributes.setAttribute(ExceptionAttributes.EXCEPTION_TYPE, "exceptionValue")
         val attributes = telemetryAttributes.snapshot()
         assertEquals(2, attributes.size)
-        assertEquals(otelSessionId, attributes[SessionAttributes.SESSION_ID])
+        assertEquals(userSessionId, attributes[EmbSessionAttributes.EMB_USER_SESSION_ID])
         assertEquals("exceptionValue", attributes[ExceptionAttributes.EXCEPTION_TYPE])
-        assertEquals(otelSessionId, telemetryAttributes.getAttribute(SessionAttributes.SESSION_ID))
+        assertEquals(userSessionId, telemetryAttributes.getAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID))
         assertEquals("exceptionValue", telemetryAttributes.getAttribute(ExceptionAttributes.EXCEPTION_TYPE))
     }
 
@@ -38,37 +37,37 @@ internal class TelemetryAttributesTest {
         telemetryAttributes = TelemetryAttributes(
             customAttributes = customAttributes,
         )
-        val otelSessionIdKey = SessionAttributes.SESSION_ID
-        telemetryAttributes.setAttribute(otelSessionIdKey, otelSessionId)
+        val userSessionIdKey = EmbSessionAttributes.EMB_USER_SESSION_ID
+        telemetryAttributes.setAttribute(userSessionIdKey, userSessionId)
 
         val attributes = telemetryAttributes.snapshot()
         assertEquals("attributeValue", attributes["custom"])
-        assertEquals(otelSessionId, attributes[otelSessionIdKey])
+        assertEquals(userSessionId, attributes[userSessionIdKey])
     }
 
     @Test
     fun `overwritten values returned`() {
-        val newOtelSessionId = TestUuidSource().createUuid()
+        val newUserSessionId = TestUuidSource().createUuid()
         telemetryAttributes = TelemetryAttributes()
-        val otelSessionIdKey = SessionAttributes.SESSION_ID
-        telemetryAttributes.setAttribute(otelSessionIdKey, otelSessionId)
-        telemetryAttributes.setAttribute(otelSessionIdKey, newOtelSessionId)
+        val userSessionIdKey = EmbSessionAttributes.EMB_USER_SESSION_ID
+        telemetryAttributes.setAttribute(userSessionIdKey, userSessionId)
+        telemetryAttributes.setAttribute(userSessionIdKey, newUserSessionId)
 
         val attributes = telemetryAttributes.snapshot()
         assertEquals(1, attributes.size)
-        assertEquals(newOtelSessionId, attributes[otelSessionIdKey])
+        assertEquals(newUserSessionId, attributes[userSessionIdKey])
     }
 
     @Test
     fun `schema attribute values take priority if the same key is used`() {
-        val newOtelSessionId = TestUuidSource().createUuid()
+        val newUserSessionId = TestUuidSource().createUuid()
         telemetryAttributes = TelemetryAttributes(
-            customAttributes = mapOf(SessionAttributes.SESSION_ID to otelSessionId),
+            customAttributes = mapOf(EmbSessionAttributes.EMB_USER_SESSION_ID to userSessionId),
         )
-        telemetryAttributes.setAttribute(SessionAttributes.SESSION_ID, newOtelSessionId)
+        telemetryAttributes.setAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID, newUserSessionId)
         val attributes = telemetryAttributes.snapshot()
         assertEquals(1, attributes.size)
-        assertEquals(newOtelSessionId, attributes[SessionAttributes.SESSION_ID])
+        assertEquals(newUserSessionId, attributes[EmbSessionAttributes.EMB_USER_SESSION_ID])
     }
 
     @Test
@@ -76,7 +75,7 @@ internal class TelemetryAttributesTest {
         telemetryAttributes = TelemetryAttributes(
             customAttributes = customAttributes,
         )
-        telemetryAttributes.setAttribute(SessionAttributes.SESSION_ID, otelSessionId)
+        telemetryAttributes.setAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID, userSessionId)
 
         val attributes = telemetryAttributes.snapshot()
         assertEquals(2, attributes.size)
@@ -88,17 +87,17 @@ internal class TelemetryAttributesTest {
         val blankishValues = listOf("", " ", "null", "NULL")
 
         // Give me Union types, plz
-        val otelSessionIdKey = SessionAttributes.SESSION_ID
+        val userSessionIdKey = EmbSessionAttributes.EMB_USER_SESSION_ID
         blankishValues.forEach { value ->
-            telemetryAttributes.setAttribute(otelSessionIdKey, value, true)
-            assertEquals(value, telemetryAttributes.getAttribute(otelSessionIdKey))
+            telemetryAttributes.setAttribute(userSessionIdKey, value, true)
+            assertEquals(value, telemetryAttributes.getAttribute(userSessionIdKey))
         }
 
-        telemetryAttributes.setAttribute(otelSessionIdKey, "test")
+        telemetryAttributes.setAttribute(userSessionIdKey, "test")
 
         blankishValues.forEach { value ->
-            telemetryAttributes.setAttribute(otelSessionIdKey, value, false)
-            assertEquals("test", telemetryAttributes.getAttribute(otelSessionIdKey))
+            telemetryAttributes.setAttribute(userSessionIdKey, value, false)
+            assertEquals("test", telemetryAttributes.getAttribute(userSessionIdKey))
         }
 
         blankishValues.forEach { value ->

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
@@ -48,7 +48,6 @@ import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
-import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.session.UserSessionRestoreDecision
 import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
 import io.embrace.android.embracesdk.internal.toEmbracePayload
@@ -56,7 +55,6 @@ import io.embrace.android.embracesdk.internal.worker.PriorityWorker
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbUserSessionTerminationReasonValues
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -325,29 +323,6 @@ class PayloadResurrectionServiceImplTest {
         val attributes =
             checkNotNull(getStoredParts().last().getSessionPartSpan()?.attributes)
         assertNull(attributes.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID))
-    }
-
-    @Test
-    fun `native crash attaches to a legacy session part that carries only session id`() {
-        val legacySessionId = "legacy-session-id"
-        nativeCrashService.addNativeCrashData(
-            createNativeCrashData(
-                nativeCrashId = "legacy-native-crash",
-                sessionPartId = legacySessionId,
-            ),
-        )
-        cacheStorageService.addPayload(
-            metadata = sessionMetadata.copy(userSessionId = "", sessionPartId = ""),
-            data = deadSessionEnvelope.asPreUserSessionPayload(legacySessionId),
-        )
-
-        resurrectInBackground()
-
-        val sessionPartSpan = getStoredParts().single().getSessionPartSpan()
-        assertEquals(
-            "legacy-native-crash",
-            sessionPartSpan?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_CRASH_ID),
-        )
     }
 
     @Test
@@ -819,35 +794,6 @@ class PayloadResurrectionServiceImplTest {
         )
         resurrectInBackground()
     }
-
-    /**
-     * Rewrites a session payload to look like one from an SDK that predates the user session concept
-     */
-    private fun Envelope<SessionPartPayload>.asPreUserSessionPayload(
-        legacySessionId: String,
-    ): Envelope<SessionPartPayload> {
-        return copy(
-            data = data.copy(
-                spans = data.spans.toPreUserSessionSpan(legacySessionId),
-                spanSnapshots = data.spanSnapshots.toPreUserSessionSpan(legacySessionId),
-            ),
-        )
-    }
-
-    private fun List<Span>?.toPreUserSessionSpan(legacySessionId: String): List<Span>? =
-        this?.map { span ->
-            span.copy(
-                attributes = checkNotNull(span.attributes)
-                    .filterNot { it.key == EmbSessionAttributes.EMB_SESSION_PART_ID || it.key == EmbSessionAttributes.EMB_USER_SESSION_ID }
-                    .map {
-                        if (it.key == SessionAttributes.SESSION_ID) {
-                            it.copy(data = legacySessionId)
-                        } else {
-                            it
-                        }
-                    },
-            )
-        }
 
     private fun getStoredParts(): List<Envelope<SessionPartPayload>> {
         return payloadStorageService.storedPayloads().map { bytes ->

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
@@ -11,7 +11,6 @@ import io.embrace.android.embracesdk.internal.session.UserSessionMetadata
 import io.embrace.android.embracesdk.semconv.EmbAppAttributes
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbUserSessionTerminationReasonValues
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Before
@@ -63,7 +62,6 @@ internal class SessionPartSpanAttrPopulatorImplTest {
         assertEquals("3", attrs[EmbSessionAttributes.EMB_USER_SESSION_NUMBER])
         assertEquals("43200", attrs[EmbSessionAttributes.EMB_USER_SESSION_MAX_DURATION_SECONDS])
         assertEquals("1800", attrs[EmbSessionAttributes.EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS])
-        assertEquals("user-session-uuid", attrs[SessionAttributes.SESSION_ID])
         assertEquals("id", attrs[EmbSessionAttributes.EMB_SESSION_PART_ID])
         assertFalse(attrs.containsKey(EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART))
     }
@@ -75,7 +73,6 @@ internal class SessionPartSpanAttrPopulatorImplTest {
         val attrs = destination.attributes
         assertEquals("1", attrs[EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART])
         assertEquals("user-session-uuid", attrs[EmbSessionAttributes.EMB_USER_SESSION_ID])
-        assertEquals("user-session-uuid", attrs[SessionAttributes.SESSION_ID])
     }
 
     @Test
@@ -91,7 +88,6 @@ internal class SessionPartSpanAttrPopulatorImplTest {
         assertEquals("state", attrs[EmbSessionAttributes.EMB_SESSION_START_TYPE])
         assertEquals("", attrs[EmbSessionAttributes.EMB_SESSION_PART_ID])
         assertEquals("", attrs[EmbSessionAttributes.EMB_USER_SESSION_ID])
-        assertEquals("", attrs[SessionAttributes.SESSION_ID])
 
         assertFalse(attrs.containsKey(EmbSessionAttributes.EMB_USER_SESSION_PART_INDEX))
         assertFalse(attrs.containsKey(EmbSessionAttributes.EMB_USER_SESSION_NUMBER))

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImplTests.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/spans/CurrentSessionPartSpanImplTests.kt
@@ -45,7 +45,6 @@ import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.kotlin.OpenTelemetry
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import io.opentelemetry.kotlin.tracing.Tracer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -930,7 +929,6 @@ internal class CurrentSessionPartSpanImplTests {
         val expectedPartLinkAttrs = mapOf(
             EmbSessionAttributes.EMB_SESSION_PART_ID to sessionPartId,
             EmbSessionAttributes.EMB_USER_SESSION_ID to userSessionId,
-            SessionAttributes.SESSION_ID to userSessionId,
         )
         checkNotNull(spanSnapshot.links).single().validateSystemLink(
             linkedSpan = sessionPartSpanSnapshot,
@@ -960,7 +958,7 @@ internal class CurrentSessionPartSpanImplTests {
         )
         assertTrue(
             checkNotNull(earlyLink.attributes).none {
-                it.key == EmbSessionAttributes.EMB_USER_SESSION_ID || it.key == SessionAttributes.SESSION_ID
+                it.key == EmbSessionAttributes.EMB_USER_SESSION_ID
             },
         )
 
@@ -976,7 +974,6 @@ internal class CurrentSessionPartSpanImplTests {
             expectedAttributes = mapOf(
                 EmbSessionAttributes.EMB_SESSION_PART_ID to sessionPartId,
                 EmbSessionAttributes.EMB_USER_SESSION_ID to userSessionId,
-                SessionAttributes.SESSION_ID to userSessionId,
             ),
         )
     }
@@ -989,7 +986,6 @@ internal class CurrentSessionPartSpanImplTests {
         val expectedPartLinkAttrs = mapOf(
             EmbSessionAttributes.EMB_SESSION_PART_ID to currentSessionPartSpan.getId(),
             EmbSessionAttributes.EMB_USER_SESSION_ID to userSessionId,
-            SessionAttributes.SESSION_ID to userSessionId,
         )
 
         repeat(2) { count ->

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/debug/DeliveryTracer.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/debug/DeliveryTracer.kt
@@ -83,8 +83,8 @@ class DeliveryTracer {
         addWithThreadInfo(DeliveryTraceState.ServerReceivedRequest(endpoint))
     }
 
-    fun onServerCompletedRequest(endpoint: String, otelSessionId: String) {
-        addWithThreadInfo(DeliveryTraceState.ServerCompletedRequest(endpoint, otelSessionId))
+    fun onServerCompletedRequest(endpoint: String, userSessionId: String) {
+        addWithThreadInfo(DeliveryTraceState.ServerCompletedRequest(endpoint, userSessionId))
     }
 
     private fun addWithThreadInfo(state: DeliveryTraceState) {

--- a/embrace-android-instrumentation-app-exit-info/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/AeiDataSourceImplTest.kt
+++ b/embrace-android-instrumentation-app-exit-info/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/AeiDataSourceImplTest.kt
@@ -21,7 +21,6 @@ import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.AfterClass
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -121,7 +120,6 @@ internal class AeiDataSourceImplTest {
         assertEquals(USER_SESSION_ID, attrs[EmbAeiAttributes.AEI_USER_SESSION_ID])
         assertEquals("", attrs[EmbSessionAttributes.EMB_SESSION_PART_ID])
         assertEquals("", attrs[EmbSessionAttributes.EMB_USER_SESSION_ID])
-        assertEquals("", attrs[SessionAttributes.SESSION_ID])
         assertEquals(IMPORTANCE.toString(), attrs[EmbAeiAttributes.PROCESS_IMPORTANCE])
         assertEquals(PSS.toString(), attrs[EmbAeiAttributes.PSS])
         assertEquals(RSS.toString(), attrs[EmbAeiAttributes.RSS])
@@ -269,7 +267,6 @@ internal class AeiDataSourceImplTest {
         assertEquals(USER_SESSION_ID, attrs[EmbAeiAttributes.AEI_USER_SESSION_ID])
         assertEquals("", attrs[EmbSessionAttributes.EMB_SESSION_PART_ID])
         assertEquals("", attrs[EmbSessionAttributes.EMB_USER_SESSION_ID])
-        assertEquals("", attrs[SessionAttributes.SESSION_ID])
     }
 
     @Test
@@ -284,7 +281,6 @@ internal class AeiDataSourceImplTest {
         val attrs = getAeiLogAttrs()
         assertEquals("", attrs[EmbAeiAttributes.AEI_SESSION_PART_ID])
         assertEquals("", attrs[EmbAeiAttributes.AEI_USER_SESSION_ID])
-        assertEquals("", attrs[SessionAttributes.SESSION_ID])
     }
 
     @Test

--- a/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashDataSourceImpl.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashDataSourceImpl.kt
@@ -12,7 +12,6 @@ import io.embrace.android.embracesdk.internal.serialization.toJson
 import io.embrace.android.embracesdk.internal.store.Ordinal
 import io.embrace.android.embracesdk.semconv.EmbAndroidAttributes
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 
 internal class NativeCrashDataSourceImpl(
     private val nativeCrashProcessor: NativeCrashProcessor,
@@ -41,11 +40,6 @@ internal class NativeCrashDataSourceImpl(
                 setAttribute(
                     key = EmbSessionAttributes.EMB_SESSION_PART_ID,
                     value = nativeCrash.sessionPartId,
-                )
-
-                setAttribute(
-                    key = SessionAttributes.SESSION_ID,
-                    value = nativeCrash.userSessionId,
                 )
 
                 setAttribute(

--- a/embrace-android-instrumentation-crash-ndk/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashDataSourceImplTest.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashDataSourceImplTest.kt
@@ -13,7 +13,6 @@ import io.embrace.android.embracesdk.internal.serialization.toJson
 import io.embrace.android.embracesdk.internal.utils.toUTF8String
 import io.embrace.android.embracesdk.semconv.EmbAndroidAttributes
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -65,10 +64,6 @@ internal class NativeCrashDataSourceImplTest {
             )
             assertEquals(
                 testNativeCrashData.userSessionId,
-                attributes[SessionAttributes.SESSION_ID],
-            )
-            assertEquals(
-                testNativeCrashData.userSessionId,
                 attributes[EmbSessionAttributes.EMB_USER_SESSION_ID],
             )
             assertEquals("1", attributes[EmbAndroidAttributes.EMB_ANDROID_CRASH_NUMBER])
@@ -101,7 +96,6 @@ internal class NativeCrashDataSourceImplTest {
             assertEquals(EmbType.System.NativeCrash, schemaType.telemetryType)
             assertEquals("1", attributes[EmbAndroidAttributes.EMB_ANDROID_CRASH_NUMBER])
             assertEquals("", attributes[EmbSessionAttributes.EMB_SESSION_PART_ID])
-            assertEquals("", attributes[SessionAttributes.SESSION_ID])
             assertEquals("", attributes[EmbSessionAttributes.EMB_USER_SESSION_ID])
             assertNull(attributes[embNativeCrashException])
             assertNull(attributes[embNativeCrashSymbols])
@@ -128,7 +122,6 @@ internal class NativeCrashDataSourceImplTest {
             assertEquals(EmbType.System.NativeCrash, schemaType.telemetryType)
             assertEquals("1", attributes[EmbAndroidAttributes.EMB_ANDROID_CRASH_NUMBER])
             assertEquals("", attributes[EmbSessionAttributes.EMB_SESSION_PART_ID])
-            assertEquals("", attributes[SessionAttributes.SESSION_ID])
             assertEquals("", attributes[EmbSessionAttributes.EMB_USER_SESSION_ID])
             assertNull(attributes[EmbSessionAttributes.EMB_STATE])
             assertNull(attributes[embNativeCrashException])

--- a/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
+++ b/embrace-android-instrumentation-schema/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/schema/SchemaType.kt
@@ -18,7 +18,6 @@ import io.embrace.android.embracesdk.semconv.EmbThermalStateAttributes
 import io.embrace.android.embracesdk.semconv.EmbViewAttributes
 import io.opentelemetry.kotlin.semconv.ExceptionAttributes
 import io.opentelemetry.kotlin.semconv.HttpAttributes
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import io.opentelemetry.kotlin.semconv.UrlAttributes
 
 /**
@@ -148,7 +147,6 @@ sealed class SchemaType(
             // keep session IDs empty as AEI is recorded in a different process
             EmbSessionAttributes.EMB_SESSION_PART_ID to "",
             EmbSessionAttributes.EMB_USER_SESSION_ID to "",
-            SessionAttributes.SESSION_ID to "",
             EmbAeiAttributes.SESSION_ID_ERROR to sessionIdError,
             EmbAeiAttributes.PROCESS_IMPORTANCE to importance.toString(),
             EmbAeiAttributes.PSS to pss.toString(),

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/EmbraceSpanDataAssertions.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/EmbraceSpanDataAssertions.kt
@@ -5,8 +5,8 @@ import io.embrace.android.embracesdk.internal.clock.nanosToMillis
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.spans.ErrorCode
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 
@@ -23,7 +23,7 @@ fun assertEmbraceSpanData(
     expectedErrorCode: ErrorCode? = null,
     expectedCustomAttributes: Map<String, String> = emptyMap(),
     expectedEvents: List<SpanEvent> = emptyList(),
-    expectedOtelSessionId: String? = null,
+    expectedUserSessionId: String? = null,
     private: Boolean = false,
 ) {
     checkNotNull(span)
@@ -49,8 +49,8 @@ fun assertEmbraceSpanData(
         }
         assertEquals(expectedEvents, events)
 
-        if (expectedOtelSessionId != null) {
-            assertEquals(expectedOtelSessionId, attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
+        if (expectedUserSessionId != null) {
+            assertEquals(expectedUserSessionId, attributes?.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID))
         }
 
         if (private) {

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/LinkAssertions.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/LinkAssertions.kt
@@ -6,7 +6,6 @@ import io.embrace.android.embracesdk.internal.arch.schema.LinkType
 import io.embrace.android.embracesdk.internal.payload.Link
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import io.opentelemetry.kotlin.tracing.SpanContext
 import org.junit.Assert.assertTrue
 
@@ -19,7 +18,6 @@ fun Link.validatePreviousSessionPartLink(
         put(EmbSessionAttributes.EMB_SESSION_PART_ID, previousSessionPartId)
         previousUserSessionId?.let {
             put(EmbSessionAttributes.EMB_USER_SESSION_ID, it)
-            put(SessionAttributes.SESSION_ID, it)
         }
     }
     validateSystemLink(

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/LogAssertions.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/LogAssertions.kt
@@ -12,7 +12,6 @@ import io.embrace.android.embracesdk.internal.serialization.truncatedStacktrace
 import io.opentelemetry.kotlin.logging.SeverityNumber
 import io.opentelemetry.kotlin.semconv.ExceptionAttributes
 import io.opentelemetry.kotlin.semconv.LogAttributes
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -41,10 +40,10 @@ fun assertOtelLogReceived(
         assertEquals(expectedSeverityText ?: expectedSeverityNumber.name, log.severityText)
         assertEquals(expectedTimeMs.millisToNanos(), log.timeUnixNano)
         if (hasSession) {
-            assertFalse(log.attributes?.findAttributeValue(SessionAttributes.SESSION_ID).isNullOrBlank())
+            assertFalse(log.attributes?.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID).isNullOrBlank())
         } else {
-            val otelSessionId = log.attributes?.findAttributeValue(SessionAttributes.SESSION_ID)
-            assertEquals("", otelSessionId ?: "")
+            val userSessionId = log.attributes?.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID)
+            assertEquals("", userSessionId ?: "")
         }
         expectedType?.let { assertAttribute(log, EmbAndroidAttributes.EMB_EXCEPTION_HANDLING, it) }
         assertEquals(expectedState, log.attributes?.findAttributeValue(EmbSessionAttributes.EMB_STATE))

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SessionIdAssertions.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SessionIdAssertions.kt
@@ -1,8 +1,6 @@
 package io.embrace.android.embracesdk.assertions
 
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
-import io.opentelemetry.kotlin.semconv.SessionAttributes
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 
@@ -23,7 +21,6 @@ data class SessionIds(
  */
 fun Map<String, String?>.assertSessionIds(): SessionIds {
     val userSessionId = get(EmbSessionAttributes.EMB_USER_SESSION_ID)
-    val otelSessionId = get(SessionAttributes.SESSION_ID)
     val partId = get(EmbSessionAttributes.EMB_SESSION_PART_ID)
 
     assertTrue(
@@ -31,14 +28,9 @@ fun Map<String, String?>.assertSessionIds(): SessionIds {
         EMB_UUID_REGEX.matches(userSessionId ?: ""),
     )
     assertTrue(
-        "session.id must be a 32-char hex UUID but was: $otelSessionId",
-        EMB_UUID_REGEX.matches(otelSessionId ?: ""),
-    )
-    assertTrue(
         "emb.session_part_id must be a 32-char hex UUID but was: $partId",
         EMB_UUID_REGEX.matches(partId ?: ""),
     )
-    assertEquals("session.id must equal emb.user_session_id", userSessionId, otelSessionId)
     assertNotEquals("emb.session_part_id must not equal emb.user_session_id", partId, userSessionId)
 
     return SessionIds(

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
@@ -29,7 +29,6 @@ import io.embrace.android.embracesdk.spans.ErrorCode
 import io.opentelemetry.kotlin.OpenTelemetry
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.factory.toHexString
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import io.opentelemetry.kotlin.tracing.StatusData
 import io.opentelemetry.kotlin.tracing.Span
 import io.opentelemetry.kotlin.tracing.SpanContext
@@ -270,7 +269,6 @@ class FakeEmbraceSdkSpan(
                     )
                 }
 
-                setSystemAttribute(SessionAttributes.SESSION_ID, userSessionId)
                 setSystemAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID, userSessionId)
                 setSystemAttribute(EmbSessionAttributes.EMB_SESSION_PART_ID, sessionPartId)
                 setSystemAttribute(EmbSessionAttributes.EMB_PROCESS_IDENTIFIER, processIdentifier)

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/LogTestFixtures.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fixtures/LogTestFixtures.kt
@@ -6,7 +6,6 @@ import io.embrace.android.embracesdk.internal.arch.schema.SendMode
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 
 val testLog: Log = Log(
     traceId = "ceadd56622414a06ae382e4e5a70bcf7",
@@ -44,7 +43,6 @@ val nativeCrashLog = Log(
         Attribute(EmbSessionAttributes.EMB_PRIVATE_SEND_MODE, SendMode.IMMEDIATE.name),
         EmbType.System.NativeCrash.toPayload(),
         Attribute(EmbSessionAttributes.EMB_SESSION_PART_ID, "bb6b5b1ea2ff48928382fe81d7991ced"),
-        Attribute(SessionAttributes.SESSION_ID, "f0e1d2c3b4a5968778695a4b3c2d1e0f"),
         Attribute(EmbSessionAttributes.EMB_USER_SESSION_ID, "f0e1d2c3b4a5968778695a4b3c2d1e0f"),
         Attribute(EmbSessionAttributes.EMB_PROCESS_IDENTIFIER, "8115ec91-3e5e-4d8a-816d-cc40306f9822"),
     )

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanProcessor.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanProcessor.kt
@@ -5,7 +5,6 @@ import io.embrace.android.embracesdk.internal.session.id.SessionIdsProvider
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.export.OperationResultCode
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import io.opentelemetry.kotlin.semconv.UserAttributes
 import io.opentelemetry.kotlin.tracing.data.SpanData
 import io.opentelemetry.kotlin.tracing.export.SpanProcessor
@@ -25,7 +24,6 @@ internal class EmbraceSpanProcessor(
             val ids = provider.getActiveSessionIds()
             span.setStringAttribute(EmbSessionAttributes.EMB_SESSION_PART_ID, ids.sessionPartId)
             span.setStringAttribute(EmbSessionAttributes.EMB_USER_SESSION_ID, ids.userSessionId)
-            span.setStringAttribute(SessionAttributes.SESSION_ID, ids.userSessionId)
         }
         userIdProvider()?.let { userId ->
             span.setStringAttribute(UserAttributes.USER_ID, userId)

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanProcessorTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanProcessorTest.kt
@@ -6,7 +6,6 @@ import io.embrace.android.embracesdk.fakes.FakeSpanExporter
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.opentelemetry.kotlin.NoopOpenTelemetry
 import io.opentelemetry.kotlin.export.OperationResultCode
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import io.opentelemetry.kotlin.semconv.UserAttributes
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -35,7 +34,6 @@ class EmbraceSpanProcessorTest {
         val processor = createProcessor()
         processor.onStart(span, context)
         assertEquals("pid", span.attributes[EmbSessionAttributes.EMB_PROCESS_IDENTIFIER])
-        assertEquals("user-sid", span.attributes[SessionAttributes.SESSION_ID])
         assertEquals("user-sid", span.attributes[EmbSessionAttributes.EMB_USER_SESSION_ID])
         assertEquals("part-sid", span.attributes[EmbSessionAttributes.EMB_SESSION_PART_ID])
         processor.onEnd(span)
@@ -51,7 +49,6 @@ class EmbraceSpanProcessorTest {
 
         assertEquals("", span.attributes[EmbSessionAttributes.EMB_SESSION_PART_ID])
         assertEquals("", span.attributes[EmbSessionAttributes.EMB_USER_SESSION_ID])
-        assertEquals("", span.attributes[SessionAttributes.SESSION_ID])
     }
 
     @Test
@@ -62,7 +59,6 @@ class EmbraceSpanProcessorTest {
 
         assertEquals("part-sid", span.attributes[EmbSessionAttributes.EMB_SESSION_PART_ID])
         assertEquals("", span.attributes[EmbSessionAttributes.EMB_USER_SESSION_ID])
-        assertEquals("", span.attributes[SessionAttributes.SESSION_ID])
     }
 
     @Test

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalLoggerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalLoggerTest.kt
@@ -29,7 +29,6 @@ import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
 import io.opentelemetry.kotlin.semconv.ExceptionAttributes
 import io.opentelemetry.kotlin.semconv.LogAttributes
 import io.opentelemetry.kotlin.semconv.ServiceAttributes
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import io.opentelemetry.kotlin.semconv.UserAttributes
 import io.opentelemetry.kotlin.tracing.SpanContext
 import org.junit.Assert.assertEquals
@@ -314,10 +313,8 @@ internal class ExternalLoggerTest {
         with(checkNotNull(attributes.mapValues { it.value.toString() })) {
             assertNotNull(filter { it.key == LogAttributes.LOG_RECORD_UID }.size)
             if (expectedUserSessionId != null) {
-                assertEquals(expectedUserSessionId, this[SessionAttributes.SESSION_ID])
                 assertEquals(expectedUserSessionId, this[EmbSessionAttributes.EMB_USER_SESSION_ID])
             } else {
-                assertFalse(containsKey(SessionAttributes.SESSION_ID))
                 assertFalse(containsKey(EmbSessionAttributes.EMB_USER_SESSION_ID))
             }
             assertEquals(expectedSessionPartId, this[EmbSessionAttributes.EMB_SESSION_PART_ID])

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalOtelJavaLoggerTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/ExternalOtelJavaLoggerTest.kt
@@ -30,7 +30,6 @@ import io.opentelemetry.kotlin.aliases.OtelJavaSeverity
 import io.opentelemetry.kotlin.aliases.OtelJavaSpanContext
 import io.opentelemetry.kotlin.semconv.LogAttributes
 import io.opentelemetry.kotlin.semconv.ServiceAttributes
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -261,10 +260,8 @@ internal class ExternalOtelJavaLoggerTest {
         with(checkNotNull(attributes.toStringMap())) {
             assertNotNull(filter { it.key == LogAttributes.LOG_RECORD_UID }.size)
             if (expectedUserSessionId != null) {
-                assertEquals(expectedUserSessionId, this[SessionAttributes.SESSION_ID])
                 assertEquals(expectedUserSessionId, this[EmbSessionAttributes.EMB_USER_SESSION_ID])
             } else {
-                assertFalse(containsKey(SessionAttributes.SESSION_ID))
                 assertFalse(containsKey(EmbSessionAttributes.EMB_USER_SESSION_ID))
             }
             assertEquals(expectedSessionPartId, this[EmbSessionAttributes.EMB_SESSION_PART_ID])

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.assertions.assertEmbraceSpanData
 import io.embrace.android.embracesdk.assertions.assertIsTypePerformance
 import io.embrace.android.embracesdk.assertions.findCustomLinks
 import io.embrace.android.embracesdk.assertions.findSpanByName
-import io.embrace.android.embracesdk.assertions.getOtelSessionId
+import io.embrace.android.embracesdk.assertions.getUserSessionId
 import io.embrace.android.embracesdk.assertions.getSessionPartId
 import io.embrace.android.embracesdk.assertions.hasLinkToEmbraceSpan
 import io.embrace.android.embracesdk.assertions.isLinkedToSpanContext
@@ -32,13 +32,13 @@ import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
 import io.embrace.android.embracesdk.internal.toEmbracePayload
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbracePayloadAssertionInterface
 import io.embrace.android.embracesdk.testframework.assertions.assertSessionIds
 import io.opentelemetry.kotlin.aliases.OtelJavaContext
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
@@ -224,7 +224,7 @@ internal class TracingApiTest {
                             attributes = emptyList()
                         ),
                     ),
-                    expectedOtelSessionId = session.getOtelSessionId()
+                    expectedUserSessionId = session.getUserSessionId()
                 )
                 val expectedParentId = traceRootSpan.spanId
                 assertEmbraceSpanData(
@@ -233,7 +233,7 @@ internal class TracingApiTest {
                     expectedEndTimeMs = testStartTimeMs + 100,
                     expectedParentId = checkNotNull(expectedParentId),
                     expectedTraceId = traceRootSpan.traceId,
-                    expectedOtelSessionId = session.getOtelSessionId()
+                    expectedUserSessionId = session.getUserSessionId()
                 )
 
                 assertEmbraceSpanData(
@@ -251,7 +251,7 @@ internal class TracingApiTest {
                             attributes = listOf(Attribute("retry", "1"))
                         )
                     ),
-                    expectedOtelSessionId = session.getOtelSessionId()
+                    expectedUserSessionId = session.getUserSessionId()
                 )
 
                 assertEmbraceSpanData(
@@ -260,7 +260,7 @@ internal class TracingApiTest {
                     expectedEndTimeMs = testStartTimeMs + 301,
                     expectedParentId = expectedParentId,
                     expectedTraceId = traceRootSpan.traceId,
-                    expectedOtelSessionId = session.getOtelSessionId()
+                    expectedUserSessionId = session.getUserSessionId()
                 )
 
                 assertEmbraceSpanData(
@@ -269,7 +269,7 @@ internal class TracingApiTest {
                     expectedEndTimeMs = testStartTimeMs + 600,
                     expectedParentId = expectedParentId,
                     expectedTraceId = traceRootSpan.traceId,
-                    expectedOtelSessionId = session.getOtelSessionId()
+                    expectedUserSessionId = session.getUserSessionId()
                 )
 
                 assertEmbraceSpanData(
@@ -277,7 +277,7 @@ internal class TracingApiTest {
                     expectedStartTimeMs = sessionStartTimeMs,
                     expectedEndTimeMs = sessionEndTimeMs,
                     expectedParentId = OtelIds.INVALID_SPAN_ID,
-                    expectedOtelSessionId = session.getOtelSessionId(),
+                    expectedUserSessionId = session.getUserSessionId(),
                     private = false
                 )
 
@@ -302,9 +302,9 @@ internal class TracingApiTest {
             },
             otelExportAssertion = {
                 val sessionPartSpan = awaitSpansWithType(2, EmbType.Ux.Session).last().toEmbracePayload()
-                val otelSessionId = checkNotNull(sessionPartSpan.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
+                val userSessionId = checkNotNull(sessionPartSpan.attributes?.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID))
                 val span = awaitSpans(1) { it.name == "test-trace-root" }.single().toEmbracePayload()
-                assertEquals(otelSessionId, span.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
+                assertEquals(userSessionId, span.attributes?.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID))
             }
         )
     }
@@ -431,18 +431,18 @@ internal class TracingApiTest {
                 val span2 = sessions.last().findSpanByName("span2")
 
                 // Both spans were started during session1, so they carry session1's user session ID
-                val session1Id = sessions.first().getOtelSessionId()
-                assertEquals(session1Id, span1.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
-                assertEquals(session1Id, span2.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
+                val session1Id = sessions.first().getUserSessionId()
+                assertEquals(session1Id, span1.attributes?.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID))
+                assertEquals(session1Id, span2.attributes?.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID))
             },
             otelExportAssertion = {
                 // Get the session ID from a session part span exported via OTel
                 val sessionPartSpan = awaitSpansWithType(2, EmbType.Ux.Session).first().toEmbracePayload()
-                val expectedOtelSessionId = checkNotNull(sessionPartSpan.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
+                val expectedUserSessionId = checkNotNull(sessionPartSpan.attributes?.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID))
                 val span1 = awaitSpans(1) { it.name == "span1" }.single().toEmbracePayload()
                 val span2 = awaitSpans(1) { it.name == "span2" }.single().toEmbracePayload()
-                assertEquals(expectedOtelSessionId, span1.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
-                assertEquals(expectedOtelSessionId, span2.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
+                assertEquals(expectedUserSessionId, span1.attributes?.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID))
+                assertEquals(expectedUserSessionId, span2.attributes?.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID))
             }
         )
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/UserSessionApiTest.kt
@@ -10,7 +10,6 @@ import io.embrace.android.embracesdk.semconv.EmbAppAttributes
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.semconv.EmbTelemetryAttributes
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -62,7 +61,7 @@ internal class UserSessionApiTest {
                 val spans = checkNotNull(message.data.spans)
                 val sessionPartSpan = spans.single { it.name == "emb-session" }
                 assertEquals(startTime, sessionPartSpan.startTimeNanos?.nanosToMillis())
-                assertNotNull(sessionPartSpan.attributes?.findAttributeValue(SessionAttributes.SESSION_ID))
+                assertNotNull(sessionPartSpan.attributes?.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID))
 
                 val attrs = checkNotNull(sessionPartSpan.attributes)
                 val attributeKeys = attrs.map { it.key }
@@ -98,7 +97,6 @@ internal class UserSessionApiTest {
     private companion object {
         // Attributes we want to know exist, but whose value we don't need to validate
         val validateExistenceOnly = setOf(
-            SessionAttributes.SESSION_ID,
             EmbTelemetryAttributes.EMB_KOTLIN_ON_CLASSPATH,
             EmbTelemetryAttributes.EMB_OKHTTP3,
             EmbSessionAttributes.EMB_PROCESS_IDENTIFIER,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
@@ -37,7 +37,6 @@ import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule.Compan
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.opentelemetry.kotlin.logging.SeverityNumber
 import io.opentelemetry.kotlin.semconv.LogAttributes
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -140,7 +139,6 @@ internal class JvmCrashFeatureTest {
                 val attrs = checkNotNull(crashLog.attributes)
                 val userSessionId = attrs.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID)
                 assertFalse(userSessionId.isNullOrBlank())
-                assertEquals(userSessionId, attrs.findAttributeValue(SessionAttributes.SESSION_ID))
                 assertEquals("", attrs.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID) ?: "")
             }
         )
@@ -171,7 +169,6 @@ internal class JvmCrashFeatureTest {
                     hasSession = false,
                 )
                 val attrs = checkNotNull(crashLog.attributes)
-                assertEquals("", attrs.findAttributeValue(SessionAttributes.SESSION_ID) ?: "")
                 assertEquals("", attrs.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID) ?: "")
                 assertEquals("", attrs.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID) ?: "")
             }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityCaptureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/BackgroundActivityCaptureTest.kt
@@ -5,8 +5,8 @@ import io.embrace.android.embracesdk.assertions.assertMatches
 import io.embrace.android.embracesdk.assertions.findEventsOfType
 import io.embrace.android.embracesdk.assertions.findSessionPartSpan
 import io.embrace.android.embracesdk.assertions.getLogsOfType
-import io.embrace.android.embracesdk.assertions.getOtelSessionId
 import io.embrace.android.embracesdk.assertions.getSessionPartId
+import io.embrace.android.embracesdk.assertions.getUserSessionId
 import io.embrace.android.embracesdk.assertions.hasSpanSnapshotsOfType
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.state.ProcessState
@@ -20,7 +20,6 @@ import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.assertions.assertSessionIds
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -109,7 +108,7 @@ internal class BackgroundActivityCaptureTest {
                             EmbSessionAttributes.EMB_STATE to "background"
                         )
                     )
-                    val sid = attributes?.findAttributeValue(SessionAttributes.SESSION_ID)
+                    val sid = attributes?.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID)
                     assertFalse(sid.isNullOrBlank())
                 }
                 with(logs[1]) {
@@ -119,14 +118,14 @@ internal class BackgroundActivityCaptureTest {
                             EmbSessionAttributes.EMB_STATE to "background"
                         )
                     )
-                    assertFalse(attributes?.findAttributeValue(SessionAttributes.SESSION_ID).isNullOrBlank())
+                    assertFalse(attributes?.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID).isNullOrBlank())
                 }
                 with(logs[2]) {
                     assertEquals("warning", body)
                     attributes?.assertMatches(
                         mapOf(
                             EmbSessionAttributes.EMB_STATE to "foreground",
-                            SessionAttributes.SESSION_ID to sessions[1].getOtelSessionId()
+                            EmbSessionAttributes.EMB_USER_SESSION_ID to sessions[1].getUserSessionId()
                         )
                     )
                 }
@@ -137,7 +136,7 @@ internal class BackgroundActivityCaptureTest {
                     attributes?.assertMatches(
                         mapOf(
                             EmbSessionAttributes.EMB_STATE to "foreground",
-                            SessionAttributes.SESSION_ID to secondSession.getOtelSessionId()
+                            EmbSessionAttributes.EMB_USER_SESSION_ID to secondSession.getUserSessionId()
                         )
                     )
                 }
@@ -248,7 +247,7 @@ internal class BackgroundActivityCaptureTest {
         )
         with(checkNotNull(attributes)) {
             assertFalse(findAttributeValue(EmbSessionAttributes.EMB_PROCESS_IDENTIFIER).isNullOrBlank())
-            assertFalse(findAttributeValue(SessionAttributes.SESSION_ID).isNullOrBlank())
+            assertFalse(findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID).isNullOrBlank())
         }
     }
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionPartPayloadTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/SessionPartPayloadTest.kt
@@ -6,7 +6,7 @@ import io.embrace.android.embracesdk.assertions.assertMatches
 import io.embrace.android.embracesdk.assertions.assertNoPreviousSessionPart
 import io.embrace.android.embracesdk.assertions.assertPreviousSessionPart
 import io.embrace.android.embracesdk.assertions.findSessionPartSpan
-import io.embrace.android.embracesdk.assertions.getOtelSessionId
+import io.embrace.android.embracesdk.assertions.getUserSessionId
 import io.embrace.android.embracesdk.assertions.getSessionPartId
 import io.embrace.android.embracesdk.assertions.hasLinkToEmbraceSpan
 import io.embrace.android.embracesdk.assertions.hasSpanSnapshotsOfType
@@ -66,7 +66,7 @@ internal class SessionPartPayloadTest {
                         assertTrue(checkNotNull(deviceModel).isNotBlank())
                         assertEquals(AppFramework.NATIVE, appFramework)
                     }
-                    assertTrue(getOtelSessionId().isNotBlank())
+                    assertTrue(getUserSessionId().isNotBlank())
                 }
             }
         )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionClockAnomalyTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionClockAnomalyTest.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.testcases.session
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.assertions.getOtelSessionId
 import io.embrace.android.embracesdk.assertions.getUserSessionId
 import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
@@ -66,7 +65,6 @@ internal class UserSessionClockAnomalyTest {
             assertAction = {
                 val session = getSingleSessionEnvelope()
                 assertNotEquals(staleUserSessionId, session.getUserSessionId())
-                assertNotEquals(staleUserSessionId, session.getOtelSessionId())
 
                 val logger = testRule.bootstrapper.initModule.logger as FakeInternalLogger
                 assertTrue(logger.internalErrorMessages.any {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionIdPropagationTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionIdPropagationTest.kt
@@ -45,7 +45,6 @@ import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterfac
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.mockk.every
 import io.mockk.mockk
-import io.opentelemetry.kotlin.semconv.SessionAttributes.SESSION_ID
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
@@ -307,14 +306,12 @@ internal class UserSessionIdPropagationTest {
                 val logAttrs = checkNotNull(getSingleLogEnvelope().getLogOfType(EmbType.System.NativeCrash).attributes)
                 assertEquals(sessionPartId, logAttrs.findAttributeValue(EMB_SESSION_PART_ID))
                 assertEquals(userSessionId, logAttrs.findAttributeValue(EMB_USER_SESSION_ID))
-                assertEquals(userSessionId, logAttrs.findAttributeValue(SESSION_ID))
             },
             otelExportAssertion = {
                 val log = awaitLogs(1) { it.attributes.toStringMap().containsKey(EmbType.System.NativeCrash.key) }.single()
                 val logAttrs = log.attributes.toStringMap()
                 assertEquals(sessionPartId, logAttrs[EMB_SESSION_PART_ID])
                 assertEquals(userSessionId, logAttrs[EMB_USER_SESSION_ID])
-                assertEquals(userSessionId, logAttrs[SESSION_ID])
             },
         )
     }
@@ -352,7 +349,6 @@ internal class UserSessionIdPropagationTest {
                 assertEquals(userSessionId, logAttrs.findAttributeValue(AEI_USER_SESSION_ID))
                 assertEquals("", logAttrs.findAttributeValue(EMB_SESSION_PART_ID))
                 assertEquals("", logAttrs.findAttributeValue(EMB_USER_SESSION_ID))
-                assertEquals("", logAttrs.findAttributeValue(SESSION_ID))
             },
             otelExportAssertion = {
                 val log = awaitLogs(1) { it.attributes.toStringMap().containsKey(EmbType.System.Exit.key) }.single()
@@ -361,7 +357,6 @@ internal class UserSessionIdPropagationTest {
                 assertEquals(userSessionId, logAttrs[AEI_USER_SESSION_ID])
                 assertEquals("", logAttrs[EMB_SESSION_PART_ID])
                 assertEquals("", logAttrs[EMB_USER_SESSION_ID])
-                assertEquals("", logAttrs[SESSION_ID])
             },
         )
     }
@@ -433,7 +428,7 @@ internal class UserSessionIdPropagationTest {
                 val newUserSessionId = sessions[1].getUserSessionId()
                 assertNotEquals(oldUserSessionId, newUserSessionId)
 
-                val logSessionId = getSingleLogEnvelope().getLastLog().attributes?.findAttributeValue(SESSION_ID)
+                val logSessionId = getSingleLogEnvelope().getLastLog().attributes?.findAttributeValue(EMB_USER_SESSION_ID)
                 assertEquals(newUserSessionId, logSessionId)
             },
         )
@@ -474,7 +469,7 @@ internal class UserSessionIdPropagationTest {
                 assertNotEquals(oldUserSessionId, newUserSessionId)
 
                 val log = getSingleLogEnvelope().getLastLog()
-                val logSessionId = log.attributes?.findAttributeValue(SESSION_ID)
+                val logSessionId = log.attributes?.findAttributeValue(EMB_USER_SESSION_ID)
                 assertEquals(oldUserSessionId, logSessionId)
                 assertTrue(checkNotNull(log.timeUnixNano) <= checkNotNull(sessionPartSpanFromOldPart.endTimeNanos))
             },
@@ -504,7 +499,7 @@ internal class UserSessionIdPropagationTest {
                 val newUserSessionId = sessions[1].getUserSessionId()
                 assertNotEquals(oldUserSessionId, newUserSessionId)
 
-                val logSessionId = getSingleLogEnvelope().getLastLog().attributes?.findAttributeValue(SESSION_ID)
+                val logSessionId = getSingleLogEnvelope().getLastLog().attributes?.findAttributeValue(EMB_USER_SESSION_ID)
                 assertEquals(newUserSessionId, logSessionId)
             },
         )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionLifecycleTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionLifecycleTest.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.testcases.session
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.findSessionPartSpan
 import io.embrace.android.embracesdk.assertions.findSpansOfType
-import io.embrace.android.embracesdk.assertions.getOtelSessionId
 import io.embrace.android.embracesdk.assertions.getUserSessionId
 import io.embrace.android.embracesdk.assertions.getUserSessionTerminationReason
 import io.embrace.android.embracesdk.assertions.isBackgroundOnlyPart
@@ -89,7 +88,6 @@ internal class UserSessionLifecycleTest {
 
                 val fgSessionPartSpan = fgSession.findSessionPartSpan()
                 assertNotNull(fgSession.getUserSessionId())
-                assertEquals(fgSession.getUserSessionId(), fgSession.getOtelSessionId())
                 assertEquals("1", fgSessionPartSpan.attributes?.findAttributeValue(EMB_USER_SESSION_NUMBER))
                 fgSession.assertNotFinalPart()
 
@@ -359,7 +357,6 @@ internal class UserSessionLifecycleTest {
             assertAction = {
                 val session = getSingleSessionEnvelope()
                 assertEquals(persistedId, session.getUserSessionId())
-                assertEquals(persistedId, session.getOtelSessionId())
                 session.assertNotFinalPart()
             }
         )
@@ -380,7 +377,6 @@ internal class UserSessionLifecycleTest {
             assertAction = {
                 val session = getSingleSessionEnvelope()
                 assertNotEquals(persistedId, session.getUserSessionId())
-                assertNotEquals(persistedId, session.getOtelSessionId())
                 session.assertNotFinalPart()
             }
         )
@@ -402,7 +398,6 @@ internal class UserSessionLifecycleTest {
             assertAction = {
                 val session = getSingleSessionEnvelope()
                 assertNotEquals(persistedId, session.getUserSessionId())
-                assertNotEquals(persistedId, session.getOtelSessionId())
                 session.assertNotFinalPart()
             }
         )

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePayloadAssertionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePayloadAssertionInterface.kt
@@ -5,7 +5,6 @@ import androidx.test.core.app.ApplicationProvider
 import io.embrace.android.embracesdk.ResourceReader
 import io.embrace.android.embracesdk.assertions.assertMatches
 import io.embrace.android.embracesdk.assertions.findSessionPartSpan
-import io.embrace.android.embracesdk.assertions.getOtelSessionId
 import io.embrace.android.embracesdk.assertions.getUserSessionId
 import io.embrace.android.embracesdk.assertions.returnIfConditionMet
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
@@ -28,7 +27,6 @@ import io.embrace.android.embracesdk.testframework.assertions.JsonComparator.com
 import io.embrace.android.embracesdk.testframework.assertions.Placeholder
 import io.embrace.android.embracesdk.testframework.server.FakeApiServer
 import io.embrace.android.embracesdk.testframework.server.FormPart
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -158,7 +156,7 @@ internal class EmbracePayloadAssertionInterface(
             val envelopes = checkNotNull(apiServer).getSessionEnvelopes()
             val sessions: List<Map<String, String?>> = envelopes.map {
                 mapOf(
-                    "otelSessionId" to it.getOtelSessionId(),
+                    "userSessionId" to it.getUserSessionId(),
                     "cleanExit" to it.findSessionPartSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_CLEAN_EXIT),
                     "state" to it.findSessionPartSpan().attributes?.findAttributeValue(EmbSessionAttributes.EMB_STATE)
                 )
@@ -271,7 +269,7 @@ internal class EmbracePayloadAssertionInterface(
         assertNotNull(attrs.findAttributeValue("log.record.uid"))
         assertNotNull(attrs.findAttributeValue(EmbAndroidAttributes.EMB_ANDROID_CRASH_NUMBER))
         assertEquals(crashData.nativeCrash.sessionPartId, attrs.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID))
-        assertEquals(crashData.nativeCrash.userSessionId, attrs.findAttributeValue(SessionAttributes.SESSION_ID))
+        assertEquals(crashData.nativeCrash.userSessionId, attrs.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID))
         assertNativeCrashDoesNotExist(crashData)
     }
 
@@ -292,8 +290,8 @@ internal class EmbracePayloadAssertionInterface(
             val nextEnd = next.findSessionPartSpan().startTimeNanos ?: return@zipWithNext
             assertTrue(
                 "Session payloads delivered out of order. " +
-                    "Previous (id=${prev.getOtelSessionId()}) startTimeNanos=$prevEnd, " +
-                    "next (id=${next.getOtelSessionId()}) startTimeNanos=$nextEnd",
+                    "Previous (id=${prev.getUserSessionId()}) startTimeNanos=$prevEnd, " +
+                    "next (id=${next.getUserSessionId()}) startTimeNanos=$nextEnd",
                 nextEnd >= prevEnd
             )
         }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -53,7 +53,6 @@ import io.embrace.android.embracesdk.internal.worker.Worker.Background.NonIoRegW
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.semconv.ExperimentalSemconv
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.robolectric.Shadows
 import org.robolectric.shadows.ShadowLooper
 import java.util.concurrent.TimeUnit.MILLISECONDS
@@ -270,7 +269,6 @@ internal class EmbraceSetupInterface(
                     put(EmbSessionAttributes.EMB_USER_SESSION_NUMBER, sessionNumber.toString())
                     put(EmbSessionAttributes.EMB_USER_SESSION_MAX_DURATION_SECONDS, maxDurationSeconds.toString())
                     put(EmbSessionAttributes.EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS, inactivityTimeoutSeconds.toString())
-                    put(SessionAttributes.SESSION_ID, userSessionId)
                     put(EmbSessionAttributes.EMB_USER_SESSION_PART_INDEX, partIndex.toString())
                     put("emb.user_session_last_activity_ts", lastActivityMs.toString())
                     if (isBackgroundOnly) {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/assertions/SessionAssertions.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/assertions/SessionAssertions.kt
@@ -1,7 +1,6 @@
 package io.embrace.android.embracesdk.testframework.assertions
 
 import io.embrace.android.embracesdk.assertions.SessionIds
-import io.embrace.android.embracesdk.assertions.getOtelSessionId
 import io.embrace.android.embracesdk.assertions.getSessionPartId
 import io.embrace.android.embracesdk.assertions.getSessionPartNumber
 import io.embrace.android.embracesdk.assertions.getUserSessionId
@@ -14,7 +13,6 @@ import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -99,40 +97,34 @@ fun assertUserSessionNumbers(
 }
 
 /**
- * Asserts the session-id attributes on a log/crash record: both the OTel `session.id` and `emb.user_session_id`
- * carry [expectedUserSessionId], and `emb.session_part_id` equals [expectedSessionPartId]. Pass empty strings or
- * the native `"null"` sentinel to assert the no-part / no-session cases.
+ * Asserts the session-id attributes on a log/crash record: `emb.user_session_id` carries [expectedUserSessionId],
+ * and `emb.session_part_id` equals [expectedSessionPartId]. Pass empty strings or the native `"null"` sentinel to
+ * assert the no-part / no-session cases.
  */
 fun Log.assertSessionIds(expectedUserSessionId: String, expectedSessionPartId: String) {
     val attrs = checkNotNull(attributes) { "no attributes found on log" }
-    assertEquals(expectedUserSessionId, attrs.findAttributeValue(SessionAttributes.SESSION_ID))
     assertEquals(expectedUserSessionId, attrs.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID))
     assertEquals(expectedSessionPartId, attrs.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID))
 }
 
 /**
- * Asserts the session part payload's session part span has all session-related IDs: emb.user_session_id, session.id, and emb.session_part_id
- * The first two are always equal, while the session part ID should not equal the other two.
+ * Asserts the session part payload's session part span has the session-related IDs: emb.user_session_id and
+ * emb.session_part_id, which must not be equal.
  */
 fun Envelope<SessionPartPayload>.assertSessionIds(): SessionIds {
-    val otelSessionId = getOtelSessionId()
     val userSessionId = getUserSessionId()
     val sessionPartId = getSessionPartId()
-    assertEquals("session.id must equal emb.user_session_id", userSessionId, otelSessionId)
     assertNotEquals("emb.session_part_id must not equal emb.user_session_id", sessionPartId, userSessionId)
     return SessionIds(userSessionId = userSessionId, partId = sessionPartId)
 }
 
 /**
- * Asserts a log has session.id and emb.user_session_id which are the same value.
+ * Asserts a log has a non-blank emb.user_session_id.
  */
 fun Log.assertSessionIdsConsistent() {
     val attrs = checkNotNull(attributes) { "no attributes found on log" }
-    val otelSessionId = attrs.findAttributeValue(SessionAttributes.SESSION_ID)
-    assertFalse("session.id must be present on the log", otelSessionId.isNullOrBlank())
-    assertEquals(
-        "session.id must equal emb.user_session_id on the log",
-        otelSessionId,
-        attrs.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID)
+    assertFalse(
+        "emb.user_session_id must be present on the log",
+        attrs.findAttributeValue(EmbSessionAttributes.EMB_USER_SESSION_ID).isNullOrBlank()
     )
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/ExportedSpanValidator.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/export/ExportedSpanValidator.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.testframework.export
 
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.opentelemetry.kotlin.aliases.OtelJavaSpanData
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 
 internal class ExportedSpanValidator {
@@ -35,7 +34,6 @@ internal class ExportedSpanValidator {
             EmbSessionAttributes.EMB_PROCESS_IDENTIFIER,
             EmbSessionAttributes.EMB_SESSION_PART_ID,
             EmbSessionAttributes.EMB_USER_SESSION_ID,
-            SessionAttributes.SESSION_ID,
         )
         val attrs: Map<String, String> = attributes.asMap().map {
             it.key.key to it.value.toString()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/server/FakeApiServer.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/server/FakeApiServer.kt
@@ -1,6 +1,6 @@
 package io.embrace.android.embracesdk.testframework.server
 
-import io.embrace.android.embracesdk.assertions.getOtelSessionId
+import io.embrace.android.embracesdk.assertions.getUserSessionId
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
 import io.embrace.android.embracesdk.internal.comms.api.Endpoint
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
@@ -102,7 +102,7 @@ internal class FakeApiServer(
     private fun handleSessionRequest(endpoint: Endpoint, envelope: Envelope<*>) {
         val obj = envelope as Envelope<SessionPartPayload>
         sessionRequests.add(obj)
-        deliveryTracer.onServerCompletedRequest(endpoint.name, obj.getOtelSessionId())
+        deliveryTracer.onServerCompletedRequest(endpoint.name, obj.getUserSessionId())
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/embrace-android-sdk/src/integrationTest/resources/log_without_user_session.json
+++ b/embrace-android-sdk/src/integrationTest/resources/log_without_user_session.json
@@ -41,10 +41,6 @@
         {
           "key": "log.record.uid",
           "value": "__EMBRACE_TEST_IGNORE__"
-        },
-        {
-          "key": "session.id",
-          "value": "__EMBRACE_TEST_USER_SESSION_ID__"
         }
       ]
     }

--- a/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-log-record.json
+++ b/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-log-record.json
@@ -5,7 +5,7 @@
     "severityText": "FATAL",
     "timestampEpochNanos": "169220160330000000",
     "observedTimestampEpochNanos": "169220160030000000",
-    "totalAttributeCount": "8",
+    "totalAttributeCount": "7",
     "attributes": {
       "emb.session_part_id": "__EMBRACE_TEST_IGNORE__",
       "emb.state": "foreground",
@@ -13,8 +13,7 @@
       "emb.state.screen-automatic": "android.app.Activity",
       "emb.state.test": "UNKNOWN",
       "emb.user_session_id": "__EMBRACE_TEST_IGNORE__",
-      "log.record.uid": "__EMBRACE_TEST_IGNORE__",
-      "session.id": "__EMBRACE_TEST_IGNORE__"
+      "log.record.uid": "__EMBRACE_TEST_IGNORE__"
     },
     "instrumentationScopeName": "external-logger",
     "resourceAttributes": {
@@ -38,7 +37,7 @@
     "severityText": "TRACE",
     "timestampEpochNanos": "169220160130000000",
     "observedTimestampEpochNanos": "169220160030000000",
-    "totalAttributeCount": "10",
+    "totalAttributeCount": "9",
     "attributes": {
       "emb.session_part_id": "__EMBRACE_TEST_IGNORE__",
       "emb.state": "foreground",
@@ -48,7 +47,6 @@
       "emb.user_session_id": "__EMBRACE_TEST_IGNORE__",
       "log.record.uid": "__EMBRACE_TEST_IGNORE__",
       "long-attr": "42",
-      "session.id": "__EMBRACE_TEST_IGNORE__",
       "string-attr": "value"
     },
     "instrumentationScopeName": "external-logger",
@@ -73,7 +71,7 @@
     "severityText": "INFO",
     "timestampEpochNanos": "169220160230000000",
     "observedTimestampEpochNanos": "169220160030000000",
-    "totalAttributeCount": "11",
+    "totalAttributeCount": "10",
     "attributes": {
       "any-value-attr": "__EMBRACE_TEST_IGNORE__",
       "boolean-list-attr": "[true, false]",
@@ -84,8 +82,7 @@
       "emb.state.screen-automatic": "android.app.Activity",
       "emb.state.test": "UNKNOWN",
       "emb.user_session_id": "__EMBRACE_TEST_IGNORE__",
-      "log.record.uid": "__EMBRACE_TEST_IGNORE__",
-      "session.id": "__EMBRACE_TEST_IGNORE__"
+      "log.record.uid": "__EMBRACE_TEST_IGNORE__"
     },
     "instrumentationScopeName": "external-logger",
     "resourceAttributes": {

--- a/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-log-span-context.json
+++ b/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-log-span-context.json
@@ -5,7 +5,7 @@
     "severityText": "WARN",
     "timestampEpochNanos": "169220160030000000",
     "observedTimestampEpochNanos": "169220160030000000",
-    "totalAttributeCount": "9",
+    "totalAttributeCount": "8",
     "attributes": {
       "emb.session_part_id": "__EMBRACE_TEST_IGNORE__",
       "emb.state": "foreground",
@@ -14,7 +14,6 @@
       "emb.state.test": "UNKNOWN",
       "emb.user_session_id": "__EMBRACE_TEST_IGNORE__",
       "log.record.uid": "__EMBRACE_TEST_IGNORE__",
-      "session.id": "__EMBRACE_TEST_IGNORE__",
       "string-attr": "value"
     },
     "instrumentationScopeName": "external-logger",
@@ -39,7 +38,7 @@
     "severityText": "WARN",
     "timestampEpochNanos": "169220160030000000",
     "observedTimestampEpochNanos": "169220160030000000",
-    "totalAttributeCount": "8",
+    "totalAttributeCount": "7",
     "attributes": {
       "emb.session_part_id": "__EMBRACE_TEST_IGNORE__",
       "emb.state": "foreground",
@@ -47,8 +46,7 @@
       "emb.state.screen-automatic": "android.app.Activity",
       "emb.state.test": "UNKNOWN",
       "emb.user_session_id": "__EMBRACE_TEST_IGNORE__",
-      "log.record.uid": "__EMBRACE_TEST_IGNORE__",
-      "session.id": "__EMBRACE_TEST_IGNORE__"
+      "log.record.uid": "__EMBRACE_TEST_IGNORE__"
     },
     "instrumentationScopeName": "external-logger",
     "resourceAttributes": {

--- a/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-log.json
+++ b/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-log.json
@@ -5,7 +5,7 @@
     "severityText": "WARNING",
     "timestampEpochNanos": "169220160030000000",
     "observedTimestampEpochNanos": "169220160030000000",
-    "totalAttributeCount": "10",
+    "totalAttributeCount": "9",
     "attributes": {
       "emb.session_part_id": "__EMBRACE_TEST_IGNORE__",
       "emb.state": "foreground",
@@ -15,8 +15,7 @@
       "emb.type": "sys.log",
       "emb.user_session_id": "__EMBRACE_TEST_IGNORE__",
       "log.record.uid": "__EMBRACE_TEST_IGNORE__",
-      "my-attribute": "my-value",
-      "session.id": "__EMBRACE_TEST_IGNORE__"
+      "my-attribute": "my-value"
     },
     "instrumentationScopeName": "io.embrace.android.embracesdk.core",
     "resourceAttributes": {

--- a/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-span-attributes.json
+++ b/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-span-attributes.json
@@ -7,7 +7,7 @@
     "endEpochNanos": "169220161030000000",
     "hasEnded": "true",
     "parentSpanName": "",
-    "totalAttributeCount": "16",
+    "totalAttributeCount": "15",
     "attributes": {
       "any-value-attr": "__EMBRACE_TEST_IGNORE__",
       "boolean-attr": "true",
@@ -22,7 +22,6 @@
       "emb.user_session_id": "__EMBRACE_TEST_IGNORE__",
       "long-attr": "42",
       "long-list-attr": "[1, 2]",
-      "session.id": "__EMBRACE_TEST_IGNORE__",
       "string-attr": "value",
       "string-list-attr": "[a, b]"
     },
@@ -35,8 +34,7 @@
         "attributes": {
           "emb.link_type": "END_SESSION_PART",
           "emb.session_part_id": "__EMBRACE_TEST_IGNORE__",
-          "emb.user_session_id": "__EMBRACE_TEST_IGNORE__",
-          "session.id": "__EMBRACE_TEST_IGNORE__"
+          "emb.user_session_id": "__EMBRACE_TEST_IGNORE__"
         }
       }
     ],

--- a/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-span-events.json
+++ b/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-span-events.json
@@ -7,14 +7,13 @@
     "endEpochNanos": "169220160530000000",
     "hasEnded": "true",
     "parentSpanName": "",
-    "totalAttributeCount": "6",
+    "totalAttributeCount": "5",
     "attributes": {
       "emb.error_code": "failure",
       "emb.process_identifier": "__EMBRACE_TEST_IGNORE__",
       "emb.session_part_id": "__EMBRACE_TEST_IGNORE__",
       "emb.type": "perf",
-      "emb.user_session_id": "__EMBRACE_TEST_IGNORE__",
-      "session.id": "__EMBRACE_TEST_IGNORE__"
+      "emb.user_session_id": "__EMBRACE_TEST_IGNORE__"
     },
     "totalRecordedEvents": "3",
     "events": [
@@ -50,8 +49,7 @@
         "attributes": {
           "emb.link_type": "END_SESSION_PART",
           "emb.session_part_id": "__EMBRACE_TEST_IGNORE__",
-          "emb.user_session_id": "__EMBRACE_TEST_IGNORE__",
-          "session.id": "__EMBRACE_TEST_IGNORE__"
+          "emb.user_session_id": "__EMBRACE_TEST_IGNORE__"
         }
       }
     ],

--- a/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-span-relationships.json
+++ b/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-span-relationships.json
@@ -7,13 +7,12 @@
     "endEpochNanos": "169220160030000000",
     "hasEnded": "true",
     "parentSpanName": "",
-    "totalAttributeCount": "5",
+    "totalAttributeCount": "4",
     "attributes": {
       "emb.process_identifier": "__EMBRACE_TEST_IGNORE__",
       "emb.session_part_id": "__EMBRACE_TEST_IGNORE__",
       "emb.type": "perf",
-      "emb.user_session_id": "__EMBRACE_TEST_IGNORE__",
-      "session.id": "__EMBRACE_TEST_IGNORE__"
+      "emb.user_session_id": "__EMBRACE_TEST_IGNORE__"
     },
     "totalRecordedEvents": "0",
     "events": [],
@@ -24,8 +23,7 @@
         "attributes": {
           "emb.link_type": "END_SESSION_PART",
           "emb.session_part_id": "__EMBRACE_TEST_IGNORE__",
-          "emb.user_session_id": "__EMBRACE_TEST_IGNORE__",
-          "session.id": "__EMBRACE_TEST_IGNORE__"
+          "emb.user_session_id": "__EMBRACE_TEST_IGNORE__"
         }
       }
     ],
@@ -53,13 +51,12 @@
     "endEpochNanos": "169220160030000000",
     "hasEnded": "true",
     "parentSpanName": "aaa-parent-span",
-    "totalAttributeCount": "5",
+    "totalAttributeCount": "4",
     "attributes": {
       "emb.process_identifier": "__EMBRACE_TEST_IGNORE__",
       "emb.session_part_id": "__EMBRACE_TEST_IGNORE__",
       "emb.type": "perf",
-      "emb.user_session_id": "__EMBRACE_TEST_IGNORE__",
-      "session.id": "__EMBRACE_TEST_IGNORE__"
+      "emb.user_session_id": "__EMBRACE_TEST_IGNORE__"
     },
     "totalRecordedEvents": "0",
     "events": [],
@@ -70,8 +67,7 @@
         "attributes": {
           "emb.link_type": "END_SESSION_PART",
           "emb.session_part_id": "__EMBRACE_TEST_IGNORE__",
-          "emb.user_session_id": "__EMBRACE_TEST_IGNORE__",
-          "session.id": "__EMBRACE_TEST_IGNORE__"
+          "emb.user_session_id": "__EMBRACE_TEST_IGNORE__"
         }
       }
     ],
@@ -99,13 +95,12 @@
     "endEpochNanos": "169220160030000000",
     "hasEnded": "true",
     "parentSpanName": "",
-    "totalAttributeCount": "5",
+    "totalAttributeCount": "4",
     "attributes": {
       "emb.process_identifier": "__EMBRACE_TEST_IGNORE__",
       "emb.session_part_id": "__EMBRACE_TEST_IGNORE__",
       "emb.type": "perf",
-      "emb.user_session_id": "__EMBRACE_TEST_IGNORE__",
-      "session.id": "__EMBRACE_TEST_IGNORE__"
+      "emb.user_session_id": "__EMBRACE_TEST_IGNORE__"
     },
     "totalRecordedEvents": "0",
     "events": [],
@@ -116,8 +111,7 @@
         "attributes": {
           "emb.link_type": "END_SESSION_PART",
           "emb.session_part_id": "__EMBRACE_TEST_IGNORE__",
-          "emb.user_session_id": "__EMBRACE_TEST_IGNORE__",
-          "session.id": "__EMBRACE_TEST_IGNORE__"
+          "emb.user_session_id": "__EMBRACE_TEST_IGNORE__"
         }
       },
       {

--- a/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-trace.json
+++ b/embrace-android-sdk/src/integrationTest/resources/otel-export-parity-trace.json
@@ -7,14 +7,13 @@
     "endEpochNanos": "169220160030000000",
     "hasEnded": "true",
     "parentSpanName": "",
-    "totalAttributeCount": "6",
+    "totalAttributeCount": "5",
     "attributes": {
       "emb.process_identifier": "__EMBRACE_TEST_IGNORE__",
       "emb.session_part_id": "__EMBRACE_TEST_IGNORE__",
       "emb.type": "perf",
       "emb.user_session_id": "__EMBRACE_TEST_IGNORE__",
-      "my-attribute": "my-value",
-      "session.id": "__EMBRACE_TEST_IGNORE__"
+      "my-attribute": "my-value"
     },
     "totalRecordedEvents": "1",
     "events": [
@@ -31,8 +30,7 @@
         "attributes": {
           "emb.link_type": "END_SESSION_PART",
           "emb.session_part_id": "__EMBRACE_TEST_IGNORE__",
-          "emb.user_session_id": "__EMBRACE_TEST_IGNORE__",
-          "session.id": "__EMBRACE_TEST_IGNORE__"
+          "emb.user_session_id": "__EMBRACE_TEST_IGNORE__"
         }
       }
     ],

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_aei_log_active.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_aei_log_active.json
@@ -83,10 +83,6 @@
           "value": "1123409"
         },
         {
-          "key": "session.id",
-          "value": ""
-        },
-        {
           "key": "session_id_error",
           "value": ""
         },

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_aei_log_no_session.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_aei_log_no_session.json
@@ -83,10 +83,6 @@
           "value": "1123409"
         },
         {
-          "key": "session.id",
-          "value": ""
-        },
-        {
           "key": "session_id_error",
           "value": ""
         },

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_basic_log.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_basic_log.json
@@ -37,10 +37,6 @@
         {
           "key": "log.record.uid",
           "value": "__EMBRACE_TEST_IGNORE__"
-        },
-        {
-          "key": "session.id",
-          "value": "__EMBRACE_TEST_USER_SESSION_ID__"
         }
       ]
     }

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_basic_span.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_basic_span.json
@@ -119,10 +119,6 @@
     {
       "key": "emb.user_session_start_ts",
       "value": "169220160000"
-    },
-    {
-      "key": "session.id",
-      "value": "__EMBRACE_TEST_USER_SESSION_ID__"
     }
   ],
   "links": "__EMBRACE_TEST_IGNORE__"

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_1.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_1.json
@@ -115,10 +115,6 @@
     {
       "key": "emb.user_session_start_ts",
       "value": "169220160000"
-    },
-    {
-      "key": "session.id",
-      "value": "__EMBRACE_TEST_USER_SESSION_ID__"
     }
   ],
   "links": "__EMBRACE_TEST_IGNORE__"

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_2.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_2.json
@@ -115,10 +115,6 @@
     {
       "key": "emb.user_session_start_ts",
       "value": "169220160000"
-    },
-    {
-      "key": "session.id",
-      "value": "__EMBRACE_TEST_USER_SESSION_ID__"
     }
   ],
   "links": "__EMBRACE_TEST_IGNORE__"

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_3.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_3.json
@@ -115,10 +115,6 @@
     {
       "key": "emb.user_session_termination_reason",
       "value": "inactivity"
-    },
-    {
-      "key": "session.id",
-      "value": "__EMBRACE_TEST_USER_SESSION_ID__"
     }
   ],
   "links": "__EMBRACE_TEST_IGNORE__"

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_4.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_4.json
@@ -119,10 +119,6 @@
     {
       "key": "emb.user_session_termination_reason",
       "value": "background_only_user_session_foregrounded"
-    },
-    {
-      "key": "session.id",
-      "value": "__EMBRACE_TEST_USER_SESSION_ID__"
     }
   ],
   "links": "__EMBRACE_TEST_IGNORE__"

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_5.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_bg_timeout_5.json
@@ -107,10 +107,6 @@
     {
       "key": "emb.user_session_start_ts",
       "value": "169351600142"
-    },
-    {
-      "key": "session.id",
-      "value": "__EMBRACE_TEST_USER_SESSION_ID__"
     }
   ],
   "links": "__EMBRACE_TEST_IGNORE__"

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_custom_timeouts.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_custom_timeouts.json
@@ -115,10 +115,6 @@
     {
       "key": "emb.user_session_start_ts",
       "value": "169220160000"
-    },
-    {
-      "key": "session.id",
-      "value": "__EMBRACE_TEST_USER_SESSION_ID__"
     }
   ],
   "links": "__EMBRACE_TEST_IGNORE__"

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_jvm_crash_log.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_jvm_crash_log.json
@@ -65,10 +65,6 @@
         {
           "key": "log.record.uid",
           "value": "__EMBRACE_TEST_IGNORE__"
-        },
-        {
-          "key": "session.id",
-          "value": "__EMBRACE_TEST_USER_SESSION_ID__"
         }
       ]
     }

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_jvm_crash_span.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_jvm_crash_span.json
@@ -127,10 +127,6 @@
     {
       "key": "emb.user_session_start_ts",
       "value": "169220160000"
-    },
-    {
-      "key": "session.id",
-      "value": "__EMBRACE_TEST_USER_SESSION_ID__"
     }
   ],
   "links": "__EMBRACE_TEST_IGNORE__"

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_manual_end_1.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_manual_end_1.json
@@ -127,10 +127,6 @@
     {
       "key": "emb.user_session_termination_reason",
       "value": "manual"
-    },
-    {
-      "key": "session.id",
-      "value": "__EMBRACE_TEST_USER_SESSION_ID__"
     }
   ],
   "links": "__EMBRACE_TEST_IGNORE__"

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_manual_end_2.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_manual_end_2.json
@@ -107,10 +107,6 @@
     {
       "key": "emb.user_session_start_ts",
       "value": "169220180030"
-    },
-    {
-      "key": "session.id",
-      "value": "__EMBRACE_TEST_USER_SESSION_ID__"
     }
   ],
   "links": "__EMBRACE_TEST_IGNORE__"

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_max_duration_1.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_max_duration_1.json
@@ -123,10 +123,6 @@
     {
       "key": "emb.user_session_termination_reason",
       "value": "max_duration_reached"
-    },
-    {
-      "key": "session.id",
-      "value": "__EMBRACE_TEST_USER_SESSION_ID__"
     }
   ],
   "links": "__EMBRACE_TEST_IGNORE__"

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_max_duration_2.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_max_duration_2.json
@@ -107,10 +107,6 @@
     {
       "key": "emb.user_session_start_ts",
       "value": "169263360031"
-    },
-    {
-      "key": "session.id",
-      "value": "__EMBRACE_TEST_USER_SESSION_ID__"
     }
   ],
   "links": "__EMBRACE_TEST_IGNORE__"

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_ndk_crash_log.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_ndk_crash_log.json
@@ -29,10 +29,6 @@
         {
           "key": "log.record.uid",
           "value": "__EMBRACE_TEST_IGNORE__"
-        },
-        {
-          "key": "session.id",
-          "value": "__EMBRACE_TEST_USER_SESSION_ID__"
         }
       ]
     }

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_part_1.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_part_1.json
@@ -115,10 +115,6 @@
     {
       "key": "emb.user_session_start_ts",
       "value": "169220160000"
-    },
-    {
-      "key": "session.id",
-      "value": "__EMBRACE_TEST_USER_SESSION_ID__"
     }
   ],
   "links": "__EMBRACE_TEST_IGNORE__"

--- a/embrace-android-sdk/src/integrationTest/resources/user_session_part_2.json
+++ b/embrace-android-sdk/src/integrationTest/resources/user_session_part_2.json
@@ -107,10 +107,6 @@
     {
       "key": "emb.user_session_start_ts",
       "value": "169220160000"
-    },
-    {
-      "key": "session.id",
-      "value": "__EMBRACE_TEST_USER_SESSION_ID__"
     }
   ],
   "links": "__EMBRACE_TEST_IGNORE__"

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
@@ -12,7 +12,6 @@ import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 import io.opentelemetry.kotlin.semconv.UserAttributes
 import java.util.ServiceLoader
 import java.util.concurrent.TimeUnit
@@ -227,7 +226,6 @@ private fun ModuleGraph.eventMetadataSupplierProvider(): Provider<Map<String, St
 
             put(EmbSessionAttributes.EMB_SESSION_PART_ID, sessionIds.sessionPartId)
             put(EmbSessionAttributes.EMB_USER_SESSION_ID, sessionIds.userSessionId)
-            put(SessionAttributes.SESSION_ID, sessionIds.userSessionId)
             put(EmbSessionAttributes.EMB_STATE, sessionState.description)
             essentialServiceModule.userService.getUserInfo().userId?.let {
                 put(UserAttributes.USER_ID, it)

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SessionPartPayloadAssertions.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SessionPartPayloadAssertions.kt
@@ -10,7 +10,6 @@ import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
 import io.embrace.android.embracesdk.internal.session.getStateSpan
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
-import io.opentelemetry.kotlin.semconv.SessionAttributes
 
 /**
  * Returns the Session Part Span
@@ -18,15 +17,6 @@ import io.opentelemetry.kotlin.semconv.SessionAttributes
 fun Envelope<SessionPartPayload>.findSessionPartSpan(): Span {
     return checkNotNull(getSessionPartSpan()) {
         "No session part span found in session payload"
-    }
-}
-
-/**
- * Return the user session ID from the session part span in the payload
- */
-fun Envelope<SessionPartPayload>.getOtelSessionId(): String {
-    return checkNotNull(findSessionPartSpan().attributes?.findAttributeValue(SessionAttributes.SESSION_ID)) {
-        "No session id found in session payload"
     }
 }
 


### PR DESCRIPTION
## Goal

Removes `session.id` which is always duplicated by the value of `emb.user_session_id`.

## Testing

Updated existing test coverage.
