### PR TITLE
Batch shared preferences writes

### DIFF
--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/DeviceIdProvider.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/DeviceIdProvider.kt
@@ -23,7 +23,7 @@ internal class DeviceIdProvider(
 
     private fun newDeviceId(): String {
         val newId = uuidSource.createUuid()
-        keyValueStore.value.edit {
+        keyValueStore.value.editAndCommit {
             putString(DEVICE_IDENTIFIER_KEY, newId)
         }
         return newId

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/DeviceIdProviderTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/DeviceIdProviderTest.kt
@@ -37,7 +37,7 @@ internal class DeviceIdProviderTest {
     @Test
     fun `falls back to the persisted store value when there is no cached id`() {
         val store = FakeKeyValueStore().apply {
-            edit { putString(key, "persisted-id") }
+            editAndCommit { putString(key, "persisted-id") }
         }
         val provider = DeviceIdProvider(lazyOf(store), cachedDeviceId = null, uuidSource = TestUuidSource())
 

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/PersistedConfigTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/PersistedConfigTest.kt
@@ -66,7 +66,7 @@ internal class PersistedConfigTest {
     @Test
     fun `device id sourced from key value store when not co-cached`() {
         val store = FakeKeyValueStore().apply {
-            edit { putString("io.embrace.deviceid", "persisted-device-id") }
+            editAndCommit { putString("io.embrace.deviceid", "persisted-device-id") }
         }
         val persistedConfig = createPersistedConfig(store = lazyOf(store))
         assertEquals("persisted-device-id", persistedConfig.deviceId)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
@@ -53,8 +53,10 @@ internal class EmbraceMetadataService(
      */
     override fun precomputeValues() {
         metadataBackgroundWorker.submit {
-            appVersion = res.appVersion
-            osVersion = res.osVersion
+            store.batch {
+                appVersion = res.appVersion
+                osVersion = res.osVersion
+            }
             val free = statFs.freeBytes
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && configService.autoDataCaptureBehavior.isDiskUsageCaptureEnabled()) {
                 val deviceDiskAppUsage = getDeviceDiskAppUsage(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceMetadataService.kt
@@ -42,11 +42,11 @@ internal class EmbraceMetadataService(
 
     private var appVersion: String?
         get() = store.getString(PREVIOUS_APP_VERSION_KEY)
-        set(value) = store.edit { putString(PREVIOUS_APP_VERSION_KEY, value) }
+        set(value) = store.editAndCommit { putString(PREVIOUS_APP_VERSION_KEY, value) }
 
     private var osVersion: String?
         get() = store.getString(PREVIOUS_OS_VERSION_KEY)
-        set(value) = store.edit { putString(PREVIOUS_OS_VERSION_KEY, value) }
+        set(value) = store.editAndCommit { putString(PREVIOUS_OS_VERSION_KEY, value) }
 
     /**
      * Queues in a single thread executor callables to retrieve values in background

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/RnBundleIdTrackerImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/RnBundleIdTrackerImpl.kt
@@ -79,11 +79,11 @@ internal class RnBundleIdTrackerImpl(
 
     private var javaScriptBundleURL: String?
         get() = store.getString(JAVA_SCRIPT_BUNDLE_URL_KEY)
-        set(value) = store.edit { putString(JAVA_SCRIPT_BUNDLE_URL_KEY, value) }
+        set(value) = store.editAndCommit { putString(JAVA_SCRIPT_BUNDLE_URL_KEY, value) }
 
     private var javaScriptBundleId: String?
         get() = store.getString(JAVA_SCRIPT_BUNDLE_ID_KEY)
-        set(value) = store.edit { putString(JAVA_SCRIPT_BUNDLE_ID_KEY, value) }
+        set(value) = store.editAndCommit { putString(JAVA_SCRIPT_BUNDLE_ID_KEY, value) }
 
     companion object {
         private const val JAVA_SCRIPT_BUNDLE_URL_KEY = "io.embrace.jsbundle.url"

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/session/EmbraceUserSessionProperties.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/session/EmbraceUserSessionProperties.kt
@@ -26,7 +26,7 @@ internal class EmbraceUserSessionProperties(
     }
 
     private fun persistPermanentProperties() {
-        store.edit {
+        store.editAndCommit {
             putStringMap(
                 SESSION_PROPERTIES_KEY,
                 properties.entries

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/user/EmbraceUserService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/user/EmbraceUserService.kt
@@ -162,10 +162,12 @@ internal class EmbraceUserService(
     }
 
     override fun clearAllUserInfo() {
-        clearUserIdentifier()
-        clearUserEmail()
-        clearUsername()
-        clearAllUserPersonas()
+        impl.batch {
+            clearUserIdentifier()
+            clearUserEmail()
+            clearUsername()
+            clearAllUserPersonas()
+        }
     }
 
     override fun addUserInfoListener(listener: () -> Unit) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/user/EmbraceUserService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/user/EmbraceUserService.kt
@@ -26,23 +26,23 @@ internal class EmbraceUserService(
 
     private var userPayer: Boolean
         get() = impl.getBoolean(USER_IS_PAYER_KEY, false)
-        set(value) = impl.edit { putBoolean(USER_IS_PAYER_KEY, value) }
+        set(value) = impl.editAndCommit { putBoolean(USER_IS_PAYER_KEY, value) }
 
     private var userId: String?
         get() = impl.getString(USER_IDENTIFIER_KEY)
-        set(value) = impl.edit { putString(USER_IDENTIFIER_KEY, value) }
+        set(value) = impl.editAndCommit { putString(USER_IDENTIFIER_KEY, value) }
 
     private var userEmailAddress: String?
         get() = impl.getString(USER_EMAIL_ADDRESS_KEY)
-        set(value) = impl.edit { putString(USER_EMAIL_ADDRESS_KEY, value) }
+        set(value) = impl.editAndCommit { putString(USER_EMAIL_ADDRESS_KEY, value) }
 
     private var userPersonas: Set<String>?
         get() = impl.getStringSet(USER_PERSONAS_KEY)
-        set(value) = impl.edit { putStringSet(USER_PERSONAS_KEY, value) }
+        set(value) = impl.editAndCommit { putStringSet(USER_PERSONAS_KEY, value) }
 
     private var name: String?
         get() = impl.getString(USER_USERNAME_KEY)
-        set(value) = impl.edit { putString(USER_USERNAME_KEY, value) }
+        set(value) = impl.editAndCommit { putString(USER_USERNAME_KEY, value) }
 
     private fun isUsersFirstDay(): Boolean {
         val installDate = installDate
@@ -51,7 +51,7 @@ internal class EmbraceUserService(
 
     private var installDate: Long?
         get() = impl.getLong(INSTALL_DATE_KEY)
-        set(value) = impl.edit { putLong(INSTALL_DATE_KEY, value) }
+        set(value) = impl.editAndCommit { putLong(INSTALL_DATE_KEY, value) }
 
     init {
         if (installDate == null) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
@@ -67,6 +67,7 @@ class UserSessionOrchestrationModuleImpl(
             essentialServiceModule.telemetryDestination,
             sessionPartSpanAttrPopulator,
             coreModule.ordinalStore,
+            coreModule.store,
             UserSessionMetadataStore(coreModule.store),
             initModule.logger,
             workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker),

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/SharedPrefsStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/SharedPrefsStore.kt
@@ -66,7 +66,7 @@ internal class SharedPrefsStore(
         }
     }
 
-    override fun edit(action: KeyValueStoreEditor.() -> Unit) {
+    override fun editAndCommit(action: KeyValueStoreEditor.() -> Unit) {
         val batch = openBatch.get()
         if (batch != null) {
             batch.action()

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/SharedPrefsStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/SharedPrefsStore.kt
@@ -25,44 +25,132 @@ internal class SharedPrefsStore(
     private val serializer: PlatformSerializer,
 ) : KeyValueStore {
 
+    private val openBatch = ThreadLocal<Batch?>()
+
     override fun getString(key: String): String? {
-        return impl.getString(key, null)
+        return pending(key) { impl.getString(key, null) }
     }
 
     override fun getInt(key: String): Int? {
-        val defaultValue: Int = -1
-        return when (val value = impl.getInt(key, defaultValue)) {
-            defaultValue -> null
-            else -> value
+        return pending(key) {
+            val defaultValue: Int = -1
+            when (val value = impl.getInt(key, defaultValue)) {
+                defaultValue -> null
+                else -> value
+            }
         }
     }
 
     override fun getLong(key: String): Long? {
-        val defaultValue: Long = -1L
-        return when (val value = impl.getLong(key, defaultValue)) {
-            defaultValue -> null
-            else -> value
+        return pending(key) {
+            val defaultValue: Long = -1L
+            when (val value = impl.getLong(key, defaultValue)) {
+                defaultValue -> null
+                else -> value
+            }
         }
     }
 
     override fun getBoolean(key: String, defaultValue: Boolean): Boolean {
-        return impl.getBoolean(key, defaultValue)
+        return pending<Boolean>(key) { impl.getBoolean(key, defaultValue) } ?: defaultValue
     }
 
     override fun getStringSet(key: String): Set<String>? {
-        return impl.getStringSet(key, null)
+        return pending(key) { impl.getStringSet(key, null) }
     }
 
     override fun getStringMap(key: String): Map<String, String>? {
-        val mapString = impl.getString(key, null) ?: return null
-        return serializer.fromJson(mapString, mapSerializer)
+        return pending(key) {
+            val mapString = impl.getString(key, null) ?: return@pending null
+            serializer.fromJson(mapString, mapSerializer)
+        }
     }
 
     override fun edit(action: KeyValueStoreEditor.() -> Unit) {
-        SharedPrefsStoreEditor(impl.edit(), serializer).use {
-            it.action()
+        val batch = openBatch.get()
+        if (batch != null) {
+            batch.action()
+        } else {
+            SharedPrefsStoreEditor(impl.edit(), serializer).use {
+                it.action()
+            }
         }
     }
+
+    override fun batch(action: () -> Unit) {
+        if (openBatch.get() != null) { // a batch is already open on this thread, so it owns the commit
+            action()
+            return
+        }
+        val batch = Batch()
+        openBatch.set(batch)
+        try {
+            action()
+        } finally {
+            openBatch.remove()
+            batch.flush()
+        }
+    }
+
+    /**
+     * Returns the value buffered by the batch open on this thread, falling back to [read] if there
+     * is no open batch or the batch hasn't written [key].
+     */
+    private inline fun <reified T> pending(key: String, read: () -> T?): T? {
+        val batch = openBatch.get() ?: return read()
+        val write = batch.writes[key] ?: return read()
+        return write.value as? T
+    }
+
+    private fun Batch.flush() {
+        if (writes.isEmpty()) {
+            return
+        }
+        SharedPrefsStoreEditor(impl.edit(), serializer).use { editor ->
+            writes.values.forEach { it.write(editor) }
+        }
+    }
+
+    /**
+     * Buffers writes so they can be replayed against a real editor in one commit.
+     */
+    private class Batch : KeyValueStoreEditor {
+
+        val writes = LinkedHashMap<String, PendingWrite>()
+
+        override fun putString(key: String, value: String?) {
+            writes[key] = PendingWrite(value) { it.putString(key, value) }
+        }
+
+        override fun putInt(key: String, value: Int?) {
+            writes[key] = PendingWrite(value) { it.putInt(key, value) }
+        }
+
+        override fun putLong(key: String, value: Long?) {
+            writes[key] = PendingWrite(value) { it.putLong(key, value) }
+        }
+
+        override fun putBoolean(key: String, value: Boolean?) {
+            writes[key] = PendingWrite(value ?: false) { it.putBoolean(key, value) }
+        }
+
+        override fun putStringSet(key: String, value: Set<String>?) {
+            writes[key] = PendingWrite(value) { it.putStringSet(key, value) }
+        }
+
+        override fun putStringMap(key: String, value: Map<String, String>?) {
+            writes[key] = PendingWrite(value) { it.putStringMap(key, value) }
+        }
+
+        override fun close() {
+            // the batch is committed when the outermost batch block exits, not per edit
+        }
+    }
+
+    private class PendingWrite(
+        val value: Any?,
+        val write: (KeyValueStoreEditor) -> Unit,
+    )
 
     private companion object {
         val mapSerializer = MapSerializer(String.serializer(), String.serializer())

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStore.kt
@@ -17,7 +17,7 @@ internal class UserSessionMetadataStore(private val store: KeyValueStore) {
      * Persists the given [UserSessionMetadata.Classified] to the store.
      */
     fun save(metadata: UserSessionMetadata.Classified) {
-        store.edit {
+        store.editAndCommit {
             val map = metadata.attributes.mapValues { it.value.toString() }.toMutableMap()
             map[EmbSessionAttributes.EMB_USER_SESSION_PART_INDEX] = metadata.partIndex.toString()
             map[KEY_LAST_ACTIVITY_TS] = metadata.lastActivityMs.toString()
@@ -29,7 +29,7 @@ internal class UserSessionMetadataStore(private val store: KeyValueStore) {
      * Clears the persisted session from the store.
      */
     fun clear() {
-        store.edit {
+        store.editAndCommit {
             putStringMap(KEY_SESSION, null)
         }
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -28,6 +28,7 @@ import io.embrace.android.embracesdk.internal.session.UserSessionState
 import io.embrace.android.embracesdk.internal.session.UserSessionState.Active
 import io.embrace.android.embracesdk.internal.session.id.SessionPartTracker
 import io.embrace.android.embracesdk.internal.session.message.PayloadFactory
+import io.embrace.android.embracesdk.internal.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.store.Ordinal
 import io.embrace.android.embracesdk.internal.store.OrdinalStore
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
@@ -54,6 +55,7 @@ internal class SessionOrchestratorImpl(
     private val destination: TelemetryDestination,
     private val sessionPartSpanAttrPopulator: SessionPartSpanAttrPopulator,
     private val ordinalStore: OrdinalStore,
+    private val store: KeyValueStore,
     private val metadataStore: UserSessionMetadataStore,
     private val logger: InternalLogger,
     private val backgroundWorker: BackgroundWorker,
@@ -351,87 +353,90 @@ internal class SessionOrchestratorImpl(
                 return
             }
 
-            EmbTrace.trace("transition-state-start") {
-                // first, disable any previous periodic caching so the job doesn't overwrite the to-be saved session
-                payloadCachingService?.stopCaching()
+            // batch the prefs writes made by the ordinal & metadata stores into a single commit
+            store.batch {
+                EmbTrace.trace("transition-state-start") {
+                    // first, disable any previous periodic caching so the job doesn't overwrite the to-be saved session
+                    payloadCachingService?.stopCaching()
 
-                val endingSession = sessionTracker.getActiveSessionPart()
-                if (endingSession != null) {
-                    sessionPartSpanAttrPopulator.populateSessionPartSpanEndAttrs(
-                        endType = transitionType.lifeEventType(state),
-                        crashId = crashId,
-                        coldStart = endingSession.isColdStart,
-                        endAttributes = transitionType.endAttributes,
-                    )
-                }
-
-                // calculate new session state
-                val endAppState = transitionType.postTransitionEndState(state)
-                val newSessionPart = sessionTracker.newActiveSessionPart(
-                    endSessionPartCallback = {
-                        // End the current session or background activity, if either exist.
-                        EmbTrace.trace("end-current-session") {
-                            processEndMessage(oldSessionAction?.invoke(this), transitionType)
-                        }
-                    },
-                    startSessionPartCallback = {
-                        // the previous session has fully ended at this point
-                        // now, we can clear the SDK state and prepare for the next session
-                        EmbTrace.trace("prepare-new-session") {
-                            boundaryDelegate.cleanupAfterSessionEnd()
-                        }
-
-                        // transition the user session before creating the new session part so that
-                        // the user session is always ready
-                        transitionUserSession(transitionType, endAppState, timestamp)
-
-                        // create the next session part span if we should, and update the SDK state to reflect the transition
-                        EmbTrace.trace("create-new-session") {
-                            newSessionAction?.invoke()
-                        }
-                    },
-                    postTransitionProcessState = endAppState,
-                )
-
-                // update the current state of the SDK
-                state = endAppState
-
-                // update newly created session part and user session, if applicable
-                val userSession = currentUserSession()
-                if (newSessionPart != null) {
-                    if (userSession != null) {
-                        // persist partIndex to handle user session restoration in new process
-                        setActiveUserSession(userSession.withPartIndex(newSessionPart.userSessionPartIndex))
-
-                        if (endAppState == ProcessState.FOREGROUND) {
-                            sessionTracker.setProcessStateSummary(newSessionPart.sessionPartId, userSession.userSessionId)
-                        }
+                    val endingSession = sessionTracker.getActiveSessionPart()
+                    if (endingSession != null) {
+                        sessionPartSpanAttrPopulator.populateSessionPartSpanEndAttrs(
+                            endType = transitionType.lifeEventType(state),
+                            crashId = crashId,
+                            coldStart = endingSession.isColdStart,
+                            endAttributes = transitionType.endAttributes,
+                        )
                     }
-                    boundaryDelegate.prepareForNewSession()
-                    sessionPartSpanAttrPopulator.populateSessionPartSpanStartAttrs(newSessionPart, userSession)
-                    if (transitionType != TransitionType.CRASH) {
-                        // initiate periodic caching of the payload if a new session has started
-                        EmbTrace.trace("initiate-periodic-caching") {
-                            updatePeriodicCacheAttrs()
-                            val updateIntervalMs = lastActivityUpdateIntervalMs(userSession)
-                            payloadCachingService?.startCaching(newSessionPart, endAppState) { state, timestamp, zygote ->
-                                synchronized(lock) {
-                                    if (state == ProcessState.FOREGROUND) {
-                                        updateUserSessionActivityIfStale(
-                                            timestamp = timestamp,
-                                            updateIntervalMs = updateIntervalMs,
-                                        )
+
+                    // calculate new session state
+                    val endAppState = transitionType.postTransitionEndState(state)
+                    val newSessionPart = sessionTracker.newActiveSessionPart(
+                        endSessionPartCallback = {
+                            // End the current session or background activity, if either exist.
+                            EmbTrace.trace("end-current-session") {
+                                processEndMessage(oldSessionAction?.invoke(this), transitionType)
+                            }
+                        },
+                        startSessionPartCallback = {
+                            // the previous session has fully ended at this point
+                            // now, we can clear the SDK state and prepare for the next session
+                            EmbTrace.trace("prepare-new-session") {
+                                boundaryDelegate.cleanupAfterSessionEnd()
+                            }
+
+                            // transition the user session before creating the new session part so that
+                            // the user session is always ready
+                            transitionUserSession(transitionType, endAppState, timestamp)
+
+                            // create the next session part span if we should, and update the SDK state to reflect the transition
+                            EmbTrace.trace("create-new-session") {
+                                newSessionAction?.invoke()
+                            }
+                        },
+                        postTransitionProcessState = endAppState,
+                    )
+
+                    // update the current state of the SDK
+                    state = endAppState
+
+                    // update newly created session part and user session, if applicable
+                    val userSession = currentUserSession()
+                    if (newSessionPart != null) {
+                        if (userSession != null) {
+                            // persist partIndex to handle user session restoration in new process
+                            setActiveUserSession(userSession.withPartIndex(newSessionPart.userSessionPartIndex))
+
+                            if (endAppState == ProcessState.FOREGROUND) {
+                                sessionTracker.setProcessStateSummary(newSessionPart.sessionPartId, userSession.userSessionId)
+                            }
+                        }
+                        boundaryDelegate.prepareForNewSession()
+                        sessionPartSpanAttrPopulator.populateSessionPartSpanStartAttrs(newSessionPart, userSession)
+                        if (transitionType != TransitionType.CRASH) {
+                            // initiate periodic caching of the payload if a new session has started
+                            EmbTrace.trace("initiate-periodic-caching") {
+                                updatePeriodicCacheAttrs()
+                                val updateIntervalMs = lastActivityUpdateIntervalMs(userSession)
+                                payloadCachingService?.startCaching(newSessionPart, endAppState) { state, timestamp, zygote ->
+                                    synchronized(lock) {
+                                        if (state == ProcessState.FOREGROUND) {
+                                            updateUserSessionActivityIfStale(
+                                                timestamp = timestamp,
+                                                updateIntervalMs = updateIntervalMs,
+                                            )
+                                        }
+                                        updatePeriodicCacheAttrs()
+                                        payloadFactory.snapshotPayload(state, timestamp, zygote)
                                     }
-                                    updatePeriodicCacheAttrs()
-                                    payloadFactory.snapshotPayload(state, timestamp, zygote)
                                 }
                             }
                         }
+                    } else if (transitionType == TransitionType.ON_BACKGROUND) {
+                        // if a new session hasn't been created when we background, cache an empty envelope to be used
+                        // in case a native crash needs to be sent in the future after the current process dies
+                        payloadStore?.cacheEmptyCrashEnvelope(payloadFactory.createEmptyLogEnvelope())
                     }
-                } else if (transitionType == TransitionType.ON_BACKGROUND) {
-                    // if a new session hasn't been created when we background, cache an empty envelope to be used
-                    // in case a native crash needs to be sent in the future after the current process dies
-                    payloadStore?.cacheEmptyCrashEnvelope(payloadFactory.createEmptyLogEnvelope())
                 }
             }
         }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/store/KeyValueStoreTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/store/KeyValueStoreTest.kt
@@ -13,6 +13,8 @@ import io.embrace.android.embracesdk.internal.store.KeyValueStore
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -63,5 +65,119 @@ internal class KeyValueStoreTest {
         assertEquals(boolValue, store.getBoolean("bool", false))
         assertEquals(setValue, store.getStringSet("set"))
         assertEquals(mapValue, store.getStringMap("map"))
+    }
+
+    @Test
+    fun `values written in a batch are readable before and after it commits`() {
+        val setValue = setOf("a", "b")
+        val mapValue = mapOf("a" to "b")
+
+        store.batch {
+            store.edit { putString("string", "value") }
+            store.edit { putInt("int", 1) }
+            store.edit { putLong("long", 2L) }
+            store.edit { putBoolean("bool", true) }
+            store.edit { putStringSet("set", setValue) }
+            store.edit { putStringMap("map", mapValue) }
+
+            assertEquals("value", store.getString("string"))
+            assertEquals(1, store.getInt("int"))
+            assertEquals(2L, store.getLong("long"))
+            assertTrue(store.getBoolean("bool", false))
+            assertEquals(setValue, store.getStringSet("set"))
+            assertEquals(mapValue, store.getStringMap("map"))
+        }
+
+        assertEquals("value", store.getString("string"))
+        assertEquals(1, store.getInt("int"))
+        assertEquals(2L, store.getLong("long"))
+        assertTrue(store.getBoolean("bool", false))
+        assertEquals(setValue, store.getStringSet("set"))
+        assertEquals(mapValue, store.getStringMap("map"))
+    }
+
+    @Test
+    fun `a batch reads through to committed values it has not written`() {
+        store.edit { putString("string", "committed") }
+
+        store.batch {
+            assertEquals("committed", store.getString("string"))
+            store.edit { putString("other", "pending") }
+            assertEquals("committed", store.getString("string"))
+        }
+    }
+
+    @Test
+    fun `a null written in a batch shadows a committed value`() {
+        store.edit {
+            putString("string", "committed")
+            putStringSet("set", setOf("a"))
+            putStringMap("map", mapOf("a" to "b"))
+            putInt("int", 1)
+            putLong("long", 2L)
+            putBoolean("bool", true)
+        }
+
+        store.batch {
+            store.edit {
+                putString("string", null)
+                putStringSet("set", null)
+                putStringMap("map", null)
+                putInt("int", null)
+                putLong("long", null)
+                putBoolean("bool", null)
+            }
+            assertNull(store.getString("string"))
+            assertNull(store.getStringSet("set"))
+            assertNull(store.getStringMap("map"))
+            assertNull(store.getInt("int"))
+            assertNull(store.getLong("long"))
+            assertFalse(store.getBoolean("bool", true))
+        }
+
+        assertNull(store.getString("string"))
+        assertNull(store.getStringSet("set"))
+        assertNull(store.getStringMap("map"))
+        assertNull(store.getInt("int"))
+        assertNull(store.getLong("long"))
+        assertFalse(store.getBoolean("bool", true))
+    }
+
+    @Test
+    fun `the last write to a key in a batch wins`() {
+        store.batch {
+            store.edit { putStringMap("map", mapOf("a" to "b")) }
+            store.edit { putStringMap("map", mapOf("c" to "d")) }
+        }
+        assertEquals(mapOf("c" to "d"), store.getStringMap("map"))
+    }
+
+    @Test
+    fun `a nested batch defers its commit to the outer batch`() {
+        store.batch {
+            store.edit { putString("outer", "a") }
+            store.batch {
+                store.edit { putString("inner", "b") }
+            }
+            // the inner batch joined the outer one, so nothing has been committed yet
+            assertEquals("b", store.getString("inner"))
+        }
+        assertEquals("a", store.getString("outer"))
+        assertEquals("b", store.getString("inner"))
+    }
+
+    @Test
+    fun `a batch commits what it buffered even if the action throws`() {
+        assertThrows(IllegalStateException::class.java) {
+            store.batch {
+                store.edit { putString("string", "value") }
+                error("boom")
+            }
+        }
+        assertEquals("value", store.getString("string"))
+
+        // the failed batch was cleaned up, so subsequent edits commit immediately again
+        store.edit { putString("other", "value") }
+        assertEquals("value", store.getString("other"))
     }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/store/KeyValueStoreTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/arch/store/KeyValueStoreTest.kt
@@ -51,7 +51,7 @@ internal class KeyValueStoreTest {
         val setValue = setOf("a", "b")
         val mapValue = mapOf("a" to "b")
 
-        store.edit {
+        store.editAndCommit {
             putString("string", strValue)
             putInt("int", intValue)
             putLong("long", longValue)
@@ -73,12 +73,12 @@ internal class KeyValueStoreTest {
         val mapValue = mapOf("a" to "b")
 
         store.batch {
-            store.edit { putString("string", "value") }
-            store.edit { putInt("int", 1) }
-            store.edit { putLong("long", 2L) }
-            store.edit { putBoolean("bool", true) }
-            store.edit { putStringSet("set", setValue) }
-            store.edit { putStringMap("map", mapValue) }
+            store.editAndCommit { putString("string", "value") }
+            store.editAndCommit { putInt("int", 1) }
+            store.editAndCommit { putLong("long", 2L) }
+            store.editAndCommit { putBoolean("bool", true) }
+            store.editAndCommit { putStringSet("set", setValue) }
+            store.editAndCommit { putStringMap("map", mapValue) }
 
             assertEquals("value", store.getString("string"))
             assertEquals(1, store.getInt("int"))
@@ -98,18 +98,18 @@ internal class KeyValueStoreTest {
 
     @Test
     fun `a batch reads through to committed values it has not written`() {
-        store.edit { putString("string", "committed") }
+        store.editAndCommit { putString("string", "committed") }
 
         store.batch {
             assertEquals("committed", store.getString("string"))
-            store.edit { putString("other", "pending") }
+            store.editAndCommit { putString("other", "pending") }
             assertEquals("committed", store.getString("string"))
         }
     }
 
     @Test
     fun `a null written in a batch shadows a committed value`() {
-        store.edit {
+        store.editAndCommit {
             putString("string", "committed")
             putStringSet("set", setOf("a"))
             putStringMap("map", mapOf("a" to "b"))
@@ -119,7 +119,7 @@ internal class KeyValueStoreTest {
         }
 
         store.batch {
-            store.edit {
+            store.editAndCommit {
                 putString("string", null)
                 putStringSet("set", null)
                 putStringMap("map", null)
@@ -146,8 +146,8 @@ internal class KeyValueStoreTest {
     @Test
     fun `the last write to a key in a batch wins`() {
         store.batch {
-            store.edit { putStringMap("map", mapOf("a" to "b")) }
-            store.edit { putStringMap("map", mapOf("c" to "d")) }
+            store.editAndCommit { putStringMap("map", mapOf("a" to "b")) }
+            store.editAndCommit { putStringMap("map", mapOf("c" to "d")) }
         }
         assertEquals(mapOf("c" to "d"), store.getStringMap("map"))
     }
@@ -155,9 +155,9 @@ internal class KeyValueStoreTest {
     @Test
     fun `a nested batch defers its commit to the outer batch`() {
         store.batch {
-            store.edit { putString("outer", "a") }
+            store.editAndCommit { putString("outer", "a") }
             store.batch {
-                store.edit { putString("inner", "b") }
+                store.editAndCommit { putString("inner", "b") }
             }
             // the inner batch joined the outer one, so nothing has been committed yet
             assertEquals("b", store.getString("inner"))
@@ -170,14 +170,14 @@ internal class KeyValueStoreTest {
     fun `a batch commits what it buffered even if the action throws`() {
         assertThrows(IllegalStateException::class.java) {
             store.batch {
-                store.edit { putString("string", "value") }
+                store.editAndCommit { putString("string", "value") }
                 error("boom")
             }
         }
         assertEquals("value", store.getString("string"))
 
         // the failed batch was cleaned up, so subsequent edits commit immediately again
-        store.edit { putString("other", "value") }
+        store.editAndCommit { putString("other", "value") }
         assertEquals("value", store.getString("other"))
     }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceRnBundleIdTrackerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceRnBundleIdTrackerTest.kt
@@ -70,7 +70,7 @@ internal class EmbraceRnBundleIdTrackerTest {
 
     @Test
     fun `test React Native bundle ID from preference if jsBundleIdUrl is the same as the value persisted `() {
-        store.edit {
+        store.editAndCommit {
             putString(JAVA_SCRIPT_BUNDLE_URL_KEY, "javaScriptBundleURL")
         }
         val metadataService = createRnBundleIdTracker()
@@ -81,7 +81,7 @@ internal class EmbraceRnBundleIdTrackerTest {
 
     @Test
     fun `test React Native bundle ID from preference if jsBundleIdUrl is a new value`() {
-        store.edit {
+        store.editAndCommit {
             putString(JAVA_SCRIPT_BUNDLE_URL_KEY, "oldJavaScriptBundleURL")
         }
         val metadataService = createRnBundleIdTracker()
@@ -129,7 +129,7 @@ internal class EmbraceRnBundleIdTrackerTest {
     fun `test React Native bundle ID url as Asset with forceUpdate param in false`() {
         val bundleIdFile = Files.createTempFile("bundle-test", ".temp").toFile()
         val inputStream = FileInputStream(bundleIdFile)
-        store.edit {
+        store.editAndCommit {
             putString(JAVA_SCRIPT_BUNDLE_URL_KEY, "assets://index.android.bundle")
             putString(JAVA_SCRIPT_BUNDLE_ID_KEY, "persistedBundleId")
         }
@@ -190,7 +190,7 @@ internal class EmbraceRnBundleIdTrackerTest {
 
     @Test
     fun `test computeReactNativeBundleId with wrong assets path`() {
-        store.edit {
+        store.editAndCommit {
             putString(JAVA_SCRIPT_BUNDLE_URL_KEY, "assets")
         }
         every { context.assets } returns assetManager
@@ -203,7 +203,7 @@ internal class EmbraceRnBundleIdTrackerTest {
 
     @Test
     fun `test computeReactNativeBundleId with wrong custom bundle stream`() {
-        store.edit {
+        store.editAndCommit {
             putString(JAVA_SCRIPT_BUNDLE_URL_KEY, "wrongFilePath")
         }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/user/EmbraceUserServiceTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/user/EmbraceUserServiceTest.kt
@@ -117,7 +117,9 @@ internal class EmbraceUserServiceTest {
     fun testClearAllUserInfo() {
         with(service) {
             getUserInfo().verifyExpectedUserInfo()
+            val editCount = store.editCount
             service.clearAllUserInfo()
+            assertEquals(editCount + 1, store.editCount)
             assertNull(getUserInfo().email)
             assertNull(getUserInfo().userId)
             assertNull(getUserInfo().username)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/user/EmbraceUserServiceTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/user/EmbraceUserServiceTest.kt
@@ -117,9 +117,9 @@ internal class EmbraceUserServiceTest {
     fun testClearAllUserInfo() {
         with(service) {
             getUserInfo().verifyExpectedUserInfo()
-            val editCount = store.editCount
+            val commitCount = store.commitCount
             service.clearAllUserInfo()
-            assertEquals(editCount + 1, store.editCount)
+            assertEquals(commitCount + 1, store.commitCount)
             assertNull(getUserInfo().email)
             assertNull(getUserInfo().userId)
             assertNull(getUserInfo().username)
@@ -174,7 +174,7 @@ internal class EmbraceUserServiceTest {
         firstDay: Boolean? = null,
         suppliedPersonas: Set<String> = userPersonas,
     ) {
-        store.edit {
+        store.editAndCommit {
             putString("io.embrace.userid", id)
             putString("io.embrace.useremail", email)
             putString("io.embrace.username", name)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStoreTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionMetadataStoreTest.kt
@@ -127,7 +127,7 @@ internal class UserSessionMetadataStoreTest {
         attribute: String,
     ): UserSessionMetadata? {
         metadataStore.save(sessionMetadata)
-        kvStore.edit {
+        kvStore.editAndCommit {
             putStringMap(
                 "embrace.user_session",
                 getRawMap().apply {

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorListenerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorListenerTest.kt
@@ -408,6 +408,7 @@ internal class SessionOrchestratorListenerTest {
                 FakeMetadataService(),
             ),
             ordinalStoreOverride ?: FakeOrdinalStore(),
+            FakeKeyValueStore(),
             metadataStoreOverride ?: UserSessionMetadataStore(FakeKeyValueStore()),
             logger,
             fakeBackgroundWorker(),

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -135,7 +135,7 @@ internal class SessionOrchestratorTest {
     fun `each transition performs a single commit to the key-value store`() {
         val kvStore = FakeKeyValueStore()
         createOrchestrator(
-            startingAppState = AppState.FOREGROUND,
+            startingProcessState = ProcessState.FOREGROUND,
             ordinalStoreOverride = OrdinalStoreImpl(kvStore),
             metadataStoreOverride = UserSessionMetadataStore(kvStore),
             keyValueStoreOverride = kvStore,
@@ -143,16 +143,16 @@ internal class SessionOrchestratorTest {
 
         // the user session ordinal, the session part ordinal, and both saves of the user session
         // metadata all land in one commit
-        assertEquals(1, kvStore.editCount)
+        assertEquals(1, kvStore.commitCount)
         assertNotNull(orchestrator.currentUserSession())
 
         clock.tick(10_000)
         orchestrator.onBackground()
-        assertEquals(2, kvStore.editCount)
+        assertEquals(2, kvStore.commitCount)
 
         clock.tick(10_000)
         orchestrator.onForeground()
-        assertEquals(3, kvStore.editCount)
+        assertEquals(3, kvStore.commitCount)
     }
 
     @Test
@@ -675,7 +675,7 @@ internal class SessionOrchestratorTest {
                 override fun getStringMap(key: String): Map<String, String> =
                     error("simulated store failure")
 
-                override fun edit(action: KeyValueStoreEditor.() -> Unit) = FakeKeyValueStore().edit(action)
+                override fun editAndCommit(action: KeyValueStoreEditor.() -> Unit) = FakeKeyValueStore().editAndCommit(action)
             },
         )
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -49,6 +49,8 @@ import io.embrace.android.embracesdk.internal.session.id.SessionPartTrackerImpl
 import io.embrace.android.embracesdk.internal.session.message.PayloadFactoryImpl
 import io.embrace.android.embracesdk.internal.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.store.KeyValueStoreEditor
+import io.embrace.android.embracesdk.internal.store.OrdinalStore
+import io.embrace.android.embracesdk.internal.store.OrdinalStoreImpl
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes.EmbUserSessionTerminationReasonValues
@@ -127,6 +129,30 @@ internal class SessionOrchestratorTest {
         assertEquals(1, fakeDataSource.enableDataCaptureCount)
         // starting in fg produces user session
         assertNotNull(orchestrator.currentUserSession())
+    }
+
+    @Test
+    fun `each transition performs a single commit to the key-value store`() {
+        val kvStore = FakeKeyValueStore()
+        createOrchestrator(
+            startingAppState = AppState.FOREGROUND,
+            ordinalStoreOverride = OrdinalStoreImpl(kvStore),
+            metadataStoreOverride = UserSessionMetadataStore(kvStore),
+            keyValueStoreOverride = kvStore,
+        )
+
+        // the user session ordinal, the session part ordinal, and both saves of the user session
+        // metadata all land in one commit
+        assertEquals(1, kvStore.editCount)
+        assertNotNull(orchestrator.currentUserSession())
+
+        clock.tick(10_000)
+        orchestrator.onBackground()
+        assertEquals(2, kvStore.editCount)
+
+        clock.tick(10_000)
+        orchestrator.onForeground()
+        assertEquals(3, kvStore.editCount)
     }
 
     @Test
@@ -972,8 +998,9 @@ internal class SessionOrchestratorTest {
         startingProcessState: ProcessState,
         configService: FakeConfigService =
             FakeConfigService(backgroundActivityBehavior = backgroundActivityBehavior(true)),
-        ordinalStoreOverride: FakeOrdinalStore? = null,
+        ordinalStoreOverride: OrdinalStore? = null,
         metadataStoreOverride: UserSessionMetadataStore? = null,
+        keyValueStoreOverride: KeyValueStore? = null,
     ) {
         store = FakePayloadStore()
         appStateTracker = FakeProcessStateTracker(startingProcessState)
@@ -1042,6 +1069,7 @@ internal class SessionOrchestratorTest {
                 FakeMetadataService(),
             ),
             ordinalStoreOverride ?: FakeOrdinalStore(),
+            keyValueStoreOverride ?: FakeKeyValueStore(),
             metadataStoreOverride ?: UserSessionMetadataStore(FakeKeyValueStore()),
             logger,
             BackgroundWorker(inactivityWorkerExecutor),

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/store/OrdinalStoreImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/store/OrdinalStoreImplTest.kt
@@ -117,6 +117,28 @@ class OrdinalStoreImplTest {
     }
 
     @Test
+    fun `increments of different ordinals in a batch share one commit`() {
+        kvStore.batch {
+            assertEquals(1, store.incrementAndGet(Ordinal.SESSION))
+            assertEquals(1, store.incrementAndGet(Ordinal.SESSION_PART))
+        }
+        assertEquals(1, kvStore.editCount)
+        assertEquals(2, store.incrementAndGet(Ordinal.SESSION))
+        assertEquals(2, store.incrementAndGet(Ordinal.SESSION_PART))
+    }
+
+    @Test
+    fun `repeated increments of one ordinal in a batch observe pending writes`() {
+        kvStore.batch {
+            assertEquals(1, store.incrementAndGet(Ordinal.SESSION_PART))
+            assertEquals(2, store.incrementAndGet(Ordinal.SESSION_PART))
+            assertEquals(3, store.incrementAndGet(Ordinal.SESSION_PART))
+        }
+        assertEquals(1, kvStore.editCount)
+        assertEquals(4, store.incrementAndGet(Ordinal.SESSION_PART))
+    }
+
+    @Test
     fun `a failure in the underlying store returns -1`() {
         val throwingStore = OrdinalStoreImpl(ThrowingKeyValueStore())
         assertEquals(-1, throwingStore.incrementAndGet(Ordinal.SESSION))

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/store/OrdinalStoreImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/store/OrdinalStoreImplTest.kt
@@ -27,7 +27,7 @@ class OrdinalStoreImplTest {
 
     @Test
     fun `user session counter seeded from legacy session counter on upgrade`() {
-        kvStore.edit { putInt(Ordinal.SESSION.key, 42) }
+        kvStore.editAndCommit { putInt(Ordinal.SESSION.key, 42) }
         assertEquals(43, store.incrementAndGet(Ordinal.USER_SESSION))
         assertEquals(44, store.incrementAndGet(Ordinal.USER_SESSION))
     }
@@ -98,22 +98,22 @@ class OrdinalStoreImplTest {
     @Test
     fun `seeding an ordinal only costs one commit`() {
         assertEquals(1, store.incrementAndGet(Ordinal.SESSION_PART))
-        assertEquals(1, kvStore.editCount)
+        assertEquals(1, kvStore.commitCount)
 
         assertEquals(2, store.incrementAndGet(Ordinal.SESSION_PART))
-        assertEquals(2, kvStore.editCount)
+        assertEquals(2, kvStore.commitCount)
     }
 
     @Test
     fun `seeding a scoped ordinal only costs one commit`() {
         assertEquals(1, store.incrementAndGet(Ordinal.APP_VERSION_STARTUP, "1.0.0"))
-        assertEquals(1, kvStore.editCount)
+        assertEquals(1, kvStore.commitCount)
 
         assertEquals(2, store.incrementAndGet(Ordinal.APP_VERSION_STARTUP, "1.0.0"))
-        assertEquals(2, kvStore.editCount)
+        assertEquals(2, kvStore.commitCount)
 
         assertEquals(1, store.incrementAndGet(Ordinal.APP_VERSION_STARTUP, "1.0.1"))
-        assertEquals(3, kvStore.editCount)
+        assertEquals(3, kvStore.commitCount)
     }
 
     @Test
@@ -122,7 +122,7 @@ class OrdinalStoreImplTest {
             assertEquals(1, store.incrementAndGet(Ordinal.SESSION))
             assertEquals(1, store.incrementAndGet(Ordinal.SESSION_PART))
         }
-        assertEquals(1, kvStore.editCount)
+        assertEquals(1, kvStore.commitCount)
         assertEquals(2, store.incrementAndGet(Ordinal.SESSION))
         assertEquals(2, store.incrementAndGet(Ordinal.SESSION_PART))
     }
@@ -134,7 +134,7 @@ class OrdinalStoreImplTest {
             assertEquals(2, store.incrementAndGet(Ordinal.SESSION_PART))
             assertEquals(3, store.incrementAndGet(Ordinal.SESSION_PART))
         }
-        assertEquals(1, kvStore.editCount)
+        assertEquals(1, kvStore.commitCount)
         assertEquals(4, store.incrementAndGet(Ordinal.SESSION_PART))
     }
 
@@ -155,6 +155,6 @@ class OrdinalStoreImplTest {
         override fun getBoolean(key: String, defaultValue: Boolean): Boolean = error("simulated store failure")
         override fun getStringSet(key: String): Set<String>? = error("simulated store failure")
         override fun getStringMap(key: String): Map<String, String>? = error("simulated store failure")
-        override fun edit(action: KeyValueStoreEditor.() -> Unit) = error("simulated store failure")
+        override fun editAndCommit(action: KeyValueStoreEditor.() -> Unit) = error("simulated store failure")
     }
 }

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/metadata/FlutterSdkVersionInfo.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/metadata/FlutterSdkVersionInfo.kt
@@ -8,11 +8,11 @@ class FlutterSdkVersionInfo(
 
     override var hostedPlatformVersion: String?
         get() = impl.getString(DART_SDK_VERSION_KEY)
-        set(value) = impl.edit { putString(DART_SDK_VERSION_KEY, value) }
+        set(value) = impl.editAndCommit { putString(DART_SDK_VERSION_KEY, value) }
 
     override var hostedSdkVersion: String?
         get() = impl.getString(EMBRACE_FLUTTER_SDK_VERSION_KEY)
-        set(value) = impl.edit { putString(EMBRACE_FLUTTER_SDK_VERSION_KEY, value) }
+        set(value) = impl.editAndCommit { putString(EMBRACE_FLUTTER_SDK_VERSION_KEY, value) }
 
     private companion object {
         private const val DART_SDK_VERSION_KEY = "io.embrace.dart.sdk.version"

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/metadata/HostedSdkVersionInfo.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/metadata/HostedSdkVersionInfo.kt
@@ -10,4 +10,5 @@ interface HostedSdkVersionInfo {
     var javaScriptPatchNumber: String?
         get() = null
         set(value) {}
+    fun batch(action: () -> Unit) = action()
 }

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/metadata/ReactNativeSdkVersionInfo.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/metadata/ReactNativeSdkVersionInfo.kt
@@ -8,15 +8,15 @@ class ReactNativeSdkVersionInfo(
 
     override var hostedSdkVersion: String?
         get() = impl.getString(REACT_NATIVE_SDK_VERSION_KEY)
-        set(value) = impl.edit { putString(REACT_NATIVE_SDK_VERSION_KEY, value) }
+        set(value) = impl.editAndCommit { putString(REACT_NATIVE_SDK_VERSION_KEY, value) }
 
     override var javaScriptPatchNumber: String?
         get() = impl.getString(JAVA_SCRIPT_PATCH_NUMBER_KEY)
-        set(value) = impl.edit { putString(JAVA_SCRIPT_PATCH_NUMBER_KEY, value) }
+        set(value) = impl.editAndCommit { putString(JAVA_SCRIPT_PATCH_NUMBER_KEY, value) }
 
     override var hostedPlatformVersion: String?
         get() = impl.getString(REACT_NATIVE_VERSION_KEY)
-        set(value) = impl.edit { putString(REACT_NATIVE_VERSION_KEY, value) }
+        set(value) = impl.editAndCommit { putString(REACT_NATIVE_VERSION_KEY, value) }
 
     private companion object {
         private const val JAVA_SCRIPT_PATCH_NUMBER_KEY = "io.embrace.javascript.patch"

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/metadata/UnitySdkVersionInfo.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/metadata/UnitySdkVersionInfo.kt
@@ -8,15 +8,15 @@ class UnitySdkVersionInfo(
 
     override var hostedPlatformVersion: String?
         get() = impl.getString(UNITY_VERSION_NUMBER_KEY)
-        set(value) = impl.edit { putString(UNITY_VERSION_NUMBER_KEY, value) }
+        set(value) = impl.editAndCommit { putString(UNITY_VERSION_NUMBER_KEY, value) }
 
     override var unityBuildIdNumber: String?
         get() = impl.getString(UNITY_BUILD_ID_NUMBER_KEY)
-        set(value) = impl.edit { putString(UNITY_BUILD_ID_NUMBER_KEY, value) }
+        set(value) = impl.editAndCommit { putString(UNITY_BUILD_ID_NUMBER_KEY, value) }
 
     override var hostedSdkVersion: String?
         get() = impl.getString(UNITY_SDK_VERSION_NUMBER_KEY)
-        set(value) = impl.edit { putString(UNITY_SDK_VERSION_NUMBER_KEY, value) }
+        set(value) = impl.editAndCommit { putString(UNITY_SDK_VERSION_NUMBER_KEY, value) }
 
     override fun batch(action: () -> Unit) = impl.batch(action)
 

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/metadata/UnitySdkVersionInfo.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/metadata/UnitySdkVersionInfo.kt
@@ -18,6 +18,8 @@ class UnitySdkVersionInfo(
         get() = impl.getString(UNITY_SDK_VERSION_NUMBER_KEY)
         set(value) = impl.edit { putString(UNITY_SDK_VERSION_NUMBER_KEY, value) }
 
+    override fun batch(action: () -> Unit) = impl.batch(action)
+
     private companion object {
         private const val UNITY_VERSION_NUMBER_KEY = "io.embrace.unity.version"
         private const val UNITY_BUILD_ID_NUMBER_KEY = "io.embrace.unity.build.id"

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/store/KeyValueStore.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/store/KeyValueStore.kt
@@ -39,4 +39,11 @@ interface KeyValueStore {
      * Performs a batch edit of values in the key-value store.
      */
     fun edit(action: KeyValueStoreEditor.() -> Unit)
+
+    /**
+     * Coalesces every [edit] performed on the calling thread inside [action] into a single commit,
+     * which is issued when the outermost [batch] returns. As with [edit], the commit happens even if
+     * [action] throws.
+     */
+    fun batch(action: () -> Unit) = action()
 }

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/store/KeyValueStore.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/store/KeyValueStore.kt
@@ -36,13 +36,16 @@ interface KeyValueStore {
     fun getStringMap(key: String): Map<String, String>?
 
     /**
-     * Performs a batch edit of values in the key-value store.
+     * Edits values in the key-value store, then commits them.
+     *
+     * Each call costs its own commit, and therefore its own disk write, so only reach for this
+     * directly when writing a single key. Wrap multiple writes in [batch] so they share one commit.
      */
-    fun edit(action: KeyValueStoreEditor.() -> Unit)
+    fun editAndCommit(action: KeyValueStoreEditor.() -> Unit)
 
     /**
-     * Coalesces every [edit] performed on the calling thread inside [action] into a single commit,
-     * which is issued when the outermost [batch] returns. As with [edit], the commit happens even if
+     * Coalesces every [editAndCommit] performed on the calling thread inside [action] into a single commit,
+     * which is issued when the outermost [batch] returns. As with [editAndCommit], the commit happens even if
      * [action] throws.
      */
     fun batch(action: () -> Unit) = action()

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/store/OrdinalStoreImpl.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/store/OrdinalStoreImpl.kt
@@ -25,7 +25,7 @@ class OrdinalStoreImpl(
                 null -> impl.getInt(sanitized.key)?.plus(1) ?: seed()
                 else -> seed()
             }
-            impl.edit {
+            impl.editAndCommit {
                 if (scopeKey != null && newScope != null) {
                     putString(scopeKey, newScope)
                 }

--- a/embrace-android-instrumentation-app-exit-info/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/AeiDataSourceImpl.kt
+++ b/embrace-android-instrumentation-app-exit-info/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/AeiDataSourceImpl.kt
@@ -105,7 +105,7 @@ internal class AeiDataSourceImpl(
 
     private var KeyValueStore.deliveredAeiIds: Set<String>
         get() = store.getStringSet(AEI_HASH_CODES) ?: emptySet()
-        set(value) = store.edit { putStringSet(AEI_HASH_CODES, value) }
+        set(value) = store.editAndCommit { putStringSet(AEI_HASH_CODES, value) }
 
     private fun ApplicationExitInfo.getAeiId(): String = "${timestamp}_$pid"
     private fun AppExitInfoData.getAeiId(): String = "${timestamp}_$pid"

--- a/embrace-android-instrumentation-app-exit-info/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/AeiDataSourceImplTest.kt
+++ b/embrace-android-instrumentation-app-exit-info/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/AeiDataSourceImplTest.kt
@@ -220,7 +220,7 @@ internal class AeiDataSourceImplTest {
         every { mockActivityManager.getHistoricalProcessExitReasons(any(), any(), any()) } returns
             listOf(appExitInfo1, appExitInfo2, appExitInfo3)
 
-        store.edit {
+        store.editAndCommit {
             putStringSet("io.embrace.aeiHashCode", setOf(appExitInfo1Hash, appExitInfo2Hash))
         }
 

--- a/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkCaptureDataSourceImpl.kt
+++ b/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkCaptureDataSourceImpl.kt
@@ -177,7 +177,7 @@ class NetworkCaptureDataSourceImpl(
     }
 
     private fun decreaseNetworkCaptureRuleRemainingCount(id: String, maxCount: Int) {
-        keyValueStore.edit {
+        keyValueStore.editAndCommit {
             putInt(NETWORK_CAPTURE_RULE_PREFIX_KEY + id, getNetworkCaptureRuleRemainingCount(id, maxCount) - 1)
         }
     }

--- a/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkCaptureDataSourceTest.kt
+++ b/embrace-android-instrumentation-network-common/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkCaptureDataSourceTest.kt
@@ -83,7 +83,7 @@ internal class NetworkCaptureDataSourceTest {
 
         val result = service.getNetworkCaptureRules("https://embrace.io/changelog", "GET")
         assertEquals(1, result.size)
-        args.store.edit {
+        args.store.editAndCommit {
             putInt(NetworkCaptureDataSourceImpl.NETWORK_CAPTURE_RULE_PREFIX_KEY + rule.id, 0)
         }
         val emptyRule = service.getNetworkCaptureRules("https://embrace.io/changelog", "GET")
@@ -95,7 +95,7 @@ internal class NetworkCaptureDataSourceTest {
         val rule = getDefaultRule()
         cfg = RemoteConfig(networkCaptureRules = setOf(rule))
         val service = getService()
-        args.store.edit {
+        args.store.editAndCommit {
             putInt(NetworkCaptureDataSourceImpl.NETWORK_CAPTURE_RULE_PREFIX_KEY + rule.id, 0)
         }
         val emptyRule = service.getNetworkCaptureRules("https://embrace.io/changelog", "GET")

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PersonaFeaturesTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/PersonaFeaturesTest.kt
@@ -19,7 +19,7 @@ internal class PersonaFeaturesTest {
     fun `personas found in metadata`() {
         testRule.runTest(
             setupAction = {
-                getStore().edit {
+                getStore().editAndCommit {
                     putStringSet("io.embrace.userpersonas", setOf("preloaded"))
                 }
             },

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UserFeaturesTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/UserFeaturesTest.kt
@@ -21,7 +21,7 @@ internal class UserFeaturesTest {
     fun `user info setting and clearing`() {
         testRule.runTest(
             setupAction = {
-                getStore().edit {
+                getStore().editAndCommit {
                     putString("io.embrace.userid", "customId")
                     putString("io.embrace.username", "customUserName")
                     putString("io.embrace.useremail", "custom@domain.com")

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -239,7 +239,7 @@ internal class EmbraceSetupInterface(
      * Setup permanent session properties without using the SDK interfaces
      */
     fun setupPermanentUserSessionProperties(properties: Map<String, String>) {
-        getStore().edit {
+        getStore().editAndCommit {
             putStringMap(
                 "io.embrace.session.properties", properties
             )
@@ -261,7 +261,7 @@ internal class EmbraceSetupInterface(
         inactivityTimeoutSeconds: Int = 1800,
         isBackgroundOnly: Boolean = false,
     ) {
-        getStore().edit {
+        getStore().editAndCommit {
             putStringMap(
                 "embrace.user_session",
                 buildMap {

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/UnityInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/UnityInternalInterfaceImpl.kt
@@ -34,9 +34,11 @@ internal class UnityInternalInterfaceImpl(
                 return
             }
             if (unitySdkVersion != null) {
-                hostedSdkVersionInfo.hostedPlatformVersion = unityVersion
-                hostedSdkVersionInfo.hostedSdkVersion = unitySdkVersion
-                hostedSdkVersionInfo.unityBuildIdNumber = buildGuid
+                hostedSdkVersionInfo.batch {
+                    hostedSdkVersionInfo.hostedPlatformVersion = unityVersion
+                    hostedSdkVersionInfo.hostedSdkVersion = unitySdkVersion
+                    hostedSdkVersionInfo.unityBuildIdNumber = buildGuid
+                }
             }
         } else {
             logger.logSdkNotInitialized("set Unity metadata")

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/UnityInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/UnityInternalInterfaceImplTest.kt
@@ -45,4 +45,15 @@ internal class UnityInternalInterfaceImplTest {
         impl.setUnityMetaData(null, null, "unitySdkVersion")
         assertEquals(emptyMap<String, Any?>(), store.values())
     }
+
+    @Test
+    fun testSetUnityMetaDataUsesSingleCommit() {
+        every { embrace.isStarted } returns true
+        impl.setUnityMetaData("unityVersion", "buildGuid", "unitySdkVersion")
+
+        assertEquals(1, store.editCount)
+        assertEquals("unityVersion", hostedSdkVersionInfo.hostedPlatformVersion)
+        assertEquals("unitySdkVersion", hostedSdkVersionInfo.hostedSdkVersion)
+        assertEquals("buildGuid", hostedSdkVersionInfo.unityBuildIdNumber)
+    }
 }

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/UnityInternalInterfaceImplTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/UnityInternalInterfaceImplTest.kt
@@ -51,7 +51,7 @@ internal class UnityInternalInterfaceImplTest {
         every { embrace.isStarted } returns true
         impl.setUnityMetaData("unityVersion", "buildGuid", "unitySdkVersion")
 
-        assertEquals(1, store.editCount)
+        assertEquals(1, store.commitCount)
         assertEquals("unityVersion", hostedSdkVersionInfo.hostedPlatformVersion)
         assertEquals("unitySdkVersion", hostedSdkVersionInfo.hostedSdkVersion)
         assertEquals("buildGuid", hostedSdkVersionInfo.unityBuildIdNumber)

--- a/embrace-test-common/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeKeyValueStore.kt
+++ b/embrace-test-common/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeKeyValueStore.kt
@@ -8,8 +8,14 @@ class FakeKeyValueStore : KeyValueStore {
     private val map = mutableMapOf<String, Any?>()
 
     /**
-     * The number of times [edit] has been called, i.e. the number of commits that a real store
-     * would have performed.
+     * Writes buffered by an open [batch]. Reads consult this first so the fake models the
+     * read-your-writes behaviour of the real store.
+     */
+    private var openBatch: MutableMap<String, Any?>? = null
+
+    /**
+     * The number of commits that a real store would have performed. Every [edit] outside a [batch]
+     * counts as one, and a [batch] counts as one no matter how many [edit] calls it contains.
      */
     var editCount: Int = 0
         private set
@@ -17,34 +23,62 @@ class FakeKeyValueStore : KeyValueStore {
     fun values(): Map<String, Any?> = map.toMap()
 
     override fun getString(key: String): String? {
-        return map[key] as? String
+        return read(key) as? String
     }
 
     override fun getInt(key: String): Int? {
-        return map[key] as? Int
+        return read(key) as? Int
     }
 
     override fun getLong(key: String): Long? {
-        return map[key] as? Long
+        return read(key) as? Long
     }
 
     override fun getBoolean(key: String, defaultValue: Boolean): Boolean {
-        return map[key] as? Boolean ?: defaultValue
+        return read(key) as? Boolean ?: defaultValue
     }
 
     @Suppress("UNCHECKED_CAST")
     override fun getStringSet(key: String): Set<String>? {
-        return map[key] as? Set<String>
+        return read(key) as? Set<String>
     }
 
     @Suppress("UNCHECKED_CAST")
     override fun getStringMap(key: String): Map<String, String>? {
-        return map[key] as? Map<String, String>
+        return read(key) as? Map<String, String>
     }
 
     override fun edit(action: KeyValueStoreEditor.() -> Unit) {
-        editCount++
-        FakeEditor(map).action()
+        val batch = openBatch
+        if (batch != null) {
+            FakeEditor(batch).action()
+        } else {
+            editCount++
+            FakeEditor(map).action()
+        }
+    }
+
+    override fun batch(action: () -> Unit) {
+        if (openBatch != null) { // a batch is already open, so it owns the commit
+            action()
+            return
+        }
+        val batch = mutableMapOf<String, Any?>()
+        openBatch = batch
+        try {
+            action()
+        } finally {
+            openBatch = null
+            if (batch.isNotEmpty()) {
+                editCount++
+                map.putAll(batch)
+            }
+        }
+    }
+
+    private fun read(key: String): Any? {
+        val batch = openBatch ?: return map[key]
+        return if (batch.containsKey(key)) batch[key] else map[key]
     }
 
     private class FakeEditor(private val map: MutableMap<String, Any?>) : KeyValueStoreEditor {

--- a/embrace-test-common/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeKeyValueStore.kt
+++ b/embrace-test-common/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeKeyValueStore.kt
@@ -14,10 +14,10 @@ class FakeKeyValueStore : KeyValueStore {
     private var openBatch: MutableMap<String, Any?>? = null
 
     /**
-     * The number of commits that a real store would have performed. Every [edit] outside a [batch]
-     * counts as one, and a [batch] counts as one no matter how many [edit] calls it contains.
+     * The number of commits that a real store would have performed. Every [editAndCommit] outside a [batch]
+     * counts as one, and a [batch] counts as one no matter how many [editAndCommit] calls it contains.
      */
-    var editCount: Int = 0
+    var commitCount: Int = 0
         private set
 
     fun values(): Map<String, Any?> = map.toMap()
@@ -48,12 +48,12 @@ class FakeKeyValueStore : KeyValueStore {
         return read(key) as? Map<String, String>
     }
 
-    override fun edit(action: KeyValueStoreEditor.() -> Unit) {
+    override fun editAndCommit(action: KeyValueStoreEditor.() -> Unit) {
         val batch = openBatch
         if (batch != null) {
             FakeEditor(batch).action()
         } else {
-            editCount++
+            commitCount++
             FakeEditor(map).action()
         }
     }
@@ -70,7 +70,7 @@ class FakeKeyValueStore : KeyValueStore {
         } finally {
             openBatch = null
             if (batch.isNotEmpty()) {
-                editCount++
+                commitCount++
                 map.putAll(batch)
             }
         }


### PR DESCRIPTION
## Goal

Every `apply()` call to `SharedPreferences` [enqueues a disk write](https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/core/java/android/app/SharedPreferencesImpl.java;l=484?q=sharedpreferencesimpl) on a background thread. We can reduce the number of disk writes by batching edits of SharedPreferences within our SDK.