### PR TITLE
Avoid reading shared prefs in Otel only mode

### DIFF
--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BehaviorThresholdCheck.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BehaviorThresholdCheck.kt
@@ -43,6 +43,9 @@ class BehaviorThresholdCheck(
         if (pctEnabled <= 0 || pctEnabled > 100) {
             return false
         }
+        if (pctEnabled == 100f) {
+            return true
+        }
         val deviceId = getNormalizedDeviceId()
         return pctEnabled >= deviceId
     }

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SdkModeBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/SdkModeBehaviorImplTest.kt
@@ -30,6 +30,13 @@ internal class SdkModeBehaviorImplTest {
     }
 
     @Test
+    fun testDefaultThresholdDoesNotResolveDeviceId() {
+        val neverResolve = BehaviorThresholdCheck { error("device ID should not be resolved for a 100% threshold") }
+        val behavior = createSdkModeBehavior(thresholdCheck = neverResolve)
+        assertFalse(behavior.isSdkDisabled())
+    }
+
+    @Test
     fun testSdkEnabled() {
         // Device disabled
         assertEquals(100.0f, disabled.getNormalizedDeviceId())


### PR DESCRIPTION
## Goal

Avoids reading `SharedPreferences` when the SDK is configured only to export via OTLP. Currently we check device ID when the threshold is set at the default of 100f - this changeset optimizes that I/O away.