### PR TITLE
Add instrumented test that checks for strictmode violations

### DIFF
--- a/embrace-android-sdk/build.gradle.kts
+++ b/embrace-android-sdk/build.gradle.kts
@@ -83,5 +83,19 @@ dependencies {
     testImplementation(libs.opentelemetry.kotlin.compat)
     testImplementation(libs.kotlinx.serialization.core)
 
+    // instrumented tests. StrictMode can only observe real disk I/O on a device, so these tests
+    // cannot be written against Robolectric. See StrictModeStartupTest for detail.
+    androidTestImplementation(libs.junit)
+    androidTestImplementation(libs.androidx.annotation)
+    androidTestImplementation(libs.androidx.test.core)
+    androidTestImplementation(libs.androidx.test.junit)
+    androidTestImplementation(libs.androidx.test.runner)
+    // the module's project deps are 'implementation', so anything androidTest needs to name
+    // directly has to be declared again here.
+    androidTestImplementation(project(":embrace-android-core"))
+    androidTestImplementation(project(":embrace-android-config-fakes"))
+    // required because embrace-android-conventions sets execution = ANDROIDX_TEST_ORCHESTRATOR
+    androidTestUtil(libs.androidx.test.orchestrator)
+
     lintChecks(project(":embrace-lint"))
 }

--- a/embrace-android-sdk/src/androidTest/kotlin/io/embrace/android/embracesdk/strictmode/KnownViolations.kt
+++ b/embrace-android-sdk/src/androidTest/kotlin/io/embrace/android/embracesdk/strictmode/KnownViolations.kt
@@ -1,0 +1,100 @@
+package io.embrace.android.embracesdk.strictmode
+
+import android.os.Build
+import android.os.strictmode.DiskReadViolation
+import android.os.strictmode.DiskWriteViolation
+import android.os.strictmode.Violation
+import android.util.Log
+import androidx.annotation.RequiresApi
+import org.junit.Assert.assertTrue
+import kotlin.reflect.KClass
+
+private const val LOG_TAG = "EmbStrictMode"
+
+internal data class KnownViolation(
+    val signature: String,
+    val violation: KClass<out Violation>,
+    val reason: String,
+)
+
+/**
+ * Violations committed by SDK startup today.
+ */
+@RequiresApi(Build.VERSION_CODES.P)
+internal val KNOWN_VIOLATIONS: List<KnownViolation> = listOf(
+    KnownViolation(
+        signature = "internal.injection.ModuleInitBootstrapper.init",
+        violation = DiskReadViolation::class,
+        reason = "context.filesDir is passed to PersistedConfig as a ctor arg, and ContextImpl.getFilesDir " +
+            "stats the directory on every call",
+    ),
+    KnownViolation(
+        signature = "internal.injection.CoreModuleImpl.<init>",
+        violation = DiskReadViolation::class,
+        reason = "CoreModuleImpl.store eagerly opens the default SharedPreferences. Only fires when it beats " +
+            "ModuleInitBootstrapper.prewarmSharedPreferences, which it usually doesn't",
+    ),
+    KnownViolation(
+        signature = "internal.injection.CoreModuleImpl.<init>",
+        violation = DiskWriteViolation::class,
+        reason = "First launch has to mkdir shared_prefs",
+    ),
+    KnownViolation(
+        signature = "internal.config.store.RemoteConfigStoreImpl.loadFromCache",
+        violation = DiskReadViolation::class,
+        reason = "PersistedConfig's ctor loads the persisted response from the config store",
+    ),
+    KnownViolation(
+        signature = "internal.config.store.RemoteConfigStoreImpl.loadFromJson",
+        violation = DiskReadViolation::class,
+        reason = "Fallback path for the read above",
+    ),
+    KnownViolation(
+        signature = "internal.prefs.SharedPrefsStore.getString",
+        violation = DiskReadViolation::class,
+        reason = "A binary cache miss makes DeviceIdProvider read the device ID out of SharedPreferences. " +
+            "Only fires when it beats ModuleInitBootstrapper.prewarmSharedPreferences and has to block in " +
+            "awaitLoadedLocked",
+    ),
+    KnownViolation(
+        signature = "internal.injection.SdkInitActionsKt.loadInstrumentationProviders",
+        violation = DiskReadViolation::class,
+        reason = "ServiceLoader reads META-INF/services out of the APK. R8 rewrites this away in release builds",
+    ),
+    KnownViolation(
+        signature = "internal.storage.EmbraceStorageService.getOrCreateEmbraceFilesDir",
+        violation = DiskWriteViolation::class,
+        reason = "Resolving the filesDirectory lazy calls File(filesDir, \"embrace\").mkdirs()",
+    ),
+    KnownViolation(
+        signature = "internal.storage.EmbraceStorageService.getOrCreateEmbraceFilesDir",
+        violation = DiskReadViolation::class,
+        reason = "As above - the mkdirs() is followed by an exists() check",
+    ),
+)
+
+/**
+ * Fails if SDK startup committed a violation that isn't in [KNOWN_VIOLATIONS]. Full stacks for
+ * everything recorded are logged under [LOG_TAG].
+ */
+@RequiresApi(Build.VERSION_CODES.P)
+internal fun assertNoUnexpectedViolations(recorded: List<RecordedViolation>) {
+    recorded.forEach { Log.i(LOG_TAG, it.describeWithStack()) }
+
+    val unexpected = recorded
+        .filter { it.signature != null }
+        .filterNot { violation -> KNOWN_VIOLATIONS.any { violation.matches(it) } }
+        .distinctBy { it.violationName to it.signature }
+
+    assertTrue(
+        unexpected.joinToString(
+            prefix = "Unexpected StrictMode violations (stacks in logcat under $LOG_TAG):\n",
+            separator = "\n",
+        ) { "  ${it.describe()}" },
+        unexpected.isEmpty(),
+    )
+}
+
+@RequiresApi(Build.VERSION_CODES.P)
+private fun RecordedViolation.matches(known: KnownViolation): Boolean =
+    signature == known.signature && known.violation.java.isInstance(violation)

--- a/embrace-android-sdk/src/androidTest/kotlin/io/embrace/android/embracesdk/strictmode/RecordedViolation.kt
+++ b/embrace-android-sdk/src/androidTest/kotlin/io/embrace/android/embracesdk/strictmode/RecordedViolation.kt
@@ -1,0 +1,30 @@
+package io.embrace.android.embracesdk.strictmode
+
+import android.os.strictmode.Violation
+
+internal class RecordedViolation(
+    val violation: Violation,
+    val threadName: String,
+) {
+
+    /**
+     * The top-most SDK frame that triggered this violation, as `Class.method`. Line numbers are
+     * excluded so unrelated edits don't invalidate [KNOWN_VIOLATIONS]. Null if no SDK frame was
+     * involved, i.e. the framework or the test harness did it and we don't assert on it.
+     */
+    val signature: String? = violation.stackTrace
+        .firstOrNull { it.className.startsWith(SDK_PACKAGE) && !it.className.startsWith(TEST_PACKAGE) }
+        ?.let { "${it.className.removePrefix(SDK_CLASS_PREFIX)}.${it.methodName}" }
+
+    val violationName: String get() = violation.javaClass.simpleName
+
+    fun describe(): String = "$violationName on '$threadName' at ${signature ?: "<no SDK frame>"}"
+
+    fun describeWithStack(): String = "${describe()}\n${violation.stackTraceToString()}"
+
+    private companion object {
+        const val SDK_PACKAGE = "io.embrace."
+        const val SDK_CLASS_PREFIX = "io.embrace.android.embracesdk."
+        const val TEST_PACKAGE = "io.embrace.android.embracesdk.strictmode."
+    }
+}

--- a/embrace-android-sdk/src/androidTest/kotlin/io/embrace/android/embracesdk/strictmode/StrictModeRecorder.kt
+++ b/embrace-android-sdk/src/androidTest/kotlin/io/embrace/android/embracesdk/strictmode/StrictModeRecorder.kt
@@ -1,0 +1,50 @@
+package io.embrace.android.embracesdk.strictmode
+
+import android.os.Build
+import android.os.StrictMode
+import android.os.strictmode.Violation
+import androidx.annotation.RequiresApi
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executor
+
+/**
+ * Installs [StrictMode] policies and records every violation they report.
+ */
+@RequiresApi(Build.VERSION_CODES.P)
+internal class StrictModeRecorder {
+
+    private val recorded = CopyOnWriteArrayList<RecordedViolation>()
+    private val directExecutor = Executor(Runnable::run)
+
+    /**
+     * [StrictMode.ThreadPolicy] is thread local, so call this on the thread whose I/O should be observed.
+     */
+    fun install() {
+        StrictMode.setThreadPolicy(threadPolicy())
+        StrictMode.setVmPolicy(vmPolicy())
+    }
+
+    fun violations(): List<RecordedViolation> = recorded.toList()
+
+    private fun threadPolicy(): StrictMode.ThreadPolicy = StrictMode.ThreadPolicy.Builder()
+        .detectDiskReads()
+        .detectDiskWrites()
+        .detectNetwork()
+        .detectUnbufferedIo()
+        .detectCustomSlowCalls()
+        .detectResourceMismatches()
+        .penaltyListener(directExecutor) { record(it) }
+        .build()
+
+    private fun vmPolicy(): StrictMode.VmPolicy = StrictMode.VmPolicy.Builder()
+        .detectUntaggedSockets()
+        .detectNonSdkApiUsage()
+        .detectLeakedSqlLiteObjects()
+        .penaltyListener(directExecutor) { record(it) }
+        .build()
+
+    private fun record(violation: Violation) {
+        recorded.add(RecordedViolation(violation, Thread.currentThread().name))
+    }
+}
+

--- a/embrace-android-sdk/src/androidTest/kotlin/io/embrace/android/embracesdk/strictmode/StrictModeStartupTest.kt
+++ b/embrace-android-sdk/src/androidTest/kotlin/io/embrace/android/embracesdk/strictmode/StrictModeStartupTest.kt
@@ -1,0 +1,126 @@
+package io.embrace.android.embracesdk.strictmode
+
+import android.content.Context
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SdkSuppress
+import androidx.test.platform.app.InstrumentationRegistry
+import io.embrace.android.embracesdk.EmbraceImpl
+import io.embrace.android.embracesdk.fakes.config.FakeBaseUrlConfig
+import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
+import io.embrace.android.embracesdk.internal.injection.InitModule
+import io.embrace.android.embracesdk.internal.injection.InitModuleImpl
+import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
+import io.embrace.android.embracesdk.internal.worker.Worker
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.util.concurrent.TimeUnit.MILLISECONDS
+
+private const val DRAIN_TIMEOUT_MS = 5000L
+
+private val BACKGROUND_WORKERS = listOf(
+    Worker.Background.NonIoRegWorker,
+    Worker.Background.IoRegWorker,
+    Worker.Background.PeriodicCacheWorker,
+    Worker.Background.LogMessageWorker,
+    Worker.Background.DeliverySchedulingWorker,
+    Worker.Background.HttpRequestWorker,
+)
+
+/**
+ * Starts the SDK on the main thread with StrictMode enabled, simulating a cold start with no data
+ * persisted by a previous run, and fails if the SDK performs any main thread I/O that is not
+ * explicitly recorded in [KNOWN_VIOLATIONS].
+ */
+@RunWith(AndroidJUnit4::class)
+@SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
+@RequiresApi(Build.VERSION_CODES.P)
+internal class StrictModeStartupTest {
+
+    private val instrumentation = InstrumentationRegistry.getInstrumentation()
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val recorder = StrictModeRecorder()
+    private lateinit var bootstrapper: ModuleInitBootstrapper
+    private lateinit var embrace: EmbraceImpl
+
+    @Before
+    fun setUp() {
+        simulateColdStart()
+    }
+
+    @After
+    fun tearDown() {
+        if (::embrace.isInitialized) {
+            embrace.stop()
+        }
+    }
+
+    @Test
+    fun testSdkStrictMode() {
+        instrumentation.runOnMainSync {
+            recorder.install()
+
+            bootstrapper = ModuleInitBootstrapper(TestInitModule(InitModuleImpl()))
+            EmbraceImpl(bootstrapper).let {
+                embrace = it
+                it.start(context)
+            }
+        }
+
+        drainInitWork()
+        assertTrue("SDK did not start.", embrace.isStarted)
+        assertNoUnexpectedViolations(recorder.violations())
+    }
+
+    /**
+     * Makes a reasonable attempt to let the instrumentation and background tasks fired by SDK init
+     * finish.
+     */
+    private fun drainInitWork() {
+        repeat(2) {
+            BACKGROUND_WORKERS.forEach { worker ->
+                runCatching {
+                    bootstrapper.workerThreadModule.backgroundWorker(worker).submit {}.get(DRAIN_TIMEOUT_MS, MILLISECONDS)
+                }
+            }
+            instrumentation.waitForIdleSync()
+            instrumentation.runOnMainSync { }
+        }
+    }
+
+    /**
+     * Deletes everything a previous SDK run could have left behind, so that startup takes the
+     * first-launch path.
+     */
+    private fun simulateColdStart() {
+        context.filesDir.deleteContents()
+        context.cacheDir.deleteContents()
+
+        // don't warm shared prefs
+        File(context.applicationInfo.dataDir, "shared_prefs").deleteRecursively()
+
+        assertFalse(
+            File(context.filesDir, "embrace_remote_config").exists(),
+        )
+    }
+
+    private fun File.deleteContents() {
+        listFiles()?.forEach { it.deleteRecursively() }
+    }
+}
+
+private class TestInitModule(base: InitModule) : InitModule by base {
+    override val instrumentedConfig = FakeInstrumentedConfig(
+        baseUrls = FakeBaseUrlConfig(
+            configImpl = "http://localhost:1",
+            dataImpl = "http://localhost:1",
+        ),
+    )
+}


### PR DESCRIPTION
## Goal

Adds an instrumented test that initializes the SDK and checks for strictmode violations, failing the test case if any violations that aren't in an allowlist are detected. This should hopefully allow us to catch any regressions that adds strictmode violations to SDK init.
