### PR TITLE
Avoid device ID shared prefs read

### DIFF
--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/PersistedConfig.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/PersistedConfig.kt
@@ -55,7 +55,10 @@ class PersistedConfig(
         DeviceIdProvider(keyValueStore, response?.deviceId, uuidSource).deviceId
     }
 
-    internal val thresholdCheck: BehaviorThresholdCheck = BehaviorThresholdCheck(::deviceId)
+    internal val thresholdCheck: BehaviorThresholdCheck = BehaviorThresholdCheck {
+        // don't use reference as this eagerly inits deviceId
+        deviceId
+    }
 
     val otelBehavior: OtelBehavior = OtelBehaviorImpl(thresholdCheck, instrumentedConfig, remoteConfig)
 


### PR DESCRIPTION
## Goal

Fixes an eager init of `deviceId` that was triggering `SharedPreferences` in the SDK init warm path.
