### PR TITLE
build(deps): bump actions/setup-java in the github group

### DIFF
--- a/.github/workflows/android-emulator-tests.yml
+++ b/.github/workflows/android-emulator-tests.yml
@@ -38,7 +38,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Setup Java
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'adopt'
           java-version: 21

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -52,7 +52,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Java
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'adopt'
           java-version: 21

--- a/.github/workflows/generate-baseline-profile.yml
+++ b/.github/workflows/generate-baseline-profile.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: true
 
       - name: Setup Java
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'adopt'
           java-version: 21

--- a/.github/workflows/publish-api-docs.yml
+++ b/.github/workflows/publish-api-docs.yml
@@ -51,7 +51,7 @@ jobs:
           persist-credentials: true
 
       - name: Setup Java
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'adopt'
           java-version: 21

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -42,7 +42,7 @@ jobs:
           grep -q -- '-SNAPSHOT$' gradle.properties || (echo "ERROR: version must end with -SNAPSHOT" && exit 1)
 
       - name: Setup Java
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'adopt'
           java-version: 21

--- a/.github/workflows/semconv-drift.yml
+++ b/.github/workflows/semconv-drift.yml
@@ -54,7 +54,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Java
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'adopt'
           java-version: 21

--- a/.github/workflows/upload-artifacts-to-maven-central.yml
+++ b/.github/workflows/upload-artifacts-to-maven-central.yml
@@ -47,7 +47,7 @@ jobs:
           persist-credentials: true
 
       - name: Setup Java
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'adopt'
           java-version: 21


### PR DESCRIPTION
https://github.com/embrace-io/embrace-android-sdk/pull/3767

Bumps the github group with 1 update: [actions/setup-java](https://github.com/actions/setup-java).


Updates `actions/setup-java` from 5.6.0 to 5.7.0
- [Release notes](https://github.com/actions/setup-java/releases)
- [Commits](https://github.com/actions/setup-java/compare/03ad4de0992f5dab5e18fcb136590ce7c4a0ac95...b6effb05e454b25005698d916606bdc6ffcbf961)

---
updated-dependencies:
- dependency-name: actions/setup-java dependency-version: 5.7.0 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: github ...

## Goal

<!-- Describe what this change seeks to address -->

## Testing

<!-- Describe how this change has been tested -->
