### PR TITLE
build(deps): bump media3 from 1.10.1 to 1.11.0 in /examples/ExampleApp

### DIFF
--- a/examples/ExampleApp/gradle/libs.versions.toml
+++ b/examples/ExampleApp/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ kotlinxSerialization = "1.11.0"
 benchmarkMacroJunit4 = "1.4.1"
 coil = "2.7.0"
 metro = "1.4.0"
-media3 = "1.10.1"
+media3 = "1.11.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
Bumps `media3` from 1.10.1 to 1.11.0.

Updates `androidx.media3:media3-exoplayer` from 1.10.1 to 1.11.0
- [Release notes](https://github.com/androidx/media/releases)
- [Changelog](https://github.com/androidx/media/blob/release/RELEASENOTES.md)
- [Commits](https://github.com/androidx/media/compare/1.10.1...1.11.0)

Updates `androidx.media3:media3-exoplayer-hls` from 1.10.1 to 1.11.0
- [Release notes](https://github.com/androidx/media/releases)
- [Changelog](https://github.com/androidx/media/blob/release/RELEASENOTES.md)
- [Commits](https://github.com/androidx/media/compare/1.10.1...1.11.0)

Updates `androidx.media3:media3-ui` from 1.10.1 to 1.11.0
- [Release notes](https://github.com/androidx/media/releases)
- [Changelog](https://github.com/androidx/media/blob/release/RELEASENOTES.md)
- [Commits](https://github.com/androidx/media/compare/1.10.1...1.11.0)

---
updated-dependencies:
- dependency-name: androidx.media3:media3-exoplayer dependency-version: 1.11.0 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: androidx.media3:media3-exoplayer-hls dependency-version: 1.11.0 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: androidx.media3:media3-ui dependency-version: 1.11.0 dependency-type: direct:production update-type: version-update:semver-minor ...

## Goal

<!-- Describe what this change seeks to address -->

## Testing

<!-- Describe how this change has been tested -->
