### PR TITLE
Make app startup counter lazy init

### DIFF
--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleImpl.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleImpl.kt
@@ -19,14 +19,14 @@ class DataCaptureServiceModuleImpl(
     logger: InternalLogger,
     destination: TelemetryDestination,
     configService: ConfigService,
-    appVersionStartupCounter: Int?,
+    appVersionStartupCounterProvider: () -> Int?,
     private val startupClassifier: StartupClassifier,
     versionChecker: VersionChecker = BuildVersionChecker,
 ) : DataCaptureServiceModule {
 
     override val startupService: StartupService = StartupServiceImpl(
         destination = destination,
-        appVersionStartupCounter = appVersionStartupCounter,
+        appVersionStartupCounterProvider = appVersionStartupCounterProvider,
     )
 
     override val appStartupDataCollector: AppStartupDataCollector = AppStartupTraceEmitter(

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleSupplier.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleSupplier.kt
@@ -16,7 +16,7 @@ typealias DataCaptureServiceModuleSupplier = (
     logger: InternalLogger,
     destination: TelemetryDestination,
     configService: ConfigService,
-    appVersionStartupCounter: Int?,
+    appVersionStartupCounterProvider: () -> Int?,
     startupClassifier: StartupClassifier,
     versionChecker: VersionChecker,
 ) -> DataCaptureServiceModule

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/StartupServiceImpl.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/StartupServiceImpl.kt
@@ -6,10 +6,10 @@ import io.embrace.android.embracesdk.semconv.EmbAppAttributes
 
 internal class StartupServiceImpl(
     private val destination: TelemetryDestination,
-    appVersionStartupCounter: Int?,
+    appVersionStartupCounterProvider: () -> Int?,
 ) : StartupService {
 
-    private val appVersionStartupCounter: Int? = appVersionStartupCounter?.takeIf { it > 0 }
+    private val startupCounter: Int? by lazy { appVersionStartupCounterProvider()?.takeIf { it > 0 } }
 
     @Volatile
     private var sdkInitStartMs: Long? = null
@@ -37,8 +37,8 @@ internal class StartupServiceImpl(
             val attributes = buildMap {
                 put("ended-in-foreground", foregroundEnd.toString())
                 put("thread-name", threadName)
-                if (appVersionStartupCounter != null) {
-                    put(EmbAppAttributes.EMB_APP_VERSION_STARTUP_COUNTER, appVersionStartupCounter.toString())
+                startupCounter?.let { counter ->
+                    put(EmbAppAttributes.EMB_APP_VERSION_STARTUP_COUNTER, counter.toString())
                 }
             }
             destination.recordCompletedSpan(
@@ -59,5 +59,5 @@ internal class StartupServiceImpl(
     override fun getSdkInitStartMs(): Long? = sdkInitStartMs
     override fun getSdkInitEndMs(): Long? = sdkInitEndMs
     override fun getInitThreadName(): String = threadName
-    override fun getAppVersionStartupCounter(): Int? = appVersionStartupCounter
+    override fun getAppVersionStartupCounter(): Int? = startupCounter
 }

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleImplTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/DataCaptureServiceModuleImplTest.kt
@@ -20,7 +20,7 @@ internal class DataCaptureServiceModuleImplTest {
             logger = FakeInternalLogger(),
             destination = FakeTelemetryDestination(),
             configService = FakeConfigService(),
-            appVersionStartupCounter = 1,
+            appVersionStartupCounterProvider = { 1 },
             startupClassifier = StartupClassifierImpl(),
         )
 
@@ -40,7 +40,7 @@ internal class DataCaptureServiceModuleImplTest {
             configService = FakeConfigService(
                 autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(uiLoadTracingEnabled = false),
             ),
-            appVersionStartupCounter = 1,
+            appVersionStartupCounterProvider = { 1 },
             startupClassifier = StartupClassifierImpl(),
         )
 
@@ -57,7 +57,7 @@ internal class DataCaptureServiceModuleImplTest {
             configService = FakeConfigService(
                 autoDataCaptureBehavior = FakeAutoDataCaptureBehavior(uiLoadTracingTraceAll = false),
             ),
-            appVersionStartupCounter = 1,
+            appVersionStartupCounterProvider = { 1 },
             startupClassifier = StartupClassifierImpl(),
         )
 

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/AppStartupTraceEmitterTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/AppStartupTraceEmitterTest.kt
@@ -71,7 +71,7 @@ internal class AppStartupTraceEmitterTest {
     fun setUp() {
         clock = FakeClock(processInitTime)
         destination = FakeTelemetryDestination()
-        startupService = StartupServiceImpl(destination, APP_VERSION_STARTUP_COUNTER)
+        startupService = StartupServiceImpl(destination) { APP_VERSION_STARTUP_COUNTER }
         clock.tick(100L)
         logger = FakeInternalLogger(false)
         firePreAndPostCreate = hasPrePostEvents(BuildVersionChecker)

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/StartupServiceImplTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/StartupServiceImplTest.kt
@@ -27,7 +27,7 @@ internal class StartupServiceImplTest {
         clock = FakeClock(10000000)
         backgroundWorker = fakeBackgroundWorker()
         destination = FakeTelemetryDestination()
-        startupService = StartupServiceImpl(destination, appVersionStartupCounter = 3)
+        startupService = StartupServiceImpl(destination, appVersionStartupCounterProvider = { 3 })
     }
 
     @Test
@@ -58,7 +58,7 @@ internal class StartupServiceImplTest {
 
     @Test
     fun `invalid app version startup counter omitted from SDK startup span`() {
-        startupService = StartupServiceImpl(destination, appVersionStartupCounter = -1)
+        startupService = StartupServiceImpl(destination, appVersionStartupCounterProvider = { -1 })
         startupService.setSdkStartupInfo(
             startTimeMs = 10,
             endTimeMs = 20,

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
@@ -184,7 +184,7 @@ internal class InitializedModuleGraph(
             initModule.logger,
             destination,
             configService,
-            coreModule.appVersionStartupCounter,
+            { coreModule.appVersionStartupCounter },
             initModule.startupClassifier,
             versionChecker,
         ) ?: DataCaptureServiceModuleImpl(
@@ -192,7 +192,7 @@ internal class InitializedModuleGraph(
             initModule.logger,
             destination,
             configService,
-            coreModule.appVersionStartupCounter,
+            { coreModule.appVersionStartupCounter },
             initModule.startupClassifier,
             versionChecker,
         )


### PR DESCRIPTION
## Goal

Alters the app startup counter to use lazy init so that it isn't resolved until later in SDK initialization. This allows `SharedPreferences` a chance to prewarm.
