### PR TITLE
Log flush optimization

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/logs/LogOrchestratorImpl.kt
@@ -91,7 +91,7 @@ internal class LogOrchestratorImpl(
     }
 
     private fun isMaxLogsPerBatchReached(): Boolean =
-        sink.logsForNextBatch().size >= MAX_LOGS_PER_BATCH
+        sink.storedLogCount() >= MAX_LOGS_PER_BATCH
 
     private fun isMaxInactivityTimeReached(now: Long): Boolean =
         now - lastLogTime.get() >= MAX_INACTIVITY_TIME

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/CollectionExtensions.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/CollectionExtensions.kt
@@ -47,33 +47,6 @@ fun <T> MutableMap<String, AtomicInteger>.lockAndRun(key: String, code: () -> T)
 }
 
 /**
- * A version of [take] that is useful for a [Collection] expected to be threadsafe but doesn't synchronize the reads with writes such
- * that the underlying data change during iteration. [take] has an optimization that returns the whole [Collection] if the size is less than
- * or equal to the size of the number of elements requested, but since the underlying data can change after the size check, you can
- * get more elements than requested if they were added during the [toList] call.
- */
-fun <T> Collection<T>.threadSafeTake(n: Int): List<T> {
-    return if (n == 0) {
-        emptyList()
-    } else {
-        val returnList = ArrayList<T>(n)
-
-        for ((count, item) in this.withIndex()) {
-            returnList.add(item)
-            if (count + 1 == n) {
-                break
-            }
-        }
-
-        return if (returnList.size <= 1) {
-            take(returnList.size)
-        } else {
-            returnList
-        }
-    }
-}
-
-/**
  * A stable and thread-safe implementation of [toList]. [toList] has a race between a `size` check and an unprotected `get(0)` or
  * `iterator().next()` call which can fail if the last item it removed from the collection after the `size == 1` check.
  */

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/LogSink.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/LogSink.kt
@@ -15,13 +15,18 @@ interface LogSink {
     fun storeLogs(logs: List<Log>): StoreDataResult
 
     /**
-     * Returns the list of currently stored [Log] objects, waiting to be sent in the next batch
+     * Returns a snapshot of the currently stored [Log] objects waiting to be sent in the next batch.
      */
     fun logsForNextBatch(): List<Log>
 
     /**
-     * Returns and clears the currently stored [Log] objects, to be used when the next batch is to be sent.
-     * Implementations of this method must make sure the clearing and returning is atomic, i.e. logs cannot be added during this operation.
+     * Returns the number of stored [Log] objects waiting to be sent in the next batch.
+     */
+    fun storedLogCount(): Int
+
+    /**
+     * Removes and returns the stored [Log] objects to be sent in the next batch, in the order they were stored, up
+     * to an implementation-defined maximum batch size.
      */
     fun flushBatch(): List<Log>
 

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/LogSinkImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/LogSinkImpl.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.internal.arch.schema.SendMode
 import io.embrace.android.embracesdk.internal.otel.sdk.StoreDataResult
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.payload.Log
-import io.embrace.android.embracesdk.internal.utils.threadSafeTake
+import io.embrace.android.embracesdk.internal.utils.threadSafeToList
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import java.util.concurrent.ConcurrentLinkedQueue
 
@@ -38,14 +38,18 @@ class LogSinkImpl : LogSink {
     }
 
     override fun logsForNextBatch(): List<Log> {
-        return storedLogs.toList()
+        return storedLogs.threadSafeToList()
     }
+
+    override fun storedLogCount(): Int = storedLogs.size
 
     override fun flushBatch(): List<Log> {
         synchronized(flushLock) {
-            val batchSize = minOf(storedLogs.size, MAX_LOGS_PER_BATCH)
-            val flushedLogs = storedLogs.threadSafeTake(batchSize)
-            storedLogs.removeAll(flushedLogs.toSet())
+            val flushedLogs = ArrayList<Log>(MAX_LOGS_PER_BATCH)
+            while (flushedLogs.size < MAX_LOGS_PER_BATCH) {
+                val log = storedLogs.poll() ?: break
+                flushedLogs.add(log)
+            }
             return flushedLogs
         }
     }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/logs/LogSinkImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/logs/LogSinkImplTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.otel.logs
 
+import io.embrace.android.embracesdk.concurrency.SingleThreadTestScheduledExecutor
 import io.embrace.android.embracesdk.fixtures.deferredLog
 import io.embrace.android.embracesdk.fixtures.sendImmediatelyLog
 import io.embrace.android.embracesdk.internal.otel.sdk.StoreDataResult
@@ -11,6 +12,8 @@ import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 internal class LogSinkImplTest {
     private lateinit var logSink: LogSink
@@ -23,6 +26,7 @@ internal class LogSinkImplTest {
     @Test
     fun `verify default state`() {
         assertEquals(0, logSink.logsForNextBatch().size)
+        assertEquals(0, logSink.storedLogCount())
         assertEquals(0, logSink.flushBatch().size)
         assertEquals(StoreDataResult.SUCCESS, logSink.storeLogs(listOf()))
     }
@@ -47,6 +51,66 @@ internal class LogSinkImplTest {
             assertSame(snapshot[it], flushedLogs[it])
         }
         assertEquals(0, logSink.logsForNextBatch().size)
+    }
+
+    @Test
+    fun `flushing does not retain previously flushed logs`() {
+        logSink.storeLogs(listOf(Log(body = "one"), Log(body = "two")))
+        assertEquals(2, logSink.flushBatch().size)
+
+        assertEquals(0, logSink.flushBatch().size)
+        assertEquals(0, logSink.logsForNextBatch().size)
+
+        logSink.storeLogs(listOf(Log(body = "three")))
+        assertEquals(1, logSink.flushBatch().size)
+    }
+
+    @Test
+    fun `flushing caps the batch and retains equal logs that were not flushed`() {
+        val total = MAX_LOGS_PER_BATCH + 10
+        logSink.storeLogs(List(total) { Log() })
+        assertEquals(total, logSink.storedLogCount())
+
+        // logs beyond the batch cap must survive the flush, even though they are all equal to each other
+        assertEquals(MAX_LOGS_PER_BATCH, logSink.flushBatch().size)
+        assertEquals(10, logSink.storedLogCount())
+        assertEquals(10, logSink.flushBatch().size)
+        assertEquals(0, logSink.flushBatch().size)
+    }
+
+    @Test
+    fun `concurrent stores and flushes neither lose nor duplicate logs`() {
+        val totalToStore = 5_000
+        val storeDoneLatch = CountDownLatch(1)
+        val flushed = ArrayList<Log>(totalToStore)
+
+        // store logs one at a time from another thread
+        val producer = SingleThreadTestScheduledExecutor()
+        producer.submit {
+            repeat(totalToStore) { i ->
+                logSink.storeLogs(listOf(Log(body = "log$i")))
+            }
+            storeDoneLatch.countDown()
+        }
+
+        // repeatedly flush on this thread while the producer is storing
+        while (storeDoneLatch.count > 0L) {
+            flushed += logSink.flushBatch()
+        }
+        assertTrue(storeDoneLatch.await(5, TimeUnit.SECONDS))
+
+        // drain anything stored after the last in-loop flush. each flush is capped at MAX_LOGS_PER_BATCH,
+        // so keep going until the sink is empty.
+        do {
+            val batch = logSink.flushBatch()
+            flushed += batch
+        } while (batch.isNotEmpty())
+
+        // every stored log should have been flushed exactly once
+        assertEquals(0, logSink.storedLogCount())
+        assertEquals(totalToStore, flushed.size)
+        val distinctBodies = flushed.mapTo(HashSet()) { it.body }
+        assertEquals(totalToStore, distinctBodies.size)
     }
 
     @Test


### PR DESCRIPTION
## Goal

Optimizes the flushing of batched logs by using a similar approach to #3638 (for spans). `Log` is a data class so the current implementation calls `equals()` on every object in its collection.
