### PR TITLE
Load config as first operation

### DIFF
--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
@@ -9,7 +9,6 @@ import io.embrace.android.embracesdk.internal.config.behavior.DataCaptureEventBe
 import io.embrace.android.embracesdk.internal.config.behavior.LogMessageBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.NetworkBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.NetworkSpanForwardingBehaviorImpl
-import io.embrace.android.embracesdk.internal.config.behavior.OtelBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.SdkModeBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.ThreadBlockageBehaviorImpl
@@ -22,47 +21,30 @@ import io.embrace.android.embracesdk.internal.config.source.CombinedRemoteConfig
 import io.embrace.android.embracesdk.internal.config.source.ConfigEndpoint
 import io.embrace.android.embracesdk.internal.config.source.OkHttpRemoteConfigSource
 import io.embrace.android.embracesdk.internal.config.source.RemoteConfigSource
-import io.embrace.android.embracesdk.internal.config.store.RemoteConfigStore
-import io.embrace.android.embracesdk.internal.config.store.RemoteConfigStoreImpl
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.AppFramework
 import io.embrace.android.embracesdk.internal.payload.NativeSymbols
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
-import io.embrace.android.embracesdk.internal.store.KeyValueStore
-import io.embrace.android.embracesdk.internal.utils.UuidSource
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import okhttp3.OkHttpClient
 import okio.ByteString.Companion.decodeBase64
-import java.io.File
 
 /**
  * Loads configuration for the app from the Embrace API.
  */
 class ConfigServiceImpl(
     private val instrumentedConfig: InstrumentedConfig,
+    private val persistedConfig: PersistedConfig,
     worker: BackgroundWorker,
     private val serializer: PlatformSerializer,
-    store: KeyValueStore,
     okHttpClient: Lazy<OkHttpClient>,
     abis: Array<String>,
     private val sdkVersion: String,
     private val apiLevel: Int,
-    private val filesDir: File,
     private val logger: InternalLogger,
     private val hasConfiguredOtlpExport: () -> Boolean,
-    private val uuidSource: UuidSource,
 ) : ConfigService {
-
-    private val onlyOtelExportEnabled: Boolean = instrumentedConfig.project.getAppId() == null
-
-    private val remoteConfigStore: RemoteConfigStore = run {
-        RemoteConfigStoreImpl(
-            serializer = serializer,
-            storageDir = File(filesDir, "embrace_remote_config"),
-            deviceIdProvider = { deviceId },
-        )
-    }
 
     override val buildInfo: BuildInfo = with(instrumentedConfig.project) {
         BuildInfo(
@@ -76,24 +58,22 @@ class ConfigServiceImpl(
         )
     }
 
-    // the stored || http proxy; lazy-loads the cached config from the store on first access.
     private val combinedRemoteConfigSource: CombinedRemoteConfigSource? = run {
-        if (onlyOtelExportEnabled) return@run null
+        val store = persistedConfig.store ?: return@run null
         CombinedRemoteConfigSource(
-            store = remoteConfigStore,
+            store = store,
+            response = persistedConfig.response,
             httpSource = lazy { checkNotNull(remoteConfigSource) },
             worker = worker,
         )
     }
 
-    // the device ID co-cached with the remote config feeds the fast path; on a cache hit nothing
-    // is read from the KeyValueStore.
-    private val deviceIdProvider = DeviceIdProvider(store, combinedRemoteConfigSource?.getDeviceId(), uuidSource)
-
-    override val deviceId: String = deviceIdProvider.deviceId
+    override val deviceId: String = persistedConfig.deviceId
 
     private val remoteConfigSource: RemoteConfigSource? = run {
-        if (onlyOtelExportEnabled) return@run null
+        if (persistedConfig.onlyOtelExportEnabled) {
+            return@run null
+        }
 
         OkHttpRemoteConfigSource(
             okhttpClient = okHttpClient,
@@ -108,7 +88,7 @@ class ConfigServiceImpl(
         )
     }
 
-    private val remoteConfig: RemoteConfig? = combinedRemoteConfigSource?.getConfig()
+    private val remoteConfig: RemoteConfig? = persistedConfig.remoteConfig
 
     // kick off config HTTP request early so the SDK can't get in a permanently disabled state.
     // scheduled only after deviceId is resolved, since the request reads it.
@@ -116,7 +96,7 @@ class ConfigServiceImpl(
         combinedRemoteConfigSource?.scheduleConfigRequests()
     }
 
-    private val thresholdCheck: BehaviorThresholdCheck = BehaviorThresholdCheck(::deviceId)
+    private val thresholdCheck: BehaviorThresholdCheck = persistedConfig.thresholdCheck
     override val backgroundActivityBehavior =
         BackgroundActivityBehaviorImpl(thresholdCheck, instrumentedConfig, remoteConfig)
     override val autoDataCaptureBehavior =
@@ -136,7 +116,7 @@ class ConfigServiceImpl(
         TraceparentInjectionBehaviorImpl(thresholdCheck, instrumentedConfig, remoteConfig)
     override val networkSpanForwardingBehavior =
         NetworkSpanForwardingBehaviorImpl(traceparentInjectionBehavior, thresholdCheck, instrumentedConfig, remoteConfig)
-    override val otelBehavior = OtelBehaviorImpl(thresholdCheck, instrumentedConfig, remoteConfig)
+    override val otelBehavior = persistedConfig.otelBehavior
 
     override val appId: String? = run {
         val id = instrumentedConfig.project.getAppId()

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/DeviceIdProvider.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/DeviceIdProvider.kt
@@ -12,18 +12,18 @@ import io.embrace.android.embracesdk.internal.utils.UuidSource
  * 3. a freshly generated UUID, persisted to the [KeyValueStore] so it is stable across launches.
  */
 internal class DeviceIdProvider(
-    private val keyValueStore: KeyValueStore,
+    private val keyValueStore: Lazy<KeyValueStore>,
     private val cachedDeviceId: String?,
     private val uuidSource: UuidSource,
 ) {
 
     val deviceId: String = cachedDeviceId
-        ?: keyValueStore.getString(DEVICE_IDENTIFIER_KEY)
+        ?: keyValueStore.value.getString(DEVICE_IDENTIFIER_KEY)
         ?: newDeviceId()
 
     private fun newDeviceId(): String {
         val newId = uuidSource.createUuid()
-        keyValueStore.edit {
+        keyValueStore.value.edit {
             putString(DEVICE_IDENTIFIER_KEY, newId)
         }
         return newId

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/PersistedConfig.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/PersistedConfig.kt
@@ -1,0 +1,69 @@
+package io.embrace.android.embracesdk.internal.config
+
+import io.embrace.android.embracesdk.internal.config.behavior.BehaviorThresholdCheck
+import io.embrace.android.embracesdk.internal.config.behavior.OtelBehavior
+import io.embrace.android.embracesdk.internal.config.behavior.OtelBehaviorImpl
+import io.embrace.android.embracesdk.internal.config.instrumented.schema.InstrumentedConfig
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.config.store.RemoteConfigStore
+import io.embrace.android.embracesdk.internal.config.store.RemoteConfigStoreImpl
+import io.embrace.android.embracesdk.internal.config.store.StoredConfigResponse
+import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
+import io.embrace.android.embracesdk.internal.store.KeyValueStore
+import io.embrace.android.embracesdk.internal.utils.UuidSource
+import java.io.File
+
+/**
+ * The remote config that was persisted by a previous launch, loaded from disk at construction time. This
+ * is the very first thing the SDK reads and is fundamental for deciding how the SDK should behave.
+ *
+ * Loading is disk-only and does not touch the network: the HTTP fetch scheduled later by
+ * [ConfigServiceImpl] only writes to the store, so a config change from the server takes effect on
+ * the next process launch.
+ */
+class PersistedConfig(
+    serializer: PlatformSerializer,
+    filesDir: File,
+    instrumentedConfig: InstrumentedConfig,
+    keyValueStore: Lazy<KeyValueStore>,
+    uuidSource: UuidSource,
+) {
+
+    /**
+     * Without an app ID there is no Embrace backend to fetch config from, so any config left on disk
+     * by a previous install must be ignored and the store is never created.
+     */
+    internal val onlyOtelExportEnabled: Boolean = instrumentedConfig.project.getAppId() == null
+
+    internal val store: RemoteConfigStore? = when {
+        onlyOtelExportEnabled -> null
+        else -> RemoteConfigStoreImpl(
+            serializer = serializer,
+            storageDir = File(filesDir, STORAGE_DIR_NAME),
+            deviceIdProvider = { deviceId },
+        )
+    }
+
+    internal val response: StoredConfigResponse? = store?.loadResponse()
+
+    internal val remoteConfig: RemoteConfig? = response?.cfg
+
+    /**
+     * Resolved lazily so that the common case (binary cache) never has to touch the [KeyValueStore].
+     */
+    val deviceId: String by lazy {
+        DeviceIdProvider(keyValueStore, response?.deviceId, uuidSource).deviceId
+    }
+
+    internal val thresholdCheck: BehaviorThresholdCheck = BehaviorThresholdCheck(::deviceId)
+
+    val otelBehavior: OtelBehavior = OtelBehaviorImpl(thresholdCheck, instrumentedConfig, remoteConfig)
+
+    companion object {
+
+        /**
+         * Subdirectory of the app's files dir where the remote config is persisted.
+         */
+        const val STORAGE_DIR_NAME: String = "embrace_remote_config"
+    }
+}

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/source/CombinedRemoteConfigSource.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/source/CombinedRemoteConfigSource.kt
@@ -1,27 +1,19 @@
 package io.embrace.android.embracesdk.internal.config.source
 
-import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.config.store.RemoteConfigStore
+import io.embrace.android.embracesdk.internal.config.store.StoredConfigResponse
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import java.util.concurrent.TimeUnit
 
 internal class CombinedRemoteConfigSource(
     private val store: RemoteConfigStore,
+    private val response: StoredConfigResponse?,
     httpSource: Lazy<RemoteConfigSource>,
     private val worker: BackgroundWorker,
     private val intervalMs: Long = 60 * 60 * 1000,
 ) {
 
     private val httpSource: RemoteConfigSource by httpSource
-
-    // the remote config that is used for the lifetime of the process.
-    private val response by lazy {
-        store.loadResponse()
-    }
-
-    fun getConfig(): RemoteConfig? = response?.cfg
-
-    fun getDeviceId(): String? = response?.deviceId
 
     fun scheduleConfigRequests() {
         worker.scheduleWithFixedDelay(

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImplTest.kt
@@ -110,18 +110,25 @@ internal class ConfigServiceImplTest {
     private fun createService(
         hasConfiguredExporters: () -> Boolean = { false },
         appId: String? = "AbCdE",
-    ): ConfigServiceImpl = ConfigServiceImpl(
-        instrumentedConfig = FakeInstrumentedConfig(project = FakeProjectConfig(appId = appId)),
-        worker = fakeBackgroundWorker(),
-        serializer = serializer,
-        store = FakeKeyValueStore(),
-        okHttpClient = lazyOf(okHttpClient),
-        abis = arrayOf("arm64-v8a"),
-        sdkVersion = "1.2.3",
-        apiLevel = 36,
-        filesDir = Files.createTempDirectory("tmp").toFile(),
-        logger = FakeInternalLogger(),
-        hasConfiguredOtlpExport = hasConfiguredExporters,
-        uuidSource = TestUuidSource(),
-    )
+    ): ConfigServiceImpl {
+        val instrumentedConfig = FakeInstrumentedConfig(project = FakeProjectConfig(appId = appId))
+        return ConfigServiceImpl(
+            instrumentedConfig = instrumentedConfig,
+            persistedConfig = PersistedConfig(
+                serializer = serializer,
+                filesDir = Files.createTempDirectory("tmp").toFile(),
+                instrumentedConfig = instrumentedConfig,
+                keyValueStore = lazyOf(FakeKeyValueStore()),
+                uuidSource = TestUuidSource(),
+            ),
+            worker = fakeBackgroundWorker(),
+            serializer = serializer,
+            okHttpClient = lazyOf(okHttpClient),
+            abis = arrayOf("arm64-v8a"),
+            sdkVersion = "1.2.3",
+            apiLevel = 36,
+            logger = FakeInternalLogger(),
+            hasConfiguredOtlpExport = hasConfiguredExporters,
+        )
+    }
 }

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/DeviceIdProviderTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/DeviceIdProviderTest.kt
@@ -2,7 +2,9 @@ package io.embrace.android.embracesdk.internal.config
 
 import io.embrace.android.embracesdk.fakes.FakeKeyValueStore
 import io.embrace.android.embracesdk.fakes.TestUuidSource
+import io.embrace.android.embracesdk.internal.store.KeyValueStore
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -13,10 +15,23 @@ internal class DeviceIdProviderTest {
     @Test
     fun `cached device id is preferred and nothing is persisted`() {
         val store = FakeKeyValueStore()
-        val provider = DeviceIdProvider(store, cachedDeviceId = "cached-id", uuidSource = TestUuidSource())
+        val provider = DeviceIdProvider(lazyOf(store), cachedDeviceId = "cached-id", uuidSource = TestUuidSource())
 
         assertEquals("cached-id", provider.deviceId)
         assertTrue(store.values().isEmpty())
+    }
+
+    @Test
+    fun `store is never resolved when a cached device id is supplied`() {
+        var resolved = false
+        val store = lazy<KeyValueStore> {
+            resolved = true
+            FakeKeyValueStore()
+        }
+        val provider = DeviceIdProvider(store, cachedDeviceId = "cached-id", uuidSource = TestUuidSource())
+
+        assertEquals("cached-id", provider.deviceId)
+        assertFalse(resolved)
     }
 
     @Test
@@ -24,7 +39,7 @@ internal class DeviceIdProviderTest {
         val store = FakeKeyValueStore().apply {
             edit { putString(key, "persisted-id") }
         }
-        val provider = DeviceIdProvider(store, cachedDeviceId = null, uuidSource = TestUuidSource())
+        val provider = DeviceIdProvider(lazyOf(store), cachedDeviceId = null, uuidSource = TestUuidSource())
 
         assertEquals("persisted-id", provider.deviceId)
     }
@@ -32,7 +47,7 @@ internal class DeviceIdProviderTest {
     @Test
     fun `generates and persists a new id when nothing is stored`() {
         val store = FakeKeyValueStore()
-        val provider = DeviceIdProvider(store, cachedDeviceId = null, uuidSource = TestUuidSource())
+        val provider = DeviceIdProvider(lazyOf(store), cachedDeviceId = null, uuidSource = TestUuidSource())
 
         val generated = provider.deviceId
         assertTrue(generated.isNotEmpty())

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/NativeSymbolTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/NativeSymbolTest.kt
@@ -76,17 +76,21 @@ class NativeSymbolTest {
 
         return ConfigServiceImpl(
             instrumentedConfig = cfg,
+            persistedConfig = PersistedConfig(
+                serializer = serializer,
+                filesDir = Files.createTempDirectory("tmp").toFile(),
+                instrumentedConfig = cfg,
+                keyValueStore = lazyOf(FakeKeyValueStore()),
+                uuidSource = TestUuidSource(),
+            ),
             worker = fakeBackgroundWorker(),
             serializer = serializer,
-            store = FakeKeyValueStore(),
             okHttpClient = lazyOf(okHttpClient),
             abis = arrayOf(arch),
             sdkVersion = "1.2.3",
             apiLevel = 36,
-            filesDir = Files.createTempDirectory("tmp").toFile(),
             logger = FakeInternalLogger(),
             hasConfiguredOtlpExport = { false },
-            uuidSource = TestUuidSource(),
         )
     }
 }

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/PersistedConfigTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/PersistedConfigTest.kt
@@ -1,0 +1,173 @@
+package io.embrace.android.embracesdk.internal.config
+
+import io.embrace.android.embracesdk.fakes.FakeKeyValueStore
+import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
+import io.embrace.android.embracesdk.fakes.TestUuidSource
+import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
+import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
+import io.embrace.android.embracesdk.fakes.config.FakeProjectConfig
+import io.embrace.android.embracesdk.internal.config.remote.OtelKotlinSdkConfig
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.config.source.ConfigHttpResponse
+import io.embrace.android.embracesdk.internal.config.store.RemoteConfigStoreImpl
+import io.embrace.android.embracesdk.internal.serialization.toJson
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+internal class PersistedConfigTest {
+
+    @get:Rule
+    val temporaryFolder: TemporaryFolder = TemporaryFolder()
+
+    private val serializer = TestPlatformSerializer()
+
+    @Test
+    fun `remote config is loaded from disk`() {
+        val cfg = RemoteConfig(threshold = 92)
+        val persistedConfig = createPersistedConfig(persisted = cfg)
+        assertEquals(cfg, persistedConfig.remoteConfig)
+    }
+
+    @Test
+    fun `remote config is null when nothing was persisted`() {
+        assertNull(createPersistedConfig().remoteConfig)
+    }
+
+    @Test
+    fun `kotlin sdk enabled by remote config`() {
+        val persistedConfig = createPersistedConfig(
+            persisted = RemoteConfig(otelKotlinSdkConfig = OtelKotlinSdkConfig(pctEnabled = 100f)),
+        )
+        assertTrue(persistedConfig.otelBehavior.shouldUseKotlinSdk())
+    }
+
+    @Test
+    fun `kotlin sdk disabled by remote config overrides local flag`() {
+        val persistedConfig = createPersistedConfig(
+            persisted = RemoteConfig(otelKotlinSdkConfig = OtelKotlinSdkConfig(pctEnabled = 0f)),
+            localEnabled = true,
+        )
+        assertFalse(persistedConfig.otelBehavior.shouldUseKotlinSdk())
+    }
+
+    @Test
+    fun `kotlin sdk falls back to local flag when remote config absent`() {
+        assertTrue(createPersistedConfig(localEnabled = true).otelBehavior.shouldUseKotlinSdk())
+        assertFalse(createPersistedConfig(localEnabled = false).otelBehavior.shouldUseKotlinSdk())
+    }
+
+    @Test
+    fun `device id sourced from key value store when not co-cached`() {
+        val store = FakeKeyValueStore().apply {
+            edit { putString("io.embrace.deviceid", "persisted-device-id") }
+        }
+        val persistedConfig = createPersistedConfig(store = lazyOf(store))
+        assertEquals("persisted-device-id", persistedConfig.deviceId)
+    }
+
+    @Test
+    fun `persisted config ignored entirely when there is no app id`() {
+        val persistedConfig = createPersistedConfig(
+            persisted = RemoteConfig(otelKotlinSdkConfig = OtelKotlinSdkConfig(pctEnabled = 100f)),
+            appId = null,
+        )
+        assertTrue(persistedConfig.onlyOtelExportEnabled)
+        assertNull(persistedConfig.store)
+        assertNull(persistedConfig.remoteConfig)
+        assertFalse(persistedConfig.otelBehavior.shouldUseKotlinSdk())
+    }
+
+    /**
+     * [ConfigServiceImpl] decides whether to build an HTTP config source from
+     * [PersistedConfig.onlyOtelExportEnabled] while the store here is built from the same flag. If the
+     * two ever disagree the scheduled config request throws on `checkNotNull` and cancels itself, so
+     * pin them to one another.
+     */
+    @Test
+    fun `store presence is the inverse of onlyOtelExportEnabled`() {
+        createPersistedConfig(appId = "abcde").run {
+            assertFalse(onlyOtelExportEnabled)
+            assertNotNull(store)
+        }
+        createPersistedConfig(appId = null).run {
+            assertTrue(onlyOtelExportEnabled)
+            assertNull(store)
+        }
+    }
+
+    @Test
+    fun `device id sourced from the binary cache`() {
+        val persistedConfig = createPersistedConfig(
+            persisted = RemoteConfig(threshold = 92),
+            cachedDeviceId = "cached-device-id",
+        )
+        assertEquals("cached-device-id", persistedConfig.deviceId)
+    }
+
+    @Test
+    fun `key value store is not touched when the config is never read`() {
+        var resolved = false
+        val store = lazy {
+            resolved = true
+            FakeKeyValueStore()
+        }
+        createPersistedConfig(store = store)
+        assertFalse(resolved)
+    }
+
+    @Test
+    fun `key value store is not touched when the binary cache supplies the device id`() {
+        var resolved = false
+        val store = lazy {
+            resolved = true
+            FakeKeyValueStore()
+        }
+        val persistedConfig = createPersistedConfig(
+            persisted = RemoteConfig(threshold = 92),
+            cachedDeviceId = "cached-device-id",
+            store = store,
+        )
+
+        assertEquals("cached-device-id", persistedConfig.deviceId)
+        assertFalse(resolved)
+    }
+
+    private fun createPersistedConfig(
+        persisted: RemoteConfig? = null,
+        localEnabled: Boolean = false,
+        appId: String? = "abcde",
+        store: Lazy<FakeKeyValueStore> = lazyOf(FakeKeyValueStore()),
+        cachedDeviceId: String? = null,
+    ): PersistedConfig {
+        val filesDir = temporaryFolder.newFolder()
+        if (persisted != null && cachedDeviceId != null) {
+            RemoteConfigStoreImpl(
+                serializer = serializer,
+                storageDir = File(filesDir, PersistedConfig.STORAGE_DIR_NAME),
+                deviceIdProvider = { cachedDeviceId },
+            ).saveResponse(ConfigHttpResponse(persisted, "etag"))
+        } else if (persisted != null) {
+            val storageDir = File(filesDir, PersistedConfig.STORAGE_DIR_NAME).apply { mkdirs() }
+            File(storageDir, "most_recent_response").outputStream().buffered().use {
+                serializer.toJson(persisted, it)
+            }
+        }
+        return PersistedConfig(
+            serializer = serializer,
+            filesDir = filesDir,
+            instrumentedConfig = FakeInstrumentedConfig(
+                enabledFeatures = FakeEnabledFeatureConfig(otelKotlinSdkEnabled = localEnabled),
+                project = FakeProjectConfig(appId = appId),
+            ),
+            keyValueStore = store,
+            uuidSource = TestUuidSource(),
+        )
+    }
+}

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/source/CombinedRemoteConfigSourceTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/source/CombinedRemoteConfigSourceTest.kt
@@ -13,7 +13,6 @@ import org.junit.Test
 
 class CombinedRemoteConfigSourceTest {
 
-    private lateinit var source: CombinedRemoteConfigSource
     private lateinit var remoteConfig: RemoteConfig
     private lateinit var executorService: BlockingScheduledExecutorService
     private lateinit var remoteConfigSource: FakeRemoteConfigSource
@@ -25,46 +24,11 @@ class CombinedRemoteConfigSourceTest {
         executorService = BlockingScheduledExecutorService()
         remoteConfigSource = FakeRemoteConfigSource(ConfigHttpResponse(remoteConfig, "another"))
         remoteConfigStore = FakeRemoteConfigStore()
-        source = CombinedRemoteConfigSource(
-            remoteConfigStore,
-            lazy { remoteConfigSource },
-            BackgroundWorker(executorService),
-        )
-    }
-
-    @Test
-    fun `test initial config null`() {
-        assertNull(source.getConfig())
-    }
-
-    @Test
-    fun `test initial config populated`() {
-        val cfg = RemoteConfig(100)
-        source = CombinedRemoteConfigSource(
-            FakeRemoteConfigStore(StoredConfigResponse(cfg, null, null)),
-            lazy { remoteConfigSource },
-            BackgroundWorker(executorService),
-        )
-        assertEquals(cfg, source.getConfig())
-    }
-
-    @Test
-    fun `test device id null when not cached`() {
-        assertNull(source.getDeviceId())
-    }
-
-    @Test
-    fun `test device id sourced from cache`() {
-        source = CombinedRemoteConfigSource(
-            FakeRemoteConfigStore(StoredConfigResponse(RemoteConfig(), null, "cached-device-id")),
-            lazy { remoteConfigSource },
-            BackgroundWorker(executorService),
-        )
-        assertEquals("cached-device-id", source.getDeviceId())
     }
 
     @Test
     fun `test requests scheduled`() {
+        val source = createSource(response = null)
         assertEquals(0, remoteConfigSource.callCount)
         source.scheduleConfigRequests()
         executorService.runCurrentlyBlocked()
@@ -74,7 +38,7 @@ class CombinedRemoteConfigSourceTest {
 
     @Test
     fun `test persisted etag value populated`() {
-        remoteConfigStore.impl = StoredConfigResponse(RemoteConfig(), "etag", null)
+        val source = createSource(response = StoredConfigResponse(RemoteConfig(), "etag", null))
         assertEquals(0, remoteConfigSource.callCount)
         source.scheduleConfigRequests()
         executorService.runCurrentlyBlocked()
@@ -82,4 +46,11 @@ class CombinedRemoteConfigSourceTest {
         assertEquals(1, remoteConfigSource.callCount)
         assertEquals(1, remoteConfigStore.saveCount)
     }
+
+    private fun createSource(response: StoredConfigResponse?) = CombinedRemoteConfigSource(
+        remoteConfigStore,
+        response,
+        lazy { remoteConfigSource },
+        BackgroundWorker(executorService),
+    )
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CoreModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CoreModuleImpl.kt
@@ -1,11 +1,8 @@
-@file:Suppress("DEPRECATION")
-
 package io.embrace.android.embracesdk.internal.injection
 
 import android.app.Application
 import android.content.Context
-import android.preference.PreferenceManager
-import io.embrace.android.embracesdk.internal.prefs.SharedPrefsStore
+import io.embrace.android.embracesdk.internal.prefs.createKeyValueStore
 import io.embrace.android.embracesdk.internal.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.store.OrdinalStore
 import io.embrace.android.embracesdk.internal.store.OrdinalStoreImpl
@@ -13,6 +10,7 @@ import io.embrace.android.embracesdk.internal.store.OrdinalStoreImpl
 class CoreModuleImpl(
     ctx: Context,
     initModule: InitModule,
+    keyValueStore: Lazy<KeyValueStore>? = null,
 ) : CoreModule {
 
     override val sdkStartTime: Long = initModule.clock.now()
@@ -24,12 +22,7 @@ class CoreModuleImpl(
 
     override val application: Application get() = context as Application
 
-    override val store: KeyValueStore = SharedPrefsStore(
-        PreferenceManager.getDefaultSharedPreferences(
-            context,
-        ),
-        initModule.jsonSerializer,
-    )
+    override val store: KeyValueStore by (keyValueStore ?: lazy { createKeyValueStore(context, initModule.jsonSerializer) })
 
-    override val ordinalStore: OrdinalStore = OrdinalStoreImpl(store)
+    override val ordinalStore: OrdinalStore by lazy { OrdinalStoreImpl(store) }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModule.kt
@@ -53,12 +53,16 @@ interface OpenTelemetryModule {
     val otelSdkWrapper: OtelSdkWrapper
 
     /**
+     * Supplies the behavior that decides which OpenTelemetry SDK implementation is used.
+     */
+    fun setOtelBehavior(otelBehavior: OtelBehavior)
+
+    /**
      * Setup configuration configuration-dependent behavior
      */
     fun applyConfiguration(
         sensitiveKeysBehavior: SensitiveKeysBehavior,
         bypassValidation: Boolean,
-        otelBehavior: OtelBehavior,
     )
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/OpenTelemetryModuleImpl.kt
@@ -34,6 +34,8 @@ class OpenTelemetryModuleImpl(
     private var storedSessionIdsProvider: SessionIdsProvider? = null
     private var storedUserIdProvider: (() -> String?)? = null
     private var storedEventMetadataProvider: (() -> Map<String, String>)? = null
+
+    @Volatile
     private var otelBehavior: OtelBehavior? = null
     private var sensitiveKeysBehavior: SensitiveKeysBehavior? = null
     private var internalSpanStopCallback: ((spanId: String) -> Unit)? = null
@@ -81,10 +83,13 @@ class OpenTelemetryModuleImpl(
         }
     }
 
-    override fun applyConfiguration(sensitiveKeysBehavior: SensitiveKeysBehavior, bypassValidation: Boolean, otelBehavior: OtelBehavior) {
+    override fun setOtelBehavior(otelBehavior: OtelBehavior) {
+        this.otelBehavior = otelBehavior
+    }
+
+    override fun applyConfiguration(sensitiveKeysBehavior: SensitiveKeysBehavior, bypassValidation: Boolean) {
         this.sensitiveKeysBehavior = sensitiveKeysBehavior
         this.bypassLimitsValidation = bypassValidation
-        this.otelBehavior = otelBehavior
     }
 
     override fun setSessionIdsProvider(sessionIdsProvider: SessionIdsProvider) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SupplierTypealiases.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SupplierTypealiases.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.lifecycle.LifecycleOwner
 import io.embrace.android.embracesdk.internal.capture.connectivity.NetworkConnectivityService
 import io.embrace.android.embracesdk.internal.config.ConfigService
+import io.embrace.android.embracesdk.internal.config.PersistedConfig
 import io.embrace.android.embracesdk.internal.delivery.debug.DeliveryTracer
 import io.embrace.android.embracesdk.internal.delivery.execution.RequestExecutionService
 import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageService
@@ -11,6 +12,7 @@ import io.embrace.android.embracesdk.internal.envelope.session.OtelPayloadMapper
 import io.embrace.android.embracesdk.internal.session.id.SessionIdsSnapshot
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionOrchestrator
 import io.embrace.android.embracesdk.internal.storage.StorageService
+import io.embrace.android.embracesdk.internal.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.utils.Provider
 
 typealias ConfigServiceSupplier = (
@@ -18,11 +20,13 @@ typealias ConfigServiceSupplier = (
     coreModule: CoreModule,
     openTelemetryModule: OpenTelemetryModule,
     workerThreadModule: WorkerThreadModule,
+    persistedConfig: PersistedConfig,
 ) -> ConfigService
 
 typealias CoreModuleSupplier = (
     context: Context,
     initModule: InitModule,
+    keyValueStore: Lazy<KeyValueStore>,
 ) -> CoreModule
 
 typealias DeliveryModuleSupplier = (

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/SharedPrefsStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/SharedPrefsStore.kt
@@ -1,11 +1,24 @@
+@file:Suppress("DEPRECATION")
+
 package io.embrace.android.embracesdk.internal.prefs
 
+import android.content.Context
 import android.content.SharedPreferences
+import android.preference.PreferenceManager
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.store.KeyValueStoreEditor
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
+
+/**
+ * Creates the SDK's [KeyValueStore], backed by the default [SharedPreferences].
+ *
+ * Loading the underlying preferences blocks on disk, so callers should hold this behind a [Lazy] and
+ * share that one instance rather than resolving it eagerly.
+ */
+fun createKeyValueStore(context: Context, serializer: PlatformSerializer): KeyValueStore =
+    SharedPrefsStore(PreferenceManager.getDefaultSharedPreferences(context), serializer)
 
 internal class SharedPrefsStore(
     private val impl: SharedPreferences,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/OtelExportParityTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/OtelExportParityTest.kt
@@ -43,6 +43,21 @@ internal class OtelExportParityTest {
     private lateinit var tracer: Tracer
     private lateinit var logger: Logger
 
+    /**
+     * The rest of this class relies on [remoteConfig] actually switching the implementation under test.
+     * Without these two, a regression that stopped the persisted config reaching the OTel module would
+     * silently run every 'kmp implementation' case against the compat implementation and still pass.
+     */
+    @Test
+    fun `persisted config selects the compat implementation`() {
+        assertSdkImplementationSelected(useKotlinSdk = false)
+    }
+
+    @Test
+    fun `persisted config selects the kmp implementation`() {
+        assertSdkImplementationSelected(useKotlinSdk = true)
+    }
+
     @Test
     fun `trace export matches golden file using compat implementation`() {
         assertTraceExport(useKotlinSdk = false)
@@ -113,6 +128,23 @@ internal class OtelExportParityTest {
     @Test
     fun `log span context export matches golden file using kmp implementation`() {
         assertLogSpanContextExport(useKotlinSdk = true)
+    }
+
+    private fun assertSdkImplementationSelected(useKotlinSdk: Boolean) {
+        testRule.runTest(
+            persistedRemoteConfig = remoteConfig(useKotlinSdk),
+            testCaseAction = {
+                recordSession {
+                    embrace.startSpan(SPAN_NAME)?.stop()
+                }
+            },
+            assertAction = {
+                assertEquals(
+                    useKotlinSdk,
+                    testRule.bootstrapper.openTelemetryModule.otelSdkWrapper.useKotlinSdk,
+                )
+            },
+        )
     }
 
     private fun assertTraceExport(useKotlinSdk: Boolean) {

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/SdkIntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/SdkIntegrationTestRule.kt
@@ -10,9 +10,7 @@ import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
 import io.embrace.android.embracesdk.fakes.config.FakeBaseUrlConfig
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
-import io.embrace.android.embracesdk.internal.config.behavior.BehaviorThresholdCheck
-import io.embrace.android.embracesdk.internal.config.behavior.OtelBehaviorImpl
-import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
+import io.embrace.android.embracesdk.internal.config.PersistedConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.delivery.debug.DeliveryTracer
 import io.embrace.android.embracesdk.internal.injection.CoreModule
@@ -157,13 +155,8 @@ internal class SdkIntegrationTestRule(
             embraceImpl.addSpanExporter(spanExporter.toOtelKotlinSpanExporter())
             embraceImpl.addLogRecordExporter(logExporter.toOtelKotlinLogRecordExporter())
 
-            // persist config here before the SDK starts up
+            // persist config here before the SDK starts up: the SDK reads it during start()
             persistConfig(persistedRemoteConfig)
-            bootstrapper.openTelemetryModule.applyConfiguration(
-                sensitiveKeysBehavior = SensitiveKeysBehaviorImpl(instrumentedConfig),
-                bypassValidation = false,
-                otelBehavior = OtelBehaviorImpl(BehaviorThresholdCheck { "123456" }, instrumentedConfig, persistedRemoteConfig)
-            )
 
             if (startSdk) {
                 embraceImpl.start(ApplicationProvider.getApplicationContext())
@@ -186,7 +179,7 @@ internal class SdkIntegrationTestRule(
      */
     private fun persistConfig(persistedRemoteConfig: RemoteConfig) {
         val ctx = ApplicationProvider.getApplicationContext<Context>()
-        val storageDir = File(ctx.filesDir, "embrace_remote_config").apply {
+        val storageDir = File(ctx.filesDir, PersistedConfig.STORAGE_DIR_NAME).apply {
             mkdirs()
         }
         File(storageDir, "etag").writeText("persisted_etag")

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -40,6 +40,7 @@ import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.sharedOb
 import io.embrace.android.embracesdk.internal.instrumentation.thread.blockage.createThreadBlockageService
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
+import io.embrace.android.embracesdk.internal.prefs.createKeyValueStore
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.serialization.toJson
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionPartSpan
@@ -102,7 +103,15 @@ internal class EmbraceSetupInterface(
     )
 
     private val fakeCoreModule: CoreModule = FakeCoreModule()
-    private val coreModule: CoreModule by lazy { CoreModuleImpl(fakeCoreModule.context, fakeInitModule) }
+
+    /**
+     * The SDK's store, backed by the same `SharedPreferences` the bootstrapper will use. Owned here
+     * rather than read off [CoreModule] because tests write to it in `setupAction`, before the module
+     * graph exists.
+     */
+    private val keyValueStore: KeyValueStore by lazy {
+        createKeyValueStore(fakeCoreModule.context, fakeInitModule.jsonSerializer)
+    }
 
     fun createBootstrapper(
         instrumentedConfig: FakeInstrumentedConfig,
@@ -112,22 +121,23 @@ internal class EmbraceSetupInterface(
             this.instrumentedConfig = instrumentedConfig
         },
         openTelemetryModule = fakeInitModule.openTelemetryModule,
-        coreModuleSupplier = { _, _ -> coreModule },
+        // forwards the supplied store so the module shares one instance with PersistedConfig, as in production
+        coreModuleSupplier = { _, _, suppliedStore ->
+            CoreModuleImpl(fakeCoreModule.context, fakeInitModule, suppliedStore)
+        },
         workerThreadModuleSupplier = { workerThreadModule },
-        configServiceSupplier = { initModule, coreModule, openTelemetryModule, workerThreadModule ->
+        configServiceSupplier = { initModule, _, openTelemetryModule, workerThreadModule, persistedConfig ->
             val impl = ConfigServiceImpl(
                 instrumentedConfig = initModule.instrumentedConfig,
+                persistedConfig = persistedConfig,
                 worker = workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker),
                 serializer = initModule.jsonSerializer,
                 okHttpClient = initModule.okHttpClient,
                 hasConfiguredOtlpExport = openTelemetryModule.otelSdkConfig::hasConfiguredOtlpExport,
                 sdkVersion = BuildConfig.VERSION_NAME,
                 apiLevel = Build.VERSION.SDK_INT,
-                filesDir = coreModule.context.filesDir,
-                store = coreModule.store,
                 abis = Build.SUPPORTED_ABIS,
                 logger = initModule.logger,
-                uuidSource = initModule.uuidSource,
             )
             DecoratedConfigService(impl)
         },
@@ -313,7 +323,7 @@ internal class EmbraceSetupInterface(
     fun getFakedWorkerExecutor(worker: Worker.Background): BlockingScheduledExecutorService =
         (workerThreadModule as FakeWorkerThreadModule).executorFor(worker)
 
-    fun getStore(): KeyValueStore = coreModule.store
+    fun getStore(): KeyValueStore = keyValueStore
 
     private companion object {
         fun initWorkerThreadModule(

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.core.BuildConfig
 import io.embrace.android.embracesdk.internal.capture.connectivity.NetworkConnectivityService
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.config.ConfigServiceImpl
+import io.embrace.android.embracesdk.internal.config.PersistedConfig
 import io.embrace.android.embracesdk.internal.instrumentation.startup.DataCaptureServiceModule
 import io.embrace.android.embracesdk.internal.instrumentation.startup.DataCaptureServiceModuleImpl
 import io.embrace.android.embracesdk.internal.instrumentation.startup.DataCaptureServiceModuleSupplier
@@ -16,6 +17,7 @@ import io.embrace.android.embracesdk.internal.instrumentation.thread.blockage.cr
 import io.embrace.android.embracesdk.internal.storage.EmbraceStorageService
 import io.embrace.android.embracesdk.internal.storage.StatFsAvailabilityChecker
 import io.embrace.android.embracesdk.internal.storage.StorageService
+import io.embrace.android.embracesdk.internal.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.android.embracesdk.internal.utils.Provider
@@ -36,6 +38,8 @@ internal class InitializedModuleGraph(
     override val initModule: InitModule,
     override val openTelemetryModule: OpenTelemetryModule,
     override val workerThreadModule: WorkerThreadModule,
+    private val keyValueStore: Lazy<KeyValueStore>,
+    private val persistedConfig: PersistedConfig,
     private val coreModuleSupplier: CoreModuleSupplier?,
     private val configServiceSupplier: ConfigServiceSupplier?,
     private val storageServiceSupplier: StorageServiceSupplier?,
@@ -51,11 +55,8 @@ internal class InitializedModuleGraph(
 ) : ModuleGraph {
 
     override val coreModule: CoreModule = init("core") {
-        coreModuleSupplier?.invoke(context, initModule) ?: CoreModuleImpl(context, initModule)
-    }.apply {
-        EmbTrace.trace("span-service-init") {
-            openTelemetryModule.spanService.initializeService(sdkStartTime)
-        }
+        coreModuleSupplier?.invoke(context, initModule, keyValueStore)
+            ?: CoreModuleImpl(context, initModule, keyValueStore)
     }
 
     override val configService: ConfigService = init("config") {
@@ -64,20 +65,19 @@ internal class InitializedModuleGraph(
             coreModule,
             openTelemetryModule,
             workerThreadModule,
+            persistedConfig,
         ) ?: EmbTrace.trace("config-service-init") {
             ConfigServiceImpl(
                 instrumentedConfig = initModule.instrumentedConfig,
+                persistedConfig = persistedConfig,
                 worker = workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker),
                 serializer = initModule.jsonSerializer,
                 okHttpClient = initModule.okHttpClient,
                 hasConfiguredOtlpExport = openTelemetryModule.otelSdkConfig::hasConfiguredOtlpExport,
                 sdkVersion = BuildConfig.VERSION_NAME,
                 apiLevel = Build.VERSION.SDK_INT,
-                filesDir = coreModule.context.filesDir,
-                store = coreModule.store,
                 abis = Build.SUPPORTED_ABIS,
                 logger = initModule.logger,
-                uuidSource = initModule.uuidSource,
             )
         }
     }.apply {
@@ -88,6 +88,12 @@ internal class InitializedModuleGraph(
                     throw SdkDisabledException()
                 }
             }
+        }
+        // Deliberately after the disable check so a disabled SDK never builds the OTel SDK, and after
+        // configService so that the otel behavior set in ModuleInitBootstrapper.init has been read
+        // from the same persisted config this service uses.
+        EmbTrace.trace("span-service-init") {
+            openTelemetryModule.spanService.initializeService(coreModule.sdkStartTime)
         }
     }
 

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -5,10 +5,12 @@ package io.embrace.android.embracesdk.internal.injection
 import android.content.Context
 import android.preference.PreferenceManager
 import io.embrace.android.embracesdk.internal.config.ConfigService
+import io.embrace.android.embracesdk.internal.config.PersistedConfig
 import io.embrace.android.embracesdk.internal.instrumentation.startup.DataCaptureServiceModule
 import io.embrace.android.embracesdk.internal.instrumentation.startup.DataCaptureServiceModuleSupplier
 import io.embrace.android.embracesdk.internal.instrumentation.thread.blockage.ThreadBlockageService
 import io.embrace.android.embracesdk.internal.instrumentation.thread.blockage.ThreadBlockageServiceSupplier
+import io.embrace.android.embracesdk.internal.prefs.createKeyValueStore
 import io.embrace.android.embracesdk.internal.storage.StorageService
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
@@ -74,6 +76,19 @@ internal class ModuleInitBootstrapper(
                 if (isInitialized()) {
                     return@trace false
                 }
+
+                val keyValueStore = lazy { createKeyValueStore(context, initModule.jsonSerializer) }
+                val persistedConfig = EmbTrace.trace("persisted-config-load") {
+                    PersistedConfig(
+                        serializer = initModule.jsonSerializer,
+                        filesDir = context.filesDir,
+                        instrumentedConfig = initModule.instrumentedConfig,
+                        keyValueStore = keyValueStore,
+                        uuidSource = initModule.uuidSource,
+                    )
+                }
+                openTelemetryModule.setOtelBehavior(persistedConfig.otelBehavior)
+
                 val workerThreadModule = EmbTrace.trace("workerthread-init") {
                     workerThreadModuleSupplier?.invoke() ?: WorkerThreadModuleImpl()
                 }
@@ -84,6 +99,8 @@ internal class ModuleInitBootstrapper(
                     initModule,
                     openTelemetryModule,
                     workerThreadModule,
+                    keyValueStore,
+                    persistedConfig,
                     coreModuleSupplier,
                     configServiceSupplier,
                     storageServiceSupplier,

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
@@ -23,10 +23,11 @@ import java.util.ServiceLoader
 internal fun ModuleGraph.postInit() {
     openTelemetryModule.setEventMetadataProvider(eventMetadataSupplierProvider())
 
+    // note: otelBehavior is not applied here - it decides which OTel SDK is built, so it is set
+    // right after the persisted config is read in ModuleInitBootstrapper.init.
     openTelemetryModule.applyConfiguration(
         sensitiveKeysBehavior = configService.sensitiveKeysBehavior,
         bypassValidation = configService.isOnlyUsingOtelExporters(),
-        otelBehavior = configService.otelBehavior,
     )
 
     initModule.logger.errorHandlerProvider = { featureModule.internalErrorDataSource.dataSource }

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
@@ -7,15 +7,22 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationModule
 import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeReadWriteLogRecord
+import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
+import io.embrace.android.embracesdk.fakes.createSdkModeBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeCoreModule
+import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.internal.arch.InstrumentationRegistry
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
 import io.embrace.android.embracesdk.internal.clock.Clock
+import io.embrace.android.embracesdk.internal.config.PersistedConfig
+import io.embrace.android.embracesdk.internal.config.remote.OtelKotlinSdkConfig
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.injection.EssentialServiceModuleImpl
 import io.embrace.android.embracesdk.internal.injection.InitModuleImpl
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.injection.postInit
 import io.embrace.android.embracesdk.internal.injection.postLoadInstrumentation
+import io.embrace.android.embracesdk.internal.serialization.toJson
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.opentelemetry.kotlin.NoopOpenTelemetry
 import org.junit.Assert.assertEquals
@@ -26,6 +33,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RuntimeEnvironment
+import java.io.File
 
 @RunWith(AndroidJUnit4::class)
 internal class ModuleInitBootstrapperTest {
@@ -46,8 +54,8 @@ internal class ModuleInitBootstrapperTest {
         context = application.applicationContext
         moduleInitBootstrapper = ModuleInitBootstrapper(
             InitModuleImpl(logger, clock),
-            configServiceSupplier = { _, _, _, _ -> FakeConfigService() },
-            coreModuleSupplier = { _, _ -> coreModule },
+            configServiceSupplier = { _, _, _, _, _ -> FakeConfigService() },
+            coreModuleSupplier = { _, _, _ -> coreModule },
             instrumentationModuleSupplier = { _, _, _, _, _, _, _, _, _ ->
                 FakeInstrumentationModule(application, logger = logger).apply {
                     registry = instrumentationRegistry
@@ -112,6 +120,79 @@ internal class ModuleInitBootstrapperTest {
         val postLog = FakeReadWriteLogRecord()
         processor.onEmit(postLog, NoopOpenTelemetry.context.implicit())
         assertTrue(postLog.attributes.containsKey(EmbSessionAttributes.EMB_STATE))
+    }
+
+    /**
+     * The persisted config decides which OTel SDK implementation is built, so it has to be read
+     * before that construction happens. Note that [ModuleGraph.postInit] is deliberately not called:
+     * if the flag were still applied there, this would fail.
+     */
+    @Test
+    fun `kotlin otel sdk selected from persisted config during init`() {
+        val bootstrapper = createBootstrapperWithPersistedConfig(
+            RemoteConfig(otelKotlinSdkConfig = OtelKotlinSdkConfig(pctEnabled = 100f)),
+        )
+        assertTrue(bootstrapper.init(context))
+        assertTrue(bootstrapper.openTelemetryModule.otelSdkWrapper.useKotlinSdk)
+    }
+
+    @Test
+    fun `kotlin otel sdk not selected when disabled by persisted config`() {
+        val bootstrapper = createBootstrapperWithPersistedConfig(
+            RemoteConfig(otelKotlinSdkConfig = OtelKotlinSdkConfig(pctEnabled = 0f)),
+        )
+        assertTrue(bootstrapper.init(context))
+        assertFalse(bootstrapper.openTelemetryModule.otelSdkWrapper.useKotlinSdk)
+    }
+
+    /**
+     * Guards the invariant that nothing constructs the OTel SDK before the config service exists.
+     * Fails if OTel-touching work is reintroduced earlier in the module graph.
+     */
+    @Test
+    fun `otel sdk is not built until the config service has been created`() {
+        var initializedWhenConfigServiceBuilt: Boolean? = null
+        val bootstrapper = ModuleInitBootstrapper(
+            initModule = FakeInitModule(clock = clock, logger = logger),
+            configServiceSupplier = { _, _, openTelemetryModule, _, _ ->
+                initializedWhenConfigServiceBuilt = openTelemetryModule.spanService.initialized()
+                FakeConfigService()
+            },
+            instrumentationModuleSupplier = { _, _, _, _, _, _, _, _, _ ->
+                FakeInstrumentationModule(RuntimeEnvironment.getApplication(), logger = logger)
+            },
+        )
+        assertTrue(bootstrapper.init(context))
+        assertEquals(false, initializedWhenConfigServiceBuilt)
+        assertTrue(bootstrapper.openTelemetryModule.spanService.initialized())
+    }
+
+    @Test
+    fun `otel sdk is not built when the sdk is remotely disabled`() {
+        val bootstrapper = ModuleInitBootstrapper(
+            initModule = FakeInitModule(clock = clock, logger = logger),
+            configServiceSupplier = { _, _, _, _, _ ->
+                FakeConfigService(
+                    sdkModeBehavior = createSdkModeBehavior(remoteCfg = RemoteConfig(threshold = 0)),
+                )
+            },
+        )
+        assertFalse(bootstrapper.init(context))
+        assertFalse(bootstrapper.openTelemetryModule.spanService.initialized())
+    }
+
+    private fun createBootstrapperWithPersistedConfig(cfg: RemoteConfig): ModuleInitBootstrapper {
+        val storageDir = File(context.filesDir, PersistedConfig.STORAGE_DIR_NAME).apply { mkdirs() }
+        File(storageDir, "most_recent_response").outputStream().buffered().use { stream ->
+            TestPlatformSerializer().toJson(cfg, stream)
+        }
+        return ModuleInitBootstrapper(
+            initModule = FakeInitModule(clock = clock, logger = logger),
+            configServiceSupplier = { _, _, _, _, _ -> FakeConfigService() },
+            instrumentationModuleSupplier = { _, _, _, _, _, _, _, _, _ ->
+                FakeInstrumentationModule(RuntimeEnvironment.getApplication(), logger = logger)
+            },
+        )
     }
 
     @Test

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/SdkStateApiDelegateTest.kt
@@ -37,7 +37,7 @@ internal class SdkStateApiDelegateTest {
         sessionIdsProvider = FakeSessionIdsProvider()
         val moduleInitBootstrapper = ModuleInitBootstrapper(
             FakeInitModule(),
-            configServiceSupplier = { _, _, _, _ ->
+            configServiceSupplier = { _, _, _, _, _ ->
                 configService
             },
             essentialServiceModuleSupplier = { _, _, _, _, _, _, _, _ ->

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeOpenTelemetryModule.kt
@@ -49,7 +49,11 @@ class FakeOpenTelemetryModule(
     override val tracingApi: TracingApi
         get() = TODO()
 
-    override fun applyConfiguration(sensitiveKeysBehavior: SensitiveKeysBehavior, bypassValidation: Boolean, otelBehavior: OtelBehavior) {
+    override fun setOtelBehavior(otelBehavior: OtelBehavior) {
+        // no-op
+    }
+
+    override fun applyConfiguration(sensitiveKeysBehavior: SensitiveKeysBehavior, bypassValidation: Boolean) {
         // no-op
     }
 


### PR DESCRIPTION
## Goal

Alters the SDK so that config is loaded from disk as the very first operation. #3703 was limited by the fact the OpenTelemetry SDK was created before config was loaded, whereas this feels like the more robust approach (independent of whatever decision we take on whether it makes sense to control distribution via a remote config).