### PR TITLE
Remove cancelled tasks from queue

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/WorkerThreadModuleImpl.kt
@@ -54,7 +54,9 @@ class WorkerThreadModuleImpl : WorkerThreadModule, RejectedExecutionHandler {
                     storedTelemetryRunnableComparator,
                 )
             } else {
-                ScheduledThreadPoolExecutor(1, threadFactory, this)
+                ScheduledThreadPoolExecutor(1, threadFactory, this).apply {
+                    removeOnCancelPolicy = true
+                }
             }
         }
     }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImpl.kt
@@ -95,11 +95,12 @@ class IntakeServiceImpl(
             )
         }
 
-        // cancel any cache attempts that are already pending to avoid unnecessary I/O.
+        // cancel any cache attempts that are already pending to avoid unnecessary I/O, and evict
+        // from the queue so superseded envelopes aren't retained until the worker drains the runnable
         if (!metadata.complete) {
             val prev = cachingTasks[metadata.envelopeType]
             cachingTasks[metadata.envelopeType] = future
-            prev?.cancel(false)
+            prev?.let { worker.cancelAndRemove(it) }
         }
 
         return future

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImplTest.kt
@@ -284,6 +284,43 @@ class IntakeServiceImplTest {
     }
 
     @Test
+    fun `cancelled cache future is removed from the executor queue`() {
+        val executor = PriorityThreadPoolExecutor(
+            Executors.defaultThreadFactory(),
+            { _, _ -> },
+            1,
+            1,
+            storedTelemetryRunnableComparator,
+        )
+        val latch = CountDownLatch(1)
+        executor.submit(
+            PriorityRunnable(sessionMetadata) {
+                latch.await(1000, TimeUnit.MILLISECONDS)
+            },
+        )
+        val worker = PriorityWorker<StoredTelemetryMetadata>(executor)
+        intakeService = IntakeServiceImpl(
+            schedulingService,
+            payloadStorageService,
+            cacheStorageService,
+            logger,
+            TestPlatformSerializer(),
+            worker,
+        )
+
+        val f1 = intakeService.take(sessionEnvelope, sessionMetadata.copy(complete = false))
+        val f2 = intakeService.take(sessionEnvelope, sessionMetadata.copy(complete = false))
+
+        assertTrue(f1.isCancelled)
+        assertFalse(executor.queue.contains(f1 as Runnable))
+        assertTrue(executor.queue.contains(f2 as Runnable))
+
+        latch.countDown()
+        worker.shutdownAndWait(1000)
+        assertEquals(1, cacheStorageService.storedPayloadCount())
+    }
+
+    @Test
     fun `previous cached session snapshot is cleaned up automatically by IntakeServiceImpl`() {
         executorService.blockingMode = false
         val snapshot1 = StoredTelemetryMetadata(

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/PriorityWorker.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/worker/PriorityWorker.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.worker
 import java.util.concurrent.Callable
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Future
+import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
 /**
@@ -33,6 +34,21 @@ class PriorityWorker<T>(
         callable: Callable<R>,
     ): Future<R> {
         return impl.submit(PriorityCallable(priorityInfo as Any, callable))
+    }
+
+    /**
+     * Cancels [future] and, if cancellation succeeds (i.e. the task hadn't already started
+     * running), removes it from the executor's task queue so it doesn't linger there until the
+     * executor drains it.
+     */
+    fun cancelAndRemove(future: Future<*>): Boolean {
+        val cancelled = future.cancel(false)
+        if (cancelled) {
+            (future as? Runnable)?.let { task ->
+                (impl as? ThreadPoolExecutor)?.remove(task)
+            }
+        }
+        return cancelled
     }
 
     /**

--- a/embrace-android-infra/src/test/kotlin/io/embrace/android/embracesdk/internal/worker/PriorityWorkerTest.kt
+++ b/embrace-android-infra/src/test/kotlin/io/embrace/android/embracesdk/internal/worker/PriorityWorkerTest.kt
@@ -1,0 +1,67 @@
+package io.embrace.android.embracesdk.internal.worker
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+internal class PriorityWorkerTest {
+
+    private val noopComparator = Comparator<Runnable> { _, _ -> 0 }
+
+    @Test
+    fun `cancelAndRemove evicts a still-queued task from a real ThreadPoolExecutor`() {
+        val executor = PriorityThreadPoolExecutor(
+            Executors.defaultThreadFactory(),
+            { _, _ -> },
+            1,
+            1,
+            noopComparator,
+        )
+        val worker = PriorityWorker<String>(executor)
+        val latch = CountDownLatch(1)
+
+        worker.submit("blocker", Runnable { latch.await(1000, TimeUnit.MILLISECONDS) })
+        val queued = worker.submit("queued", Runnable { })
+
+        assertTrue(worker.cancelAndRemove(queued))
+        assertFalse(executor.queue.contains(queued as Runnable))
+
+        latch.countDown()
+        worker.shutdownAndWait(1000)
+    }
+
+    @Test
+    fun `cancelAndRemove is a safe no-op when the executor is not a ThreadPoolExecutor`() {
+        val executor = Executors.newSingleThreadExecutor()
+        val worker = PriorityWorker<String>(executor)
+        val latch = CountDownLatch(1)
+
+        worker.submit("blocker", Runnable { latch.await(1000, TimeUnit.MILLISECONDS) })
+        val queued = worker.submit("queued", Runnable { })
+
+        assertTrue(worker.cancelAndRemove(queued))
+
+        latch.countDown()
+        worker.shutdownAndWait(1000)
+    }
+
+    @Test
+    fun `cancelAndRemove returns false and removes nothing once the task has already run`() {
+        val executor = PriorityThreadPoolExecutor(
+            Executors.defaultThreadFactory(),
+            { _, _ -> },
+            1,
+            1,
+            noopComparator,
+        )
+        val worker = PriorityWorker<String>(executor)
+
+        val future = worker.submit("task", Runnable { })
+        worker.shutdownAndWait(1000)
+
+        assertFalse(worker.cancelAndRemove(future))
+    }
+}


### PR DESCRIPTION
## Goal

Removes cancelled tasks from the queue so that they can be GC'd as soon as they are cancelled. Currently we rely on the worker draining the queue to remove tasks, which is bad if each queue in the task could potentially contain a payload.
