### PR TITLE
Avoid storing screen resolution in shared prefs

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
@@ -86,10 +86,9 @@ class PayloadSourceModuleImpl(
             device = EmbTrace.trace("deviceImpl") {
                 DeviceImpl(
                     windowManagerProvider = { coreModule.context.getSystemServiceSafe(Context.WINDOW_SERVICE) },
-                    coreModule.store,
-                    workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker),
-                    initModule.systemInfo,
-                    initModule.logger,
+                    backgroundWorker = workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker),
+                    systemInfo = initModule.systemInfo,
+                    logger = initModule.logger,
                 )
             },
             rnBundleIdProvider = { rnBundleIdTracker.getReactNativeBundleId() },

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/Device.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/Device.kt
@@ -15,7 +15,6 @@ interface Device {
     /**
      * Gets the device's screen resolution.
      *
-     * @param windowManager the {@link WindowManager} from the {@link Context}
      * @return the device's screen resolution
      */
     val screenResolution: String

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/DeviceImpl.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/DeviceImpl.kt
@@ -9,7 +9,6 @@ import io.embrace.android.embracesdk.internal.SystemInfo
 import io.embrace.android.embracesdk.internal.isEmulator
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
-import io.embrace.android.embracesdk.internal.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import java.io.File
@@ -17,7 +16,6 @@ import java.util.Locale
 
 class DeviceImpl(
     private val windowManagerProvider: Provider<WindowManager?>,
-    private val store: KeyValueStore,
     private val backgroundWorker: BackgroundWorker,
     override val systemInfo: SystemInfo,
     private val logger: InternalLogger,
@@ -50,19 +48,8 @@ class DeviceImpl(
     }
 
     private fun asyncRetrieveScreenResolution() {
-        // if the screenResolution exists in memory, don't try to retrieve it
-        if (screenResolution.isNotEmpty()) {
-            return
-        }
         backgroundWorker.submit {
-            val storedScreenResolution = persistedScreenResolution
-            // get from shared preferences
-            if (storedScreenResolution != null) {
-                screenResolution = storedScreenResolution
-            } else {
-                screenResolution = getScreenResolution(windowManagerProvider())
-                persistedScreenResolution = screenResolution
-            }
+            screenResolution = getScreenResolution(windowManagerProvider())
         }
     }
 
@@ -130,12 +117,4 @@ class DeviceImpl(
         } else {
             null
         }
-
-    private var persistedScreenResolution: String?
-        get() = store.getString(SCREEN_RESOLUTION_KEY)
-        set(value) = store.edit { putString(SCREEN_RESOLUTION_KEY, value) }
-
-    private companion object {
-        private const val SCREEN_RESOLUTION_KEY = "io.embrace.screen.resolution"
-    }
 }


### PR DESCRIPTION
## Goal

Avoid storing screen resolution in shared prefs as it's probably faster to make the API call than retrieve from disk.
