### PR TITLE
Initialize instrumentation async

### DIFF
--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/DataSourceStateTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/DataSourceStateTest.kt
@@ -4,6 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.fakes.FakeDataSource
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RuntimeEnvironment
@@ -14,11 +15,14 @@ internal class DataSourceStateTest {
     @Test
     fun `test config gate defaults to enabled`() {
         val source = FakeDataSource(RuntimeEnvironment.getApplication())
-        DataSourceState(
+        val state = DataSourceState(
             factory = { source },
         )
 
         // data capture is enabled by default.
+        assertEquals(source, state.dataSource)
+
+        state.enableDataCapture()
         assertEquals(1, source.enableDataCaptureCount)
         assertEquals(0, source.disableDataCaptureCount)
     }
@@ -26,12 +30,13 @@ internal class DataSourceStateTest {
     @Test
     fun `test config gate enabled`() {
         val source = FakeDataSource(RuntimeEnvironment.getApplication())
-        DataSourceState(
+        val state = DataSourceState(
             factory = { source },
             configGate = { true },
         )
+        assertEquals(source, state.dataSource)
 
-        // data capture is enabled by default.
+        state.enableDataCapture()
         assertEquals(1, source.enableDataCaptureCount)
         assertEquals(0, source.disableDataCaptureCount)
     }
@@ -39,13 +44,22 @@ internal class DataSourceStateTest {
     @Test
     fun `test config gate disabled`() {
         val source = FakeDataSource(RuntimeEnvironment.getApplication())
-        DataSourceState(
+        val state = DataSourceState(
             factory = { source },
             configGate = { false },
         )
+        assertNull(state.dataSource)
 
-        // data capture is enabled by default.
+        // enabling data capture is a no-op when the config gate is closed
+        state.enableDataCapture()
         assertEquals(0, source.enableDataCaptureCount)
         assertEquals(0, source.disableDataCaptureCount)
+    }
+
+    @Test
+    fun `constructing the state does not enable data capture`() {
+        val source = FakeDataSource(RuntimeEnvironment.getApplication())
+        DataSourceState(factory = { source })
+        assertEquals(0, source.enableDataCaptureCount)
     }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistryTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistryTest.kt
@@ -11,7 +11,9 @@ import io.embrace.android.embracesdk.internal.arch.datasource.DataSource
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
 import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
 import io.embrace.android.embracesdk.internal.logging.InternalLoggerImpl
+import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -74,6 +76,47 @@ internal class InstrumentationRegistryTest {
         registry.onPostSessionChange()
         assertEquals(1, dataSource.sessionEnds)
         assertEquals(1, dataSource.sessionChanges)
+    }
+
+    @Test
+    fun `async provider registers and enables capture on a worker, not the calling thread`() {
+        val executor = BlockingScheduledExecutorService(blockingMode = true)
+        val args = FakeInstrumentationArgs(
+            application = ApplicationProvider.getApplicationContext(),
+            backgroundWorkerSupplier = { BackgroundWorker(executor) },
+        )
+        var registerCount = 0
+        val provider = FakeInstrumentationProvider(
+            action = { registerCount++ },
+            dataSourceState = DataSourceState(factory = { dataSource }),
+            asyncInit = true,
+        )
+
+        registry.loadInstrumentations(listOf(provider), args)
+
+        // nothing ran on the calling thread - it was all deferred to the worker
+        assertEquals(0, registerCount)
+        assertNull(registry.findByType(FakeDataSource::class))
+        assertEquals(0, dataSource.enableDataCaptureCount)
+
+        // register and the enable callback both happen in a single worker task
+        executor.runCurrentlyBlocked()
+        assertEquals(1, registerCount)
+        assertEquals(dataSource, registry.findByType(FakeDataSource::class))
+        assertEquals(1, dataSource.enableDataCaptureCount)
+    }
+
+    @Test
+    fun `sync provider enables capture on the calling thread`() {
+        val args = FakeInstrumentationArgs(ApplicationProvider.getApplicationContext())
+        val provider = FakeInstrumentationProvider(
+            action = {},
+            dataSourceState = DataSourceState(factory = { dataSource }),
+        )
+
+        registry.loadInstrumentations(listOf(provider), args)
+        assertEquals(dataSource, registry.findByType(FakeDataSource::class))
+        assertEquals(1, dataSource.enableDataCaptureCount)
     }
 
     @Test

--- a/embrace-android-instrumentation-androidx-navigation/api/embrace-android-instrumentation-androidx-navigation.api
+++ b/embrace-android-instrumentation-androidx-navigation/api/embrace-android-instrumentation-androidx-navigation.api
@@ -6,6 +6,7 @@ public final class io/embrace/android/embracesdk/instrumentation/androidx/naviga
 public final class io/embrace/android/embracesdk/instrumentation/androidx/navigation/internal/AndroidxNavigationInstrumentationProvider : io/embrace/android/embracesdk/internal/arch/InstrumentationProvider {
 	public static final field $stable I
 	public fun <init> ()V
+	public fun getAsyncInit ()Z
 	public fun getPriority ()I
 	public fun register (Lio/embrace/android/embracesdk/internal/arch/InstrumentationArgs;)Lio/embrace/android/embracesdk/internal/arch/datasource/DataSourceState;
 }

--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationProvider.kt
@@ -7,7 +7,8 @@ import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
 class FakeInstrumentationProvider(
     override val priority: Int = 10000,
     private val action: (k: Int) -> Unit,
-    private val dataSourceState: DataSourceState<*>? = null
+    private val dataSourceState: DataSourceState<*>? = null,
+    override val asyncInit: Boolean = false,
 ) : InstrumentationProvider {
 
     override fun register(args: InstrumentationArgs): DataSourceState<*>? {

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationProvider.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationProvider.kt
@@ -25,4 +25,11 @@ interface InstrumentationProvider {
      */
     val priority: Int
         get() = 10000
+
+    /**
+     * Whether this instrumentation's [register] call should be executed on a background worker
+     * rather than on the main thread. Defaults to false.
+     */
+    val asyncInit: Boolean
+        get() = false
 }

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistryImpl.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationRegistryImpl.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
 import io.embrace.android.embracesdk.internal.arch.datasource.StateDataSource
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
+import io.embrace.android.embracesdk.internal.worker.Worker
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.reflect.KClass
 
@@ -40,6 +41,8 @@ class InstrumentationRegistryImpl(
 
     override fun add(state: DataSourceState<*>) {
         dataSourceStates.add(state)
+        // enable data capture once the state is registered
+        state.enableDataCapture()
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -61,13 +64,23 @@ class InstrumentationRegistryImpl(
     ) {
         val loader = instrumentationProviders.sortedBy { it.priority }
         loader.forEach { provider ->
-            try {
-                provider.register(args)?.let { dataSourceState ->
-                    add(dataSourceState)
+            if (provider.asyncInit) {
+                args.backgroundWorker(Worker.Background.NonIoRegWorker).submit {
+                    registerProvider(provider, args)
                 }
-            } catch (exc: Throwable) {
-                logger.trackInternalError(InternalErrorType.InstrumentationRegFail, exc)
+            } else {
+                registerProvider(provider, args)
             }
+        }
+    }
+
+    private fun registerProvider(provider: InstrumentationProvider, args: InstrumentationArgs) {
+        try {
+            provider.register(args)?.let { dataSourceState ->
+                add(dataSourceState)
+            }
+        } catch (exc: Throwable) {
+            logger.trackInternalError(InternalErrorType.InstrumentationRegFail, exc)
         }
     }
 

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/DataSourceState.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/datasource/DataSourceState.kt
@@ -23,10 +23,19 @@ class DataSourceState<T : DataSource>(
 
     private val factoryRef = lazy(factory)
 
+    /**
+     * The data source, or null if [configGate] disabled data capture. A non-null value means data
+     * capture is enabled, but does not imply [enableDataCapture] has run yet.
+     */
     var dataSource: T? = when {
-        configGate() -> factoryRef.value?.apply {
-            onDataCaptureEnabled()
-        }
+        configGate() -> factoryRef.value
         else -> null
+    }
+
+    /**
+     * Invokes [DataSource.onDataCaptureEnabled] if data capture is enabled, otherwise does nothing.
+     */
+    fun enableDataCapture() {
+        dataSource?.onDataCaptureEnabled()
     }
 }

--- a/embrace-android-instrumentation-app-exit-info/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/AeiDataSourceImplTest.kt
+++ b/embrace-android-instrumentation-app-exit-info/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/AeiDataSourceImplTest.kt
@@ -4,6 +4,7 @@ import android.app.ActivityManager
 import android.app.ApplicationExitInfo
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeKeyValueStore
 import io.embrace.android.embracesdk.fakes.FakeOrdinalStore
 import io.embrace.android.embracesdk.fakes.behavior.FakeAppExitInfoBehavior
@@ -11,6 +12,7 @@ import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.arch.datasource.LogSeverity
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
@@ -80,8 +82,9 @@ internal class AeiDataSourceImplTest {
     private fun startApplicationExitInfoService(
         versionChecker: VersionChecker = BuildVersionChecker,
         activityManagerProvider: Provider<ActivityManager?> = { mockActivityManager },
+        logger: FakeInternalLogger = FakeInternalLogger(),
     ) {
-        args = FakeInstrumentationArgs(mockk(), configService = configService)
+        args = FakeInstrumentationArgs(mockk(), configService = configService, logger = logger)
         applicationExitInfoService = AeiDataSourceImpl(
             args,
             worker,
@@ -468,10 +471,14 @@ internal class AeiDataSourceImplTest {
         } throws NullPointerException()
 
         // when the service is started
-        startApplicationExitInfoService()
+        val logger = FakeInternalLogger(throwOnInternalError = false)
+        startApplicationExitInfoService(logger = logger)
 
-        // no logs were sent
+        // no logs were sent, and the failure was tracked as an internal error
         assertTrue(args.destination.logEvents.isEmpty())
+        val internalError = logger.internalErrorMessages.single()
+        assertEquals(InternalErrorType.ProcessAeiRecords.toString(), internalError.msg)
+        assertTrue(internalError.throwable is NullPointerException)
     }
 
     @Test


### PR DESCRIPTION
## Goal

Adds the ability to initialize instrumentation asynchronously with a `DataSource` and converts `AeiDataSource` to use this as an initial test. Fundamentally we are already processing AEI records asynchronously, but we load the instrumentation at SDK init time on the main thread.

If this approach seems good, I'll aim to move a few more non-critical `DataSource` implementations to the background.

## Testing

Relied on existing test coverage.
