### PR TITLE
Fix synchronization of start calls

### DIFF
--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -93,6 +93,7 @@ internal class EmbraceImpl(
 
     private val logger get() = bootstrapper.initModule.logger
     private val clock get() = bootstrapper.initModule.clock
+    private val startStopLock = Any()
 
     @Volatile
     private var applicationInitStartMs: Long? = null
@@ -100,33 +101,35 @@ internal class EmbraceImpl(
     private var internalInterfaceModule: InternalInterfaceModule? = null
 
     override fun start(context: Context) {
-        try {
-            if (!bootstrapper.init(context)) {
-                return
-            }
-            bootstrapper.postInit()
+        synchronized(startStopLock) {
+            try {
+                if (!bootstrapper.init(context)) {
+                    return
+                }
+                bootstrapper.postInit()
 
-            EmbTrace.trace("post-services-setup") {
-                internalInterfaceModule = InternalInterfaceModuleImpl(
-                    bootstrapper.initModule,
-                    bootstrapper.configService,
-                    bootstrapper.payloadSourceModule,
-                    this,
-                    bootstrapper,
-                )
+                EmbTrace.trace("post-services-setup") {
+                    internalInterfaceModule = InternalInterfaceModuleImpl(
+                        bootstrapper.initModule,
+                        bootstrapper.configService,
+                        bootstrapper.payloadSourceModule,
+                        this,
+                        bootstrapper,
+                    )
 
-                // not fully initialized, but the SDK shouldn't catastrophically throw after this point,
-                // so we allow external calls.
-                sdkCallChecker.started.set(true)
-                bootstrapper.registerListeners()
-                bootstrapper.loadInstrumentation()
-                initializeHucInstrumentation(bootstrapper.configService.networkBehavior)
-                bootstrapper.postLoadInstrumentation()
-                bootstrapper.triggerPayloadSend()
-                bootstrapper.markSdkInitComplete()
+                    // not fully initialized, but the SDK shouldn't catastrophically throw after this point,
+                    // so we allow external calls.
+                    sdkCallChecker.started.set(true)
+                    bootstrapper.registerListeners()
+                    bootstrapper.loadInstrumentation()
+                    initializeHucInstrumentation(bootstrapper.configService.networkBehavior)
+                    bootstrapper.postLoadInstrumentation()
+                    bootstrapper.triggerPayloadSend()
+                    bootstrapper.markSdkInitComplete()
+                }
+            } catch (ignored: Throwable) {
+                Log.w("Embrace", "Failed to initialize Embrace SDK", ignored)
             }
-        } catch (ignored: Throwable) {
-            Log.w("Embrace", "Failed to initialize Embrace SDK", ignored)
         }
     }
 
@@ -161,29 +164,33 @@ internal class EmbraceImpl(
      * Shuts down the Embrace SDK.
      */
     fun stop() {
-        sdkCallChecker.started.set(false)
-        bootstrapper.stop()
+        synchronized(startStopLock) {
+            sdkCallChecker.started.set(false)
+            bootstrapper.stop()
+        }
     }
 
     override fun disable() {
-        if (sdkCallChecker.started.get()) {
-            bootstrapper.openTelemetryModule.otelSdkConfig.disableDataExport()
-            val rootDir = bootstrapper.coreModule.context.filesDir
-            val fallbackDir = bootstrapper.coreModule.context.cacheDir
-            stop()
-            Executors.newSingleThreadExecutor().execute {
-                runCatching {
-                    StorageLocation.entries.map {
-                        it.asFile(
-                            logger = null,
-                            rootDirSupplier = { rootDir },
-                            fallbackDirSupplier = { fallbackDir },
-                        ).value
-                    }.forEach {
-                        it.deleteRecursively()
+        synchronized(startStopLock) {
+            if (sdkCallChecker.started.get()) {
+                bootstrapper.openTelemetryModule.otelSdkConfig.disableDataExport()
+                val rootDir = bootstrapper.coreModule.context.filesDir
+                val fallbackDir = bootstrapper.coreModule.context.cacheDir
+                stop()
+                Executors.newSingleThreadExecutor().execute {
+                    runCatching {
+                        StorageLocation.entries.map {
+                            it.asFile(
+                                logger = null,
+                                rootDirSupplier = { rootDir },
+                                fallbackDirSupplier = { fallbackDir },
+                            ).value
+                        }.forEach {
+                            it.deleteRecursively()
+                        }
+                    }.onFailure { exception ->
+                        Log.e("[Embrace]", "An error occurred while trying to disable Embrace SDK.", exception)
                     }
-                }.onFailure { exception ->
-                    Log.e("[Embrace]", "An error occurred while trying to disable Embrace SDK.", exception)
                 }
             }
         }

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -73,52 +73,47 @@ internal class ModuleInitBootstrapper(
             if (isInitialized()) {
                 return@trace false
             }
-            synchronized(delegate) {
-                if (isInitialized()) {
-                    return@trace false
-                }
-                // stamped before anything else so that the SDK init span covers all the work below
-                val startTimeMs = initModule.clock.now()
-                val keyValueStore = lazy { createKeyValueStore(context, initModule.jsonSerializer) }
-                val persistedConfig = EmbTrace.trace("persisted-config-load") {
-                    PersistedConfig(
-                        serializer = initModule.jsonSerializer,
-                        filesDir = context.filesDir,
-                        instrumentedConfig = initModule.instrumentedConfig,
-                        keyValueStore = keyValueStore,
-                        uuidSource = initModule.uuidSource,
-                    )
-                }
-                openTelemetryModule.setOtelBehavior(persistedConfig.otelBehavior)
-
-                val workerThreadModule = EmbTrace.trace("workerthread-init") {
-                    workerThreadModuleSupplier?.invoke() ?: WorkerThreadModuleImpl()
-                }
-                prewarmSharedPreferences(context, workerThreadModule)
-                delegate = InitializedModuleGraph(
-                    context,
-                    versionChecker,
-                    startTimeMs,
-                    initModule,
-                    openTelemetryModule,
-                    workerThreadModule,
-                    keyValueStore,
-                    persistedConfig,
-                    coreModuleSupplier,
-                    configServiceSupplier,
-                    storageServiceSupplier,
-                    essentialServiceModuleSupplier,
-                    featureModuleSupplier,
-                    instrumentationModuleSupplier,
-                    dataCaptureServiceModuleSupplier,
-                    deliveryModuleSupplier,
-                    threadBlockageServiceSupplier,
-                    logModuleSupplier,
-                    userSessionOrchestrationModuleSupplier,
-                    payloadSourceModuleSupplier,
+            // stamped before anything else so that the SDK init span covers all the work below
+            val startTimeMs = initModule.clock.now()
+            val keyValueStore = lazy { createKeyValueStore(context, initModule.jsonSerializer) }
+            val persistedConfig = EmbTrace.trace("persisted-config-load") {
+                PersistedConfig(
+                    serializer = initModule.jsonSerializer,
+                    filesDir = context.filesDir,
+                    instrumentedConfig = initModule.instrumentedConfig,
+                    keyValueStore = keyValueStore,
+                    uuidSource = initModule.uuidSource,
                 )
-                isInitialized()
             }
+            openTelemetryModule.setOtelBehavior(persistedConfig.otelBehavior)
+
+            val workerThreadModule = EmbTrace.trace("workerthread-init") {
+                workerThreadModuleSupplier?.invoke() ?: WorkerThreadModuleImpl()
+            }
+            prewarmSharedPreferences(context, workerThreadModule)
+            delegate = InitializedModuleGraph(
+                context,
+                versionChecker,
+                startTimeMs,
+                initModule,
+                openTelemetryModule,
+                workerThreadModule,
+                keyValueStore,
+                persistedConfig,
+                coreModuleSupplier,
+                configServiceSupplier,
+                storageServiceSupplier,
+                essentialServiceModuleSupplier,
+                featureModuleSupplier,
+                instrumentationModuleSupplier,
+                dataCaptureServiceModuleSupplier,
+                deliveryModuleSupplier,
+                threadBlockageServiceSupplier,
+                logModuleSupplier,
+                userSessionOrchestrationModuleSupplier,
+                payloadSourceModuleSupplier,
+            )
+            isInitialized()
         } catch (ignored: SdkDisabledException) {
             // do nothing - avoid instantiating SDK code any more than necessary.
             false
@@ -129,13 +124,9 @@ internal class ModuleInitBootstrapper(
         if (!isInitialized()) {
             return
         }
-        synchronized(delegate) {
-            if (isInitialized()) {
-                essentialServiceModule.networkConnectivityService.close()
-                workerThreadModule.close()
-                delegate = UninitializedModuleGraph
-            }
-        }
+        essentialServiceModule.networkConnectivityService.close()
+        workerThreadModule.close()
+        delegate = UninitializedModuleGraph
     }
 
     private fun isInitialized(): Boolean = delegate != UninitializedModuleGraph


### PR DESCRIPTION
## Goal

Properly synchronizes on `Embrace.start()`, along with `stop()` and `disable()`. Previously we were relying on `ModuleInitBootstrapper.init()` which did not exclude every potential double-call.
