### PR TITLE
Alter worker thread used for config requests

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
@@ -33,8 +33,6 @@ import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.opentelemetry.kotlin.semconv.SessionAttributes
 import java.io.InputStream
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
 import java.util.zip.GZIPInputStream
 import java.util.zip.ZipException
 import kotlin.math.max
@@ -290,18 +288,15 @@ internal class PayloadResurrectionServiceImpl(
             else -> null
         }
 
-        // Synchronously provide the payload to the IntakeService, blocking on the returned Future
+        // Hand the payload to the IntakeService without blocking. The write is queued on the data
+        // persistence worker while this thread moves on to the next payload; the envelope is already
+        // fully in memory, so we assume the cached copy is reasonably safe to delete.
         if (resurrectedPayload != null) {
-            val task = intakeService.take(
+            intakeService.take(
                 intake = resurrectedPayload,
                 metadata = copy(complete = true),
                 staleEntry = this,
             )
-            try {
-                task.get(5, TimeUnit.SECONDS)
-            } catch (e: TimeoutException) {
-                logger.trackInternalError(InternalErrorType.IntakeFail, e)
-            }
         }
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
@@ -60,6 +60,7 @@ import io.opentelemetry.kotlin.semconv.SessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
 import java.io.ByteArrayInputStream
@@ -67,7 +68,6 @@ import java.io.InputStream
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
 import java.util.zip.GZIPInputStream
 
 class PayloadResurrectionServiceImplTest {
@@ -758,25 +758,28 @@ class PayloadResurrectionServiceImplTest {
     }
 
     @Test
-    fun `resurrection timeout logged when future throws timeout on get`() {
-        val hangingIntakeService = object : IntakeService {
+    fun `resurrection does not wait for the intake service to persist the payload`() {
+        var takeCount = 0
+        val neverCompletingIntakeService = object : IntakeService {
             override fun shutdown() {}
             override fun take(
                 intake: Envelope<*>,
                 metadata: StoredTelemetryMetadata,
                 staleEntry: StoredTelemetryMetadata?,
             ): Future<*> {
+                takeCount++
                 return object : Future<Unit> {
                     override fun cancel(mayInterruptIfRunning: Boolean) = false
                     override fun isCancelled() = false
                     override fun isDone() = false
-                    override fun get() = throw TimeoutException("test")
-                    override fun get(timeout: Long, unit: TimeUnit) = throw TimeoutException("test")
+                    override fun get(): Unit = fail("resurrection must not block on the intake future")
+                    override fun get(timeout: Long, unit: TimeUnit): Unit =
+                        fail("resurrection must not block on the intake future")
                 }
             }
         }
         val service = PayloadResurrectionServiceImpl(
-            intakeService = hangingIntakeService,
+            intakeService = neverCompletingIntakeService,
             payloadStorageService = payloadStorageService,
             cacheStorageService = cacheStorageService,
             cachedLogEnvelopeStore = cachedLogEnvelopeStore,
@@ -790,12 +793,9 @@ class PayloadResurrectionServiceImplTest {
         service.addResurrectionCompleteListener { listenerCalled = true }
         service.resurrectOldPayloads(nativeCrashServiceProvider = { nativeCrashService })
 
+        assertEquals(1, takeCount)
         assertTrue(listenerCalled)
-        assertTrue(
-            logger.internalErrorMessages.any {
-                it.throwable is TimeoutException
-            },
-        )
+        assertEquals(0, cacheStorageService.storedPayloadCount())
     }
 
     /**


### PR DESCRIPTION
## Goal

Alters the worker thread that the config HTTP request is enqueued on. The config request is enqueued on the IoRegWorker thread. In the worst case of a request taking ~1 min to timeout, this could block everything on the IoRegWorker (shared prefs warming, native crash handler installation, cached data sending). It feels more reasonable to enqueue it on the HttpRequestWorker instead.

I've also altered the `PayloadResurrectionService` which had a similar problem.