### PR TITLE
Alter OTLP export to avoid runBlocking

### DIFF
--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogRecordExporter.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeLogRecordExporter.kt
@@ -1,19 +1,27 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.internal.otel.export.InlineExporter
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.logging.export.LogRecordExporter
 import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
 
-class FakeLogRecordExporter : LogRecordExporter {
+class FakeLogRecordExporter : LogRecordExporter, InlineExporter<ReadableLogRecord> {
 
     val exportedLogs: MutableList<ReadableLogRecord> = mutableListOf()
+    var forceFlushCount: Int = 0
+        private set
 
-    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode {
+    override fun exportInline(telemetry: List<ReadableLogRecord>): OperationResultCode {
         exportedLogs += telemetry
         return OperationResultCode.Success
     }
 
+    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode = exportInline(telemetry)
+
     override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
 
-    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun forceFlush(): OperationResultCode {
+        forceFlushCount++
+        return OperationResultCode.Success
+    }
 }

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanExporter.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSpanExporter.kt
@@ -1,18 +1,26 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.internal.otel.export.InlineExporter
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.tracing.data.SpanData
 import io.opentelemetry.kotlin.tracing.export.SpanExporter
 
-class FakeSpanExporter : SpanExporter {
+class FakeSpanExporter : SpanExporter, InlineExporter<SpanData> {
 
     val exportedSpans: MutableList<SpanData> = mutableListOf()
+    var forceFlushCount: Int = 0
+        private set
 
-    override suspend fun export(telemetry: List<SpanData>): OperationResultCode {
+    override fun exportInline(telemetry: List<SpanData>): OperationResultCode {
         exportedSpans += telemetry
         return OperationResultCode.Success
     }
 
-    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun export(telemetry: List<SpanData>): OperationResultCode = exportInline(telemetry)
+
+    override suspend fun forceFlush(): OperationResultCode {
+        forceFlushCount++
+        return OperationResultCode.Success
+    }
     override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.otel.config
 
 import io.embrace.android.embracesdk.internal.SystemInfo
+import io.embrace.android.embracesdk.internal.otel.export.ExternalExportDispatcher
 import io.embrace.android.embracesdk.internal.otel.logs.DefaultLogRecordExporter
 import io.embrace.android.embracesdk.internal.otel.logs.EmbraceLogRecordProcessor
 import io.embrace.android.embracesdk.internal.otel.logs.LogSink
@@ -36,6 +37,7 @@ class OtelSdkConfig(
     private val userIdProvider: () -> String? = { null },
     private val eventMetadataProvider: () -> Map<String, String> = { emptyMap() },
     private val processIdentifierProvider: () -> String = IdGenerator.Companion::generateLaunchInstanceId,
+    private val externalExportDispatcher: ExternalExportDispatcher = ExternalExportDispatcher(),
 ) {
 
     private val customAttributes: MutableMap<String, String> = ConcurrentHashMap()
@@ -81,11 +83,16 @@ class OtelSdkConfig(
         exportEnabled = false
     }
 
-    private val spanExporter: SpanExporter by lazy {
+    fun shutdownExport() {
+        externalExportDispatcher.shutdown()
+    }
+
+    private val spanExporter: DefaultSpanExporter by lazy {
         DefaultSpanExporter(
             spanRepository = spanRepository,
             externalExporters = externalSpanExporters.toList(),
             exportCheck = exportCheck,
+            externalExportDispatcher = externalExportDispatcher,
         )
     }
     val spanProcessor: SpanProcessor by lazy {
@@ -97,11 +104,12 @@ class OtelSdkConfig(
         )
     }
 
-    private val logRecordExporter: LogRecordExporter by lazy {
+    private val logRecordExporter: DefaultLogRecordExporter by lazy {
         DefaultLogRecordExporter(
             logSink = logSink,
             externalExporters = externalLogExporters.toList(),
             exportCheck = exportCheck,
+            externalExportDispatcher = externalExportDispatcher,
         )
     }
 

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/export/ExternalExportDispatcher.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/export/ExternalExportDispatcher.kt
@@ -1,0 +1,76 @@
+package io.embrace.android.embracesdk.internal.otel.export
+
+import io.embrace.android.embracesdk.internal.utils.EmbTrace
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExecutorCoroutineDispatcher
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.job
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import java.util.concurrent.Executors
+
+/**
+ * Runs export to customer-supplied OTel exporters away from the thread that produced the telemetry.
+ *
+ * A customer exporter is arbitrary suspending code - an OTLP exporter performs network I/O - so
+ * exporting inline would block whichever thread ended a span or emitted a log.
+ */
+class ExternalExportDispatcher(
+    dispatcherProvider: () -> CoroutineDispatcher = ::singleThreadedDispatcher,
+) {
+
+    private val lazyDispatcher = lazy(dispatcherProvider)
+    private val lazyScope = lazy { CoroutineScope(SupervisorJob() + lazyDispatcher.value) }
+
+    /**
+     * Exports to every exporter in [exporters] on the export thread and returns immediately. Each
+     * exporter is isolated: one that throws neither stops the others nor propagates into the app.
+     */
+    fun <E> dispatch(exporters: List<E>, export: suspend (E) -> Unit) {
+        lazyScope.value.launch {
+            EmbTrace.trace("otel-external-export") {
+                exporters.forEach { exporter ->
+                    try {
+                        export(exporter)
+                    } catch (ignored: Throwable) {
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Suspends until everything dispatched before this call has finished exporting.
+     */
+    suspend fun awaitPendingExports() {
+        if (!lazyScope.isInitialized()) {
+            return
+        }
+        lazyScope.value.coroutineContext.job.children.toList().joinAll()
+    }
+
+    /**
+     * Releases the export thread once the exports already queued have run.
+     */
+    fun shutdown() {
+        if (!lazyDispatcher.isInitialized()) {
+            return
+        }
+        (lazyDispatcher.value as? ExecutorCoroutineDispatcher)?.close()
+    }
+
+    private companion object {
+
+        /**
+         * Single-threaded so that telemetry reaches the customer in the order the SDK produced it.
+         */
+        fun singleThreadedDispatcher(): CoroutineDispatcher =
+            Executors.newSingleThreadExecutor { runnable ->
+                Executors.defaultThreadFactory().newThread(runnable).apply {
+                    name = "emb-otel-export"
+                }
+            }.asCoroutineDispatcher()
+    }
+}

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/export/InlineExporter.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/export/InlineExporter.kt
@@ -1,0 +1,22 @@
+package io.embrace.android.embracesdk.internal.otel.export
+
+import io.opentelemetry.kotlin.export.OperationResultCode
+
+/**
+ * Exports telemetry to the SDK's own in-memory sinks on the calling thread.
+ */
+interface InlineExporter<T> {
+
+    /**
+     * Stores [telemetry] in the SDK's sink, returning once the caller is able to read it back.
+     * Never suspends and never blocks on I/O.
+     */
+    fun exportInline(telemetry: List<T>): OperationResultCode
+
+    /**
+     * Waits for any export that [exportInline] handed off to another thread to finish. Shares the
+     * signature of the OTel exporters' own `forceFlush` so that a single implementation satisfies
+     * both interfaces.
+     */
+    suspend fun forceFlush(): OperationResultCode
+}

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/DefaultLogRecordExporter.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/DefaultLogRecordExporter.kt
@@ -1,9 +1,10 @@
 package io.embrace.android.embracesdk.internal.otel.logs
 
 import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
+import io.embrace.android.embracesdk.internal.otel.export.ExternalExportDispatcher
+import io.embrace.android.embracesdk.internal.otel.export.InlineExporter
 import io.embrace.android.embracesdk.internal.otel.payload.toEmbracePayload
 import io.embrace.android.embracesdk.internal.otel.sdk.StoreDataResult
-import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.logging.export.LogRecordExporter
 import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
@@ -15,36 +16,32 @@ internal class DefaultLogRecordExporter(
     private val logSink: LogSink,
     private val externalExporters: List<LogRecordExporter>,
     private val exportCheck: () -> Boolean,
-) : LogRecordExporter {
+    private val externalExportDispatcher: ExternalExportDispatcher,
+) : LogRecordExporter, InlineExporter<ReadableLogRecord> {
 
-    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode {
+    override fun exportInline(telemetry: List<ReadableLogRecord>): OperationResultCode {
         if (!exportCheck()) {
             return OperationResultCode.Success
         }
-        val exportable = if (externalExporters.isEmpty()) {
-            emptyList()
-        } else {
-            telemetry.filterNot { it.attributes.containsKey(PrivateSpan.key) }
-        }
-        var result = logSink.storeLogs(telemetry.map(ReadableLogRecord::toEmbracePayload))
+        val result = logSink.storeLogs(telemetry.map(ReadableLogRecord::toEmbracePayload))
 
-        if (externalExporters.isNotEmpty() && result == StoreDataResult.SUCCESS) {
-            EmbTrace.trace("otel-external-export") {
-                externalExporters.forEach { exporter ->
-                    try {
-                        exporter.export(exportable)
-                    } catch (ignored: Throwable) {
-                        result = StoreDataResult.FAILURE
-                    }
-                }
-            }
+        if (result == StoreDataResult.SUCCESS && externalExporters.isNotEmpty()) {
+            val exportable = telemetry.filterNot { it.attributes.containsKey(PrivateSpan.key) }
+            externalExportDispatcher.dispatch(externalExporters) { it.export(exportable) }
         }
+
         return when (result) {
             StoreDataResult.SUCCESS -> OperationResultCode.Success
             StoreDataResult.FAILURE -> OperationResultCode.Failure
         }
     }
 
-    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode = exportInline(telemetry)
+
+    override suspend fun forceFlush(): OperationResultCode {
+        externalExportDispatcher.awaitPendingExports()
+        return OperationResultCode.Success
+    }
+
     override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EmbraceLogRecordProcessor.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EmbraceLogRecordProcessor.kt
@@ -1,15 +1,15 @@
 package io.embrace.android.embracesdk.internal.otel.logs
 
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.otel.export.InlineExporter
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.utils.UuidSource
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.export.OperationResultCode
-import io.opentelemetry.kotlin.logging.export.LogRecordExporter
 import io.opentelemetry.kotlin.logging.export.LogRecordProcessor
 import io.opentelemetry.kotlin.logging.model.ReadWriteLogRecord
+import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
 import io.opentelemetry.kotlin.semconv.LogAttributes
-import kotlinx.coroutines.runBlocking
 
 /**
  * A [LogRecordProcessor] that adds the attributes Embrace requires on every log record, then exports it.
@@ -17,10 +17,10 @@ import kotlinx.coroutines.runBlocking
 internal class EmbraceLogRecordProcessor(
     private val uuidSource: UuidSource,
     private val metadataProvider: Provider<Map<String, String>>,
-    private val logRecordExporter: LogRecordExporter,
+    private val logRecordExporter: InlineExporter<ReadableLogRecord>,
 ) : LogRecordProcessor {
 
-    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun forceFlush(): OperationResultCode = logRecordExporter.forceFlush()
 
     override fun onEmit(log: ReadWriteLogRecord, context: Context) {
         val attributes = log.attributes
@@ -40,7 +40,9 @@ internal class EmbraceLogRecordProcessor(
             }
         }
 
-        runBlocking { logRecordExporter.export(mutableListOf(log)) }
+        // exported on the calling thread: a crash log has to reach the sink before crash teardown
+        // persists the payload and the process dies. See [InlineExporter].
+        logRecordExporter.exportInline(listOf(log))
     }
 
     override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/DefaultSpanExporter.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/DefaultSpanExporter.kt
@@ -1,9 +1,10 @@
 package io.embrace.android.embracesdk.internal.otel.spans
 
 import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
+import io.embrace.android.embracesdk.internal.otel.export.ExternalExportDispatcher
+import io.embrace.android.embracesdk.internal.otel.export.InlineExporter
 import io.embrace.android.embracesdk.internal.otel.sdk.StoreDataResult
 import io.embrace.android.embracesdk.internal.otel.sdk.toEmbracePayload
-import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.tracing.data.SpanData
 import io.opentelemetry.kotlin.tracing.export.SpanExporter
@@ -15,28 +16,18 @@ internal class DefaultSpanExporter(
     private val spanRepository: SpanRepository,
     private val externalExporters: List<SpanExporter>,
     private val exportCheck: () -> Boolean,
-) : SpanExporter {
+    private val externalExportDispatcher: ExternalExportDispatcher,
+) : SpanExporter, InlineExporter<SpanData> {
 
-    override suspend fun export(telemetry: List<SpanData>): OperationResultCode {
+    override fun exportInline(telemetry: List<SpanData>): OperationResultCode {
         if (!exportCheck()) {
             return OperationResultCode.Success
         }
-        val exportable = if (externalExporters.isEmpty()) {
-            emptyList()
-        } else {
-            telemetry.filterNot { it.attributes.containsKey(PrivateSpan.key) }
-        }
-        var result = spanRepository.storeCompletedOtelSpans(telemetry.map(SpanData::toEmbracePayload))
-        if (externalExporters.isNotEmpty() && result == StoreDataResult.SUCCESS) {
-            EmbTrace.trace("otel-external-export") {
-                externalExporters.forEach { exporter ->
-                    try {
-                        exporter.export(exportable)
-                    } catch (ignored: Throwable) {
-                        result = StoreDataResult.FAILURE
-                    }
-                }
-            }
+        val result = spanRepository.storeCompletedOtelSpans(telemetry.map(SpanData::toEmbracePayload))
+
+        if (result == StoreDataResult.SUCCESS && externalExporters.isNotEmpty()) {
+            val exportable = telemetry.filterNot { it.attributes.containsKey(PrivateSpan.key) }
+            externalExportDispatcher.dispatch(externalExporters) { it.export(exportable) }
         }
 
         return when (result) {
@@ -45,7 +36,12 @@ internal class DefaultSpanExporter(
         }
     }
 
-    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun export(telemetry: List<SpanData>): OperationResultCode = exportInline(telemetry)
+
+    override suspend fun forceFlush(): OperationResultCode {
+        externalExportDispatcher.awaitPendingExports()
+        return OperationResultCode.Success
+    }
 
     override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
 }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanProcessor.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanProcessor.kt
@@ -1,22 +1,22 @@
 package io.embrace.android.embracesdk.internal.otel.spans
 
+import io.embrace.android.embracesdk.internal.otel.export.InlineExporter
 import io.embrace.android.embracesdk.internal.session.id.SessionIdsProvider
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.semconv.SessionAttributes
 import io.opentelemetry.kotlin.semconv.UserAttributes
-import io.opentelemetry.kotlin.tracing.export.SpanExporter
+import io.opentelemetry.kotlin.tracing.data.SpanData
 import io.opentelemetry.kotlin.tracing.export.SpanProcessor
 import io.opentelemetry.kotlin.tracing.model.ReadWriteSpan
 import io.opentelemetry.kotlin.tracing.model.ReadableSpan
-import kotlinx.coroutines.runBlocking
 
-class EmbraceSpanProcessor(
+internal class EmbraceSpanProcessor(
     private val sessionIdsProvider: () -> SessionIdsProvider?,
     private val userIdProvider: () -> String? = { null },
     private val processIdentifier: String,
-    private val spanExporter: SpanExporter,
+    private val spanExporter: InlineExporter<SpanData>,
 ) : SpanProcessor {
 
     override fun onStart(span: ReadWriteSpan, parentContext: Context) {
@@ -36,11 +36,11 @@ class EmbraceSpanProcessor(
     }
 
     override fun onEnd(span: ReadableSpan) {
-        runBlocking { spanExporter.export(mutableListOf(span)) }
+        spanExporter.exportInline(listOf(span))
     }
 
     override fun isStartRequired() = true
     override fun isEndRequired() = true
-    override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+    override suspend fun forceFlush(): OperationResultCode = spanExporter.forceFlush()
     override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
 }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/export/ImmediateExportDispatcher.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/export/ImmediateExportDispatcher.kt
@@ -1,0 +1,10 @@
+package io.embrace.android.embracesdk.internal.otel.export
+
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * An [ExternalExportDispatcher] that runs exports on the calling thread, so that a test asserting on
+ * what reached an external exporter doesn't have to drain anything first.
+ */
+internal fun immediateExportDispatcher(): ExternalExportDispatcher =
+    ExternalExportDispatcher { Dispatchers.Unconfined }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/logs/DefaultLogRecordExporterTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/logs/DefaultLogRecordExporterTest.kt
@@ -4,21 +4,37 @@ import io.embrace.android.embracesdk.fakes.FakeAttributesMutator
 import io.embrace.android.embracesdk.fakes.FakeLogRecordExporter
 import io.embrace.android.embracesdk.fakes.FakeReadWriteLogRecord
 import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
+import io.embrace.android.embracesdk.internal.otel.export.ExternalExportDispatcher
+import io.embrace.android.embracesdk.internal.otel.export.immediateExportDispatcher
 import io.embrace.android.embracesdk.internal.otel.payload.toEmbracePayload
+import io.opentelemetry.kotlin.export.OperationResultCode
+import io.opentelemetry.kotlin.logging.export.LogRecordExporter
+import io.opentelemetry.kotlin.logging.model.ReadableLogRecord
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class DefaultLogRecordExporterTest {
 
+    private fun exporter(
+        logSink: LogSink,
+        externalExporters: List<LogRecordExporter> = emptyList(),
+        dispatcher: ExternalExportDispatcher = immediateExportDispatcher(),
+    ) = DefaultLogRecordExporter(
+        logSink = logSink,
+        externalExporters = externalExporters,
+        exportCheck = { true },
+        externalExportDispatcher = dispatcher,
+    )
+
     @Test
     fun `export() should store logs in LogSink`() {
         val logSink: LogSink = LogSinkImpl()
-        val exporter = DefaultLogRecordExporter(logSink, emptyList()) { true }
         val data = FakeReadWriteLogRecord()
 
-        runBlocking { exporter.export(listOf(FakeReadWriteLogRecord())) }
+        runBlocking { exporter(logSink).export(listOf(FakeReadWriteLogRecord())) }
 
         assertFalse(logSink.logsForNextBatch().isEmpty())
         assertEquals(data.toEmbracePayload(), logSink.logsForNextBatch()[0])
@@ -28,7 +44,6 @@ internal class DefaultLogRecordExporterTest {
     fun `private logs should be filtered out from external exporters`() {
         val logSink: LogSink = LogSinkImpl()
         val externalExporter = FakeLogRecordExporter()
-        val exporter = DefaultLogRecordExporter(logSink, listOf(externalExporter)) { true }
         val logKey = "test_log"
         val data = FakeReadWriteLogRecord(body = logKey)
 
@@ -38,7 +53,7 @@ internal class DefaultLogRecordExporterTest {
             },
         )
 
-        runBlocking { exporter.export(listOf(data, privateData)) }
+        exporter(logSink, listOf(externalExporter)).exportInline(listOf(data, privateData))
 
         assertEquals(2, logSink.logsForNextBatch().size)
         assertEquals(data.toEmbracePayload(), logSink.logsForNextBatch()[0])
@@ -46,5 +61,72 @@ internal class DefaultLogRecordExporterTest {
 
         assertEquals(1, externalExporter.exportedLogs.size)
         assertEquals(data.body, externalExporter.exportedLogs.first().body)
+    }
+
+    @Test
+    fun `logs reach the sink before exportInline() returns`() {
+        val logSink: LogSink = LogSinkImpl()
+        val exporter = exporter(logSink, listOf(FakeLogRecordExporter()), ExternalExportDispatcher())
+
+        exporter.exportInline(listOf(FakeReadWriteLogRecord()))
+
+        assertEquals(1, logSink.logsForNextBatch().size)
+    }
+
+    @Test
+    fun `external export runs off the calling thread and is awaited by forceFlush()`() {
+        val exportThreads = mutableListOf<String>()
+        val threadRecordingExporter = object : LogRecordExporter {
+            override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode {
+                exportThreads += Thread.currentThread().name
+                return OperationResultCode.Success
+            }
+
+            override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+            override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+        }
+        val exporter = exporter(LogSinkImpl(), listOf(threadRecordingExporter), ExternalExportDispatcher())
+
+        exporter.exportInline(listOf(FakeReadWriteLogRecord()))
+        runBlocking { exporter.forceFlush() }
+
+        assertTrue(exportThreads.single().startsWith("emb-otel-export"))
+    }
+
+    @Test
+    fun `a throwing external exporter neither stops the others nor fails the internal store`() {
+        val logSink: LogSink = LogSinkImpl()
+        val throwingExporter = object : LogRecordExporter {
+            override suspend fun export(telemetry: List<ReadableLogRecord>): OperationResultCode =
+                throw RuntimeException("boom")
+
+            override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+            override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+        }
+        val workingExporter = FakeLogRecordExporter()
+
+        val result = exporter(logSink, listOf(throwingExporter, workingExporter))
+            .exportInline(listOf(FakeReadWriteLogRecord()))
+
+        assertEquals(OperationResultCode.Success, result)
+        assertEquals(1, logSink.logsForNextBatch().size)
+        assertEquals(1, workingExporter.exportedLogs.size)
+    }
+
+    @Test
+    fun `nothing is exported when the export check fails`() {
+        val logSink: LogSink = LogSinkImpl()
+        val externalExporter = FakeLogRecordExporter()
+        val exporter = DefaultLogRecordExporter(
+            logSink = logSink,
+            externalExporters = listOf(externalExporter),
+            exportCheck = { false },
+            externalExportDispatcher = immediateExportDispatcher(),
+        )
+
+        assertEquals(OperationResultCode.Success, exporter.exportInline(listOf(FakeReadWriteLogRecord())))
+
+        assertTrue(logSink.logsForNextBatch().isEmpty())
+        assertTrue(externalExporter.exportedLogs.isEmpty())
     }
 }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EmbraceLogRecordProcessorTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/logs/EmbraceLogRecordProcessorTest.kt
@@ -6,7 +6,9 @@ import io.embrace.android.embracesdk.fakes.TestUuidSource
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.opentelemetry.kotlin.NoopOpenTelemetry
+import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.semconv.LogAttributes
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -125,6 +127,25 @@ internal class EmbraceLogRecordProcessorTest {
         processor.onEmit(log)
 
         assertEquals("foo", log.attributes[SESSION_ATTRIBUTE_NAME])
+    }
+
+    @Test
+    fun `onEmit() exports before returning, so a crash log reaches the sink before the process dies`() {
+        val log = FakeReadWriteLogRecord()
+
+        processor.onEmit(log)
+
+        // no drain and no waiting: crash teardown persists the payload on the crashing thread
+        // straight after the log is emitted, so anything not yet in the sink is lost
+        assertEquals(log, logRecordExporter.exportedLogs.single())
+    }
+
+    @Test
+    fun `forceFlush() flushes the exporter, which is what drains export dispatched off-thread`() {
+        val result = runBlocking { processor.forceFlush() }
+
+        assertEquals(OperationResultCode.Success, result)
+        assertEquals(1, logRecordExporter.forceFlushCount)
     }
 
     private fun EmbraceLogRecordProcessor.onEmit(log: FakeReadWriteLogRecord) =

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OpenTelemetrySdkTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OpenTelemetrySdkTest.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.fakes.TestUuidSource
 import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.otel.config.OtelSdkConfig
 import io.embrace.android.embracesdk.internal.otel.createSdkOtelInstance
+import io.embrace.android.embracesdk.internal.otel.export.immediateExportDispatcher
 import io.embrace.android.embracesdk.internal.otel.logs.LogSink
 import io.embrace.android.embracesdk.internal.otel.logs.LogSinkImpl
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
@@ -156,6 +157,7 @@ internal class OpenTelemetrySdkTest {
             packageName = "com.test.app",
             systemInfo = systemInfo,
             uuidSource = TestUuidSource(),
+            externalExportDispatcher = immediateExportDispatcher(),
         )
         spanExporter = FakeSpanExporter()
         logExporter = FakeLogRecordExporter()

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/DefaultSpanExporterTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/DefaultSpanExporterTest.kt
@@ -4,12 +4,15 @@ import io.embrace.android.embracesdk.fakes.FakeReadWriteSpan
 import io.embrace.android.embracesdk.fakes.FakeSpan
 import io.embrace.android.embracesdk.fakes.FakeSpanExporter
 import io.embrace.android.embracesdk.internal.arch.schema.PrivateSpan
+import io.embrace.android.embracesdk.internal.otel.export.ExternalExportDispatcher
+import io.embrace.android.embracesdk.internal.otel.export.immediateExportDispatcher
 import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.tracing.data.SpanData
 import io.opentelemetry.kotlin.tracing.export.SpanExporter
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class DefaultSpanExporterTest {
@@ -17,26 +20,54 @@ internal class DefaultSpanExporterTest {
     private fun span(name: String, vararg attrs: Pair<String, String>): SpanData =
         FakeReadWriteSpan(FakeSpan(name = name).apply { this.attrs.putAll(attrs) })
 
+    private fun exporter(
+        spanRepository: SpanRepository,
+        externalExporters: List<SpanExporter> = emptyList(),
+        exportCheck: () -> Boolean = { true },
+        dispatcher: ExternalExportDispatcher = immediateExportDispatcher(),
+    ) = DefaultSpanExporter(
+        spanRepository = spanRepository,
+        externalExporters = externalExporters,
+        exportCheck = exportCheck,
+        externalExportDispatcher = dispatcher,
+    )
+
+    private fun threadRecordingExporter(threads: MutableList<String>) = object : SpanExporter {
+        override suspend fun export(telemetry: List<SpanData>): OperationResultCode {
+            threads += Thread.currentThread().name
+            return OperationResultCode.Success
+        }
+
+        override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+        override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+    }
+
+    private fun throwingExporter() = object : SpanExporter {
+        override suspend fun export(telemetry: List<SpanData>): OperationResultCode =
+            throw RuntimeException("boom")
+
+        override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
+        override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
+    }
+
     @Test
     fun `export() should store spans in SpanRepository`() {
-        val spanRepository: SpanRepository = SpanRepository()
-        val exporter = DefaultSpanExporter(spanRepository, emptyList()) { true }
+        val spanRepository = SpanRepository()
 
-        runBlocking { exporter.export(listOf(span("public-span"))) }
+        runBlocking { exporter(spanRepository).export(listOf(span("public-span"))) }
 
         assertFalse(spanRepository.completedOtelSpans().isEmpty())
     }
 
     @Test
     fun `private spans should be filtered out from external exporters but still stored internally`() {
-        val spanRepository: SpanRepository = SpanRepository()
+        val spanRepository = SpanRepository()
         val externalExporter = FakeSpanExporter()
-        val exporter = DefaultSpanExporter(spanRepository, listOf(externalExporter)) { true }
 
         val publicSpan = span("public-span")
         val privateSpan = span("private-span", PrivateSpan.key to PrivateSpan.value)
 
-        runBlocking { exporter.export(listOf(publicSpan, privateSpan)) }
+        exporter(spanRepository, listOf(externalExporter)).exportInline(listOf(publicSpan, privateSpan))
 
         assertEquals(2, spanRepository.completedOtelSpans().size)
         assertEquals(1, externalExporter.exportedSpans.size)
@@ -44,19 +75,57 @@ internal class DefaultSpanExporterTest {
     }
 
     @Test
-    fun `export() returns failure when an external exporter throws`() {
-        val spanRepository: SpanRepository = SpanRepository()
-        val throwingExporter = object : SpanExporter {
-            override suspend fun export(telemetry: List<SpanData>): OperationResultCode =
-                throw RuntimeException("boom")
+    fun `spans reach the repository before exportInline() returns`() {
+        val spanRepository = SpanRepository()
+        // a real dispatcher, so only a genuinely inline store is visible without draining first
+        val exporter = exporter(
+            spanRepository = spanRepository,
+            externalExporters = listOf(FakeSpanExporter()),
+            dispatcher = ExternalExportDispatcher(),
+        )
 
-            override suspend fun forceFlush(): OperationResultCode = OperationResultCode.Success
-            override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
-        }
-        val exporter = DefaultSpanExporter(spanRepository, listOf(throwingExporter)) { true }
+        exporter.exportInline(listOf(span("public-span")))
 
-        val result = runBlocking { exporter.export(listOf(span("public-span"))) }
+        assertEquals(1, spanRepository.completedOtelSpans().size)
+    }
 
-        assertEquals(OperationResultCode.Failure, result)
+    @Test
+    fun `external export runs off the calling thread and is awaited by forceFlush()`() {
+        val exportThreads = mutableListOf<String>()
+        val exporter = exporter(
+            spanRepository = SpanRepository(),
+            externalExporters = listOf(threadRecordingExporter(exportThreads)),
+            dispatcher = ExternalExportDispatcher(),
+        )
+
+        exporter.exportInline(listOf(span("public-span")))
+        runBlocking { exporter.forceFlush() }
+
+        assertTrue(exportThreads.single().startsWith("emb-otel-export"))
+    }
+
+    @Test
+    fun `a throwing external exporter neither stops the others nor fails the internal store`() {
+        val spanRepository = SpanRepository()
+        val workingExporter = FakeSpanExporter()
+
+        val result = exporter(spanRepository, listOf(throwingExporter(), workingExporter))
+            .exportInline(listOf(span("public-span")))
+
+        assertEquals(OperationResultCode.Success, result)
+        assertEquals(1, spanRepository.completedOtelSpans().size)
+        assertEquals("public-span", workingExporter.exportedSpans.single().name)
+    }
+
+    @Test
+    fun `nothing is exported when the export check fails`() {
+        val spanRepository = SpanRepository()
+        val externalExporter = FakeSpanExporter()
+        val exporter = exporter(spanRepository, listOf(externalExporter), exportCheck = { false })
+
+        assertEquals(OperationResultCode.Success, exporter.exportInline(listOf(span("public-span"))))
+
+        assertTrue(spanRepository.completedOtelSpans().isEmpty())
+        assertTrue(externalExporter.exportedSpans.isEmpty())
     }
 }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanProcessorTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanProcessorTest.kt
@@ -5,8 +5,10 @@ import io.embrace.android.embracesdk.fakes.FakeSessionIdsProvider
 import io.embrace.android.embracesdk.fakes.FakeSpanExporter
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.opentelemetry.kotlin.NoopOpenTelemetry
+import io.opentelemetry.kotlin.export.OperationResultCode
 import io.opentelemetry.kotlin.semconv.SessionAttributes
 import io.opentelemetry.kotlin.semconv.UserAttributes
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Before
@@ -75,6 +77,27 @@ class EmbraceSpanProcessorTest {
         val processor = createProcessor()
         processor.onStart(span, context)
         assertFalse(span.attributes.containsKey(UserAttributes.USER_ID))
+    }
+
+    @Test
+    fun `onEnd() exports before returning, so ending a session part can drain the spans immediately`() {
+        val processor = createProcessor()
+
+        processor.onEnd(span)
+
+        // no drain and no waiting: the span has to be with the exporter by the time onEnd returns,
+        // otherwise a session payload can ship without its own session span
+        assertEquals(span, spanExporter.exportedSpans.single())
+    }
+
+    @Test
+    fun `forceFlush() flushes the exporter, which is what drains export dispatched off-thread`() {
+        val processor = createProcessor()
+
+        val result = runBlocking { processor.forceFlush() }
+
+        assertEquals(OperationResultCode.Success, result)
+        assertEquals(1, spanExporter.forceFlushCount)
     }
 
     private fun createProcessor(userIdProvider: () -> String? = { null }) =

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanServiceImplTest.kt
@@ -849,7 +849,8 @@ internal class SpanServiceImplTest {
             systemInfo = SystemInfo(),
             uuidSource = TestUuidSource(),
             sessionIdsProvider = { FakeSessionIdsProvider(userSessionId = "fake-session-id") },
-        ) { "fake-pid" }
+            processIdentifierProvider = { "fake-pid" },
+        )
         val otelSdkWrapper = OtelSdkWrapper(
             otelClock = otelClock,
             configuration = otelSdkConfig,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/SdkIntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/SdkIntegrationTestRule.kt
@@ -35,6 +35,7 @@ import io.embrace.android.embracesdk.testframework.export.FilteredSpanExporter
 import io.embrace.android.embracesdk.testframework.server.FakeApiServer
 import io.opentelemetry.kotlin.logging.export.toOtelKotlinLogRecordExporter
 import io.opentelemetry.kotlin.tracing.export.toOtelKotlinSpanExporter
+import kotlinx.coroutines.runBlocking
 import okhttp3.Protocol
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Assert.assertEquals
@@ -180,9 +181,18 @@ internal class SdkIntegrationTestRule(
             }
         }
         testCaseAction(action)
+        drainExternalExports()
         assertAction(payloadAssertion)
         spanExporter.failOnDuplicate()
         otelExportAssertion(otelAssertion)
+    }
+
+    private fun drainExternalExports() {
+        val otelSdkConfig = bootstrapper.openTelemetryModule.otelSdkConfig
+        runBlocking {
+            otelSdkConfig.spanProcessor.forceFlush()
+            otelSdkConfig.logRecordProcessor.forceFlush()
+        }
     }
 
     /**

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -125,6 +125,7 @@ internal class ModuleInitBootstrapper(
             return
         }
         essentialServiceModule.networkConnectivityService.close()
+        openTelemetryModule.otelSdkConfig.shutdownExport()
         workerThreadModule.close()
         delegate = UninitializedModuleGraph
     }


### PR DESCRIPTION
## Goal

Fixes the OTLP export pathway so that it doesn't call `runBlocking`.

## Testing

Relied on existing test coverage.
