### PR TITLE
Make periodic cache interval configurable via remote config

### DIFF
--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/OtelBehavior.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/OtelBehavior.kt
@@ -32,6 +32,12 @@ interface OtelBehavior {
      */
     fun getMaxSpanEventsPerSessionPart(): Int
 
+    /**
+     * The interval in milliseconds between periodic caching of the in-progress session part to disk.
+     * This is clamped to the range [MIN_PERIODIC_CACHE_INTERVAL_MS]..[MAX_PERIODIC_CACHE_INTERVAL_MS].
+     */
+    fun getPeriodicCacheIntervalMs(): Long
+
     companion object {
 
         /**
@@ -44,3 +50,6 @@ interface OtelBehavior {
 const val DEFAULT_MAX_CUSTOM_SPANS_PER_SESSION_PART: Int = 500
 const val DEFAULT_MAX_INTERNAL_SPANS_PER_SESSION_PART: Int = 1500
 const val DEFAULT_MAX_NETWORK_SPANS_PER_SESSION_PART: Int = 2000
+const val DEFAULT_PERIODIC_CACHE_INTERVAL_MS: Long = 2000L
+const val MIN_PERIODIC_CACHE_INTERVAL_MS: Long = 2000L
+const val MAX_PERIODIC_CACHE_INTERVAL_MS: Long = 120000L

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/OtelBehaviorImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/OtelBehaviorImpl.kt
@@ -33,5 +33,9 @@ class OtelBehaviorImpl(
     override fun getMaxSpanEventsPerSessionPart(): Int =
         dataRemote?.maxSpanEventsPerSessionPart ?: DEFAULT_MAX_SPAN_EVENTS_PER_SESSION_PART
 
+    override fun getPeriodicCacheIntervalMs(): Long =
+        dataRemote?.periodicCacheIntervalMs?.coerceIn(MIN_PERIODIC_CACHE_INTERVAL_MS, MAX_PERIODIC_CACHE_INTERVAL_MS)
+            ?: DEFAULT_PERIODIC_CACHE_INTERVAL_MS
+
     private fun Int?.asSpanLimit(default: Int): Int = this?.coerceAtLeast(0) ?: default
 }

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/OtelBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/OtelBehaviorImplTest.kt
@@ -87,4 +87,59 @@ internal class OtelBehaviorImplTest {
             assertEquals(0, getMaxNetworkSpansPerSessionPart())
         }
     }
+
+    @Test
+    fun `periodic cache interval defaults when no remote config supplied`() {
+        with(createOtelBehavior()) {
+            assertEquals(DEFAULT_PERIODIC_CACHE_INTERVAL_MS, getPeriodicCacheIntervalMs())
+        }
+    }
+
+    @Test
+    fun `periodic cache interval defaults when remote config omits it`() {
+        with(createOtelBehavior(remoteCfg = RemoteConfig(dataConfig = DataRemoteConfig()))) {
+            assertEquals(DEFAULT_PERIODIC_CACHE_INTERVAL_MS, getPeriodicCacheIntervalMs())
+        }
+    }
+
+    @Test
+    fun `periodic cache interval is read from remote config`() {
+        val remote = RemoteConfig(dataConfig = DataRemoteConfig(periodicCacheIntervalMs = 5000L))
+        with(createOtelBehavior(remoteCfg = remote)) {
+            assertEquals(5000L, getPeriodicCacheIntervalMs())
+        }
+    }
+
+    @Test
+    fun `periodic cache interval is clamped to the minimum`() {
+        listOf(-1L, 0L, 1999L).forEach { interval ->
+            val remote = RemoteConfig(dataConfig = DataRemoteConfig(periodicCacheIntervalMs = interval))
+            with(createOtelBehavior(remoteCfg = remote)) {
+                assertEquals(MIN_PERIODIC_CACHE_INTERVAL_MS, getPeriodicCacheIntervalMs())
+            }
+        }
+    }
+
+    @Test
+    fun `periodic cache interval is clamped to the maximum`() {
+        listOf(120001L, Long.MAX_VALUE).forEach { interval ->
+            val remote = RemoteConfig(dataConfig = DataRemoteConfig(periodicCacheIntervalMs = interval))
+            with(createOtelBehavior(remoteCfg = remote)) {
+                assertEquals(MAX_PERIODIC_CACHE_INTERVAL_MS, getPeriodicCacheIntervalMs())
+            }
+        }
+    }
+
+    @Test
+    fun `periodic cache interval bounds are honored`() {
+        assertEquals(2000L, MIN_PERIODIC_CACHE_INTERVAL_MS)
+        assertEquals(120000L, MAX_PERIODIC_CACHE_INTERVAL_MS)
+
+        listOf(MIN_PERIODIC_CACHE_INTERVAL_MS, MAX_PERIODIC_CACHE_INTERVAL_MS).forEach { interval ->
+            val remote = RemoteConfig(dataConfig = DataRemoteConfig(periodicCacheIntervalMs = interval))
+            with(createOtelBehavior(remoteCfg = remote)) {
+                assertEquals(interval, getPeriodicCacheIntervalMs())
+            }
+        }
+    }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/DeliveryModuleImpl.kt
@@ -123,6 +123,7 @@ class DeliveryModuleImpl(
     private val partCacher: PeriodicSessionPartCacher = PeriodicSessionPartCacher(
         workerThreadModule.backgroundWorker(Worker.Background.PeriodicCacheWorker),
         initModule.logger,
+        configService.otelBehavior.getPeriodicCacheIntervalMs(),
     )
 
     override val payloadCachingService: PayloadCachingService = PayloadCachingServiceImpl(

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/cache/CachedConfiguration.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/cache/CachedConfiguration.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.internal.serialization.BinaryVersion
 import kotlinx.serialization.Serializable
 
 @Serializable
-@BinaryVersion(-1697170294738086038)
+@BinaryVersion(-6589151518767578639)
 data class CachedConfiguration(
     val deviceId: String,
     val etag: String?,

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/DataRemoteConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/DataRemoteConfig.kt
@@ -44,4 +44,11 @@ data class DataRemoteConfig(
      */
     @SerialName("max_span_events_per_session_part")
     val maxSpanEventsPerSessionPart: Int? = null,
+
+    /**
+     * The interval in milliseconds between periodic caching of the in-progress session part to disk.
+     * Values are clamped to the range 2000..120000 when this config is read.
+     */
+    @SerialName("periodic_cache_interval_ms")
+    val periodicCacheIntervalMs: Long? = null,
 )


### PR DESCRIPTION
## Goal

Alters the periodic cache interval so that we can tweak it via remote config. This is intended as a short-term control that can be used while wider data persistence improvements take place.
