### PR TITLE
Add tracking for EmbTrace custom sections and broad sdk init breakdown

### DIFF
--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/AppStartupTraceEmitter.kt
@@ -280,6 +280,7 @@ internal class AppStartupTraceEmitter(
                     applicationInitEndMs = if (recordColdStart) applicationInitEndMs else null,
                     sdkInitStartMs = if (recordColdStart) startupService.getSdkInitStartMs() else null,
                     sdkInitEndMs = if (recordColdStart) sdkInitEndMs else null,
+                    sdkInitDurations = if (recordColdStart) startupService.getSdkInitDurations() else emptyMap(),
                     firstActivityInitMs = firstActivityInitStartMs,
                     activityInitStartMs = activityInitStartMs,
                     activityInitEndMs = activityInitEndMs,
@@ -325,6 +326,7 @@ internal class AppStartupTraceEmitter(
         applicationInitEndMs: Long?,
         sdkInitStartMs: Long?,
         sdkInitEndMs: Long?,
+        sdkInitDurations: Map<String, Long>,
         firstActivityInitMs: Long?,
         activityInitStartMs: Long?,
         activityInitEndMs: Long?,
@@ -353,10 +355,11 @@ internal class AppStartupTraceEmitter(
 
             if (sdkInitStartMs != null && sdkInitEndMs != null) {
                 val counter = startupServiceProvider()?.getAppVersionStartupCounter()
-                val attributes = if (counter != null) {
-                    mapOf(EmbAppAttributes.EMB_APP_VERSION_STARTUP_COUNTER to counter.toString())
-                } else {
-                    emptyMap()
+                val attributes = buildMap(sdkInitDurations.size + 1) {
+                    if (counter != null) {
+                        put(EmbAppAttributes.EMB_APP_VERSION_STARTUP_COUNTER, counter.toString())
+                    }
+                    putSdkInitDurations(sdkInitDurations)
                 }
 
                 destination.recordCompletedSpan(

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/StartupService.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/StartupService.kt
@@ -15,6 +15,7 @@ interface StartupService {
         endTimeMs: Long,
         endState: ProcessState,
         threadName: String,
+        sdkInitDurations: Map<String, Long> = emptyMap(),
     )
 
     /**
@@ -42,4 +43,20 @@ interface StartupService {
      * Returns null if the counter could not be determined.
      */
     fun getAppVersionStartupCounter(): Int?
+
+    /**
+     * Durations in milliseconds of the instrumented SDK init sections, keyed by section name.
+     * Empty until startup info is recorded.
+     */
+    fun getSdkInitDurations(): Map<String, Long>
+}
+
+/**
+ * Add an entry to the map given a map of sdk init durations where the key name comprises the
+ * section name with an additional suffix.
+ */
+internal fun MutableMap<String, String>.putSdkInitDurations(durations: Map<String, Long>) {
+    durations.forEach { (sectionName, durationMs) ->
+        put("$sectionName-duration-ms", durationMs.toString())
+    }
 }

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/StartupServiceImpl.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/StartupServiceImpl.kt
@@ -26,20 +26,25 @@ internal class StartupServiceImpl(
     @Volatile
     private var sdkStartupDurationMs: Long? = null
 
+    @Volatile
+    private var sdkInitDurations: Map<String, Long> = emptyMap()
+
     override fun setSdkStartupInfo(
         startTimeMs: Long,
         endTimeMs: Long,
         endState: ProcessState,
         threadName: String,
+        sdkInitDurations: Map<String, Long>,
     ) {
         val foregroundEnd = endState == ProcessState.FOREGROUND
         if (sdkStartupDurationMs == null) {
-            val attributes = buildMap {
+            val attributes = buildMap(sdkInitDurations.size + 3) {
                 put("ended-in-foreground", foregroundEnd.toString())
                 put("thread-name", threadName)
                 startupCounter?.let { counter ->
                     put(EmbAppAttributes.EMB_APP_VERSION_STARTUP_COUNTER, counter.toString())
                 }
+                putSdkInitDurations(sdkInitDurations)
             }
             destination.recordCompletedSpan(
                 name = "sdk-init",
@@ -53,6 +58,7 @@ internal class StartupServiceImpl(
         sdkInitEndMs = endTimeMs
         this.threadName = threadName
         sdkStartupDurationMs = endTimeMs - startTimeMs
+        this.sdkInitDurations = sdkInitDurations
     }
 
     override fun getSdkStartupDuration(): Long? = sdkStartupDurationMs
@@ -60,4 +66,5 @@ internal class StartupServiceImpl(
     override fun getSdkInitEndMs(): Long? = sdkInitEndMs
     override fun getInitThreadName(): String = threadName
     override fun getAppVersionStartupCounter(): Int? = startupCounter
+    override fun getSdkInitDurations(): Map<String, Long> = sdkInitDurations
 }

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/AppStartupTraceEmitterTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/AppStartupTraceEmitterTest.kt
@@ -700,6 +700,7 @@ internal class AppStartupTraceEmitterTest {
         val trace = if (isColdStart) {
             with(appInitTimestamps) {
                 assertChildSpan(spanMap.embraceInitSpan(), sdkInitStart, sdkInitEnd)
+                assertEquals("30", spanMap.embraceInitSpan()?.attributes?.get("modules-init-duration-ms"))
                 assertEquals(
                     APP_VERSION_STARTUP_COUNTER.toString(),
                     spanMap.embraceInitSpan()?.attributes?.get(EmbAppAttributes.EMB_APP_VERSION_STARTUP_COUNTER),
@@ -775,6 +776,7 @@ internal class AppStartupTraceEmitterTest {
             endTimeMs = end,
             endState = ProcessState.BACKGROUND,
             threadName = "main",
+            sdkInitDurations = mapOf("modules-init" to 30L),
         )
 
         val applicationInitEnd = if (hasAppInitEvents) {

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/StartupServiceImplTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/StartupServiceImplTest.kt
@@ -40,6 +40,7 @@ internal class StartupServiceImplTest {
             endTimeMs = endTimeMillis,
             endState = ProcessState.BACKGROUND,
             threadName = "main",
+            sdkInitDurations = mapOf("modules-init" to 100L),
         )
         val currentSpans = destination.completedSpans()
         assertEquals(1, currentSpans.size)
@@ -51,6 +52,7 @@ internal class StartupServiceImplTest {
             assertTrue(private)
             assertEquals("false", attributes["ended-in-foreground"])
             assertEquals("main", attributes["thread-name"])
+            assertEquals("100", attributes["modules-init-duration-ms"])
             assertEquals("3", attributes[EmbAppAttributes.EMB_APP_VERSION_STARTUP_COUNTER])
         }
         assertEquals(3, startupService.getAppVersionStartupCounter())
@@ -94,10 +96,11 @@ internal class StartupServiceImplTest {
 
     @Test
     fun `startup info available right after setting on the service`() {
-        startupService.setSdkStartupInfo(1111L, 3222L, ProcessState.BACKGROUND, "main")
+        startupService.setSdkStartupInfo(1111L, 3222L, ProcessState.BACKGROUND, "main", mapOf("modules-init" to 100L))
         assertEquals(1111L, startupService.getSdkInitStartMs())
         assertEquals(3222L, startupService.getSdkInitEndMs())
         assertEquals(2111L, startupService.getSdkStartupDuration())
+        assertEquals(mapOf("modules-init" to 100L), startupService.getSdkInitDurations())
         assertEquals(3, startupService.getAppVersionStartupCounter())
     }
 }

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
@@ -2,15 +2,18 @@ package io.embrace.android.embracesdk.assertions
 
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.LinkType
+import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttribute
 import io.embrace.android.embracesdk.internal.otel.sdk.hasEmbraceAttributeKey
 import io.embrace.android.embracesdk.internal.otel.spans.hasEmbraceAttributeValue
+import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Link
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.semconv.EmbSpanAttributes
 import io.embrace.android.embracesdk.semconv.EmbStateTransitionAttributes.EMB_STATE_INITIAL_VALUE
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 
 /**
@@ -93,3 +96,14 @@ fun Span.assertStateSpan(
         }
     }
 }
+
+fun List<Attribute>?.assertSdkInitSectionDurationsRecorded() {
+    expectedSdkInitSections.forEach { section ->
+        assertNotNull(
+            "duration for init section `$section` not found",
+            this?.findAttributeValue("$section-duration-ms")
+        )
+    }
+}
+
+private val expectedSdkInitSections = listOf("modules-init", "post-init", "post-services-setup")

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/config/OtelSdkConfig.kt
@@ -68,7 +68,7 @@ class OtelSdkConfig(
      * this out by proximity for stitched sessions.
      */
     val processIdentifier: String by lazy {
-        EmbTrace.trace("process-identifier-init", processIdentifierProvider)
+        EmbTrace.trace(sectionName = "process-identifier-init", code = processIdentifierProvider)
     }
 
     private val externalSpanExporters = mutableListOf<SpanExporter>()

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/AppStartupTraceTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.testcases
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.assertError
+import io.embrace.android.embracesdk.assertions.assertSdkInitSectionDurationsRecorded
 import io.embrace.android.embracesdk.assertions.findSpansOfType
 import io.embrace.android.embracesdk.fakes.FakeActivity
 import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
@@ -111,11 +112,10 @@ internal class AppStartupTraceTest {
             otelExportAssertion = {
                 with(awaitSpansWithType(7, EmbType.Performance.Default).associateBy { it.name }) {
                     assertEquals("yes", coldAppStartupRootSpan().attributes.toEmbracePayload().findAttributeValue("custom-attribute"))
-                    assertEquals(
-                        "1",
-                        embraceInitSpan().attributes.toEmbracePayload()
-                            .findAttributeValue(EmbAppAttributes.EMB_APP_VERSION_STARTUP_COUNTER)
-                    )
+                    with(embraceInitSpan().attributes.toEmbracePayload()) {
+                        assertEquals("1", findAttributeValue(EmbAppAttributes.EMB_APP_VERSION_STARTUP_COUNTER))
+                        assertSdkInitSectionDurationsRecorded()
+                    }
                     with(initGapSpan()) {
                         assertEquals(sdkStartTimeMs, startEpochNanos.nanosToMillis())
                         assertEquals(activityInitStartMs, endEpochNanos.nanosToMillis())

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/TracingApiTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.testcases
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.embrace.android.embracesdk.assertions.assertEmbraceSpanData
+import io.embrace.android.embracesdk.assertions.assertSdkInitSectionDurationsRecorded
 import io.embrace.android.embracesdk.assertions.assertIsTypePerformance
 import io.embrace.android.embracesdk.assertions.findCustomLinks
 import io.embrace.android.embracesdk.assertions.findSpanByName
@@ -25,13 +26,13 @@ import io.embrace.android.embracesdk.internal.arch.state.ProcessState
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.otel.sdk.id.OtelIds
-import io.embrace.android.embracesdk.semconv.EmbAppAttributes
 import io.embrace.android.embracesdk.internal.otel.spans.NoopEmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
 import io.embrace.android.embracesdk.internal.toEmbracePayload
+import io.embrace.android.embracesdk.semconv.EmbAppAttributes
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 import io.embrace.android.embracesdk.spans.ErrorCode
@@ -195,11 +196,13 @@ internal class TracingApiTest {
                     checkNotNull(spansMap[it]) { "$it not found: $results" }
                 }
 
+                val sdkInitSpan = checkNotNull(spansMap["emb-sdk-init"])
                 assertEquals(
                     "1",
-                    checkNotNull(spansMap["emb-sdk-init"]).attributes
-                        ?.findAttributeValue(EmbAppAttributes.EMB_APP_VERSION_STARTUP_COUNTER)
+                    sdkInitSpan.attributes?.findAttributeValue(EmbAppAttributes.EMB_APP_VERSION_STARTUP_COUNTER)
                 )
+
+                sdkInitSpan.attributes.assertSdkInitSectionDurationsRecorded()
 
                 assertEmbraceSpanData(
                     span = traceRootSpan,

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/SdkIntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/SdkIntegrationTestRule.kt
@@ -24,6 +24,7 @@ import io.embrace.android.embracesdk.internal.injection.EssentialServiceModuleIm
 import io.embrace.android.embracesdk.internal.injection.InitModule
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.serialization.toJson
+import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface
 import io.embrace.android.embracesdk.testframework.actions.EmbraceOtelExportAssertionInterface
@@ -216,6 +217,7 @@ internal class SdkIntegrationTestRule(
      */
     override fun before() {
         Thread.setDefaultUncaughtExceptionHandler(null)
+        EmbTrace.durationTracker.reset()
     }
 
     /**

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/Embrace.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/Embrace.kt
@@ -4,7 +4,7 @@ import android.annotation.SuppressLint
 import io.embrace.android.embracesdk.internal.api.SdkApi
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 
-private val delegate = EmbTrace.trace("embrace-impl-init") { EmbraceImpl() }
+private val delegate = EmbTrace.trace(sectionName = "embrace-impl-init", recordDuration = true) { EmbraceImpl() }
 
 /**
  * Entry point for the SDK. This class is part of the Embrace Public API.

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -58,7 +58,11 @@ import java.util.concurrent.Executors
  */
 @SuppressLint("EmbracePublicApiPackageRule")
 internal class EmbraceImpl(
-    private val bootstrapper: ModuleInitBootstrapper = EmbTrace.trace("bootstrapper-init", ::ModuleInitBootstrapper),
+    private val bootstrapper: ModuleInitBootstrapper = EmbTrace.trace(
+        sectionName = "bootstrapper-init",
+        recordDuration = true,
+        code = ::ModuleInitBootstrapper,
+    ),
     private val sdkCallChecker: SdkCallChecker =
         SdkCallChecker(bootstrapper.initModule.logger, bootstrapper.initModule.telemetryService),
     private val userApiDelegate: UserApiDelegate = UserApiDelegate(bootstrapper, sdkCallChecker),
@@ -108,7 +112,7 @@ internal class EmbraceImpl(
                 }
                 bootstrapper.postInit()
 
-                EmbTrace.trace("post-services-setup") {
+                EmbTrace.trace(sectionName = "post-services-setup", recordDuration = true) {
                     internalInterfaceModule = InternalInterfaceModuleImpl(
                         bootstrapper.initModule,
                         bootstrapper.configService,
@@ -125,8 +129,8 @@ internal class EmbraceImpl(
                     initializeHucInstrumentation(bootstrapper.configService.networkBehavior)
                     bootstrapper.postLoadInstrumentation()
                     bootstrapper.triggerPayloadSend()
-                    bootstrapper.markSdkInitComplete()
                 }
+                bootstrapper.markSdkInitComplete(EmbTrace.durationTracker.flush())
             } catch (ignored: Throwable) {
                 Log.w("Embrace", "Failed to initialize Embrace SDK", ignored)
             }

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -21,7 +21,7 @@ import io.embrace.android.embracesdk.internal.worker.Worker
  * A class that wires together and initializes modules in a manner that makes them work as a cohesive whole.
  */
 internal class ModuleInitBootstrapper(
-    override val initModule: InitModule = EmbTrace.trace("init-module", ::InitModuleImpl),
+    override val initModule: InitModule = EmbTrace.trace("init-module", code = ::InitModuleImpl),
     override val openTelemetryModule: OpenTelemetryModule = EmbTrace.trace("otel-module") {
         OpenTelemetryModuleImpl(initModule)
     },
@@ -68,7 +68,7 @@ internal class ModuleInitBootstrapper(
     fun init(
         context: Context,
         versionChecker: VersionChecker = BuildVersionChecker,
-    ): Boolean = EmbTrace.trace("modules-init") {
+    ): Boolean = EmbTrace.trace(sectionName = "modules-init", recordDuration = true) {
         try {
             if (isInitialized()) {
                 return@trace false

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit
  * Performs bootstrapping by setting required values where there is an interdependency
  * between modules.
  */
-internal fun ModuleGraph.postInit() {
+internal fun ModuleGraph.postInit() = EmbTrace.trace(sectionName = "post-init", recordDuration = true) {
     openTelemetryModule.setEventMetadataProvider(eventMetadataSupplierProvider())
 
     // note: otelBehavior is not applied here - it decides which OTel SDK is built, so it is set
@@ -202,13 +202,14 @@ internal fun ModuleGraph.triggerPayloadSend() {
 /**
  * Mark SDK initialization as complete.
  */
-internal fun ModuleGraph.markSdkInitComplete() {
+internal fun ModuleGraph.markSdkInitComplete(sdkInitDurations: Map<String, Long>) {
     EmbTrace.trace("startup-tracking") {
         dataCaptureServiceModule.startupService.setSdkStartupInfo(
-            sdkStartTimeMs,
-            initModule.clock.now(),
-            essentialServiceModule.processStateTracker.getAppState(),
-            Thread.currentThread().name,
+            startTimeMs = sdkStartTimeMs,
+            endTimeMs = initModule.clock.now(),
+            endState = essentialServiceModule.processStateTracker.getAppState(),
+            threadName = Thread.currentThread().name,
+            sdkInitDurations = sdkInitDurations,
         )
     }
     val appId = configService.appId

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeStartupService.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeStartupService.kt
@@ -9,16 +9,19 @@ class FakeStartupService : StartupService {
     var processState: ProcessState? = null
     var threadName: String? = null
     var appVersionStartupCounterImpl: Int? = null
+    var sdkInitDurationsImpl: Map<String, Long> = emptyMap()
 
     override fun setSdkStartupInfo(
         startTimeMs: Long,
         endTimeMs: Long,
         endState: ProcessState,
         threadName: String,
+        sdkInitDurations: Map<String, Long>,
     ) {
         sdkStartupDurationImpl = endTimeMs - startTimeMs
         this.processState = endState
         this.threadName = threadName
+        sdkInitDurationsImpl = sdkInitDurations
     }
 
     override fun getSdkStartupDuration(): Long? {
@@ -36,4 +39,6 @@ class FakeStartupService : StartupService {
     override fun getInitThreadName(): String? = threadName
 
     override fun getAppVersionStartupCounter(): Int? = appVersionStartupCounterImpl
+
+    override fun getSdkInitDurations(): Map<String, Long> = sdkInitDurationsImpl
 }

--- a/embrace-android-utils/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/EmbTrace.kt
+++ b/embrace-android-utils/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/EmbTrace.kt
@@ -3,7 +3,9 @@ package io.embrace.android.embracesdk.internal.utils
 import android.annotation.SuppressLint
 import android.os.Build
 import android.os.Build.VERSION_CODES
+import android.os.SystemClock
 import android.os.Trace
+import io.embrace.android.embracesdk.internal.utils.EmbTrace.durationTracker
 
 /**
  * Shim to add custom events to system traces for API 29+. Basic alternative to using androidx.tracing that is safe to interleave.
@@ -13,6 +15,11 @@ object EmbTrace {
     const val MAX_KEY_LENGTH = 127
 
     /**
+     * Tracks the durations of sections traced with `recordDuration = true`.
+     */
+    val durationTracker: SectionDurationTracker = SectionDurationTracker()
+
+    /**
      * Create a trace section around the lambda passed in and return the result.
      * The name of the section will be [sectionName] prefixed by "emb-" and truncated to 127 characters.
      *
@@ -20,9 +27,13 @@ object EmbTrace {
      * [VERSION_CODES.Q] or when no system trace is currently being captured. Whether a section was
      * opened is captured once up front, so the section stays balanced even if tracing is toggled
      * while [code] runs.
+     *
+     * If [recordDuration] is true, the total elapsed time of the section is also accumulated
+     * in [durationTracker] under the unprefixed [sectionName]. This is recorded even when the actual
+     * trace section isn't recorded because we are running in an old Android version.
      */
     @SuppressLint("UnclosedTrace")
-    inline fun <T> trace(sectionName: String, code: Provider<T>): T {
+    inline fun <T> trace(sectionName: String, recordDuration: Boolean = false, code: Provider<T>): T {
         val enabled = Build.VERSION.SDK_INT >= VERSION_CODES.Q && Trace.isEnabled()
         if (enabled) {
             // android.os.Trace rejects section names longer than 127 chars, so only pay for the
@@ -35,9 +46,17 @@ object EmbTrace {
                 },
             )
         }
+        val startMs = if (recordDuration) {
+            SystemClock.elapsedRealtime()
+        } else {
+            0L
+        }
         try {
             return code()
         } finally {
+            if (recordDuration) {
+                durationTracker.record(sectionName, SystemClock.elapsedRealtime() - startMs)
+            }
             if (enabled) {
                 Trace.endSection()
             }

--- a/embrace-android-utils/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/SectionDurationTracker.kt
+++ b/embrace-android-utils/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/SectionDurationTracker.kt
@@ -1,0 +1,44 @@
+package io.embrace.android.embracesdk.internal.utils
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Records elapsed times in milliseconds keyed by section name until [flush] is called.
+ * The first recording for a given section is retained, while subsequent ones are discarded.
+ */
+class SectionDurationTracker {
+
+    @Volatile
+    private var enabled: Boolean = true
+
+    private val durationsMs = ConcurrentHashMap<String, Long>()
+
+    /**
+     * Record [durationMs] against [sectionName], unless a duration was already recorded for that
+     * name or recording has been disabled by [flush].
+     */
+    fun record(sectionName: String, durationMs: Long) {
+        if (enabled) {
+            durationsMs.putIfAbsent(sectionName, durationMs)
+        }
+    }
+
+    /**
+     * Disable recording, snapshot the already-recorded section durations, clear the stored recordings,
+     * and return the snapshot.
+     */
+    fun flush(): Map<String, Long> {
+        enabled = false
+        val snapshot = durationsMs.toMap()
+        durationsMs.clear()
+        return snapshot
+    }
+
+    /**
+     * Re-enable recording with cleared state.
+     */
+    fun reset() {
+        durationsMs.clear()
+        enabled = true
+    }
+}

--- a/embrace-android-utils/src/test/kotlin/io/embrace/android/embracesdk/internal/utils/EmbTraceTest.kt
+++ b/embrace-android-utils/src/test/kotlin/io/embrace/android/embracesdk/internal/utils/EmbTraceTest.kt
@@ -18,11 +18,13 @@ internal class EmbTraceTest {
     fun setUp() {
         ShadowTrace.reset()
         ShadowTrace.setEnabled(true)
+        EmbTrace.durationTracker.reset()
     }
 
     @After
     fun tearDown() {
         ShadowTrace.reset()
+        EmbTrace.durationTracker.reset()
     }
 
     @Test
@@ -32,23 +34,39 @@ internal class EmbTraceTest {
 
     @Test
     fun `trace records a section prefixed with emb-`() {
-        EmbTrace.trace("test 屈福特") { }
+        EmbTrace.trace(sectionName = "test 屈福特", recordDuration = true) { }
         assertEquals("emb-test 屈福特", ShadowTrace.getPreviousSections().single())
+        assertEquals(setOf("test 屈福特"), EmbTrace.durationTracker.flush().keys)
     }
 
     @Test
     fun `trace truncates long section names to 127 characters`() {
-        EmbTrace.trace(longName) { }
+        EmbTrace.trace(sectionName = longName, recordDuration = true) { }
         val section = ShadowTrace.getPreviousSections().single()
         assertEquals(127, section.length)
         assertTrue(section.startsWith("emb-a"))
+        assertEquals(setOf(longName), EmbTrace.durationTracker.flush().keys)
     }
 
     @Test
-    fun `trace runs the lambda but records nothing when tracing is disabled`() {
+    fun `trace runs the lambda and records a duration when tracing is disabled`() {
         ShadowTrace.setEnabled(false)
-        assertEquals(2, EmbTrace.trace("test") { 1 + 1 })
+        assertEquals(2, EmbTrace.trace(sectionName = "test", recordDuration = true) { 1 + 1 })
         assertTrue(ShadowTrace.getPreviousSections().isEmpty())
+        assertEquals(setOf("test"), EmbTrace.durationTracker.flush().keys)
+    }
+
+    @Test
+    fun `trace does not record a duration by default`() {
+        EmbTrace.trace("test") { }
+        assertTrue(EmbTrace.durationTracker.flush().isEmpty())
+    }
+
+    @Test
+    fun `trace does not record a duration after the tracker is flushed`() {
+        EmbTrace.durationTracker.flush()
+        EmbTrace.trace(sectionName = "test", recordDuration = true) { }
+        assertTrue(EmbTrace.durationTracker.flush().isEmpty())
     }
 
     @Config(sdk = [VERSION_CODES.Q])
@@ -60,9 +78,10 @@ internal class EmbTraceTest {
 
     @Config(sdk = [VERSION_CODES.P])
     @Test
-    fun `trace runs the lambda but records nothing below the supported API version`() {
-        assertEquals(2, EmbTrace.trace("test") { 1 + 1 })
+    fun `trace runs the lambda and records a duration below the supported API version`() {
+        assertEquals(2, EmbTrace.trace(sectionName = "test", recordDuration = true) { 1 + 1 })
         assertTrue(ShadowTrace.getPreviousSections().isEmpty())
+        assertEquals(setOf("test"), EmbTrace.durationTracker.flush().keys)
     }
 
     private companion object {

--- a/embrace-android-utils/src/test/kotlin/io/embrace/android/embracesdk/internal/utils/SectionDurationTrackerTest.kt
+++ b/embrace-android-utils/src/test/kotlin/io/embrace/android/embracesdk/internal/utils/SectionDurationTrackerTest.kt
@@ -1,0 +1,41 @@
+package io.embrace.android.embracesdk.internal.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+internal class SectionDurationTrackerTest {
+
+    private lateinit var tracker: SectionDurationTracker
+
+    @Before
+    fun setUp() {
+        tracker = SectionDurationTracker()
+    }
+
+    @Test
+    fun `record keeps the first duration for repeated sections`() {
+        tracker.record("x", 2)
+        tracker.record("x", 5)
+        tracker.record("y", 1)
+        assertEquals(mapOf("x" to 2L, "y" to 1L), tracker.flush())
+    }
+
+    @Test
+    fun `flush disables recording and clears state`() {
+        tracker.record("x", 2)
+        assertEquals(mapOf("x" to 2L), tracker.flush())
+        tracker.record("x", 2)
+        assertTrue(tracker.flush().isEmpty())
+    }
+
+    @Test
+    fun `reset re-enables recording with cleared state`() {
+        tracker.record("x", 2)
+        tracker.flush()
+        tracker.reset()
+        tracker.record("y", 3)
+        assertEquals(mapOf("y" to 3L), tracker.flush())
+    }
+}


### PR DESCRIPTION
Allow `EmbTrace` to track the duration of custom sections and use it to track parts of the SDK init process to further narrow down where time is spent.