### PR TITLE
Resolve device id lazily

### DIFF
--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
@@ -68,11 +68,11 @@ class ConfigServiceImpl(
         )
     }
 
-    override val deviceId: String = persistedConfig.deviceId
+    override val deviceId: String by lazy { persistedConfig.deviceId }
 
-    private val remoteConfigSource: RemoteConfigSource? = run {
+    private val remoteConfigSource: RemoteConfigSource? by lazy {
         if (persistedConfig.onlyOtelExportEnabled) {
-            return@run null
+            return@lazy null
         }
 
         OkHttpRemoteConfigSource(


### PR DESCRIPTION
## Goal

Resolve device ID lazily rather than eagerly in `ConfigServiceImpl` to avoid hitting disk for the value until absolutely critical