### PR TITLE
Move system service call to background

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/EmbraceNetworkConnectivityService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/EmbraceNetworkConnectivityService.kt
@@ -9,18 +9,20 @@ import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
 
 @Suppress("DEPRECATION") // uses deprecated APIs for backwards compat
 internal class EmbraceNetworkConnectivityService(
     private val context: Context,
     private val backgroundWorker: BackgroundWorker,
     private val logger: InternalLogger,
-    private val connectivityManager: ConnectivityManager?,
+    private val connectivityManager: Lazy<ConnectivityManager?>,
 ) : BroadcastReceiver(), NetworkConnectivityService {
 
     private val intentFilter = IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
     private var lastConnectivityStatus: ConnectivityStatus = ConnectivityStatus.Unverified
     private val networkConnectivityListeners = CopyOnWriteArrayList<NetworkConnectivityListener>()
+    private val registered = AtomicBoolean(false)
 
     override fun onReceive(context: Context, intent: Intent) {
         try {
@@ -35,10 +37,11 @@ internal class EmbraceNetworkConnectivityService(
     }
 
     private fun getCurrentConnectivityStatus(): ConnectivityStatus {
-        var status: ConnectivityStatus
-        try {
-            val networkInfo = connectivityManager?.activeNetworkInfo
-            status = if (networkInfo != null && networkInfo.isConnected) {
+        return try {
+            // if ConnectivityManager is unavailable, assume the network is reachable
+            val manager = connectivityManager.value ?: return ConnectivityStatus.Unverified
+            val networkInfo = manager.activeNetworkInfo
+            if (networkInfo != null && networkInfo.isConnected) {
                 // Network is reachable
                 when (networkInfo.type) {
                     ConnectivityManager.TYPE_WIFI -> OptimisticWifi
@@ -51,21 +54,28 @@ internal class EmbraceNetworkConnectivityService(
             }
         } catch (e: Exception) {
             logger.trackInternalError(InternalErrorType.NetworkStatusCaptureFail, e)
-            status = OptimisticUnknown
+            OptimisticUnknown
         }
-        return status
     }
 
     override fun register() {
         backgroundWorker.submit {
-            runCatching {
-                context.registerReceiver(this, intentFilter)
+            if (connectivityManager.value != null && !registered.getAndSet(true)) {
+                runCatching {
+                    context.registerReceiver(this, intentFilter)
+                }.onFailure {
+                    registered.set(false)
+                }
             }
         }
     }
 
     override fun close() {
-        context.unregisterReceiver(this)
+        if (registered.getAndSet(false)) {
+            runCatching {
+                context.unregisterReceiver(this)
+            }
+        }
     }
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/NetworkCallbackConnectivityService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/NetworkCallbackConnectivityService.kt
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicReference
 internal class NetworkCallbackConnectivityService(
     private val backgroundWorker: BackgroundWorker,
     private val logger: InternalLogger,
-    private val connectivityManager: ConnectivityManager?,
+    private val connectivityManager: Lazy<ConnectivityManager?>,
 ) : NetworkConnectivityService, ConnectivityManager.NetworkCallback() {
 
     private var currentNetwork: AtomicReference<Network?> = AtomicReference(null)
@@ -45,18 +45,19 @@ internal class NetworkCallbackConnectivityService(
 
     override fun register() {
         backgroundWorker.submit {
-            if (connectivityManager != null && !registered.getAndSet(true)) {
+            val manager = connectivityManager.value
+            if (manager != null && !registered.getAndSet(true)) {
                 updateSafely {
-                    connectivityManager.activeNetwork?.let { defaultNetwork ->
+                    manager.activeNetwork?.let { defaultNetwork ->
                         synchronized(currentNetwork) {
                             updateNetwork(defaultNetwork)
                             updateStatus(
                                 updatedNetwork = defaultNetwork,
-                                networkCapabilities = connectivityManager.getNetworkCapabilities(defaultNetwork),
+                                networkCapabilities = manager.getNetworkCapabilities(defaultNetwork),
                             )
                         }
                     }
-                    connectivityManager.registerDefaultNetworkCallback(this)
+                    manager.registerDefaultNetworkCallback(this)
                 }
             }
         }
@@ -65,8 +66,8 @@ internal class NetworkCallbackConnectivityService(
     override fun close() {
         backgroundWorker.submit {
             updateSafely {
-                if (connectivityManager != null && registered.getAndSet(false)) {
-                    connectivityManager.unregisterNetworkCallback(this)
+                if (registered.getAndSet(false)) {
+                    connectivityManager.value?.unregisterNetworkCallback(this)
                 }
             }
         }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.injection
 
 import android.content.Context
+import android.net.ConnectivityManager
 import android.os.Build
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
@@ -45,6 +46,10 @@ class EssentialServiceModuleImpl(
 
     override val navigationTrackingService: NavigationTrackingService = NavigationTrackingServiceImpl()
 
+    private val connectivityManager: Lazy<ConnectivityManager?> = lazy {
+        coreModule.context.getSystemServiceSafe<ConnectivityManager>(Context.CONNECTIVITY_SERVICE)
+    }
+
     override val networkConnectivityService: NetworkConnectivityService =
         networkConnectivityServiceProvider() ?: EmbTrace.trace("network-connectivity-service-init") {
             val worker = workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker)
@@ -54,14 +59,14 @@ class EssentialServiceModuleImpl(
                 NetworkCallbackConnectivityService(
                     worker,
                     initModule.logger,
-                    coreModule.context.getSystemServiceSafe(Context.CONNECTIVITY_SERVICE),
+                    connectivityManager,
                 )
             } else {
                 EmbraceNetworkConnectivityService(
                     coreModule.context,
                     worker,
                     initModule.logger,
-                    coreModule.context.getSystemServiceSafe(Context.CONNECTIVITY_SERVICE),
+                    connectivityManager,
                 )
             }
         }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/EmbraceNetworkConnectivityServiceTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/EmbraceNetworkConnectivityServiceTest.kt
@@ -17,6 +17,8 @@ import io.mockk.verify
 import org.junit.After
 import org.junit.AfterClass
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -69,7 +71,7 @@ internal class EmbraceNetworkConnectivityServiceTest {
             context,
             worker,
             logger,
-            mockConnectivityManager,
+            lazyOf<ConnectivityManager?>(mockConnectivityManager),
         )
 
         testListener = NetworkConnectivityListener { status -> this@EmbraceNetworkConnectivityServiceTest.status = status }
@@ -152,4 +154,35 @@ internal class EmbraceNetworkConnectivityServiceTest {
 
         assertEquals(OptimisticWan, status)
     }
+
+    @Test
+    fun `network is assumed available when connectivity manager is unavailable`() {
+        var observed: ConnectivityStatus? = null
+        createService(lazyOf<ConnectivityManager?>(null)).apply {
+            addNetworkConnectivityListener { observed = it }
+            assertEquals(ConnectivityStatus.Unverified, observed)
+            assertTrue(checkNotNull(observed).isConnected)
+
+            // a broadcast must not downgrade the status to None
+            onReceive(context, mockk<Intent>())
+            assertEquals(ConnectivityStatus.Unverified, observed)
+        }
+    }
+
+    @Test
+    fun `close without register does not unregister the receiver`() {
+        val service = createService(lazyOf<ConnectivityManager?>(mockConnectivityManager))
+        service.close()
+        verify(exactly = 0) { context.unregisterReceiver(service) }
+    }
+
+    @Test
+    fun `connectivity manager is not obtained when service is constructed`() {
+        val lazyManager = lazy<ConnectivityManager?> { mockConnectivityManager }
+        createService(lazyManager)
+        assertFalse(lazyManager.isInitialized())
+    }
+
+    private fun createService(connectivityManager: Lazy<ConnectivityManager?>) =
+        EmbraceNetworkConnectivityService(context, worker, logger, connectivityManager)
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/NetworkCallbackConnectivityServiceTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/connectivity/NetworkCallbackConnectivityServiceTest.kt
@@ -13,8 +13,10 @@ import android.net.NetworkCapabilities.TRANSPORT_WIFI
 import android.net.NetworkInfo
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.logging.InternalLoggerImpl
+import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -33,6 +35,7 @@ internal class NetworkCallbackConnectivityServiceTest {
 
     private lateinit var service: NetworkCallbackConnectivityService
     private lateinit var connectivityManager: ConnectivityManager
+    private lateinit var lazyConnectivityManager: Lazy<ConnectivityManager?>
     private lateinit var shadowConnectivityManager: ShadowConnectivityManager
     private lateinit var receivedConnectivityStatuses: MutableList<ConnectivityStatus>
     private val networkConnectivityListener =
@@ -45,11 +48,38 @@ internal class NetworkCallbackConnectivityServiceTest {
             setActiveNetworkInfo(null)
         }
         receivedConnectivityStatuses = mutableListOf()
+        lazyConnectivityManager = lazy { connectivityManager }
         service = NetworkCallbackConnectivityService(
             fakeBackgroundWorker(),
             InternalLoggerImpl(),
-            connectivityManager,
+            lazyConnectivityManager,
         )
+    }
+
+    @Test
+    fun `connectivity manager is not obtained when service is constructed`() {
+        val lazyManager = lazy { connectivityManager }
+        NetworkCallbackConnectivityService(
+            fakeBackgroundWorker(),
+            InternalLoggerImpl(),
+            lazyManager,
+        )
+        assertFalse(lazyManager.isInitialized())
+    }
+
+    @Test
+    fun `connectivity manager is obtained on the background worker rather than the calling thread`() {
+        val executor = BlockingScheduledExecutorService()
+        val lazyManager = lazy { connectivityManager }
+        NetworkCallbackConnectivityService(
+            BackgroundWorker(executor),
+            InternalLoggerImpl(),
+            lazyManager,
+        ).register()
+
+        assertFalse(lazyManager.isInitialized())
+        executor.runCurrentlyBlocked()
+        assertTrue(lazyManager.isInitialized())
     }
 
     @Test
@@ -85,7 +115,7 @@ internal class NetworkCallbackConnectivityServiceTest {
         NetworkCallbackConnectivityService(
             fakeBackgroundWorker(),
             InternalLoggerImpl(),
-            connectivityManager = null,
+            connectivityManager = lazyOf<ConnectivityManager?>(null),
         ).apply {
             register()
         }


### PR DESCRIPTION
## Goal

Refactors the `NetworkConnectivityService` so that the `ConnectivityManager` is obtained in the background. If the service isn't populated the SDK assumes the network is available.
