### PR TITLE
Report the startup reason on the app startup root span

### DIFF
--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/AppStartupTraceEmitter.kt
@@ -50,7 +50,7 @@ internal class AppStartupTraceEmitter(
     private val logger: InternalLogger,
     private val startupClassifier: StartupClassifier,
     manualEnd: Boolean,
-    processInfo: ProcessInfo,
+    private val processInfo: ProcessInfo,
 ) : AppStartupDataCollector {
     private val additionalTrackedIntervals = ConcurrentLinkedQueue<TrackedInterval>()
     private val customAttributes: MutableMap<String, String> = ConcurrentHashMap()
@@ -426,6 +426,11 @@ internal class AppStartupTraceEmitter(
 
         startupActivityName?.let { name ->
             setSystemAttribute(EmbSessionAttributes.EMB_STARTUP_ACTIVITY, name)
+        }
+
+        // already resolved when the SDK started, so this does not go near the platform on the thread the app is starting up on
+        processInfo.launchReason()?.let { reason ->
+            setSystemAttribute(EmbSessionAttributes.EMB_STARTUP_LAUNCH_REASON, reason)
         }
     }
 

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleImpl.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleImpl.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.instrumentation.startup
 
+import android.app.ActivityManager
 import android.app.Application
 import android.os.SystemClock
 import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
@@ -13,6 +14,7 @@ import io.embrace.android.embracesdk.internal.instrumentation.startup.ui.createD
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
+import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 
 class DataCaptureServiceModuleImpl(
     clock: Clock,
@@ -22,12 +24,27 @@ class DataCaptureServiceModuleImpl(
     appVersionStartupCounterProvider: () -> Int?,
     private val startupClassifier: StartupClassifier,
     versionChecker: VersionChecker = BuildVersionChecker,
+    activityManager: ActivityManager? = null,
+    backgroundWorker: BackgroundWorker? = null,
 ) : DataCaptureServiceModule {
 
     override val startupService: StartupService = StartupServiceImpl(
         destination = destination,
         appVersionStartupCounterProvider = appVersionStartupCounterProvider,
     )
+
+    private val processInfo: ProcessInfo = ProcessInfoImpl(
+        deviceStartTimeMs = clock.now() - SystemClock.elapsedRealtime(),
+        versionChecker = versionChecker,
+        activityManager = activityManager,
+    ).apply {
+        // resolve the launch reason as close to the process starting as we can, but off the thread the app is starting up on
+        if (backgroundWorker != null) {
+            backgroundWorker.submit { prefetchLaunchReason() }
+        } else {
+            prefetchLaunchReason()
+        }
+    }
 
     override val appStartupDataCollector: AppStartupDataCollector = AppStartupTraceEmitter(
         clock = clock,
@@ -37,10 +54,7 @@ class DataCaptureServiceModuleImpl(
         logger = logger,
         startupClassifier = startupClassifier,
         manualEnd = configService.autoDataCaptureBehavior.isEndStartupWithAppReadyEnabled(),
-        processInfo = ProcessInfoImpl(
-            deviceStartTimeMs = clock.now() - SystemClock.elapsedRealtime(),
-            versionChecker = versionChecker,
-        ),
+        processInfo = processInfo,
     )
 
     override val uiLoadDataListener: UiLoadDataListener? =

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleSupplier.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleSupplier.kt
@@ -1,11 +1,13 @@
 package io.embrace.android.embracesdk.internal.instrumentation.startup
 
+import android.app.ActivityManager
 import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
 import io.embrace.android.embracesdk.internal.arch.startup.StartupClassifier
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
+import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 
 /**
  * Function that returns an instance of [DataCaptureServiceModule]. Matches the signature of the constructor for
@@ -19,4 +21,6 @@ typealias DataCaptureServiceModuleSupplier = (
     appVersionStartupCounterProvider: () -> Int?,
     startupClassifier: StartupClassifier,
     versionChecker: VersionChecker,
+    activityManager: ActivityManager?,
+    backgroundWorker: BackgroundWorker?,
 ) -> DataCaptureServiceModule

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/ProcessInfo.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/ProcessInfo.kt
@@ -8,4 +8,25 @@ internal interface ProcessInfo {
      * Return the best-available estimated time for the when the app process was requested to fork
      */
     fun startRequestedTimeMs(): Long?
+
+    /**
+     * Return why the OS started this app process, as one of the
+     * [io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbStartupLaunchReasonValues], or null if the platform does not
+     * report it or we cannot confirm that what it reports describes this process. Note this describes the creation of the process
+     * rather than what the user did to launch the app: a process forked to handle a push message and subsequently used for a user
+     * launch reports a launch reason of "push".
+     */
+    fun launchReason(): String?
+
+    /**
+     * Work out [launchReason] and hold onto it, so that the value is already known by the time the startup trace is recorded. The
+     * platform only lets us read start information that has not been narrowed to a single process, so the further into startup we
+     * leave the read, the more opportunity there is for another start belonging to this app to have been logged over ours. Resolving
+     * it as soon as the SDK starts keeps that window to the few milliseconds between the process being forked and the SDK
+     * initialising, rather than letting it grow with the length of the startup being measured.
+     *
+     * Safe to call from a background thread, and safe to call more than once. [launchReason] falls back to doing the work itself if
+     * this was never called.
+     */
+    fun prefetchLaunchReason()
 }

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/ProcessInfoImpl.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/ProcessInfoImpl.kt
@@ -1,13 +1,26 @@
 package io.embrace.android.embracesdk.internal.instrumentation.startup
 
+import android.app.ActivityManager
+import android.app.ApplicationStartInfo
 import android.os.Build.VERSION_CODES
 import android.os.Process
+import androidx.annotation.RequiresApi
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbStartupLaunchReasonValues
+import java.util.concurrent.TimeUnit
 
 internal class ProcessInfoImpl(
     private val deviceStartTimeMs: Long,
     private val versionChecker: VersionChecker,
+    private val activityManager: ActivityManager? = null,
 ) : ProcessInfo {
+
+    @Volatile
+    private var launchReasonValue: String? = null
+
+    @Volatile
+    private var launchReasonResolved: Boolean = false
+
     override fun startRequestedTimeMs(): Long? {
         return if (versionChecker.isAtLeast(VERSION_CODES.TIRAMISU)) {
             deviceStartTimeMs + Process.getStartRequestedElapsedRealtime()
@@ -16,5 +29,86 @@ internal class ProcessInfoImpl(
         } else {
             null
         }
+    }
+
+    @Synchronized
+    override fun prefetchLaunchReason() {
+        if (!launchReasonResolved) {
+            launchReasonValue = resolveLaunchReason()
+            launchReasonResolved = true
+        }
+    }
+
+    override fun launchReason(): String? {
+        if (!launchReasonResolved) {
+            prefetchLaunchReason()
+        }
+        return launchReasonValue
+    }
+
+    private fun resolveLaunchReason(): String? {
+        if (!versionChecker.isAtLeast(VERSION_CODES.VANILLA_ICE_CREAM)) {
+            return null
+        }
+        val manager = activityManager ?: return null
+
+        // this makes a binder call, hence being kept off the thread the app is starting up on
+        return runCatching { manager.startInfoForThisProcess()?.reason?.toLaunchReason() }.getOrNull()
+    }
+
+    /**
+     * Read rather than waiting on `ActivityManager.addApplicationStartInfoCompletionListener`, which reports only once the platform treats
+     * startup as finished at first frame drawn. That callback comes back from the system server after our own first draw callback does, so
+     * it would arrive too late to put on the trace. What we get here instead is the in-progress record for this launch, which is the
+     * documented use of this call, and the reason is set when a record is created so it is populated even though most of the record is not.
+     *
+     * Records are not narrowed to a single process. They cover the whole package, are returned newest first, and carry no pid or process
+     * name until the start they describe completes, so a start logged for this app after ours is indistinguishable from ours by identity
+     * alone. Rule those out by time instead: a start requested after the system was already about to fork this process cannot be what
+     * caused this process to exist. Anything we cannot place before our own fork is discarded rather than reported as if it were ours.
+     */
+    @RequiresApi(VERSION_CODES.VANILLA_ICE_CREAM)
+    internal fun ActivityManager.startInfoForThisProcess(): ApplicationStartInfo? {
+        val processStartRequestedMs = Process.getStartRequestedUptimeMillis()
+        return getHistoricalProcessStartReasons(MAX_START_INFO_RECORDS_QUERIED)
+            .firstOrNull { it.startedBy(processStartRequestedMs) }
+    }
+
+    /**
+     * Whether this record describes a start that was already underway when the system was about to fork us, given as a
+     * [android.os.SystemClock.uptimeMillis] value. The platform stamps startup timestamps from the uptime clock, so
+     * [Process.getStartRequestedUptimeMillis] is the comparable reading of our own start; the elapsed realtime equivalents used elsewhere
+     * in this class are not, as they count time spent in deep sleep.
+     */
+    @RequiresApi(VERSION_CODES.VANILLA_ICE_CREAM)
+    private fun ApplicationStartInfo.startedBy(processStartRequestedMs: Long): Boolean {
+        val launchUptimeNs = startupTimestamps[ApplicationStartInfo.START_TIMESTAMP_LAUNCH] ?: return false
+        return TimeUnit.NANOSECONDS.toMillis(launchUptimeNs) <= processStartRequestedMs
+    }
+
+    /**
+     * Maps a platform start reason to the value used in telemetry. Returns null for reasons added in future Android versions that we don't
+     * know about yet, as reporting those as [EmbStartupLaunchReasonValues.OTHER] would be indistinguishable from the platform itself
+     * saying the launch was uncategorised.
+     */
+    @RequiresApi(VERSION_CODES.VANILLA_ICE_CREAM)
+    internal fun Int.toLaunchReason(): String? = when (this) {
+        ApplicationStartInfo.START_REASON_ALARM -> EmbStartupLaunchReasonValues.ALARM
+        ApplicationStartInfo.START_REASON_BACKUP -> EmbStartupLaunchReasonValues.BACKUP
+        ApplicationStartInfo.START_REASON_BOOT_COMPLETE -> EmbStartupLaunchReasonValues.BOOT_COMPLETE
+        ApplicationStartInfo.START_REASON_BROADCAST -> EmbStartupLaunchReasonValues.BROADCAST
+        ApplicationStartInfo.START_REASON_CONTENT_PROVIDER -> EmbStartupLaunchReasonValues.CONTENT_PROVIDER
+        ApplicationStartInfo.START_REASON_JOB -> EmbStartupLaunchReasonValues.JOB
+        ApplicationStartInfo.START_REASON_LAUNCHER -> EmbStartupLaunchReasonValues.LAUNCHER
+        ApplicationStartInfo.START_REASON_LAUNCHER_RECENTS -> EmbStartupLaunchReasonValues.LAUNCHER_RECENTS
+        ApplicationStartInfo.START_REASON_OTHER -> EmbStartupLaunchReasonValues.OTHER
+        ApplicationStartInfo.START_REASON_PUSH -> EmbStartupLaunchReasonValues.PUSH
+        ApplicationStartInfo.START_REASON_SERVICE -> EmbStartupLaunchReasonValues.SERVICE
+        ApplicationStartInfo.START_REASON_START_ACTIVITY -> EmbStartupLaunchReasonValues.START_ACTIVITY
+        else -> null
+    }
+
+    companion object {
+        private const val MAX_START_INFO_RECORDS_QUERIED = 5
     }
 }

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeProcessInfo.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeProcessInfo.kt
@@ -2,6 +2,17 @@ package io.embrace.android.embracesdk.fakes
 
 import io.embrace.android.embracesdk.internal.instrumentation.startup.ProcessInfo
 
-class FakeProcessInfo(private val fakeStartRequestedTime: Long?) : ProcessInfo {
+class FakeProcessInfo(
+    private val fakeStartRequestedTime: Long?,
+    private val fakeLaunchReason: String? = null,
+) : ProcessInfo {
+    var prefetchCount: Int = 0
+        private set
+
     override fun startRequestedTimeMs(): Long? = fakeStartRequestedTime
+    override fun launchReason(): String? = fakeLaunchReason
+
+    override fun prefetchLaunchReason() {
+        prefetchCount++
+    }
 }

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/ProcessInfoImplTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/ProcessInfoImplTest.kt
@@ -1,9 +1,15 @@
 package io.embrace.android.embracesdk.internal.instrumentation.startup
 
+import android.app.ActivityManager
+import android.app.ApplicationStartInfo
 import android.os.Build
 import android.os.Process
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbStartupLaunchReasonValues
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -42,5 +48,120 @@ internal class ProcessInfoImplTest {
     @Test
     fun `verify start time in L`() {
         assertNull(processInfo.startRequestedTimeMs())
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
+    @Test
+    fun `verify launch reason in V`() {
+        val activityManager = activityManagerWith(startInfo(ApplicationStartInfo.START_REASON_PUSH, startedBeforeUs))
+        assertEquals(EmbStartupLaunchReasonValues.PUSH, processInfo(activityManager).launchReason())
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
+    @Test
+    fun `verify launch reason read from records the platform did not populate a pid for in V`() {
+        val record = startInfo(ApplicationStartInfo.START_REASON_LAUNCHER, startedBeforeUs)
+        every { record.pid } returns 0
+        assertEquals(EmbStartupLaunchReasonValues.LAUNCHER, processInfo(activityManagerWith(record)).launchReason())
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
+    @Test
+    fun `verify starts logged after our process was requested are not reported as ours in V`() {
+        val activityManager = activityManagerWith(
+            startInfo(ApplicationStartInfo.START_REASON_BROADCAST, startedAfterUs),
+            startInfo(ApplicationStartInfo.START_REASON_LAUNCHER, startedBeforeUs),
+        )
+        assertEquals(EmbStartupLaunchReasonValues.LAUNCHER, processInfo(activityManager).launchReason())
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
+    @Test
+    fun `verify no launch reason when every record postdates our process being requested in V`() {
+        val activityManager =
+            activityManagerWith(startInfo(ApplicationStartInfo.START_REASON_BROADCAST, startedAfterUs))
+        assertNull(processInfo(activityManager).launchReason())
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
+    @Test
+    fun `verify no launch reason when a record cannot be placed in time in V`() {
+        val record = startInfo(ApplicationStartInfo.START_REASON_LAUNCHER, startedBeforeUs)
+        every { record.startupTimestamps } returns emptyMap()
+        assertNull(processInfo(activityManagerWith(record)).launchReason())
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
+    @Test
+    fun `verify no launch reason when no start records exist in V`() {
+        assertNull(processInfo(activityManagerWith()).launchReason())
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
+    @Test
+    fun `verify no launch reason for an unrecognised platform reason in V`() {
+        assertNull(processInfo(activityManagerWith(startInfo(Int.MAX_VALUE, startedBeforeUs))).launchReason())
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
+    @Test
+    fun `verify no launch reason when the platform call fails in V`() {
+        val activityManager = mockk<ActivityManager> {
+            every { getHistoricalProcessStartReasons(any()) } throws IllegalStateException("dead")
+        }
+        assertNull(processInfo(activityManager).launchReason())
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
+    @Test
+    fun `verify no launch reason without an ActivityManager in V`() {
+        assertNull(processInfo(activityManager = null).launchReason())
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+    @Test
+    fun `verify no launch reason in U`() {
+        val activityManager =
+            activityManagerWith(startInfo(ApplicationStartInfo.START_REASON_LAUNCHER, startedBeforeUs))
+        assertNull(processInfo(activityManager).launchReason())
+    }
+
+    @Config(sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
+    @Test
+    fun `verify the platform is only consulted once however often the reason is read in V`() {
+        val activityManager = activityManagerWith(startInfo(ApplicationStartInfo.START_REASON_JOB, startedBeforeUs))
+        val processInfo = processInfo(activityManager)
+
+        processInfo.prefetchLaunchReason()
+        assertEquals(EmbStartupLaunchReasonValues.JOB, processInfo.launchReason())
+        assertEquals(EmbStartupLaunchReasonValues.JOB, processInfo.launchReason())
+
+        verify(exactly = 1) { activityManager.getHistoricalProcessStartReasons(any()) }
+    }
+
+    private fun processInfo(activityManager: ActivityManager?) =
+        ProcessInfoImpl(fakeDeviceStartTime, BuildVersionChecker, activityManager)
+
+    private fun activityManagerWith(vararg records: ApplicationStartInfo) = mockk<ActivityManager> {
+        every { getHistoricalProcessStartReasons(any()) } returns records.toList()
+    }
+
+    /**
+     * Records are matched against [Process.getStartRequestedUptimeMillis], so anchor the fixtures to whatever this process reports
+     * rather than to a literal.
+     */
+    private val startedBeforeUs: Long
+        get() = (Process.getStartRequestedUptimeMillis() - 10L) * NANOS_PER_MS
+
+    private val startedAfterUs: Long
+        get() = (Process.getStartRequestedUptimeMillis() + 10L) * NANOS_PER_MS
+
+    private fun startInfo(reason: Int, launchUptimeNs: Long) = mockk<ApplicationStartInfo> {
+        every { this@mockk.reason } returns reason
+        every { startupTimestamps } returns mapOf(ApplicationStartInfo.START_TIMESTAMP_LAUNCH to launchUptimeNs)
+    }
+
+    private companion object {
+        const val NANOS_PER_MS = 1_000_000L
     }
 }

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/AppStartupTraceEmitterTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/AppStartupTraceEmitterTest.kt
@@ -35,6 +35,7 @@ import io.embrace.android.embracesdk.internal.instrumentation.startup.ui.support
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.semconv.EmbAppAttributes
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbStartupLaunchReasonValues
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -63,6 +64,7 @@ internal class AppStartupTraceEmitterTest {
     private var trackProcessStart: Boolean = true
     private var hasRenderEvent = true
     private var hasFrameCommitEvent = true
+    private var launchReason: String? = EmbStartupLaunchReasonValues.LAUNCHER
 
     private lateinit var clock: FakeClock
     private lateinit var destination: FakeTelemetryDestination
@@ -91,6 +93,20 @@ internal class AppStartupTraceEmitterTest {
     @Config(sdk = [VERSION_CODES.TIRAMISU])
     @Test
     fun `verify cold start trace with every event triggered in T`() {
+        createTraceEmitter().simulateAppStartup()
+    }
+
+    @Config(sdk = [VERSION_CODES.TIRAMISU])
+    @Test
+    fun `verify launch reason reported by the platform is recorded on the trace`() {
+        launchReason = EmbStartupLaunchReasonValues.PUSH
+        createTraceEmitter().simulateAppStartup()
+    }
+
+    @Config(sdk = [VERSION_CODES.TIRAMISU])
+    @Test
+    fun `verify launch reason omitted from the trace when the platform does not report one`() {
+        launchReason = null
         createTraceEmitter().simulateAppStartup()
     }
 
@@ -633,6 +649,7 @@ internal class AppStartupTraceEmitterTest {
                 } else {
                     null
                 },
+                fakeLaunchReason = launchReason,
             ),
         )
 
@@ -914,6 +931,7 @@ internal class AppStartupTraceEmitterTest {
 
         val attrs = checkNotNull(trace.attributes)
         assertEquals(STARTUP_ACTIVITY_NAME, attrs[EmbSessionAttributes.EMB_STARTUP_ACTIVITY])
+        assertEquals(launchReason, attrs[EmbSessionAttributes.EMB_STARTUP_LAUNCH_REASON])
         assertEquals(1, dataCollectionCompletedCallbackInvokedCount)
 
         expectedCustomAttributes.forEach { entry ->

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.injection
 
+import android.app.ActivityManager
 import android.content.Context
 import android.os.Build
 import io.embrace.android.embracesdk.core.BuildConfig
@@ -183,7 +184,10 @@ internal class InitializedModuleGraph(
     }
 
     override val dataCaptureServiceModule: DataCaptureServiceModule = init("data-capture-service") {
-        val destination = instrumentationModule.instrumentationArgs.destination
+        val instrumentationArgs = instrumentationModule.instrumentationArgs
+        val destination = instrumentationArgs.destination
+        val activityManager = instrumentationArgs.systemService<ActivityManager>(Context.ACTIVITY_SERVICE)
+        val backgroundWorker = workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker)
         dataCaptureServiceModuleSupplier?.invoke(
             initModule.clock,
             initModule.logger,
@@ -192,6 +196,8 @@ internal class InitializedModuleGraph(
             { coreModule.appVersionStartupCounter },
             initModule.startupClassifier,
             versionChecker,
+            activityManager,
+            backgroundWorker,
         ) ?: DataCaptureServiceModuleImpl(
             initModule.clock,
             initModule.logger,
@@ -200,6 +206,8 @@ internal class InitializedModuleGraph(
             { coreModule.appVersionStartupCounter },
             initModule.startupClassifier,
             versionChecker,
+            activityManager,
+            backgroundWorker,
         )
     }
 

--- a/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSessionAttributes.kt
+++ b/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSessionAttributes.kt
@@ -126,6 +126,87 @@ object EmbSessionAttributes {
     const val EMB_STARTUP_DURATION: String = "emb.startup_duration"
 
     /**
+     * Why the OS started the app process that the startup trace was recorded in. Reported by the platform from Android 15 onwards, and omitted where it is unavailable. This describes the creation of the process, which is not necessarily what the user did to launch the app: a process forked to handle a push message and subsequently used for a user launch is reported as `push`.
+     */
+    @ExperimentalSemconv
+    const val EMB_STARTUP_LAUNCH_REASON: String = "emb.startup_launch_reason"
+
+    object EmbStartupLaunchReasonValues {
+
+        /**
+         * The process was started to deliver an alarm.
+         */
+        @ExperimentalSemconv
+        const val ALARM: String = "alarm"
+
+        /**
+         * The process was started to run a backup or restore operation.
+         */
+        @ExperimentalSemconv
+        const val BACKUP: String = "backup"
+
+        /**
+         * The process was started in response to the device finishing booting.
+         */
+        @ExperimentalSemconv
+        const val BOOT_COMPLETE: String = "boot_complete"
+
+        /**
+         * The process was started to receive a broadcast.
+         */
+        @ExperimentalSemconv
+        const val BROADCAST: String = "broadcast"
+
+        /**
+         * The process was started because one of its content providers was accessed.
+         */
+        @ExperimentalSemconv
+        const val CONTENT_PROVIDER: String = "content_provider"
+
+        /**
+         * The process was started to run a scheduled job.
+         */
+        @ExperimentalSemconv
+        const val JOB: String = "job"
+
+        /**
+         * The process was started because the app was launched from the launcher.
+         */
+        @ExperimentalSemconv
+        const val LAUNCHER: String = "launcher"
+
+        /**
+         * The process was started because the app was launched from the recents screen.
+         */
+        @ExperimentalSemconv
+        const val LAUNCHER_RECENTS: String = "launcher_recents"
+
+        /**
+         * The process was started for a reason the platform does not categorise further.
+         */
+        @ExperimentalSemconv
+        const val OTHER: String = "other"
+
+        /**
+         * The process was started to handle a push message.
+         */
+        @ExperimentalSemconv
+        const val PUSH: String = "push"
+
+        /**
+         * The process was started because one of its services was bound or started.
+         */
+        @ExperimentalSemconv
+        const val SERVICE: String = "service"
+
+        /**
+         * The process was started because another component started one of its activities.
+         */
+        @ExperimentalSemconv
+        const val START_ACTIVITY: String = "start_activity"
+    }
+
+    /**
      * The application state (foreground/background) at the time the log was recorded.
      */
     @ExperimentalSemconv

--- a/embrace-android-semconv/src/main/semconv/session.yaml
+++ b/embrace-android-semconv/src/main/semconv/session.yaml
@@ -20,6 +20,7 @@ attribute_groups:
       - ref: emb.disk_free_bytes
       - ref: emb.private.send_mode
       - ref: emb.startup_activity
+      - ref: emb.startup_launch_reason
       - ref: emb.process_identifier
       - ref: emb.user_session_id
       - ref: emb.user_session_number
@@ -106,6 +107,61 @@ attributes:
     brief: "The name of the Activity that app startup completed in."
     stability: development
     examples: ["MainActivity"]
+  - key: emb.startup_launch_reason
+    type:
+      allow_custom_values: false
+      members:
+        - id: alarm
+          value: "alarm"
+          brief: "The process was started to deliver an alarm."
+          stability: development
+        - id: backup
+          value: "backup"
+          brief: "The process was started to run a backup or restore operation."
+          stability: development
+        - id: boot_complete
+          value: "boot_complete"
+          brief: "The process was started in response to the device finishing booting."
+          stability: development
+        - id: broadcast
+          value: "broadcast"
+          brief: "The process was started to receive a broadcast."
+          stability: development
+        - id: content_provider
+          value: "content_provider"
+          brief: "The process was started because one of its content providers was accessed."
+          stability: development
+        - id: job
+          value: "job"
+          brief: "The process was started to run a scheduled job."
+          stability: development
+        - id: launcher
+          value: "launcher"
+          brief: "The process was started because the app was launched from the launcher."
+          stability: development
+        - id: launcher_recents
+          value: "launcher_recents"
+          brief: "The process was started because the app was launched from the recents screen."
+          stability: development
+        - id: other
+          value: "other"
+          brief: "The process was started for a reason the platform does not categorise further."
+          stability: development
+        - id: push
+          value: "push"
+          brief: "The process was started to handle a push message."
+          stability: development
+        - id: service
+          value: "service"
+          brief: "The process was started because one of its services was bound or started."
+          stability: development
+        - id: start_activity
+          value: "start_activity"
+          brief: "The process was started because another component started one of its activities."
+          stability: development
+    brief: "Why the OS started the app process that the startup trace was recorded in. Reported by the platform from Android 15 onwards, and omitted where it is unavailable. This describes the creation of the process, which is not necessarily what the user did to launch the app: a process forked to handle a push message and subsequently used for a user launch is reported as `push`."
+    stability: development
+    examples: ["launcher", "push", "job"]
   - key: emb.process_identifier
     type: string
     brief: "Monotonically increasing sequence ID given to completed spans expected to be sent to the server."


### PR DESCRIPTION
## Goal
Report the startup reason (when it is available from the `ActivityManager`) as part of the app start root span.

To avoid waiting for the OS reported startup to be complete we use the fact that `ActivityManager. getHistoricalProcessStartReasons` includes "currently in progress" as incomplete records. Unfortunately these records do not include a valid PID (at least in testing), so we use the process start time to filter the records (to avoid picking up child processes in a multi-process app).

## Testing
Some new unit tests and manual testing on several devices.