### PR TITLE
Add more details to track on sdk startup

### DIFF
--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
@@ -106,4 +106,18 @@ fun List<Attribute>?.assertSdkInitSectionDurationsRecorded() {
     }
 }
 
-private val expectedSdkInitSections = listOf("modules-init", "post-init", "post-services-setup")
+/**
+ * Sections known to run within the SDK init flow during integration tests.
+ */
+private val expectedSdkInitSections = listOf(
+    "modules-init",
+    "persisted-config-load",
+    "span-service-init",
+    "essential-service-init",
+    "delivery-init",
+    "payload-source-init",
+    "otel-tracer-init",
+    "post-init",
+    "load-instrumentation",
+    "post-services-setup",
+)

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OtelSdkWrapper.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/OtelSdkWrapper.kt
@@ -39,7 +39,7 @@ class OtelSdkWrapper(
     }
 
     val sdkTracer: Tracer by lazy {
-        EmbTrace.trace("otel-tracer-init") {
+        EmbTrace.trace(sectionName = "otel-tracer-init", recordDuration = true) {
             kotlinApi.tracerProvider.getTracer(
                 name = configuration.sdkName,
                 version = configuration.sdkVersion,

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -105,34 +105,36 @@ internal class EmbraceImpl(
     private var internalInterfaceModule: InternalInterfaceModule? = null
 
     override fun start(context: Context) {
-        synchronized(startStopLock) {
-            try {
-                if (!bootstrapper.init(context)) {
-                    return
-                }
-                bootstrapper.postInit()
+        EmbTrace.trace("sdk-start") {
+            synchronized(startStopLock) {
+                try {
+                    if (!bootstrapper.init(context)) {
+                        return
+                    }
+                    bootstrapper.postInit()
 
-                EmbTrace.trace(sectionName = "post-services-setup", recordDuration = true) {
-                    internalInterfaceModule = InternalInterfaceModuleImpl(
-                        bootstrapper.initModule,
-                        bootstrapper.configService,
-                        bootstrapper.payloadSourceModule,
-                        this,
-                        bootstrapper,
-                    )
+                    EmbTrace.trace(sectionName = "post-services-setup", recordDuration = true) {
+                        internalInterfaceModule = InternalInterfaceModuleImpl(
+                            bootstrapper.initModule,
+                            bootstrapper.configService,
+                            bootstrapper.payloadSourceModule,
+                            this,
+                            bootstrapper,
+                        )
 
-                    // not fully initialized, but the SDK shouldn't catastrophically throw after this point,
-                    // so we allow external calls.
-                    sdkCallChecker.started.set(true)
-                    bootstrapper.registerListeners()
-                    bootstrapper.loadInstrumentation()
-                    initializeHucInstrumentation(bootstrapper.configService.networkBehavior)
-                    bootstrapper.postLoadInstrumentation()
-                    bootstrapper.triggerPayloadSend()
+                        // not fully initialized, but the SDK shouldn't catastrophically throw after this point,
+                        // so we allow external calls.
+                        sdkCallChecker.started.set(true)
+                        bootstrapper.registerListeners()
+                        bootstrapper.loadInstrumentation()
+                        initializeHucInstrumentation(bootstrapper.configService.networkBehavior)
+                        bootstrapper.postLoadInstrumentation()
+                        bootstrapper.triggerPayloadSend()
+                    }
+                    bootstrapper.markSdkInitComplete(EmbTrace.durationTracker.flush())
+                } catch (ignored: Throwable) {
+                    Log.w("Embrace", "Failed to initialize Embrace SDK", ignored)
                 }
-                bootstrapper.markSdkInitComplete(EmbTrace.durationTracker.flush())
-            } catch (ignored: Throwable) {
-                Log.w("Embrace", "Failed to initialize Embrace SDK", ignored)
             }
         }
     }

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
@@ -67,7 +67,7 @@ internal class InitializedModuleGraph(
             openTelemetryModule,
             workerThreadModule,
             persistedConfig,
-        ) ?: EmbTrace.trace("config-service-init") {
+        ) ?: EmbTrace.trace(sectionName = "config-service-init", recordDuration = true) {
             ConfigServiceImpl(
                 instrumentedConfig = initModule.instrumentedConfig,
                 persistedConfig = persistedConfig,
@@ -93,38 +93,39 @@ internal class InitializedModuleGraph(
         // Deliberately after the disable check so a disabled SDK never builds the OTel SDK, and after
         // configService so that the otel behavior set in ModuleInitBootstrapper.init has been read
         // from the same persisted config this service uses.
-        EmbTrace.trace("span-service-init") {
+        EmbTrace.trace(sectionName = "span-service-init", recordDuration = true) {
             openTelemetryModule.spanService.initializeService(sdkStartTimeMs)
         }
     }
 
-    override val essentialServiceModule: EssentialServiceModule = init("essential-service") {
-        val lifecycleTrackerProvider: Provider<LifecycleTracker?> = { null }
-        val networkConnectivityServiceProvider: Provider<NetworkConnectivityService?> = { null }
-        val sessionOrchestratorProvider = { userSessionOrchestrationModule.sessionOrchestrator }
+    override val essentialServiceModule: EssentialServiceModule =
+        init(name = "essential-service", recordDuration = true) {
+            val lifecycleTrackerProvider: Provider<LifecycleTracker?> = { null }
+            val networkConnectivityServiceProvider: Provider<NetworkConnectivityService?> = { null }
+            val sessionOrchestratorProvider = { userSessionOrchestrationModule.sessionOrchestrator }
 
-        essentialServiceModuleSupplier?.invoke(
-            initModule,
-            configService,
-            openTelemetryModule,
-            coreModule,
-            workerThreadModule,
-            context,
-            lifecycleTrackerProvider,
-            networkConnectivityServiceProvider,
-            sessionOrchestratorProvider,
-        ) ?: EssentialServiceModuleImpl(
-            initModule,
-            configService,
-            openTelemetryModule,
-            coreModule,
-            workerThreadModule,
-            context,
-            lifecycleTrackerProvider,
-            networkConnectivityServiceProvider,
-            sessionOrchestratorProvider,
-        )
-    }
+            essentialServiceModuleSupplier?.invoke(
+                initModule,
+                configService,
+                openTelemetryModule,
+                coreModule,
+                workerThreadModule,
+                context,
+                lifecycleTrackerProvider,
+                networkConnectivityServiceProvider,
+                sessionOrchestratorProvider,
+            ) ?: EssentialServiceModuleImpl(
+                initModule,
+                configService,
+                openTelemetryModule,
+                coreModule,
+                workerThreadModule,
+                context,
+                lifecycleTrackerProvider,
+                networkConnectivityServiceProvider,
+                sessionOrchestratorProvider,
+            )
+        }
 
     override val storageService: StorageService = init("storage") {
         storageServiceSupplier?.invoke(initModule, coreModule, workerThreadModule)
@@ -200,7 +201,7 @@ internal class InitializedModuleGraph(
         )
     }
 
-    override val deliveryModule: DeliveryModule? = init("delivery") {
+    override val deliveryModule: DeliveryModule? = init(name = "delivery", recordDuration = true) {
         if (configService.isOnlyUsingOtelExporters()) {
             null
         } else {
@@ -234,7 +235,7 @@ internal class InitializedModuleGraph(
         threadBlockageServiceSupplier?.invoke(args) ?: createThreadBlockageService(args)
     }
 
-    override val payloadSourceModule: PayloadSourceModule = init("payload-source") {
+    override val payloadSourceModule: PayloadSourceModule = init(name = "payload-source", recordDuration = true) {
         payloadSourceModuleSupplier?.invoke(
             initModule,
             coreModule,
@@ -308,6 +309,6 @@ internal class InitializedModuleGraph(
         )
     }
 
-    private inline fun <T> init(name: String, supplier: () -> T): T =
-        EmbTrace.trace("$name-init") { supplier() }
+    private inline fun <T> init(name: String, recordDuration: Boolean = false, supplier: () -> T): T =
+        EmbTrace.trace("$name-init", recordDuration) { supplier() }
 }

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -76,7 +76,10 @@ internal class ModuleInitBootstrapper(
             // stamped before anything else so that the SDK init span covers all the work below
             val startTimeMs = initModule.clock.now()
             val keyValueStore = lazy { createKeyValueStore(context, initModule.jsonSerializer) }
-            val persistedConfig = EmbTrace.trace("persisted-config-load") {
+            val persistedConfig = EmbTrace.trace(
+                sectionName = "persisted-config-load",
+                recordDuration = true,
+            ) {
                 PersistedConfig(
                     serializer = initModule.jsonSerializer,
                     filesDir = context.filesDir,

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
@@ -106,16 +106,17 @@ internal fun ModuleGraph.registerListeners() {
 /**
  * Loads instrumentation via SPI and legacy methods.
  */
-internal fun ModuleGraph.loadInstrumentation() {
-    val registry = instrumentationModule.instrumentationRegistry
-    registry.loadInstrumentations(loadInstrumentationProviders(), instrumentationModule.instrumentationArgs)
+internal fun ModuleGraph.loadInstrumentation() =
+    EmbTrace.trace(sectionName = "load-instrumentation", recordDuration = true) {
+        val registry = instrumentationModule.instrumentationRegistry
+        registry.loadInstrumentations(loadInstrumentationProviders(), instrumentationModule.instrumentationArgs)
 
-    threadBlockageService?.startCapture()
+        threadBlockageService?.startCapture()
 
-    featureModule.lastRunCrashVerifier.readAndCleanMarkerAsync(
-        workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker),
-    )
-}
+        featureModule.lastRunCrashVerifier.readAndCleanMarkerAsync(
+            workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker),
+        )
+    }
 
 /**
  * Loads the [InstrumentationProvider] implementations declared via SPI. Before making changes


### PR DESCRIPTION
Add seemingly expensive sub-sections in the SDK init to the startup tracking