### PR TITLE
Add macrobenchmark test to profile sdk startup with accompanying skill

### DIFF
--- a/.claude/skills/startup-analysis/SKILL.md
+++ b/.claude/skills/startup-analysis/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: startup-analysis
+description: Run the SDK startup macrobenchmark on a connected Android device and analyze the EmbTrace section durations and SDK-init span timing, including each section's share of the SDK-init span. Defaults to benchmarking a locally built SDK; can also target a publicly released SDK version. Use when asked to measure, verify, or compare SDK startup/init performance on-device.
+---
+
+# SDK startup analysis (macrobenchmark)
+
+Measures Embrace SDK init on a real device via `examples/ExampleApp` and reports per-section
+durations, SDK-init span timing, each section's percentage of the span, and a main-thread
+scheduling readout per iteration. The analysis is derived ENTIRELY from the per-iteration
+`.perfetto-trace` files via perfetto's trace_processor — no logcat, grep, jq, or benchmark-JSON
+parsing. All paths below are relative to the SDK repo root.
+
+## Bundled files (relative to this skill's base directory)
+
+Primary analysis:
+- `scripts/analyze_startup.py` — THE analysis entry point (python3 stdlib only): runs
+  trace_processor over every iteration trace in a directory and prints section stats,
+  window stats, TTID stats, and the per-iteration contention/slow-execution table.
+- `scripts/startup_metrics.sql` — the per-trace query analyze_startup.py executes (sections,
+  window, TTID, main-thread thread-state; commented).
+- `scripts/init_window_sched.sql` — standalone deep-dive on ONE trace: thread-state + per-CPU
+  residency over the modules-init window. To find who stole the CPUs, query `sched` joined to
+  `thread`/`process` excluding the window's utid.
+- `scripts/serve_trace.py` — CORS-enabled static server for opening traces in ui.perfetto.dev
+  (`python3 serve_trace.py <dir> [port]`).
+
+References:
+- `references/sections.md` — section nesting/execution order, which environments each section
+  appears in, reference numbers, and the two slow-pass signatures (contention vs slow
+  execution) for judging noisy passes.
+- `references/report-template.html` — the report page to adapt (a real past report; see the
+  comment at the top for what to replace vs keep). Write each analysis's report to
+  `claude-output/startup-analysis-<YYYY-MM-DD-HHMMSS>.html` using the SAME timestamp as that
+  analysis's summary .txt, so the pair is uniquely referencable and never clobbered.
+  Publishing a new path mints a new artifact URL per analysis — reuse a previous report's
+  exact file path only when intentionally updating that report (and its URL) in place.
+
+There is deliberately no logcat/jq/grep/benchmark-JSON path — the traces are the single source
+of truth. The one thing traces cannot verify is the `<section>-duration-ms` attributes on the
+exported span (`recordDuration`); if that mechanism ever needs validating, it is an SDK
+integration-test concern, not this skill's.
+
+## What you get (all from the traces)
+
+- Duration of EVERY `emb-*` section (first occurrence, matching TraceSectionMetric
+  `Mode.First`), as min/median/max over N iterations — the 13 canonical sections in execution
+  order with %-of-window, plus every finer-grained section the SDK emits (`emb-sdk-start`,
+  `emb-install-native-crash-signal-handlers`, `emb-record-startup`, …), which the old
+  JSON-metric path never captured.
+- SDK-init window per iteration, from the `emb-sdk-start` slice — it wraps the whole
+  `Embrace.start()` call and runs <1 ms wider than the exported `emb-embrace-init` /private
+  `emb-sdk-init` span. On SDKs without `emb-sdk-start` (before 9.2.0) the window falls back to
+  first `emb-modules-init` start → first `emb-post-services-setup` end, which equals the
+  exported span interval by construction. The output states which source was used; never
+  compare windows across sources.
+- TTID per iteration from trace_processor's `android.startup` stdlib module. Its anchor differs
+  from macrobenchmark's `timeToInitialDisplayMs` by a few ms (consistently, e.g. +6–7 ms on the
+  Galaxy A14) — fine for comparisons as long as both sides come from the same source.
+- Per-iteration main-thread scheduling inside the window: Running time, runnable-wait (R/R+)
+  time, distinct CPUs — flags CONTENDED iterations and distinguishes the two slow signatures
+  (see references/sections.md).
+
+## Prerequisites
+
+- Physical device on `adb devices`, booted (`adb shell getprop sys.boot_completed` → 1),
+  screen on/unlocked.
+- `examples/ExampleApp/app/benchmark/src/main/java/io/embrace/android/benchmark/StartupBenchmarks.kt`
+  is purely the harness: it drives N instrumented cold starts so each iteration records a
+  perfetto trace. Its metric list is the minimum `measureRepeated` requires
+  (`StartupTimingMetric` only) and is NOT the source of any reported number — it never needs to
+  track SDK sections.
+
+## Choosing the SDK under test
+
+Do NOT assume the version already in `examples/ExampleApp/gradle/libs.versions.toml` is correct —
+always set it explicitly for the run, note the value you replaced, and restore it afterwards.
+
+**Default — locally built SDK (the working tree):**
+1. `./gradlew publishToMavenLocal -q` from the repo root.
+2. Read `version=` from `gradle.properties` at the repo root (e.g. `9.2.0-SNAPSHOT`) and set
+   `embrace = "<that version>"` in the ExampleApp catalog. Both ExampleApp repo blocks already
+   include `mavenLocal()`, and the `io.embrace.gradle` plugin resolves from there at the same
+   version.
+
+**Option — publicly released SDK (e.g. comparing against a shipped version):**
+1. Set `embrace = "<released version>"` (e.g. `9.0.0`) in the ExampleApp catalog; artifacts and
+   the gradle plugin resolve from mavenCentral. No publish step.
+2. Compile-check first (`:app:assembleBenchmark`) — the ExampleApp uses current public API, so
+   very old versions may not compile; that bounds how far back this option reaches.
+
+## Procedure
+
+1. Set the SDK version (above), then run:
+   ```
+   examples/ExampleApp/gradlew -p examples/ExampleApp :app:benchmark:connectedBenchmarkAndroidTest \
+     -Pandroid.testInstrumentationRunnerArguments.class=io.embrace.android.benchmark.StartupBenchmarks \
+     -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.dryRunMode.enable=false
+   ```
+   The dry-run override is mandatory — the module defaults it to true, and dry runs produce NO
+   traces (there would be nothing to analyze).
+2. **Collect**: the per-iteration traces land in
+   `examples/ExampleApp/app/benchmark/build/outputs/connected_android_test_additional_output/benchmark/connected/<device>/`
+   as `StartupBenchmarks_coldStartup_iterNNN_<timestamp>.perfetto-trace`. Each rerun WIPES this
+   directory — copy any traces you need to keep (e.g. per-pass comparisons) before rerunning.
+3. **Analyze**: fetch the trace_processor launcher once per machine (it is a python3 script that
+   self-downloads the native binary on first use):
+   ```
+   curl -sL -o <scratchpad>/trace_processor https://get.perfetto.dev/trace_processor
+   ```
+   then run
+   ```
+   python3 .claude/skills/startup-analysis/scripts/analyze_startup.py \
+     --trace-processor <scratchpad>/trace_processor "<traces dir>"
+   ```
+   (`--all-sections` to list every emb-* section instead of the top 15 extras.) Besides
+   printing, the summary is written to a uniquely named file —
+   `claude-output/startup-analysis-<YYYY-MM-DD-HHMMSS>.txt` (analysis start time;
+   `--output-dir` overrides) — so successive runs never clobber each other; cite that file
+   in reports and keep it as the per-pass record (the traces themselves get wiped by the
+   next benchmark run).
+   Every analysis/report must state the test context up front: device manufacturer + model and
+   Android version (via
+   `adb shell "getprop ro.product.manufacturer; getprop ro.product.model; getprop ro.build.version.release"`
+   — `getprop` takes ONE property per call; the model also appears in the results directory
+   name), the SDK version under test, iteration count, and date.
+4. **Interpret**: present the canonical sections in execution order with nesting; children
+   overlap parents, so percentages do not sum to 100; the class-load sections
+   (`embrace-impl-init`, `bootstrapper-init`) run BEFORE the window opens, so their % is context
+   relative to the window, not a share of it. Check the scheduling table before comparing
+   passes — iterations flagged CONTENDED, or whole passes with elevated Running time, are
+   environment noise, not regressions (signatures in references/sections.md).
+5. **Inspect a trace visually (optional)**: serve the traces dir on `127.0.0.1:9001` with
+   `serve_trace.py` (plain `python3 -m http.server` lacks the CORS header) and open
+   `https://ui.perfetto.dev/#!/?url=http://127.0.0.1:9001/<file>` — the first fetch can take
+   ~30 s (private-network preflight). Once loaded, the address bar rewrites to a durable
+   `local_cache_key` URL that resolves from that machine's Chrome afterwards; use that form in
+   reports. Pick the iteration whose window is the median (or a flagged-vs-clean pair when
+   illustrating variance).
+6. **Restore** the catalog's `embrace` version to the value you replaced.
+
+## Handling missing data (older SDK versions)
+
+- **Missing sections**: analyze_startup.py prints "not instrumented in this SDK version" for
+  canonical sections with no slice — report those explicitly; never present the found set as
+  complete. (At public 9.0.0, present: `embrace-impl-init`, `bootstrapper-init`, `modules-init`,
+  `config-service-init`, `span-service-init`, `otel-tracer-init`, `post-services-setup`.)
+- **Window**: `emb-sdk-start` exists from 9.2.0; older SDKs automatically fall back to the
+  composed window (`emb-modules-init` + `emb-post-services-setup`, both present since 9.0.0) —
+  the output names the source, and windows from different sources must not be compared
+  directly. TTID from the `android.startup` module works regardless of SDK version.
+- **Section semantics drift between versions.** A section that exists in both versions may cover
+  different work (e.g. 9.0.0's `post-services-setup` includes what later versions subdivide into
+  `load-instrumentation` and `post-init`-adjacent work, and its `config-service-init` covers a
+  different construction path). When comparing versions, compare only sections present in both,
+  call out semantic drift, and lean on the window duration and TTID as the apples-to-apples
+  numbers.
+- Confirm which sections a public version *should* emit with
+  `git grep -n "EmbTrace.trace" <version-tag> -- "*.kt"` — and beware pathspec globs: `*` does
+  not cross directory separators, so use the bare `"*.kt"` form over module-scoped globs.
+
+## Interpretation gotchas
+
+- **Section counts differ by environment**: sections behind supplier fallbacks
+  (`config-service-init`) and the class-load sections (`embrace-impl-init`, `bootstrapper-init`)
+  appear on-device but not in the Robolectric integration harness — the authoritative
+  integration-test list lives in `SpanAssertions.expectedSdkInitSections` (embrace-android-otel-fakes).
+- **Pre-start Embrace references skew the window**: the class-load init (`embrace-impl-init`,
+  `bootstrapper-init`) fires on the app's FIRST reference to the `Embrace` class — any API call
+  or property access triggers it, not any one method in particular. Pre-start API calls can
+  additionally force SDK lazies (e.g. an exporter registration constructing the OTel config)
+  before the window opens, hoisting that work out of the window. ExampleApp touches the API
+  before `Embrace.start()`, so its window durations under-count relative to an app whose first
+  Embrace reference is `start()` itself. Individual section durations remain comparable either
+  way.
+- **TTID source consistency**: trace-derived TTID (android.startup module) and macrobenchmark's
+  JSON `timeToInitialDisplayMs` differ by a few ms in anchor. Never mix the two sources within
+  one comparison.

--- a/.claude/skills/startup-analysis/SKILL.md
+++ b/.claude/skills/startup-analysis/SKILL.md
@@ -29,7 +29,7 @@ References:
 - `references/sections.md` — section nesting/execution order, which environments each section
   appears in, reference numbers, and the two slow-pass signatures (contention vs slow
   execution) for judging noisy passes.
-- `references/report-template.html` — the report page to adapt (a real past report; see the
+- `references/report-template.html` — the report page to adapt (a filled example; see the
   comment at the top for what to replace vs keep). Write each analysis's report to
   `claude-output/startup-analysis-<YYYY-MM-DD-HHMMSS>.html` using the SAME timestamp as that
   analysis's summary .txt, so the pair is uniquely referencable and never clobbered.

--- a/.claude/skills/startup-analysis/references/report-template.html
+++ b/.claude/skills/startup-analysis/references/report-template.html
@@ -1,0 +1,224 @@
+<!--
+  TEMPLATE for the startup-analysis report. This is a real report from a past run, kept intact as
+  a working example. To produce a new report: keep the CSS tokens (both themes), layout, table
+  structure, and the standing footnotes (nesting/percentage caveats, class-load-section star,
+  method paragraph) — and replace every number, the context line (device/OS/SDK version/iteration
+  count/date — device context is mandatory), the verdict, the section rows (drop rows for
+  sections the SDK under test lacks and say so), and the "Reading the breakdown" prose. Remove
+  the perfetto link unless you minted one for this run.
+-->
+<title>SDK Init Timing — Current State</title>
+<style>
+  :root {
+    --ground: #FAF9F6;
+    --surface: #FFFFFF;
+    --ink: #1C1E21;
+    --ink-secondary: #55524B;
+    --muted: #8A8577;
+    --line: #E5E2D9;
+    --accent: #D9930D;
+    --accent-soft: #F5E3BC;
+    --good: #3E7C4F;
+    --good-soft: #E4EFE6;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --ground: #16181C;
+      --surface: #1E2126;
+      --ink: #ECEAE4;
+      --ink-secondary: #B5B1A6;
+      --muted: #7D796E;
+      --line: #33363C;
+      --accent: #E8B04B;
+      --accent-soft: #3A3123;
+      --good: #7FBB8E;
+      --good-soft: #24352A;
+    }
+  }
+  :root[data-theme="dark"] {
+    --ground: #16181C;
+    --surface: #1E2126;
+    --ink: #ECEAE4;
+    --ink-secondary: #B5B1A6;
+    --muted: #7D796E;
+    --line: #33363C;
+    --accent: #E8B04B;
+    --accent-soft: #3A3123;
+    --good: #7FBB8E;
+    --good-soft: #24352A;
+  }
+  body {
+    background: var(--ground);
+    color: var(--ink);
+    font-family: -apple-system, "Segoe UI", Roboto, sans-serif;
+    line-height: 1.55;
+    margin: 0;
+    padding: 40px 24px 72px;
+  }
+  main { max-width: 920px; margin: 0 auto; }
+  h1 { font-size: 1.7rem; letter-spacing: -0.01em; margin: 0 0 4px; text-wrap: balance; }
+  h2 { font-size: 1.05rem; margin: 44px 0 12px; letter-spacing: -0.005em; }
+  .context { color: var(--ink-secondary); font-size: 0.9rem; margin: 0 0 20px; }
+  .verdict {
+    background: var(--good-soft);
+    color: var(--good);
+    border-radius: 6px;
+    padding: 12px 16px;
+    font-size: 0.92rem;
+    font-weight: 600;
+    margin-bottom: 28px;
+  }
+  .tiles { display: flex; gap: 12px; flex-wrap: wrap; }
+  .tile {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 14px 18px;
+    flex: 1 1 150px;
+  }
+  .tile .label {
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: var(--muted);
+    margin-bottom: 2px;
+  }
+  .tile .value {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-variant-numeric: tabular-nums;
+    font-size: 1.55rem;
+    font-weight: 650;
+  }
+  .tile .unit { font-size: 0.85rem; color: var(--ink-secondary); font-weight: 400; }
+  .tablewrap { overflow-x: auto; background: var(--surface); border: 1px solid var(--line); border-radius: 8px; }
+  table { border-collapse: collapse; width: 100%; font-size: 0.86rem; }
+  th {
+    text-align: left;
+    font-size: 0.66rem;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: var(--muted);
+    font-weight: 600;
+    padding: 10px 12px 6px;
+    border-bottom: 1px solid var(--line);
+  }
+  th.num, td.num {
+    text-align: right;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-variant-numeric: tabular-nums;
+  }
+  td { padding: 7px 12px; border-bottom: 1px solid var(--line); }
+  tr:last-child td { border-bottom: none; }
+  td.section { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 0.82rem; white-space: nowrap; }
+  .nest1 { padding-left: 28px; }
+  .nest2 { padding-left: 44px; }
+  .nest1::before, .nest2::before { content: "↳ "; color: var(--muted); }
+  td.pct { font-weight: 650; }
+  td.pct-outside { color: var(--muted); font-style: italic; }
+  td.barcell { width: 26%; min-width: 120px; }
+  .bar {
+    height: 10px;
+    background: var(--accent);
+    border-radius: 0 4px 4px 0;
+    min-width: 2px;
+  }
+  .note { color: var(--ink-secondary); font-size: 0.84rem; margin-top: 10px; }
+  .runs { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 0.8rem; color: var(--ink-secondary); overflow-x: auto; white-space: nowrap; padding: 4px 0; }
+  code {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 0.85em;
+    background: var(--accent-soft);
+    border-radius: 4px;
+    padding: 1px 5px;
+  }
+  a { color: var(--accent); font-weight: 600; }
+  footer { margin-top: 48px; color: var(--muted); font-size: 0.8rem; border-top: 1px solid var(--line); padding-top: 16px; }
+  footer p { margin: 4px 0; }
+</style>
+
+<main>
+  <h1>SDK Init Timing — Current State</h1>
+  <p class="context">Samsung Galaxy A14 (SM-A145M) · Android 15 · Embrace SDK 9.2.0-SNAPSHOT (13 instrumented sections, <code>otel-tracer-init</code> replacing <code>otel-sdk-wrapper-init</code>) · ExampleApp benchmark variant, R8-minified, no baseline profile · 2026-08-11 · 20 cold-start iterations</p>
+
+  <div class="verdict">✓ All 13 sections recorded on every run. Span-vs-section cross-check holds (48.0 ms span median vs 48.8 ms Σ window sections). The newly tracked <code>otel-tracer-init</code> surfaces 12.2 ms — 25% of the span — that the old wrapper section reported as 0.07 ms.</div>
+
+  <div class="tiles">
+    <div class="tile">
+      <div class="label">Cold start (TTID) · median</div>
+      <div class="value">948 <span class="unit">ms</span></div>
+    </div>
+    <div class="tile">
+      <div class="label">SDK-init span · median</div>
+      <div class="value">48 <span class="unit">ms</span></div>
+    </div>
+    <div class="tile">
+      <div class="label">SDK share of startup</div>
+      <div class="value">~5.1 <span class="unit">%</span></div>
+    </div>
+    <div class="tile">
+      <div class="label">Measured iterations</div>
+      <div class="value">20</div>
+    </div>
+  </div>
+
+  <h2>Init sections, in execution order</h2>
+  <div class="tablewrap">
+    <table>
+      <thead>
+        <tr>
+          <th>Section</th>
+          <th class="num">min</th>
+          <th class="num">median</th>
+          <th class="num">max</th>
+          <th class="num">% of span</th>
+          <th>Median (ms)</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td class="section">embrace-impl-init</td><td class="num">3.47</td><td class="num">4.87</td><td class="num">8.08</td><td class="num pct pct-outside">10.1*</td><td class="barcell"><div class="bar" style="width:10.9%"></div></td></tr>
+        <tr><td class="section nest1">bootstrapper-init</td><td class="num">2.22</td><td class="num">3.22</td><td class="num">6.51</td><td class="num pct pct-outside">6.7*</td><td class="barcell"><div class="bar" style="width:7.2%"></div></td></tr>
+        <tr><td class="section">modules-init</td><td class="num">36.53</td><td class="num">44.53</td><td class="num">66.76</td><td class="num pct">92.8</td><td class="barcell"><div class="bar" style="width:100%"></div></td></tr>
+        <tr><td class="section nest1">persisted-config-load</td><td class="num">1.91</td><td class="num">13.20</td><td class="num">20.45</td><td class="num pct">27.5</td><td class="barcell"><div class="bar" style="width:29.6%"></div></td></tr>
+        <tr><td class="section nest1">config-service-init</td><td class="num">1.43</td><td class="num">1.93</td><td class="num">4.59</td><td class="num pct">4.0</td><td class="barcell"><div class="bar" style="width:4.3%"></div></td></tr>
+        <tr><td class="section nest1">span-service-init</td><td class="num">13.53</td><td class="num">15.46</td><td class="num">20.86</td><td class="num pct">32.2</td><td class="barcell"><div class="bar" style="width:34.7%"></div></td></tr>
+        <tr><td class="section nest2">otel-tracer-init</td><td class="num">9.99</td><td class="num">12.22</td><td class="num">15.72</td><td class="num pct">25.5</td><td class="barcell"><div class="bar" style="width:27.4%"></div></td></tr>
+        <tr><td class="section nest1">essential-service-init</td><td class="num">0.87</td><td class="num">1.27</td><td class="num">2.76</td><td class="num pct">2.6</td><td class="barcell"><div class="bar" style="width:2.8%"></div></td></tr>
+        <tr><td class="section nest1">delivery-init</td><td class="num">2.03</td><td class="num">2.27</td><td class="num">5.33</td><td class="num pct">4.7</td><td class="barcell"><div class="bar" style="width:5.1%"></div></td></tr>
+        <tr><td class="section nest1">payload-source-init</td><td class="num">4.27</td><td class="num">6.06</td><td class="num">9.79</td><td class="num pct">12.6</td><td class="barcell"><div class="bar" style="width:13.6%"></div></td></tr>
+        <tr><td class="section">post-init</td><td class="num">0.68</td><td class="num">0.97</td><td class="num">2.24</td><td class="num pct">2.0</td><td class="barcell"><div class="bar" style="width:2.2%"></div></td></tr>
+        <tr><td class="section">post-services-setup</td><td class="num">2.71</td><td class="num">3.26</td><td class="num">9.77</td><td class="num pct">6.8</td><td class="barcell"><div class="bar" style="width:7.3%"></div></td></tr>
+        <tr><td class="section nest1">load-instrumentation</td><td class="num">2.54</td><td class="num">3.06</td><td class="num">8.08</td><td class="num pct">6.4</td><td class="barcell"><div class="bar" style="width:6.9%"></div></td></tr>
+      </tbody>
+    </table>
+  </div>
+  <p class="note">Perfetto trace-slice medians over 20 runs; <strong>% of span</strong> = section median ÷ SDK-init span median (48 ms). Indentation shows nesting — a parent's time includes its children, so percentages deliberately do not sum to 100. *Starred sections run at class-load, <em>before</em> the span window opens: their % is scale context relative to the span, not a share of it. The three top-level window sections (<code>modules-init</code> 92.8% + <code>post-init</code> 2.0% + <code>post-services-setup</code> 6.8%) tile the span (≈101.6%, within rounding of the whole-ms attribute values).</p>
+
+  <h2>SDK-init span timing</h2>
+  <div class="tablewrap">
+    <table>
+      <thead>
+        <tr>
+          <th class="num">min</th>
+          <th class="num">median</th>
+          <th class="num">mean</th>
+          <th class="num">max</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td class="num">44</td><td class="num">48</td><td class="num">51.2</td><td class="num">74</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="runs">Runs (ms): 48 · 59 · 44 · 47 · 46 · 48 · 46 · 52 · 74 · 48 · 47 · 46 · 53 · 51 · 48 · 52 · 58 · 55 · 48 · 53</div>
+  <p class="note">Span duration = <code>EndNanos − StartNanos</code> of the exported <code>emb-embrace-init</code> span; the private <code>emb-sdk-init</code> span covers the identical interval by construction.</p>
+
+  <h2>Reading the breakdown</h2>
+  <p class="note" style="margin-top:0">
+    The span decomposes into three big costs plus a tail: <strong><code>persisted-config-load</code> (27.5%)</strong> — cached-config read, the most variable section (1.9–20.4 ms); <strong><code>otel-tracer-init</code> (25.5%)</strong> — assembling the OTel SDK instance (tracer provider, resource, processors), newly visible after replacing the constructor-only <code>otel-sdk-wrapper-init</code> (~0.07 ms) with the section that absorbs the real cost; and <strong><code>payload-source-init</code> (12.6%)</strong>. Everything else is ≤ 7% each. This pass ran on a warm device (TTID 948 ms vs 828–939 ms in earlier passes) — absolute ms drift with thermals; the percentage shares are the stabler signal across passes.
+  </p>
+
+  <footer>
+    <p><strong>Method.</strong> androidx.macrobenchmark, <code>StartupMode.COLD</code>, 20 measured iterations, 0 warm-up, dry-run disabled, default CompilationMode, no baseline profile. Section durations from perfetto trace slices; span timing from the SDK's own <code>SystemClock.elapsedRealtime()</code>-based timestamps. Runbook: <code>.claude/skills/startup-analysis</code> (<code>/startup-analysis</code>).</p>
+    <p><strong>Representative trace</strong> (earlier 12-section pass): <a href="https://ui.perfetto.dev/#!/viewer?local_cache_key=f751dff6-61ba-aa63-aaee-c8bc88d396cb">open in Perfetto UI</a> (resolves from this machine's Chrome cache). Raw traces + JSON: <code>…/app/benchmark/build/outputs/connected_android_test_additional_output/benchmark/connected/SM-A145M - 15/</code></p>
+  </footer>
+</main>

--- a/.claude/skills/startup-analysis/references/report-template.html
+++ b/.claude/skills/startup-analysis/references/report-template.html
@@ -1,13 +1,33 @@
 <!--
-  TEMPLATE for the startup-analysis report. This is a real report from a past run, kept intact as
-  a working example. To produce a new report: keep the CSS tokens (both themes), layout, table
-  structure, and the standing footnotes (nesting/percentage caveats, class-load-section star,
-  method paragraph) — and replace every number, the context line (device/OS/SDK version/iteration
-  count/date — device context is mandatory), the verdict, the section rows (drop rows for
-  sections the SDK under test lacks and say so), and the "Reading the breakdown" prose. Remove
-  the perfetto link unless you minted one for this run.
+  TEMPLATE for the startup-analysis report.            (FYI: template last updated 2026-08-12)
+
+  Each generated report covers exactly one skill invocation — every pass run during that
+  invocation, on the same device/SDK build — not the status of any broader investigation.
+
+  Identity fields are placeholders in ⟨angle brackets⟩: ANY device meeting the skill's
+  prerequisites works — the report must state which device was used and its important
+  attributes (manufacturer, model, device code, Android version/API level), all obtainable
+  via the adb command in the skill. The numeric values below are ILLUSTRATIVE ONLY — they show
+  the expected shape/precision of each cell, not expected magnitudes (real numbers vary by an
+  order of magnitude across device tiers).
+
+  SDK version: report it because it determines WHICH trace data exists, not as an identity —
+  it fixes the window source (emb-sdk-start slice on newer SDKs; composed
+  modules-init→post-services-setup fallback on older ones; analyze_startup.py names which) and
+  the set of emb-* sections present. State the expected-vs-found section set; drop table rows
+  for sections the SDK under test lacks and say so (see SKILL.md "Handling missing data").
+
+  Keep: the CSS tokens (both light/dark themes), layout, tiles row, table structure including
+  the nest1/nest2 indentation markers, and the standing footnotes (nesting/percentage caveats,
+  the class-load-section star note, the method paragraph). The report's filename timestamp must
+  match its paired summary .txt from the same invocation.
+
+  Replace: every number and every ⟨placeholder⟩, the verdict, the section rows, and the
+  "Reading the breakdown" prose — written about this invocation's own runs only (spread across
+  iterations, contention flags), never comparing to other analyses. Remove the perfetto link
+  unless you minted one for this run.
 -->
-<title>SDK Init Timing — Current State</title>
+<title>SDK Init Timing — ⟨YYYY-MM-DD⟩ (⟨SDK version under test⟩)</title>
 <style>
   :root {
     --ground: #FAF9F6;
@@ -137,10 +157,10 @@
 </style>
 
 <main>
-  <h1>SDK Init Timing — Current State</h1>
-  <p class="context">Samsung Galaxy A14 (SM-A145M) · Android 15 · Embrace SDK 9.2.0-SNAPSHOT (13 instrumented sections, <code>otel-tracer-init</code> replacing <code>otel-sdk-wrapper-init</code>) · ExampleApp benchmark variant, R8-minified, no baseline profile · 2026-08-11 · 20 cold-start iterations</p>
+  <h1>SDK Init Timing — ⟨YYYY-MM-DD⟩ (⟨SDK version under test⟩)</h1>
+  <p class="context">⟨Manufacturer⟩ ⟨Model⟩ (⟨device code⟩) · Android ⟨version⟩ (API ⟨level⟩) · Embrace SDK ⟨version under test⟩ · ExampleApp benchmark variant, R8-minified, no baseline profile · ⟨analysis date⟩ · ⟨N⟩ cold-start iterations</p>
 
-  <div class="verdict">✓ All 13 sections recorded on every run. Span-vs-section cross-check holds (48.0 ms span median vs 48.8 ms Σ window sections). The newly tracked <code>otel-tracer-init</code> surfaces 12.2 ms — 25% of the span — that the old wrapper section reported as 0.07 ms.</div>
+  <div class="verdict">✓ All ⟨M⟩ sections expected for this SDK version recorded on ⟨N⟩/⟨N⟩ runs (window source: ⟨emb-sdk-start | composed fallback⟩). SDK-init window median ⟨X⟩ ms; ⟨0⟩/⟨N⟩ iterations flagged CONTENDED. ⟨If any sections expected for this SDK version were absent, or iterations were contended, say so here.⟩</div>
 
   <div class="tiles">
     <div class="tile">
@@ -214,11 +234,11 @@
 
   <h2>Reading the breakdown</h2>
   <p class="note" style="margin-top:0">
-    The span decomposes into three big costs plus a tail: <strong><code>persisted-config-load</code> (27.5%)</strong> — cached-config read, the most variable section (1.9–20.4 ms); <strong><code>otel-tracer-init</code> (25.5%)</strong> — assembling the OTel SDK instance (tracer provider, resource, processors), newly visible after replacing the constructor-only <code>otel-sdk-wrapper-init</code> (~0.07 ms) with the section that absorbs the real cost; and <strong><code>payload-source-init</code> (12.6%)</strong>. Everything else is ≤ 7% each. This pass ran on a warm device (TTID 948 ms vs 828–939 ms in earlier passes) — absolute ms drift with thermals; the percentage shares are the stabler signal across passes.
+    The span decomposes into three big costs plus a tail: <strong><code>persisted-config-load</code> (27.5%)</strong> — cached-config read, the most variable section in this run (1.9–20.4 ms); <strong><code>otel-tracer-init</code> (25.5%)</strong> — assembling the OTel SDK instance (tracer provider, resource, processors); and <strong><code>payload-source-init</code> (12.6%)</strong>. Everything else is ≤ 7% each. All 20 iterations in this pass came in clean (0/20 flagged CONTENDED in the scheduling table), so the 44–74 ms spread across runs reflects section-level variance rather than scheduling noise.
   </p>
 
   <footer>
-    <p><strong>Method.</strong> androidx.macrobenchmark, <code>StartupMode.COLD</code>, 20 measured iterations, 0 warm-up, dry-run disabled, default CompilationMode, no baseline profile. Section durations from perfetto trace slices; span timing from the SDK's own <code>SystemClock.elapsedRealtime()</code>-based timestamps. Runbook: <code>.claude/skills/startup-analysis</code> (<code>/startup-analysis</code>).</p>
-    <p><strong>Representative trace</strong> (earlier 12-section pass): <a href="https://ui.perfetto.dev/#!/viewer?local_cache_key=f751dff6-61ba-aa63-aaee-c8bc88d396cb">open in Perfetto UI</a> (resolves from this machine's Chrome cache). Raw traces + JSON: <code>…/app/benchmark/build/outputs/connected_android_test_additional_output/benchmark/connected/SM-A145M - 15/</code></p>
+    <p><strong>Method.</strong> androidx.macrobenchmark, <code>StartupMode.COLD</code>, ⟨N⟩ measured iterations, 0 warm-up, dry-run disabled, default CompilationMode, no baseline profile. Section durations from perfetto trace slices; span timing from the SDK's own <code>SystemClock.elapsedRealtime()</code>-based timestamps. Runbook: <code>.claude/skills/startup-analysis</code> (<code>/startup-analysis</code>).</p>
+    <p><strong>Representative trace</strong> (median-window iteration from this pass): ⟨Perfetto UI local_cache_key link — include only if minted for this run, else remove this sentence⟩. Raw traces + JSON: <code>…/app/benchmark/build/outputs/connected_android_test_additional_output/benchmark/connected/⟨device model - API⟩/</code></p>
   </footer>
 </main>

--- a/.claude/skills/startup-analysis/references/sections.md
+++ b/.claude/skills/startup-analysis/references/sections.md
@@ -1,0 +1,65 @@
+# SDK init sections: nesting, environments, and reference numbers
+
+## Nesting and execution order (as of 9.2.0-SNAPSHOT, 2026-08)
+
+Indentation = nesting; a parent's duration includes its children. Presentation in reports should
+follow this order.
+
+```
+embrace-impl-init            class-load: EmbraceImpl construction (before the span window)
+└─ bootstrapper-init         class-load: ModuleInitBootstrapper ctor default
+sdk-start                    wraps the whole Embrace.start() call — the SDK-init window proxy
+├─ modules-init              bootstrapper.init() — opens the SDK-init span window
+│  ├─ persisted-config-load  cached-config read; most variable section
+│  ├─ config-service-init    only on the no-supplier path (always on-device, never in harness)
+│  ├─ span-service-init
+│  │  └─ otel-tracer-init    first touch of the OTel SDK assembly (the real OTel cost)
+│  ├─ essential-service-init
+│  ├─ delivery-init
+│  └─ payload-source-init
+├─ post-init                 SdkInitActions.postInit()
+└─ post-services-setup       tail of EmbraceImpl.start()
+   └─ load-instrumentation
+```
+
+The exported `emb-embrace-init` span is tiled by `modules-init + post-init +
+post-services-setup` (± ~1 ms of unattributed sliver); `sdk-start` wraps that interval plus
+<1 ms of Embrace.start() overhead, and is what analyze_startup.py reports as the window
+(falling back to the composed interval on SDKs without it). The class-load sections run before
+the window opens.
+
+## Where each section appears
+
+| Environment | Sections present |
+|---|---|
+| Real device via `Embrace` entry point (this skill) | all of the above |
+| Robolectric integration harness | all EXCEPT `embrace-impl-init`, `bootstrapper-init` (harness bypasses the entry point) and `config-service-init` (harness supplies a config service). Authoritative list: `SpanAssertions.expectedSdkInitSections` in embrace-android-otel-fakes |
+| Public 9.0.0 | only `embrace-impl-init`, `bootstrapper-init`, `modules-init`, `config-service-init`, `span-service-init`, `otel-tracer-init`, `post-services-setup`; no duration attributes at all |
+
+## Reference numbers (sanity check, not baselines)
+
+Samsung Galaxy A14 (SM-A145M), Android 15, R8-minified ExampleApp, 20 cold starts, 2026-08-11,
+9.2.0-SNAPSHOT, cool device: TTID median ~865 ms; SDK-init span median ~37 ms; biggest sections
+`modules-init` ~34, `span-service-init` ~15.5, `persisted-config-load` ~10, `otel-tracer-init`
+~12. Public 9.0.0 on the same device: span median ~55 ms at TTID ~857.
+
+Back-to-back passes on the same device ALTERNATE fast/slow (~37→50→39→48→39→50 ms span over six
+passes, 2026-08-11) at flat battery temperature — this is NOT thermal throttling. The inflation
+is NOT uniform: pure-CPU sections (`otel-tracer-init`, `span-service-init`) stay ≤1.04×, while
+short block-and-resume sections (`config-service-init`, `payload-source-init`, `post-init`,
+`essential-service-init`, `delivery-init`) run ~2×. Judge regressions on fast-pass numbers.
+
+Slow iterations/passes come in TWO trace signatures (analyze_startup.py's scheduling table
+separates them; judge regressions only on iterations showing neither):
+1. **Contention** — high main-thread wait (R/R+) inside the window plus migration across many
+   CPUs. Observed pass 4 slow iteration: 14.8 ms wait / 7 CPUs vs 0.2 ms / 2 CPUs when fast;
+   competitors were install-triggered background work (system_server GC `HeapTaskDaemon`, Play
+   Store `stall_source.db` — each benchmark pass reinstalls the APK).
+2. **Slow execution** — near-zero wait but elevated Running time (pass 5: 43–59 ms running vs
+   ~31 ms on fast passes, wait ~1%): the same work simply consumes more CPU-time — core
+   placement/clocks, uncapturable via cpufreq counters in these traces (too sparse in a ~50 ms
+   window; all 8 cores report the same 2.0 GHz ceiling on the A14).
+
+If a fresh run diverges wildly from these shapes (e.g. a section at 10× its usual share), suspect
+setup problems before concluding regression: dry-run mode left on, wrong SDK version resolved
+(check mavenLocal vs mavenCentral), or device under load.

--- a/.claude/skills/startup-analysis/scripts/analyze_startup.py
+++ b/.claude/skills/startup-analysis/scripts/analyze_startup.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Aggregate SDK startup metrics purely from macrobenchmark .perfetto-trace files.
+
+Runs perfetto trace_processor with startup_metrics.sql against every iteration trace in a
+directory and prints min/median/mean/max per metric, each canonical section's share of the
+SDK-init window, and a per-iteration scheduler-contention readout. No logcat, jq, grep, or
+benchmark-JSON involvement. The window is the emb-sdk-start slice when the SDK emits it
+(9.2.0+), else composed from modules-init start -> post-services-setup end.
+
+The summary is also written to a uniquely named file,
+<output-dir>/startup-analysis-<YYYY-MM-DD-HHMMSS>.txt (analysis start time), so successive
+runs never clobber each other; --output-dir overrides the default <repo>/claude-output.
+
+Usage:
+  python3 analyze_startup.py --trace-processor <path-to-launcher-or-binary> <traces-dir>
+
+The trace_processor launcher is a python script; fetch it once with:
+  curl -sL -o <scratchpad>/trace_processor https://get.perfetto.dev/trace_processor
+(analyze_startup.py runs it via this same python3 when it is not executable).
+
+Notes:
+- Section duration = FIRST occurrence of each emb-* slice (TraceSectionMetric Mode.First
+  semantics). Sections absent from a trace are reported as missing, never as zero.
+- ttid_ms comes from trace_processor's android.startup module; its anchor differs from
+  macrobenchmark's timeToInitialDisplayMs by a few ms (consistently), so compare like with
+  like across runs.
+- wait_ms is main-thread R/R+ time inside the SDK-init window; iterations where it exceeds
+  CONTENTION_THRESHOLD of the window are flagged CONTENDED (see references/sections.md for
+  why that matters when judging regressions).
+"""
+
+import argparse
+import contextlib
+import csv
+import datetime
+import io
+import os
+import re
+import statistics
+import subprocess
+import sys
+
+CONTENTION_THRESHOLD = 0.15
+
+# Canonical init sections in execution order (see references/sections.md); value = nesting depth.
+CANONICAL_SECTIONS = [
+    ("emb-embrace-impl-init", 0),
+    ("emb-bootstrapper-init", 1),
+    ("emb-modules-init", 0),
+    ("emb-persisted-config-load", 1),
+    ("emb-config-service-init", 1),
+    ("emb-span-service-init", 1),
+    ("emb-otel-tracer-init", 2),
+    ("emb-essential-service-init", 1),
+    ("emb-delivery-init", 1),
+    ("emb-payload-source-init", 1),
+    ("emb-post-init", 0),
+    ("emb-post-services-setup", 0),
+    ("emb-load-instrumentation", 1),
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("traces_dir", help="directory containing *.perfetto-trace files")
+    parser.add_argument("--trace-processor", required=True, dest="tp",
+                        help="path to the trace_processor launcher/binary")
+    parser.add_argument("--all-sections", action="store_true",
+                        help="list every emb-* section (default: canonical + top 15 others)")
+    parser.add_argument("--output-dir", default=None,
+                        help="directory for the timestamped summary file "
+                             "(default: <repo>/claude-output)")
+    args = parser.parse_args()
+
+    start = datetime.datetime.now()
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    sql = os.path.join(script_dir, "startup_metrics.sql")
+    # scripts/ -> startup-analysis/ -> skills/ -> .claude/ -> repo root
+    repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(script_dir))))
+    out_dir = args.output_dir or os.path.join(repo_root, "claude-output")
+    traces = sorted(
+        (f for f in os.listdir(args.traces_dir) if f.endswith(".perfetto-trace")),
+        key=iter_index,
+    )
+    if not traces:
+        print(f"no .perfetto-trace files in {args.traces_dir}", file=sys.stderr)
+        return 1
+
+    per_trace = []
+    for name in traces:
+        path = os.path.join(args.traces_dir, name)
+        per_trace.append((name, extract_metrics(args.tp, sql, path)))
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        print(f"startup analysis started {start:%Y-%m-%d %H:%M:%S}")
+        print(f"traces dir: {os.path.abspath(args.traces_dir)}")
+        report(per_trace, args.all_sections)
+    text = buf.getvalue()
+    sys.stdout.write(text)
+
+    os.makedirs(out_dir, exist_ok=True)
+    out_path = os.path.join(out_dir, f"startup-analysis-{start:%Y-%m-%d-%H%M%S}.txt")
+    with open(out_path, "w") as f:
+        f.write(text)
+    print(f"\nsummary written to {out_path}")
+    return 0
+
+
+def extract_metrics(tp: str, sql: str, trace_path: str) -> dict:
+    """Run trace_processor -q sql on one trace; return {'sections': {...}, scalars...}."""
+    cmd = [tp, "-q", sql, trace_path]
+    if not os.access(tp, os.X_OK):
+        cmd = [sys.executable] + cmd
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(f"trace_processor failed on {trace_path}:\n{proc.stderr}")
+
+    metrics = {"sections": {}}
+    rows = csv.reader(io.StringIO(proc.stdout))
+    seen_header = False
+    for row in rows:
+        if row == ["what", "k", "val"]:
+            seen_header = True
+            continue
+        if not seen_header or len(row) != 3:
+            continue
+        what, k, raw = row
+        if raw == "[NULL]":
+            continue
+        if what == "window_source":
+            metrics["window_source"] = k
+            continue
+        val = float(raw)
+        if what == "section":
+            metrics["sections"][k] = val
+        else:
+            metrics[what] = val
+    if not seen_header:
+        raise RuntimeError(f"no result header in trace_processor output for {trace_path}")
+    return metrics
+
+
+def report(per_trace: list, all_sections: bool) -> None:
+    n = len(per_trace)
+    windows = [m["window_ms"] for _, m in per_trace if "window_ms" in m]
+    ttids = [m["ttid_ms"] for _, m in per_trace if "ttid_ms" in m]
+
+    sources = {m.get("window_source", "?") for _, m in per_trace}
+    if sources == {"emb-sdk-start"}:
+        window_desc = "emb-sdk-start slice (wraps Embrace.start(); ~<1 ms wider than the exported emb-embrace-init span)"
+    elif sources == {"composed"}:
+        window_desc = "composed: modules-init start -> post-services-setup end (= exported emb-embrace-init span; emb-sdk-start absent in this SDK version)"
+    else:
+        window_desc = f"MIXED sources across traces: {sorted(sources)} — do not compare iterations across sources"
+
+    print(f"traces analyzed: {n}")
+    print()
+    print(f"SDK-init window, ms — source: {window_desc}")
+    print(f"  {fmt_stats(windows)}")
+    print(f"  per-iteration: {', '.join(f'{w:.1f}' for w in windows)}")
+    print()
+    print("TTID (android.startup module; anchor differs a few ms from macrobenchmark JSON), ms:")
+    print(f"  {fmt_stats(ttids)}")
+    print()
+
+    window_median = statistics.median(windows) if windows else None
+    print("canonical sections, execution order (first-occurrence slice durations, ms):")
+    header = f"  {'section':<44}{'n':>4}{'min':>9}{'median':>9}{'max':>9}{'% of win':>10}"
+    print(header)
+    section_values = collect_sections(per_trace)
+    for name, depth in CANONICAL_SECTIONS:
+        vals = section_values.pop(name, [])
+        label = "  " * depth + ("↳ " if depth else "") + name
+        if not vals:
+            print(f"  {label:<44}{'-- not instrumented in this SDK version --':>41}")
+            continue
+        pct = f"{statistics.median(vals) / window_median * 100:.1f}" if window_median else "n/a"
+        print(f"  {label:<44}{len(vals):>4}{min(vals):>9.2f}{statistics.median(vals):>9.2f}"
+              f"{max(vals):>9.2f}{pct:>10}")
+    print()
+
+    section_values.pop("emb-sdk-start", None)  # reported as the window, not a section
+    extras = sorted(section_values.items(), key=lambda kv: -statistics.median(kv[1]))
+    if not all_sections:
+        extras = extras[:15]
+    if extras:
+        shown = "all" if all_sections else "top 15 by median"
+        print(f"other emb-* sections ({shown}; not part of the canonical breakdown):")
+        for name, vals in extras:
+            print(f"  {name:<44}{len(vals):>4}{min(vals):>9.2f}{statistics.median(vals):>9.2f}"
+                  f"{max(vals):>9.2f}")
+        print()
+
+    print("main-thread scheduling inside the window (contention / slow-execution check):")
+    print(f"  {'iteration':<52}{'window':>8}{'run':>8}{'wait':>8}{'wait%':>7}{'cpus':>6}")
+    contended = 0
+    for name, m in per_trace:
+        window = m.get("window_ms")
+        wait = m.get("wait_ms")
+        if window is None or wait is None:
+            continue
+        ratio = wait / window
+        flag = ""
+        if ratio > CONTENTION_THRESHOLD:
+            contended += 1
+            flag = "  CONTENDED"
+        print(f"  {short(name):<52}{window:>8.1f}{m.get('running_ms', 0):>8.1f}{wait:>8.1f}"
+              f"{ratio * 100:>6.1f}%{int(m.get('cpus', 0)):>6}{flag}")
+    print(f"  {contended}/{n} iterations contended (wait > {CONTENTION_THRESHOLD:.0%} of window).")
+    print("  Two slow signatures (see references/sections.md): high wait% = scheduler contention;")
+    print("  low wait% but elevated run time vs a fast pass = slower execution (core placement /")
+    print("  clocks). Judge regressions on iterations that show neither.")
+
+
+def collect_sections(per_trace: list) -> dict:
+    out: dict = {}
+    for _, m in per_trace:
+        for name, val in m["sections"].items():
+            out.setdefault(name, []).append(val)
+    return out
+
+
+def fmt_stats(vals: list) -> str:
+    if not vals:
+        return "no data"
+    return (f"n={len(vals)}  min={min(vals):.1f}  median={statistics.median(vals):.1f}  "
+            f"mean={statistics.mean(vals):.1f}  max={max(vals):.1f}")
+
+
+def iter_index(filename: str) -> int:
+    m = re.search(r"iter(\d+)", filename)
+    if m:
+        return int(m.group(1))
+    return 1 << 30
+
+
+def short(filename: str) -> str:
+    m = re.search(r"iter\d+.*", filename)
+    if m:
+        return m.group(0).removesuffix(".perfetto-trace")
+    return filename
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/startup-analysis/scripts/init_window_sched.sql
+++ b/.claude/skills/startup-analysis/scripts/init_window_sched.sql
@@ -1,0 +1,27 @@
+-- Scheduling analysis of the main thread over the emb-modules-init window, for diagnosing
+-- slow-pass variance (contention vs thermal). Run with perfetto trace_processor
+-- (https://get.perfetto.dev/trace_processor is a python3 launcher script):
+--   python3 trace_processor -q init_window_sched.sql <iteration>.perfetto-trace
+-- Interpretation: high R/R+ thread_state time + residency spread over many CPUs means the
+-- iteration lost time to scheduler contention (check competing threads with a sched query
+-- excluding the window utid), not SDK code. trace_processor allows one result-returning
+-- statement per file, hence the UNION ALL.
+WITH w AS (
+  SELECT s.ts AS ws, s.ts + s.dur AS we, tt.utid AS utid
+  FROM slice s JOIN thread_track tt ON s.track_id = tt.id
+  WHERE s.name = 'emb-modules-init'
+  ORDER BY s.ts LIMIT 1
+)
+SELECT 'window_ms' AS what, '' AS k, CAST((we - ws) / 1e6 AS REAL) AS val FROM w
+UNION ALL
+SELECT 'thread_state_ms' AS what, ts.state AS k,
+       CAST(SUM(MIN(ts.ts + ts.dur, w.we) - MAX(ts.ts, w.ws)) / 1e6 AS REAL) AS val
+FROM thread_state ts, w
+WHERE ts.utid = w.utid AND ts.ts < w.we AND ts.ts + ts.dur > w.ws
+GROUP BY ts.state
+UNION ALL
+SELECT 'cpu_residency_ms' AS what, CAST(sched.cpu AS TEXT) AS k,
+       CAST(SUM(MIN(sched.ts + sched.dur, w.we) - MAX(sched.ts, w.ws)) / 1e6 AS REAL) AS val
+FROM sched, w
+WHERE sched.utid = w.utid AND sched.ts < w.we AND sched.ts + sched.dur > w.ws
+GROUP BY sched.cpu;

--- a/.claude/skills/startup-analysis/scripts/serve_trace.py
+++ b/.claude/skills/startup-analysis/scripts/serve_trace.py
@@ -1,0 +1,28 @@
+"""Serves a directory over HTTP with the CORS header ui.perfetto.dev needs to fetch a local
+trace via its ?url= deep link (plain `python3 -m http.server` lacks the header, so the fetch
+hangs in a private-network preflight).
+
+Usage:
+    python3 serve_trace.py <directory-to-serve> [port]
+
+Then open: https://ui.perfetto.dev/#!/?url=http://127.0.0.1:<port>/<trace-filename>
+The first fetch can take ~30s. Stop the server once the trace shows a local_cache_key URL —
+after that, perfetto serves it from the browser's cache.
+"""
+import http.server
+import os
+import sys
+
+
+class CorsHandler(http.server.SimpleHTTPRequestHandler):
+    def end_headers(self):
+        self.send_header("Access-Control-Allow-Origin", "*")
+        super().end_headers()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        raise SystemExit("usage: serve_trace.py <directory-to-serve> [port]")
+    os.chdir(sys.argv[1])
+    port = int(sys.argv[2]) if len(sys.argv) > 2 else 9001
+    http.server.ThreadingHTTPServer(("127.0.0.1", port), CorsHandler).serve_forever()

--- a/.claude/skills/startup-analysis/scripts/startup_metrics.sql
+++ b/.claude/skills/startup-analysis/scripts/startup_metrics.sql
@@ -1,0 +1,66 @@
+-- Per-trace startup metrics, extracted purely from a macrobenchmark .perfetto-trace.
+-- Executed per iteration trace by analyze_startup.py (one result-returning statement, hence
+-- the UNION ALL). Rows: (what, k, val)
+--   section        k = slice name    val = duration ms of the FIRST occurrence (Mode.First)
+--   window_ms      SDK-init window. Preferred source: the emb-sdk-start slice, which wraps
+--                  the whole Embrace.start() call (slightly wider — <1 ms — than the exported
+--                  emb-embrace-init / private emb-sdk-init span). Fallback when emb-sdk-start
+--                  is absent (SDKs before 9.2.0): first emb-modules-init start -> first
+--                  emb-post-services-setup end, which equals the exported span interval by
+--                  construction. window_source reports which one was used.
+--   ttid_ms        cold-start TTID from the android.startup stdlib module (definition differs
+--                  from macrobenchmark's timeToInitialDisplayMs by a few ms — consistent
+--                  anchor, fine for comparisons, not identical to the JSON metric)
+--   wait_ms        main-thread runnable-but-not-running (R / R+) time inside the window —
+--                  the scheduler-contention signal
+--   running_ms     main-thread Running time inside the window
+--   cpus           distinct CPUs the main thread ran on inside the window
+INCLUDE PERFETTO MODULE android.startup.startups;
+WITH firsts AS (
+  SELECT s.name AS name, s.ts AS ts, s.dur AS dur,
+         ROW_NUMBER() OVER (PARTITION BY s.name ORDER BY s.ts) AS rn
+  FROM slice s
+  WHERE s.name GLOB 'emb-*'
+),
+w AS (
+  SELECT ws, we, src FROM (
+    SELECT ts AS ws, ts + dur AS we, 'emb-sdk-start' AS src, 0 AS pri
+    FROM firsts WHERE name = 'emb-sdk-start' AND rn = 1
+    UNION ALL
+    SELECT m.ts AS ws, p.ts + p.dur AS we, 'composed' AS src, 1 AS pri
+    FROM (SELECT ts FROM firsts WHERE name = 'emb-modules-init' AND rn = 1) m,
+         (SELECT ts, dur FROM firsts WHERE name = 'emb-post-services-setup' AND rn = 1) p
+  ) ORDER BY pri LIMIT 1
+),
+mt AS (
+  SELECT tt.utid AS utid
+  FROM slice s JOIN thread_track tt ON s.track_id = tt.id
+  WHERE s.name = 'emb-modules-init'
+  ORDER BY s.ts LIMIT 1
+)
+SELECT 'section' AS what, name AS k, CAST(dur / 1e6 AS REAL) AS val
+FROM firsts WHERE rn = 1
+UNION ALL
+SELECT 'window_ms' AS what, '' AS k, CAST((we - ws) / 1e6 AS REAL) AS val FROM w
+UNION ALL
+SELECT 'window_source' AS what, src AS k, 0.0 AS val FROM w
+UNION ALL
+SELECT 'ttid_ms' AS what, '' AS k,
+       (SELECT CAST(dur / 1e6 AS REAL) FROM android_startups ORDER BY ts LIMIT 1) AS val
+UNION ALL
+SELECT 'wait_ms' AS what, '' AS k,
+       COALESCE((SELECT CAST(SUM(MIN(ts.ts + ts.dur, w.we) - MAX(ts.ts, w.ws)) / 1e6 AS REAL)
+                 FROM thread_state ts, w, mt
+                 WHERE ts.utid = mt.utid AND ts.state IN ('R', 'R+')
+                   AND ts.ts < w.we AND ts.ts + ts.dur > w.ws), 0.0) AS val
+UNION ALL
+SELECT 'running_ms' AS what, '' AS k,
+       COALESCE((SELECT CAST(SUM(MIN(ts.ts + ts.dur, w.we) - MAX(ts.ts, w.ws)) / 1e6 AS REAL)
+                 FROM thread_state ts, w, mt
+                 WHERE ts.utid = mt.utid AND ts.state = 'Running'
+                   AND ts.ts < w.we AND ts.ts + ts.dur > w.ws), 0.0) AS val
+UNION ALL
+SELECT 'cpus' AS what, '' AS k,
+       (SELECT CAST(COUNT(DISTINCT sched.cpu) AS REAL)
+        FROM sched, w, mt
+        WHERE sched.utid = mt.utid AND sched.ts < w.we AND sched.ts + sched.dur > w.ws) AS val;

--- a/examples/ExampleApp/app/benchmark/src/main/java/io/embrace/android/benchmark/StartupBenchmarks.kt
+++ b/examples/ExampleApp/app/benchmark/src/main/java/io/embrace/android/benchmark/StartupBenchmarks.kt
@@ -1,0 +1,34 @@
+package io.embrace.android.benchmark
+
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.StartupTimingMetric
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Drives repeated instrumented cold starts so each iteration records a perfetto trace. The
+ * analysis of SDK init (EmbTrace section durations, SDK-init window, scheduling) is done
+ * entirely from those traces by the startup-analysis skill's analyze_startup.py — the metric
+ * list here is only the minimum measureRepeated requires, not the source of the numbers.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class StartupBenchmarks {
+    @get:Rule
+    val benchmarkRule = MacrobenchmarkRule()
+
+    @Test
+    fun coldStartup() {
+        benchmarkRule.measureRepeated(
+            packageName = "io.embrace.android.exampleapp",
+            metrics = listOf(StartupTimingMetric()),
+            iterations = 20,
+            startupMode = StartupMode.COLD,
+            setupBlock = { pressHome() }
+        ) {
+            startActivityAndWait()
+        }
+    }
+}


### PR DESCRIPTION
Add a macrobenchmark test that does SDK startup profiling. That can be run on its own or with a Claude skill that does a bunch of runs and formats the output nicely. More capabilities can be added to the skill later, including device warmup, version comparisons, etc.