### PR TITLE
Harden config layer

### DIFF
--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/PersistedConfig.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/PersistedConfig.kt
@@ -44,7 +44,7 @@ class PersistedConfig(
         )
     }
 
-    internal val response: StoredConfigResponse? = store?.loadResponse()
+    internal val response: StoredConfigResponse? = runCatching { store?.loadResponse() }.getOrNull()
 
     internal val remoteConfig: RemoteConfig? = response?.cfg
 

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/source/CombinedRemoteConfigSource.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/source/CombinedRemoteConfigSource.kt
@@ -25,11 +25,13 @@ internal class CombinedRemoteConfigSource(
     }
 
     private fun attemptConfigRequest() {
-        response?.etag?.let {
-            httpSource.setInitialEtag(it)
-        }
-        httpSource.getConfig()?.let {
-            store.saveResponse(it)
+        runCatching {
+            response?.etag?.let {
+                httpSource.setInitialEtag(it)
+            }
+            httpSource.getConfig()?.let {
+                store.saveResponse(it)
+            }
         }
     }
 }

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/source/OkHttpRemoteConfigSource.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/source/OkHttpRemoteConfigSource.kt
@@ -7,7 +7,6 @@ import okhttp3.Request
 import okhttp3.Response
 import okio.GzipSource
 import okio.buffer
-import java.io.IOException
 
 internal class OkHttpRemoteConfigSource(
     private val okhttpClient: Lazy<OkHttpClient>,
@@ -15,11 +14,9 @@ internal class OkHttpRemoteConfigSource(
     private val configEndpoint: ConfigEndpoint,
 ) : RemoteConfigSource {
 
-    override fun getConfig(): ConfigHttpResponse? = try {
+    override fun getConfig(): ConfigHttpResponse? = runCatching {
         fetchConfigImpl()
-    } catch (exc: IOException) {
-        null
-    }
+    }.getOrNull()
 
     override fun setInitialEtag(etag: String) {
         this.etag = etag

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/store/RemoteConfigStoreImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/store/RemoteConfigStoreImpl.kt
@@ -37,9 +37,10 @@ internal class RemoteConfigStoreImpl(
             )
         } catch (_: IllegalArgumentException) {
             // delete the cache file if it appears to be corrupted
-            cachedConfigFile.delete()
+            deleteQuietly(cachedConfigFile)
             null
-        } catch (exc: Exception) {
+        } catch (_: Throwable) {
+            // assume error may be recoverable (e.g. transient IO)
             null
         }
     }
@@ -56,9 +57,10 @@ internal class RemoteConfigStoreImpl(
             )
         } catch (_: IllegalArgumentException) {
             // delete the cache file if it appears to be corrupted
-            configFile.delete()
+            deleteQuietly(configFile)
             null
-        } catch (exc: Exception) {
+        } catch (_: Throwable) {
+            // assume error may be recoverable (e.g. transient IO)
             null
         }
     }
@@ -90,7 +92,7 @@ internal class RemoteConfigStoreImpl(
         try {
             // nothing to cache without a config; remove any stale blob so the fast path is skipped.
             val cfg = response.cfg ?: run {
-                cachedConfigFile.delete()
+                deleteQuietly(cachedConfigFile)
                 return
             }
             val cached = CachedConfiguration(
@@ -104,16 +106,17 @@ internal class RemoteConfigStoreImpl(
         } catch (exc: Exception) {
             // a partially-written or failed blob must not be read back: delete it and rely on the
             // fallback path that was already written successfully.
-            runCatching { cachedConfigFile.delete() }
+            deleteQuietly(cachedConfigFile)
         }
     }
 
     private fun purgeCache() {
-        try {
-            configFile.delete()
-            etagFile.delete()
-            cachedConfigFile.delete()
-        } catch (ignored: Exception) {
-        }
+        deleteQuietly(configFile)
+        deleteQuietly(etagFile)
+        deleteQuietly(cachedConfigFile)
+    }
+
+    private fun deleteQuietly(file: File) {
+        runCatching { file.delete() }
     }
 }

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeRemoteConfigSource.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeRemoteConfigSource.kt
@@ -5,6 +5,12 @@ import io.embrace.android.embracesdk.internal.config.source.RemoteConfigSource
 
 class FakeRemoteConfigSource(
     var cfg: ConfigHttpResponse? = null,
+
+    /**
+     * Invoked on every [getConfig] call after [callCount] is incremented. Lets a test observe calls
+     * as they happen, or make a chosen call fail.
+     */
+    var onCall: () -> Unit = {},
 ) : RemoteConfigSource {
 
     var callCount: Int = 0
@@ -12,6 +18,7 @@ class FakeRemoteConfigSource(
 
     override fun getConfig(): ConfigHttpResponse? {
         callCount++
+        onCall()
         return cfg
     }
 

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeThrowingSerializer.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeThrowingSerializer.kt
@@ -1,0 +1,20 @@
+package io.embrace.android.embracesdk.fakes
+
+import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
+import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
+import kotlinx.serialization.DeserializationStrategy
+import java.io.InputStream
+
+/**
+ * Fails every stream deserialization with [error], delegating everything else to a real serializer.
+ *
+ * [TestPlatformSerializer.errorOnNextOperation] only throws an [IllegalAccessException], so it cannot
+ * exercise a handler that has to cope with a [Throwable] that is not an [Exception].
+ */
+internal class FakeThrowingSerializer(
+    private val error: Throwable,
+    private val impl: PlatformSerializer = EmbraceSerializer(),
+) : PlatformSerializer by impl {
+
+    override fun <T> fromJson(inputStream: InputStream, deserializer: DeserializationStrategy<T>): T = throw error
+}

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/OkHttpRemoteConfigSourceTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/OkHttpRemoteConfigSourceTest.kt
@@ -107,6 +107,24 @@ class OkHttpRemoteConfigSourceTest {
         assertConfigResponseNotDeserialized(cfg)
     }
 
+    /**
+     * A backend schema regression produces a 200 with valid gzip that cannot be deserialized. The
+     * resulting SerializationException is an IllegalArgumentException, so it used to escape
+     * [OkHttpRemoteConfigSource.getConfig] and cancel the caller's recurring schedule for the whole
+     * process.
+     */
+    @Test
+    fun `a schema-mismatched response does not propagate`() {
+        val body = Buffer()
+        GzipSink(body).buffer().use { it.writeUtf8("""{"threshold":"not-a-number"}""") }
+
+        val (cfg, request) = executeRequest(
+            MockResponse().setResponseCode(200).setBody(body),
+        )
+        assertConfigRequestReceived(request)
+        assertConfigResponseNotDeserialized(cfg)
+    }
+
     @Test
     fun `test etag header respected`() {
         val etagValue = "attempt_1"

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/PersistedConfigTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/PersistedConfigTest.kt
@@ -112,6 +112,20 @@ internal class PersistedConfigTest {
     }
 
     @Test
+    fun `corrupt config on disk degrades to no config rather than throwing`() {
+        val filesDir = temporaryFolder.newFolder()
+        val storageDir = File(filesDir, PersistedConfig.STORAGE_DIR_NAME).apply { mkdirs() }
+        File(storageDir, "most_recent_response").writeText("!!! not json !!!")
+        File(storageDir, "cached_config").writeBytes(ByteArray(8))
+
+        val persistedConfig = createPersistedConfig(filesDir = filesDir)
+
+        assertNull(persistedConfig.response)
+        assertNull(persistedConfig.remoteConfig)
+        assertFalse(persistedConfig.otelBehavior.shouldUseKotlinSdk())
+    }
+
+    @Test
     fun `key value store is not touched when the config is never read`() {
         var resolved = false
         val store = lazy {
@@ -145,8 +159,8 @@ internal class PersistedConfigTest {
         appId: String? = "abcde",
         store: Lazy<FakeKeyValueStore> = lazyOf(FakeKeyValueStore()),
         cachedDeviceId: String? = null,
+        filesDir: File = temporaryFolder.newFolder(),
     ): PersistedConfig {
-        val filesDir = temporaryFolder.newFolder()
         if (persisted != null && cachedDeviceId != null) {
             RemoteConfigStoreImpl(
                 serializer = serializer,

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/source/CombinedRemoteConfigSourceTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/source/CombinedRemoteConfigSourceTest.kt
@@ -1,15 +1,20 @@
 package io.embrace.android.embracesdk.internal.config.source
 
+import io.embrace.android.embracesdk.assertions.assertCountedDown
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeRemoteConfigSource
 import io.embrace.android.embracesdk.fakes.FakeRemoteConfigStore
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.config.store.StoredConfigResponse
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import kotlinx.serialization.SerializationException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ScheduledThreadPoolExecutor
 
 class CombinedRemoteConfigSourceTest {
 
@@ -47,10 +52,37 @@ class CombinedRemoteConfigSourceTest {
         assertEquals(1, remoteConfigStore.saveCount)
     }
 
-    private fun createSource(response: StoredConfigResponse?) = CombinedRemoteConfigSource(
+    @Test
+    fun `a throwing request does not stop the recurring schedule`() {
+        val worker = BackgroundWorker(ScheduledThreadPoolExecutor(1))
+        val latch = CountDownLatch(3)
+        remoteConfigSource.onCall = {
+            latch.countDown()
+            if (remoteConfigSource.callCount == 1) {
+                throw SerializationException("schema mismatch")
+            }
+        }
+
+        try {
+            createSource(response = null, worker = worker, intervalMs = 1).scheduleConfigRequests()
+            latch.assertCountedDown(waitTimeMs = 5000)
+        } finally {
+            worker.shutdownAndWait(timeoutMs = 1000)
+        }
+
+        // the config that arrived after the failure was still persisted
+        assertTrue("expected at least one config to be saved", remoteConfigStore.saveCount > 0)
+    }
+
+    private fun createSource(
+        response: StoredConfigResponse?,
+        worker: BackgroundWorker = BackgroundWorker(executorService),
+        intervalMs: Long = 60 * 60 * 1000,
+    ) = CombinedRemoteConfigSource(
         remoteConfigStore,
         response,
         lazy { remoteConfigSource },
-        BackgroundWorker(executorService),
+        worker,
+        intervalMs,
     )
 }

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/store/RemoteConfigStoreImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/store/RemoteConfigStoreImplTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.config.store
 
+import io.embrace.android.embracesdk.fakes.FakeThrowingSerializer
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.config.source.ConfigHttpResponse
@@ -182,6 +183,18 @@ internal class RemoteConfigStoreImplTest {
         // the load fails...
         assertNull(store.loadResponse())
         // ...but the file is intact so a later attempt can succeed once the error clears.
+        assertTrue(configFile().exists())
+    }
+
+    @Test
+    fun `a non-Exception failure while loading degrades to no config`() {
+        val config = RemoteConfig(50)
+        store.saveResponse(ConfigHttpResponse(config, "etag"))
+        cachedConfigFile().delete()
+
+        store = RemoteConfigStoreImpl(FakeThrowingSerializer(StackOverflowError()), dir) { deviceId }
+
+        assertNull(store.loadResponse())
         assertTrue(configFile().exists())
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/RemoteConfigTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/RemoteConfigTest.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.assertions.returnIfConditionMet
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbracePayloadAssertionInterface
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -57,6 +58,24 @@ internal class RemoteConfigTest {
             assertAction = {
                 assertConfigRequested(1)
                 assertConfigStored(100)
+            })
+    }
+
+    @Test
+    fun `a malformed config response leaves the persisted config intact`() {
+        testRule.runTest(
+            persistedRemoteConfig = sdkEnabledConfig,
+            serverResponseConfigJson = """{"threshold":"not-a-number"}""",
+            testCaseAction = {
+                assertTrue(embrace.isStarted)
+            },
+            assertAction = {
+                assertConfigRequested(1)
+
+                // good config already on disk is not overwritten
+                val persisted = readPersistedConfigResponse()
+                assertEquals(100, persisted.cfg?.threshold)
+                assertEquals("persisted_etag", persisted.etag)
             })
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/SdkIntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/SdkIntegrationTestRule.kt
@@ -117,6 +117,7 @@ internal class SdkIntegrationTestRule(
         instrumentedConfig: FakeInstrumentedConfig = FakeInstrumentedConfig(),
         persistedRemoteConfig: RemoteConfig = RemoteConfig(),
         serverResponseConfig: RemoteConfig = persistedRemoteConfig,
+        serverResponseConfigJson: String? = null,
         expectSdkToStart: Boolean = startSdk,
         setupAction: EmbraceSetupInterface.() -> Unit = {},
         preSdkStartAction: EmbracePreSdkStartInterface.() -> Unit = {},
@@ -126,7 +127,7 @@ internal class SdkIntegrationTestRule(
     ) {
         setup = embraceSetupInterfaceSupplier()
         val deliveryTracer = DeliveryTracer()
-        val apiServer = FakeApiServer(serverResponseConfig, deliveryTracer)
+        val apiServer = FakeApiServer(serverResponseConfig, deliveryTracer, serverResponseConfigJson)
         val server: MockWebServer = MockWebServer().apply {
             protocols = listOf(Protocol.HTTP_2, Protocol.HTTP_1_1)
             dispatcher = apiServer

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/server/FakeApiServer.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/server/FakeApiServer.kt
@@ -30,6 +30,7 @@ import org.junit.Assert.assertNotNull
 internal class FakeApiServer(
     private val remoteConfig: RemoteConfig,
     private val deliveryTracer: DeliveryTracer,
+    private val configResponseJson: String? = null,
 ) : Dispatcher() {
 
     private val serializer by threadLocal { TestPlatformSerializer() }
@@ -131,7 +132,11 @@ internal class FakeApiServer(
         // serialize the config response
         val configResponseBuffer = Buffer()
         val gzipSink = GzipSink(configResponseBuffer).buffer()
-        serializer.toJson(remoteConfig, gzipSink.outputStream())
+        if (configResponseJson != null) {
+            gzipSink.use { it.writeUtf8(configResponseJson) }
+        } else {
+            serializer.toJson(remoteConfig, gzipSink.outputStream())
+        }
         val response = MockResponse()
             .setBody(configResponseBuffer)
             .addHeader("etag", "server_etag_value")


### PR DESCRIPTION
## Goal

Hardens the remote config layer by catching exceptions that currently failed SDK init, and deletes malformed files.

## Testing

Added unit test coverage.
