### PR TITLE
Alter config worker

### DIFF
--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/Worker.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/Worker.kt
@@ -55,7 +55,9 @@ sealed class Worker(val threadName: String) {
         object DeliverySchedulingWorker : Background("delivery-scheduling")
 
         /**
-         * Worker that performs HTTP requests that push data to the server.
+         * Worker that performs blocking HTTP requests against the Embrace API: payload upload and
+         * remote config fetch. Network work belongs here rather than on a worker shared with
+         * latency-sensitive registration tasks such as [IoRegWorker].
          */
         object HttpRequestWorker : Background("http-request")
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -117,7 +117,7 @@ internal class EmbraceSetupInterface(
         configServiceSupplier = { initModule, coreModule, openTelemetryModule, workerThreadModule ->
             val impl = ConfigServiceImpl(
                 instrumentedConfig = initModule.instrumentedConfig,
-                worker = workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker),
+                worker = workerThreadModule.backgroundWorker(Worker.Background.HttpRequestWorker),
                 serializer = initModule.jsonSerializer,
                 okHttpClient = initModule.okHttpClient,
                 hasConfiguredOtlpExport = openTelemetryModule.otelSdkConfig::hasConfiguredOtlpExport,

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
@@ -67,7 +67,7 @@ internal class InitializedModuleGraph(
         ) ?: EmbTrace.trace("config-service-init") {
             ConfigServiceImpl(
                 instrumentedConfig = initModule.instrumentedConfig,
-                worker = workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker),
+                worker = workerThreadModule.backgroundWorker(Worker.Background.HttpRequestWorker),
                 serializer = initModule.jsonSerializer,
                 okHttpClient = initModule.okHttpClient,
                 hasConfiguredOtlpExport = openTelemetryModule.otelSdkConfig::hasConfiguredOtlpExport,


### PR DESCRIPTION
## Goal

Alters the worker thread that the config HTTP request is enqueued on. The config request is enqueued on the IoRegWorker thread. In the worst case of a request taking ~1 min to timeout, this could block everything on the IoRegWorker (shared prefs warming, native crash handler installation, cached data sending). It feels more reasonable to enqueue it on the HttpRequestWorker instead.

Broken out from #3722