### PR TITLE
Address some strictmode violations

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/InstrumentationArgsImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/InstrumentationArgsImpl.kt
@@ -34,7 +34,7 @@ internal class InstrumentationArgsImpl(
     override val clock: Clock,
     override val context: Context,
     override val application: Application,
-    override val store: KeyValueStore,
+    storeProvider: () -> KeyValueStore,
     override val serializer: PlatformSerializer,
     override val uuidSource: UuidSource,
     override val ordinalStore: OrdinalStore,
@@ -51,6 +51,8 @@ internal class InstrumentationArgsImpl(
 ) : InstrumentationArgs {
 
     override val crashMarkerFile: File by lazy { crashMarkerFileProvider() }
+
+    override val store: KeyValueStore by lazy { storeProvider() }
 
     override val httpRequestInfoModifierChain: HttpRequestInfoModifierChain = HttpRequestInfoModifierChain(logger)
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InstrumentationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InstrumentationModuleImpl.kt
@@ -32,7 +32,7 @@ class InstrumentationModuleImpl(
         application = coreModule.application,
         destination = essentialServiceModule.telemetryDestination,
         workerThreadModule = workerThreadModule,
-        store = coreModule.store,
+        storeProvider = { coreModule.store },
         serializer = initModule.jsonSerializer,
         uuidSource = initModule.uuidSource,
         sessionPartTracker = essentialServiceModule.sessionPartTracker,

--- a/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImpl.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashHandlerInstallerImpl.kt
@@ -28,7 +28,6 @@ internal class NativeCrashHandlerInstallerImpl(
 ) : NativeCrashHandlerInstaller {
 
     private val processIdentifier = args.processIdentifier
-    private val markerFilePath = args.crashMarkerFile.absolutePath
 
     private val configService: ConfigService = args.configService
     private val logger: InternalLogger = args.logger
@@ -48,8 +47,9 @@ internal class NativeCrashHandlerInstallerImpl(
     private fun startNativeCrashMonitoring() {
         try {
             if (sharedObjectLoader.loadEmbraceNative()) {
+                val markerFilePath = args.crashMarkerFile.absolutePath
                 updateSessionIds()
-                mainThreadHandler.postAtFrontOfQueue { installSignals() }
+                mainThreadHandler.postAtFrontOfQueue { installSignals(markerFilePath) }
                 mainThreadHandler.postDelayed(
                     Runnable(::checkSignalHandlersOverwritten),
                     HANDLER_CHECK_DELAY_MS,
@@ -103,7 +103,7 @@ internal class NativeCrashHandlerInstallerImpl(
         return allowList.any(culprit::contains)
     }
 
-    private fun installSignals() {
+    private fun installSignals(markerFilePath: String) {
         EmbTrace.trace("native-install-handlers") {
             delegate.installSignalHandlers(
                 markerFilePath,

--- a/embrace-android-sdk/src/androidTest/kotlin/io/embrace/android/embracesdk/strictmode/KnownViolations.kt
+++ b/embrace-android-sdk/src/androidTest/kotlin/io/embrace/android/embracesdk/strictmode/KnownViolations.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.strictmode
 
 import android.os.Build
 import android.os.strictmode.DiskReadViolation
-import android.os.strictmode.DiskWriteViolation
 import android.os.strictmode.Violation
 import android.util.Log
 import androidx.annotation.RequiresApi
@@ -29,17 +28,6 @@ internal val KNOWN_VIOLATIONS: List<KnownViolation> = listOf(
             "stats the directory on every call",
     ),
     KnownViolation(
-        signature = "internal.injection.CoreModuleImpl.<init>",
-        violation = DiskReadViolation::class,
-        reason = "CoreModuleImpl.store eagerly opens the default SharedPreferences. Only fires when it beats " +
-            "ModuleInitBootstrapper.prewarmSharedPreferences, which it usually doesn't",
-    ),
-    KnownViolation(
-        signature = "internal.injection.CoreModuleImpl.<init>",
-        violation = DiskWriteViolation::class,
-        reason = "First launch has to mkdir shared_prefs",
-    ),
-    KnownViolation(
         signature = "internal.config.store.RemoteConfigStoreImpl.loadFromCache",
         violation = DiskReadViolation::class,
         reason = "PersistedConfig's ctor loads the persisted response from the config store",
@@ -60,16 +48,6 @@ internal val KNOWN_VIOLATIONS: List<KnownViolation> = listOf(
         signature = "internal.injection.SdkInitActionsKt.loadInstrumentationProviders",
         violation = DiskReadViolation::class,
         reason = "ServiceLoader reads META-INF/services out of the APK. R8 rewrites this away in release builds",
-    ),
-    KnownViolation(
-        signature = "internal.storage.EmbraceStorageService.getOrCreateEmbraceFilesDir",
-        violation = DiskWriteViolation::class,
-        reason = "Resolving the filesDirectory lazy calls File(filesDir, \"embrace\").mkdirs()",
-    ),
-    KnownViolation(
-        signature = "internal.storage.EmbraceStorageService.getOrCreateEmbraceFilesDir",
-        violation = DiskReadViolation::class,
-        reason = "As above - the mkdirs() is followed by an exists() check",
     ),
 )
 


### PR DESCRIPTION
## Goal

`CoreModuleImpl` eagerly initializes SharedPreferences at SDK init. This refactors it to make access lazy for all of SDK init, in the happy path where the binary config cache exists already.
