### PR TITLE
Improve system service lookup

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/EssentialServiceModuleImpl.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.injection
 
+import android.app.ActivityManager
 import android.content.Context
 import android.net.ConnectivityManager
 import android.os.Build
@@ -71,8 +72,12 @@ class EssentialServiceModuleImpl(
             }
         }
 
+    private val activityManager: Lazy<ActivityManager?> = lazy {
+        coreModule.context.getSystemServiceSafe<ActivityManager>(Context.ACTIVITY_SERVICE)
+    }
+
     override val sessionPartTracker: SessionPartTracker = SessionPartTrackerImpl(
-        coreModule.context.getSystemServiceSafe(Context.ACTIVITY_SERVICE),
+        activityManager,
         initModule.logger,
     )
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
@@ -85,7 +85,7 @@ class PayloadSourceModuleImpl(
             configService = configService,
             device = EmbTrace.trace("deviceImpl") {
                 DeviceImpl(
-                    coreModule.context.getSystemServiceSafe(Context.WINDOW_SERVICE),
+                    windowManagerProvider = { coreModule.context.getSystemServiceSafe(Context.WINDOW_SERVICE) },
                     coreModule.store,
                     workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker),
                     initModule.systemInfo,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionPartTrackerImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionPartTrackerImpl.kt
@@ -11,7 +11,7 @@ import io.embrace.android.embracesdk.internal.session.SessionPartToken
 import java.util.concurrent.CopyOnWriteArraySet
 
 internal class SessionPartTrackerImpl(
-    private val activityManager: ActivityManager?,
+    private val activityManager: Lazy<ActivityManager?>,
     private val logger: InternalLogger,
 ) : SessionPartTracker {
 
@@ -54,7 +54,7 @@ internal class SessionPartTrackerImpl(
     override fun setProcessStateSummary(sessionPartId: String, userSessionId: String) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             try {
-                activityManager?.setProcessStateSummary("${sessionPartId}_$userSessionId".toByteArray())
+                activityManager.value?.setProcessStateSummary("${sessionPartId}_$userSessionId".toByteArray())
             } catch (e: Throwable) {
                 logger.trackInternalError(InternalErrorType.ProcessStateSummaryFail, e)
             }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionPartTrackerImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionPartTrackerImplTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.session.id
 
+import android.app.ActivityManager
 import io.embrace.android.embracesdk.fakes.fakeSessionPartToken
 import io.embrace.android.embracesdk.internal.arch.state.AppState
 import io.embrace.android.embracesdk.internal.logging.InternalLoggerImpl
@@ -15,7 +16,7 @@ internal class SessionPartTrackerImplTest {
 
     @Before
     fun setUp() {
-        tracker = SessionPartTrackerImpl(null, InternalLoggerImpl())
+        tracker = SessionPartTrackerImpl(lazyOf<ActivityManager?>(null), InternalLoggerImpl())
     }
 
     @Test

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorListenerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorListenerTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.session.orchestrator
 
+import android.app.ActivityManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.SessionStateEvent
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
@@ -356,7 +357,7 @@ internal class SessionOrchestratorListenerTest {
         userSessionPropertiesService = FakeUserSessionPropertiesService()
         userService = FakeUserService()
         sessionTracker = SessionPartTrackerImpl(
-            activityManager = null,
+            activityManager = lazyOf<ActivityManager?>(null),
             logger = logger,
         )
         sessionCacheExecutor = BlockingScheduledExecutorService(clock, true)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.session.orchestrator
 
+import android.app.ActivityManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeAppStateTracker
@@ -990,7 +991,7 @@ internal class SessionOrchestratorTest {
         )
         userSessionPropertiesService = FakeUserSessionPropertiesService()
         sessionTracker = SessionPartTrackerImpl(
-            activityManager = null,
+            activityManager = lazyOf<ActivityManager?>(null),
             logger = logger,
         )
         sessionCacheExecutor = BlockingScheduledExecutorService(clock, true)

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/DeviceImpl.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/DeviceImpl.kt
@@ -10,12 +10,13 @@ import io.embrace.android.embracesdk.internal.isEmulator
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.store.KeyValueStore
+import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import java.io.File
 import java.util.Locale
 
 class DeviceImpl(
-    private val windowManager: WindowManager?,
+    private val windowManagerProvider: Provider<WindowManager?>,
     private val store: KeyValueStore,
     private val backgroundWorker: BackgroundWorker,
     override val systemInfo: SystemInfo,
@@ -59,7 +60,7 @@ class DeviceImpl(
             if (storedScreenResolution != null) {
                 screenResolution = storedScreenResolution
             } else {
-                screenResolution = getScreenResolution(windowManager)
+                screenResolution = getScreenResolution(windowManagerProvider())
                 persistedScreenResolution = screenResolution
             }
         }


### PR DESCRIPTION
## Goal

Delays calls to `getSystemService` so that they either happen in the background or later on during SDK init (which will allow further optimizations later on).
