### PR TITLE
Refresh payload in progress checks

### DIFF
--- a/embrace-android-delivery-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadStorageService.kt
+++ b/embrace-android-delivery-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadStorageService.kt
@@ -115,6 +115,10 @@ class FakePayloadStorageService(
         cachedPayloads.clear()
     }
 
+    fun removePayloadSilently(metadata: StoredTelemetryMetadata) {
+        cachedPayloads.remove(metadata)
+    }
+
     private fun createFakePayload(metadata: StoredTelemetryMetadata) =
         when (metadata.envelopeType) {
             SupportedEnvelopeType.SESSION -> Envelope(data = SessionPartPayload())

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImpl.kt
@@ -139,6 +139,7 @@ class SchedulingServiceImpl(
 
     private fun findNextPayload(): StoredTelemetryMetadata? {
         val payloadsByPriority = storageService.getPayloadsByPriority()
+        reconcileRetryState(payloadsByPriority)
         val payloadToSend = payloadsByPriority
             .filter { !connectionStatus.isPayloadBlocked(it) && it.eligibleForSending() }
             .sortedWith(storedTelemetryComparator)
@@ -148,6 +149,22 @@ class SchedulingServiceImpl(
             payloadToSend,
         )
         return payloadToSend
+    }
+
+    /**
+     * Payloads can be removed from disk by the storage layer (e.g. age/count-based pruning) without
+     * [processDeliveryResult] ever running. Drop any entries that are no longer around
+     * to free up memory.
+     */
+    private fun reconcileRetryState(payloadsOnDisk: List<StoredTelemetryMetadata>) {
+        if (payloadsToRetry.isEmpty()) {
+            return
+        }
+        val onDisk = payloadsOnDisk.toHashSet()
+        payloadsToRetry.keys.filterNot(onDisk::contains).forEach { orphaned ->
+            payloadsToRetry.remove(orphaned)
+            payloadsInProgress.remove(orphaned.envelopeType, orphaned)
+        }
     }
 
     /**

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImplTest.kt
@@ -230,6 +230,25 @@ internal class SchedulingServiceImplTest {
     }
 
     @Test
+    fun `orphaned retry entry from a silently pruned payload does not block later payloads of the same type`() {
+        resetToSingleSessionPartPayload()
+        allSendsFail()
+        waitForResurrectionAndDeliveryAttempt()
+        assertEquals(1, executionService.sendAttempts())
+
+        // simulate the storage layer pruning the payload off disk without going through delete(),
+        // leaving it orphaned in payloadsToRetry/payloadsInProgress
+        storageService.removePayloadSilently(fakeSessionStoredTelemetryMetadata)
+        assertEquals(0, storageService.storedPayloadCount())
+
+        // a new payload of the same envelope type should still be deliverable
+        allSendsSucceed()
+        storageService.addFakePayload(fakeSessionStoredTelemetryMetadata2)
+        waitForPayloadIntakeAndDeliveryAttempt()
+        assertEquals(2, executionService.sendAttempts())
+    }
+
+    @Test
     fun `losing network will cause payload sends to stop and reconnection makes it start again`() {
         allSendsFail()
         switchToConnectionType(ConnectionType.WAN, 2)


### PR DESCRIPTION
## Goal

The scheduling service does not check whether payloads exist on disk. Check each time something is scheduled and remove deleted payloads from the in-progress cache, so they can't block delivery.
