### PR TITLE
Fix emb-sdk-init span

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CoreModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CoreModule.kt
@@ -12,11 +12,6 @@ import io.embrace.android.embracesdk.internal.store.OrdinalStore
 interface CoreModule {
 
     /**
-     * Start time in milliseconds at which SDK initialization started
-     */
-    val sdkStartTime: Long
-
-    /**
      * Reference to the context. This will always return the application context so won't leak.
      */
     val context: Context

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CoreModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/CoreModuleImpl.kt
@@ -13,8 +13,6 @@ class CoreModuleImpl(
     keyValueStore: Lazy<KeyValueStore>? = null,
 ) : CoreModule {
 
-    override val sdkStartTime: Long = initModule.clock.now()
-
     override val context: Context = when (ctx) {
         is Application -> ctx
         else -> ctx.applicationContext

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit
 internal class InitializedModuleGraph(
     context: Context,
     versionChecker: VersionChecker = BuildVersionChecker,
+    override val sdkStartTimeMs: Long,
     override val initModule: InitModule,
     override val openTelemetryModule: OpenTelemetryModule,
     override val workerThreadModule: WorkerThreadModule,
@@ -93,7 +94,7 @@ internal class InitializedModuleGraph(
         // configService so that the otel behavior set in ModuleInitBootstrapper.init has been read
         // from the same persisted config this service uses.
         EmbTrace.trace("span-service-init") {
-            openTelemetryModule.spanService.initializeService(coreModule.sdkStartTime)
+            openTelemetryModule.spanService.initializeService(sdkStartTimeMs)
         }
     }
 

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleGraph.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleGraph.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.internal.storage.StorageService
  * Contains all the dependency modules that are required by the initialized SDK.
  */
 internal interface ModuleGraph {
+    val sdkStartTimeMs: Long
     val initModule: InitModule
     val openTelemetryModule: OpenTelemetryModule
     val coreModule: CoreModule

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -47,6 +47,7 @@ internal class ModuleInitBootstrapper(
 
     @Volatile
     private var delegate: ModuleGraph = UninitializedModuleGraph
+    override val sdkStartTimeMs: Long get() = delegate.sdkStartTimeMs
     override val coreModule: CoreModule get() = delegate.coreModule
     override val configService: ConfigService get() = delegate.configService
     override val workerThreadModule: WorkerThreadModule get() = delegate.workerThreadModule
@@ -76,7 +77,8 @@ internal class ModuleInitBootstrapper(
                 if (isInitialized()) {
                     return@trace false
                 }
-
+                // stamped before anything else so that the SDK init span covers all the work below
+                val startTimeMs = initModule.clock.now()
                 val keyValueStore = lazy { createKeyValueStore(context, initModule.jsonSerializer) }
                 val persistedConfig = EmbTrace.trace("persisted-config-load") {
                     PersistedConfig(
@@ -96,6 +98,7 @@ internal class ModuleInitBootstrapper(
                 delegate = InitializedModuleGraph(
                     context,
                     versionChecker,
+                    startTimeMs,
                     initModule,
                     openTelemetryModule,
                     workerThreadModule,

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
@@ -188,7 +188,7 @@ internal fun ModuleGraph.triggerPayloadSend() {
 internal fun ModuleGraph.markSdkInitComplete() {
     EmbTrace.trace("startup-tracking") {
         dataCaptureServiceModule.startupService.setSdkStartupInfo(
-            coreModule.sdkStartTime,
+            sdkStartTimeMs,
             initModule.clock.now(),
             essentialServiceModule.appStateTracker.getAppState(),
             Thread.currentThread().name,

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UninitializedModuleGraph.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UninitializedModuleGraph.kt
@@ -11,6 +11,7 @@ internal class SdkDisabledException : IllegalStateException()
  * Uninitialized modules that will throw an IllegalStateException if they are accessed.
  */
 internal object UninitializedModuleGraph : ModuleGraph {
+    override val sdkStartTimeMs: Long get() = throwSdkNotInitialized()
     override val initModule: InitModule get() = throwSdkNotInitialized()
     override val openTelemetryModule: OpenTelemetryModule get() = throwSdkNotInitialized()
     override val coreModule: CoreModule get() = throwSdkNotInitialized()

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeCoreModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakeCoreModule.kt
@@ -26,7 +26,6 @@ class FakeCoreModule(
         if (isMockKMock(application)) getMockedContext() else application.applicationContext,
     override val store: KeyValueStore = FakeKeyValueStore(),
     override val ordinalStore: OrdinalStore = FakeOrdinalStore(),
-    override val sdkStartTime: Long = -1,
 ) : CoreModule {
 
     companion object {


### PR DESCRIPTION
## Goal

The emb-sdk-init span missed the first few bits of SDK initialization after several refactors extracted code. This changeset sets the start time at the very start of SDK init so that the time is accurate.
