### PR TITLE
Add CPU usage stats to sdk init spans

### DIFF
--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/AppStartupTraceEmitter.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/AppStartupTraceEmitter.kt
@@ -280,7 +280,7 @@ internal class AppStartupTraceEmitter(
                     applicationInitEndMs = if (recordColdStart) applicationInitEndMs else null,
                     sdkInitStartMs = if (recordColdStart) startupService.getSdkInitStartMs() else null,
                     sdkInitEndMs = if (recordColdStart) sdkInitEndMs else null,
-                    sdkInitDurations = if (recordColdStart) startupService.getSdkInitDurations() else emptyMap(),
+                    sdkInitAttributes = if (recordColdStart) startupService.getSdkInitAttributes() else emptyMap(),
                     firstActivityInitMs = firstActivityInitStartMs,
                     activityInitStartMs = activityInitStartMs,
                     activityInitEndMs = activityInitEndMs,
@@ -326,7 +326,7 @@ internal class AppStartupTraceEmitter(
         applicationInitEndMs: Long?,
         sdkInitStartMs: Long?,
         sdkInitEndMs: Long?,
-        sdkInitDurations: Map<String, Long>,
+        sdkInitAttributes: Map<String, String>,
         firstActivityInitMs: Long?,
         activityInitStartMs: Long?,
         activityInitEndMs: Long?,
@@ -355,11 +355,11 @@ internal class AppStartupTraceEmitter(
 
             if (sdkInitStartMs != null && sdkInitEndMs != null) {
                 val counter = startupServiceProvider()?.getAppVersionStartupCounter()
-                val attributes = buildMap(sdkInitDurations.size + 1) {
+                val attributes = buildMap(sdkInitAttributes.size + 1) {
                     if (counter != null) {
                         put(EmbAppAttributes.EMB_APP_VERSION_STARTUP_COUNTER, counter.toString())
                     }
-                    putSdkInitDurations(sdkInitDurations)
+                    putAll(sdkInitAttributes)
                 }
 
                 destination.recordCompletedSpan(

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitResourceUsageTracker.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitResourceUsageTracker.kt
@@ -91,16 +91,28 @@ class SdkInitResourceUsageTracker(
                 if (cpuStart != null && cpuEnd != null && cpuEnd >= cpuStart) {
                     put(INIT_CPU_PCT, wholePercent(cpuEnd - cpuStart, wallMs).toString())
                 }
-                val runDelayStartNs = startSchedstat?.let(::parseRunDelayNs)
-                val runDelayEndNs = endSchedstat?.let(::parseRunDelayNs)
+                val runDelayStartNs = startSchedstat?.let { parseRunDelayNs(it) }
+                val runDelayEndNs = endSchedstat?.let { parseRunDelayNs(it) }
                 if (runDelayStartNs != null && runDelayEndNs != null && runDelayEndNs >= runDelayStartNs) {
-                    val runDelayMs = (runDelayEndNs - runDelayStartNs) / NANOS_PER_MS
+                    val runDelayMs = (runDelayEndNs - runDelayStartNs) / 1_000_000L
                     put(INIT_RUN_DELAY_PCT, wholePercent(runDelayMs, wallMs).toString())
                 }
             }
         }
     } catch (_: Throwable) {
         emptyMap()
+    }
+
+    private fun wholePercent(part: Long, whole: Long): Long = (100.0 * part / whole).roundToLong()
+
+    /**
+     * Extracts the cumulative run-delay (second field, in nanoseconds) from raw
+     * /proc/<pid>/task/<tid>/schedstat contents: "<running_ns> <run_delay_ns> <timeslices>".
+     */
+    private fun parseRunDelayNs(raw: ByteArray): Long? = try {
+        raw.decodeToString().trim().split(' ').getOrNull(1)?.toLong()
+    } catch (_: Throwable) {
+        null
     }
 
     companion object {
@@ -116,18 +128,6 @@ class SdkInitResourceUsageTracker(
          */
         const val INIT_RUN_DELAY_PCT: String = "init-run-delay-pct"
     }
-}
-
-private fun wholePercent(part: Long, whole: Long): Long = (100.0 * part / whole).roundToLong()
-
-/**
- * Extracts the cumulative run-delay (second field, in nanoseconds) from raw
- * /proc/<pid>/task/<tid>/schedstat contents: "<running_ns> <run_delay_ns> <timeslices>".
- */
-private fun parseRunDelayNs(raw: ByteArray): Long? = try {
-    raw.decodeToString().trim().split(' ').getOrNull(1)?.toLong()
-} catch (_: Throwable) {
-    null
 }
 
 /**
@@ -149,4 +149,3 @@ private fun readProcFile(path: String): ByteArray? = try {
 }
 
 private const val PROC_READ_BUFFER_BYTES = 128
-private const val NANOS_PER_MS = 1_000_000L

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitResourceUsageTracker.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitResourceUsageTracker.kt
@@ -1,0 +1,152 @@
+package io.embrace.android.embracesdk.internal.instrumentation.startup
+
+import android.os.Process
+import android.os.SystemClock
+import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitResourceUsageTracker.Companion.INIT_CPU_PCT
+import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitResourceUsageTracker.Companion.INIT_RUN_DELAY_PCT
+import java.io.FileInputStream
+import kotlin.math.roundToLong
+
+/**
+ * Collects metadata about the execution environment during SDK init and provides a set of attributes
+ * to contextualize and explain performance anomalies.
+ *
+ * The job of this is to collect the data required to derive those attributes quickly and efficiently.
+ * Turning that captured data into the desired attributes is done in the [buildAttributes] method, which
+ * should not be called in perf-sensitive places, as computation and other potentially slow operations
+ * could be triggered by that call.
+ */
+class SdkInitResourceUsageTracker(
+    private val threadCpuTimeMs: () -> Long = { SystemClock.currentThreadTimeMillis() },
+    private val elapsedRealtimeMs: () -> Long = { SystemClock.elapsedRealtime() },
+    private val schedstatPathProvider: () -> String = { "/proc/self/task/${Process.myTid()}/schedstat" },
+    private val procFileReader: (path: String) -> ByteArray? = ::readProcFile,
+) {
+
+    @Volatile
+    private var schedstatPath: String? = null
+
+    @Volatile
+    private var startCpuMs: Long? = null
+
+    @Volatile
+    private var endCpuMs: Long? = null
+
+    @Volatile
+    private var startWallMs: Long? = null
+
+    @Volatile
+    private var endWallMs: Long? = null
+
+    @Volatile
+    private var startSchedstat: ByteArray? = null
+
+    @Volatile
+    private var endSchedstat: ByteArray? = null
+
+    /**
+     * Captures the state right before the SDK starts. Should be called as close to the SDK start call as possible.
+     */
+    fun captureStart() {
+        try {
+            startWallMs = elapsedRealtimeMs()
+            startCpuMs = threadCpuTimeMs()
+            val path = schedstatPathProvider()
+            schedstatPath = path
+            startSchedstat = procFileReader(path)
+        } catch (_: Throwable) {
+        }
+    }
+
+    /**
+     * Captures the state right before the SDK finishes starting. Should be called as close to when SDK startup ends as possible.
+     */
+    fun captureEnd() {
+        try {
+            endWallMs = elapsedRealtimeMs()
+            endCpuMs = threadCpuTimeMs()
+            endSchedstat = schedstatPath?.let(procFileReader)
+        } catch (_: Throwable) {
+        }
+    }
+
+    /**
+     * Computes attributes from the raw data. Attributes without the valid, requisite raw data will be omitted.
+     *
+     * The wall interval (the actual perceived sdk init time) comprises three things: time on-CPU ([INIT_CPU_PCT]),
+     * time runnable but waiting for a CPU ([INIT_RUN_DELAY_PCT]), and time blocked/sleeping (locks, IO, parks).
+     * The values recorded are the most precisely measurable among the three, while the implied third value combines
+     * numbers that are harder to accurately obtain, as well as rounding errors.
+     *
+     * Values are whole percentages of the captured wall interval.
+     */
+    fun buildAttributes(): Map<String, String> = try {
+        buildMap {
+            val wallStart = startWallMs
+            val wallEnd = endWallMs
+            if (wallStart != null && wallEnd != null && wallEnd > wallStart) {
+                val wallMs = wallEnd - wallStart
+                val cpuStart = startCpuMs
+                val cpuEnd = endCpuMs
+                if (cpuStart != null && cpuEnd != null && cpuEnd >= cpuStart) {
+                    put(INIT_CPU_PCT, wholePercent(cpuEnd - cpuStart, wallMs).toString())
+                }
+                val runDelayStartNs = startSchedstat?.let(::parseRunDelayNs)
+                val runDelayEndNs = endSchedstat?.let(::parseRunDelayNs)
+                if (runDelayStartNs != null && runDelayEndNs != null && runDelayEndNs >= runDelayStartNs) {
+                    val runDelayMs = (runDelayEndNs - runDelayStartNs) / NANOS_PER_MS
+                    put(INIT_RUN_DELAY_PCT, wholePercent(runDelayMs, wallMs).toString())
+                }
+            }
+        }
+    } catch (_: Throwable) {
+        emptyMap()
+    }
+
+    companion object {
+        /**
+         * Percentage of the init window the init thread spent executing on a CPU, rounded to a whole
+         * number. It measures the CPU utilization rate on the init thread during SDK init.
+         */
+        const val INIT_CPU_PCT: String = "init-cpu-pct"
+
+        /**
+         * Percentage of the init window the init thread spent runnable but waiting for a CPU,
+         * as a whole number. It measures CPU contention from concurrent work.
+         */
+        const val INIT_RUN_DELAY_PCT: String = "init-run-delay-pct"
+    }
+}
+
+private fun wholePercent(part: Long, whole: Long): Long = (100.0 * part / whole).roundToLong()
+
+/**
+ * Extracts the cumulative run-delay (second field, in nanoseconds) from raw
+ * /proc/<pid>/task/<tid>/schedstat contents: "<running_ns> <run_delay_ns> <timeslices>".
+ */
+private fun parseRunDelayNs(raw: ByteArray): Long? = try {
+    raw.decodeToString().trim().split(' ').getOrNull(1)?.toLong()
+} catch (_: Throwable) {
+    null
+}
+
+/**
+ * Reads a small procfs file in a single read. This should be fast because it should be backed by memory,
+ * not disk.
+ */
+private fun readProcFile(path: String): ByteArray? = try {
+    FileInputStream(path).use { stream ->
+        val buffer = ByteArray(PROC_READ_BUFFER_BYTES)
+        val count = stream.read(buffer)
+        if (count > 0) {
+            buffer.copyOf(count)
+        } else {
+            null
+        }
+    }
+} catch (_: Throwable) {
+    null
+}
+
+private const val PROC_READ_BUFFER_BYTES = 128
+private const val NANOS_PER_MS = 1_000_000L

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/StartupService.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/StartupService.kt
@@ -9,13 +9,18 @@ interface StartupService {
 
     /**
      * Sets the SDK startup info. This is called when the SDK is initialized.
+     *
+     * [attributesProvider] is a deferred supplier of the SDK init attributes (section durations,
+     * perf counters) attached to the spans that describe the init. It is invoked when a span is
+     * recorded - i.e. off the startup hot path - so suppliers may do work (parsing, binder
+     * calls) that must not happen during init itself.
      */
     fun setSdkStartupInfo(
         startTimeMs: Long,
         endTimeMs: Long,
         endState: ProcessState,
         threadName: String,
-        sdkInitDurations: Map<String, Long> = emptyMap(),
+        attributesProvider: (() -> Map<String, String>)? = null,
     )
 
     /**
@@ -52,18 +57,19 @@ interface StartupService {
     fun getAppVersionStartupCounter(): Int?
 
     /**
-     * Durations in milliseconds of the instrumented SDK init sections, keyed by section name.
-     * Empty until startup info is recorded.
+     * Extra attributes to be attached to telemetry tracking SDK startup. Empty until startup info is
+     * recorded. Invokes the provider given to [setSdkStartupInfo], which could require computation or
+     * code execution that could be slow. Do not call this in perf-sensitive places. The result is
+     * memoized on first use, so the provider runs at most once and every caller sees the same
+     * attributes.
      */
-    fun getSdkInitDurations(): Map<String, Long>
+    fun getSdkInitAttributes(): Map<String, String>
 }
 
 /**
- * Add an entry to the map given a map of sdk init durations where the key name comprises the
- * section name with an additional suffix.
+ * Converts SDK init section durations to span attributes, keyed by section name with the `-duration-ms` suffix.
  */
-internal fun MutableMap<String, String>.putSdkInitDurations(durations: Map<String, Long>) {
-    durations.forEach { (sectionName, durationMs) ->
-        put("$sectionName-duration-ms", durationMs.toString())
+fun Map<String, Long>.toSdkInitDurationAttributes(): Map<String, String> =
+    entries.associate { (sectionName, durationMs) ->
+        "$sectionName-duration-ms" to durationMs.toString()
     }
-}

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/StartupServiceImpl.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/StartupServiceImpl.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestinati
 import io.embrace.android.embracesdk.internal.arch.state.ProcessState
 import io.embrace.android.embracesdk.semconv.EmbAppAttributes
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 internal class StartupServiceImpl(
     private val destination: TelemetryDestination,
@@ -28,10 +29,16 @@ internal class StartupServiceImpl(
     private var sdkStartupDurationMs: Long? = null
 
     @Volatile
-    private var sdkInitDurations: Map<String, Long> = emptyMap()
+    private var endedInForeground: Boolean = false
 
     @Volatile
-    private var endedInForeground: Boolean = false
+    private var attributesProvider: (() -> Map<String, String>)? = null
+
+    /**
+     * The built attributes, memoized on first use so the provider is only ever invoked once
+     * and every consumer attaches an identical set.
+     */
+    private val sdkInitAttributes = AtomicReference<Map<String, String>?>(null)
 
     private val sdkInitSpanRecorded = AtomicBoolean(false)
 
@@ -40,28 +47,28 @@ internal class StartupServiceImpl(
         endTimeMs: Long,
         endState: ProcessState,
         threadName: String,
-        sdkInitDurations: Map<String, Long>,
+        attributesProvider: (() -> Map<String, String>)?,
     ) {
         sdkInitStartMs = startTimeMs
         sdkInitEndMs = endTimeMs
         this.threadName = threadName
         endedInForeground = endState == ProcessState.FOREGROUND
         sdkStartupDurationMs = endTimeMs - startTimeMs
-        this.sdkInitDurations = sdkInitDurations
+        this.attributesProvider = attributesProvider
+        sdkInitAttributes.set(null)
     }
 
     override fun recordSdkInitSpan() {
         val startTimeMs = sdkInitStartMs ?: return
         val endTimeMs = sdkInitEndMs ?: return
         if (sdkInitSpanRecorded.compareAndSet(false, true)) {
-            val initDurations = sdkInitDurations
-            val attributes = buildMap(initDurations.size + 3) {
+            val attributes = buildMap {
                 put("ended-in-foreground", endedInForeground.toString())
                 put("thread-name", threadName)
                 startupCounter?.let { counter ->
                     put(EmbAppAttributes.EMB_APP_VERSION_STARTUP_COUNTER, counter.toString())
                 }
-                putSdkInitDurations(initDurations)
+                putAll(getSdkInitAttributes())
             }
             destination.recordCompletedSpan(
                 name = "sdk-init",
@@ -78,5 +85,10 @@ internal class StartupServiceImpl(
     override fun getSdkInitEndMs(): Long? = sdkInitEndMs
     override fun getInitThreadName(): String = threadName
     override fun getAppVersionStartupCounter(): Int? = startupCounter
-    override fun getSdkInitDurations(): Map<String, Long> = sdkInitDurations
+    override fun getSdkInitAttributes(): Map<String, String> {
+        sdkInitAttributes.get()?.let { return it }
+        val computed = attributesProvider?.invoke() ?: emptyMap()
+        sdkInitAttributes.compareAndSet(null, computed)
+        return sdkInitAttributes.get() ?: computed
+    }
 }

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitResourceUsageTrackerTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitResourceUsageTrackerTest.kt
@@ -1,0 +1,175 @@
+package io.embrace.android.embracesdk.internal.instrumentation.startup
+
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+internal class SdkInitResourceUsageTrackerTest {
+
+    private lateinit var cpuTimesMs: ArrayDeque<Long>
+    private lateinit var wallTimesMs: ArrayDeque<Long>
+    private lateinit var schedstatContents: ArrayDeque<ByteArray?>
+    private lateinit var readPaths: MutableList<String>
+
+    @Before
+    fun setUp() {
+        cpuTimesMs = ArrayDeque(listOf(100L, 130L))
+        wallTimesMs = ArrayDeque(listOf(5000L, 5060L))
+        // fields are "<running_ns> <run_delay_ns> <timeslices>"
+        schedstatContents = ArrayDeque(
+            listOf(
+                "300000000 5000000 120\n".toByteArray(),
+                "800000000 12000000 150\n".toByteArray(),
+            ),
+        )
+        readPaths = mutableListOf()
+    }
+
+    @Test
+    fun `cpu and run delay reported as whole percentages of the captured window`() {
+        val tracker = createTracker()
+        tracker.captureStart()
+        tracker.captureEnd()
+        // window = 60 ms wall
+        // cpu delta = 30 ms
+        // run delay = 7 ms
+        assertEquals(
+            mapOf(
+                SdkInitResourceUsageTracker.INIT_CPU_PCT to "50",
+                SdkInitResourceUsageTracker.INIT_RUN_DELAY_PCT to "12",
+            ),
+            tracker.buildAttributes(),
+        )
+        assertEquals(listOf(SCHEDSTAT_PATH, SCHEDSTAT_PATH), readPaths)
+    }
+
+    @Test
+    fun `unreadable schedstat omits run delay but keeps cpu time`() {
+        schedstatContents = ArrayDeque(listOf(null, null))
+        val tracker = createTracker()
+        tracker.captureStart()
+        tracker.captureEnd()
+        assertEquals(
+            mapOf(SdkInitResourceUsageTracker.INIT_CPU_PCT to "50"),
+            tracker.buildAttributes(),
+        )
+    }
+
+    @Test
+    fun `malformed schedstat omits run delay but keeps cpu time`() {
+        schedstatContents = ArrayDeque(listOf("garbage".toByteArray(), "more garbage".toByteArray()))
+        val tracker = createTracker()
+        tracker.captureStart()
+        tracker.captureEnd()
+        assertEquals(
+            mapOf(SdkInitResourceUsageTracker.INIT_CPU_PCT to "50"),
+            tracker.buildAttributes(),
+        )
+    }
+
+    @Test
+    fun `throwing reader omits run delay but keeps cpu time`() {
+        val tracker = createTracker(procFileReader = { error("SELinux says no") })
+        tracker.captureStart()
+        tracker.captureEnd()
+        assertEquals(
+            mapOf(SdkInitResourceUsageTracker.INIT_CPU_PCT to "50"),
+            tracker.buildAttributes(),
+        )
+    }
+
+    @Test
+    fun `schedstat parsing reads exactly the second space-separated field`() {
+        schedstatContents = ArrayDeque(
+            listOf(
+                "100 6000000 999999999\n".toByteArray(),
+                "200 18000000 1\n".toByteArray(),
+            ),
+        )
+        val tracker = createTracker()
+        tracker.captureStart()
+        tracker.captureEnd()
+        assertEquals("20", tracker.buildAttributes()[SdkInitResourceUsageTracker.INIT_RUN_DELAY_PCT])
+    }
+
+    @Test
+    fun `schedstat without a trailing newline still parses`() {
+        schedstatContents = ArrayDeque(
+            listOf(
+                "300000000 5000000 120".toByteArray(),
+                "800000000 12000000 150".toByteArray(),
+            ),
+        )
+        val tracker = createTracker()
+        tracker.captureStart()
+        tracker.captureEnd()
+        assertEquals("12", tracker.buildAttributes()[SdkInitResourceUsageTracker.INIT_RUN_DELAY_PCT])
+    }
+
+    @Test
+    fun `schedstat with fewer than two fields omits run delay but keeps cpu`() {
+        schedstatContents = ArrayDeque(listOf("12345\n".toByteArray(), "67890\n".toByteArray()))
+        val tracker = createTracker()
+        tracker.captureStart()
+        tracker.captureEnd()
+        assertEquals(
+            mapOf(SdkInitResourceUsageTracker.INIT_CPU_PCT to "50"),
+            tracker.buildAttributes(),
+        )
+    }
+
+    @Test
+    fun `schedstat with hours of accumulated run delay parses without overflow`() {
+        // cumulative counters on a long-lived device: ~2.5 h of run delay in ns
+        schedstatContents = ArrayDeque(
+            listOf(
+                "1 9000000000000 1\n".toByteArray(),
+                "1 9000012000000 1\n".toByteArray(),
+            ),
+        )
+        val tracker = createTracker()
+        tracker.captureStart()
+        tracker.captureEnd()
+        assertEquals("20", tracker.buildAttributes()[SdkInitResourceUsageTracker.INIT_RUN_DELAY_PCT])
+    }
+
+    @Test
+    fun `invalid readings omitted`() {
+        cpuTimesMs = ArrayDeque(listOf(130L, 100L))
+        schedstatContents = ArrayDeque(listOf("1 9000000 1".toByteArray(), "1 2000000 1".toByteArray()))
+        val tracker = createTracker()
+        tracker.captureStart()
+        tracker.captureEnd()
+        assertEquals(emptyMap<String, String>(), tracker.buildAttributes())
+    }
+
+    @Test
+    fun `no attributes when samples were never taken`() {
+        assertEquals(emptyMap<String, String>(), createTracker().buildAttributes())
+    }
+
+    @Test
+    fun `zero-length window omits everything rather than dividing by zero`() {
+        wallTimesMs = ArrayDeque(listOf(5000L, 5000L))
+        val tracker = createTracker()
+        tracker.captureStart()
+        tracker.captureEnd()
+        assertEquals(emptyMap<String, String>(), tracker.buildAttributes())
+    }
+
+    private fun createTracker(
+        procFileReader: (String) -> ByteArray? = { path ->
+            readPaths.add(path)
+            schedstatContents.removeFirst()
+        },
+    ) = SdkInitResourceUsageTracker(
+        threadCpuTimeMs = { cpuTimesMs.removeFirst() },
+        elapsedRealtimeMs = { wallTimesMs.removeFirst() },
+        schedstatPathProvider = { SCHEDSTAT_PATH },
+        procFileReader = procFileReader,
+    )
+
+    private companion object {
+        const val SCHEDSTAT_PATH = "/proc/self/task/123/schedstat"
+    }
+}

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/AppStartupTraceEmitterTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/AppStartupTraceEmitterTest.kt
@@ -29,6 +29,7 @@ import io.embrace.android.embracesdk.internal.instrumentation.startup.AppStartup
 import io.embrace.android.embracesdk.internal.instrumentation.startup.StartupService
 import io.embrace.android.embracesdk.internal.instrumentation.startup.StartupServiceImpl
 import io.embrace.android.embracesdk.internal.instrumentation.startup.activity.hasPrePostEvents
+import io.embrace.android.embracesdk.internal.instrumentation.startup.toSdkInitDurationAttributes
 import io.embrace.android.embracesdk.internal.instrumentation.startup.ui.hasRenderEvent
 import io.embrace.android.embracesdk.internal.instrumentation.startup.ui.supportFrameCommitCallback
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
@@ -776,7 +777,7 @@ internal class AppStartupTraceEmitterTest {
             endTimeMs = end,
             endState = ProcessState.BACKGROUND,
             threadName = "main",
-            sdkInitDurations = mapOf("modules-init" to 30L),
+            attributesProvider = { mapOf("modules-init" to 30L).toSdkInitDurationAttributes() },
         )
 
         val applicationInitEnd = if (hasAppInitEvents) {

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/StartupServiceImplTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/StartupServiceImplTest.kt
@@ -4,8 +4,10 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeTelemetryDestination
 import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.arch.state.ProcessState
+import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitResourceUsageTracker
 import io.embrace.android.embracesdk.internal.instrumentation.startup.StartupService
 import io.embrace.android.embracesdk.internal.instrumentation.startup.StartupServiceImpl
+import io.embrace.android.embracesdk.internal.instrumentation.startup.toSdkInitDurationAttributes
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.embrace.android.embracesdk.semconv.EmbAppAttributes
 import org.junit.Assert.assertEquals
@@ -35,12 +37,20 @@ internal class StartupServiceImplTest {
         val startTimeMillis = clock.now()
         clock.tick(10L)
         val endTimeMillis = clock.now()
+        var providerInvocationCount = 0
         startupService.setSdkStartupInfo(
             startTimeMs = startTimeMillis,
             endTimeMs = endTimeMillis,
             endState = ProcessState.BACKGROUND,
             threadName = "main",
-            sdkInitDurations = mapOf("modules-init" to 100L),
+            attributesProvider = {
+                providerInvocationCount++
+                mapOf("modules-init" to 100L).toSdkInitDurationAttributes() +
+                    mapOf(
+                        SdkInitResourceUsageTracker.INIT_CPU_PCT to "85",
+                        SdkInitResourceUsageTracker.INIT_RUN_DELAY_PCT to "10",
+                    )
+            },
         )
         assertTrue(destination.completedSpans().isEmpty())
         startupService.recordSdkInitSpan()
@@ -56,8 +66,15 @@ internal class StartupServiceImplTest {
             assertEquals("main", attributes["thread-name"])
             assertEquals("100", attributes["modules-init-duration-ms"])
             assertEquals("3", attributes[EmbAppAttributes.EMB_APP_VERSION_STARTUP_COUNTER])
+            assertEquals("85", attributes[SdkInitResourceUsageTracker.INIT_CPU_PCT])
+            assertEquals("10", attributes[SdkInitResourceUsageTracker.INIT_RUN_DELAY_PCT])
         }
         assertEquals(3, startupService.getAppVersionStartupCounter())
+
+        // the built attributes are memoized: later consumers get the identical set without
+        // re-invoking the provider
+        assertEquals(startupService.getSdkInitAttributes(), startupService.getSdkInitAttributes())
+        assertEquals(1, providerInvocationCount)
     }
 
     @Test
@@ -115,11 +132,13 @@ internal class StartupServiceImplTest {
 
     @Test
     fun `startup info available right after setting on the service`() {
-        startupService.setSdkStartupInfo(1111L, 3222L, ProcessState.BACKGROUND, "main", mapOf("modules-init" to 100L))
+        startupService.setSdkStartupInfo(1111L, 3222L, ProcessState.BACKGROUND, "main") {
+            mapOf("modules-init" to 100L).toSdkInitDurationAttributes()
+        }
         assertEquals(1111L, startupService.getSdkInitStartMs())
         assertEquals(3222L, startupService.getSdkInitEndMs())
         assertEquals(2111L, startupService.getSdkStartupDuration())
-        assertEquals(mapOf("modules-init" to 100L), startupService.getSdkInitDurations())
+        assertEquals(mapOf("modules-init-duration-ms" to "100"), startupService.getSdkInitAttributes())
         assertEquals(3, startupService.getAppVersionStartupCounter())
     }
 }

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/InitializedModuleGraph.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.internal.config.PersistedConfig
 import io.embrace.android.embracesdk.internal.instrumentation.startup.DataCaptureServiceModule
 import io.embrace.android.embracesdk.internal.instrumentation.startup.DataCaptureServiceModuleImpl
 import io.embrace.android.embracesdk.internal.instrumentation.startup.DataCaptureServiceModuleSupplier
+import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitResourceUsageTracker
 import io.embrace.android.embracesdk.internal.instrumentation.thread.blockage.ThreadBlockageService
 import io.embrace.android.embracesdk.internal.instrumentation.thread.blockage.ThreadBlockageServiceSupplier
 import io.embrace.android.embracesdk.internal.instrumentation.thread.blockage.createThreadBlockageService
@@ -36,6 +37,7 @@ internal class InitializedModuleGraph(
     context: Context,
     versionChecker: VersionChecker = BuildVersionChecker,
     override val sdkStartTimeMs: Long,
+    override val sdkInitResourceUsageTracker: SdkInitResourceUsageTracker,
     override val initModule: InitModule,
     override val openTelemetryModule: OpenTelemetryModule,
     override val workerThreadModule: WorkerThreadModule,

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleGraph.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleGraph.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.instrumentation.startup.DataCaptureServiceModule
+import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitResourceUsageTracker
 import io.embrace.android.embracesdk.internal.instrumentation.thread.blockage.ThreadBlockageService
 import io.embrace.android.embracesdk.internal.storage.StorageService
 
@@ -10,6 +11,7 @@ import io.embrace.android.embracesdk.internal.storage.StorageService
  */
 internal interface ModuleGraph {
     val sdkStartTimeMs: Long
+    val sdkInitResourceUsageTracker: SdkInitResourceUsageTracker
     val initModule: InitModule
     val openTelemetryModule: OpenTelemetryModule
     val coreModule: CoreModule

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -8,6 +8,7 @@ import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.config.PersistedConfig
 import io.embrace.android.embracesdk.internal.instrumentation.startup.DataCaptureServiceModule
 import io.embrace.android.embracesdk.internal.instrumentation.startup.DataCaptureServiceModuleSupplier
+import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitResourceUsageTracker
 import io.embrace.android.embracesdk.internal.instrumentation.thread.blockage.ThreadBlockageService
 import io.embrace.android.embracesdk.internal.instrumentation.thread.blockage.ThreadBlockageServiceSupplier
 import io.embrace.android.embracesdk.internal.prefs.createKeyValueStore
@@ -48,6 +49,7 @@ internal class ModuleInitBootstrapper(
     @Volatile
     private var delegate: ModuleGraph = UninitializedModuleGraph
     override val sdkStartTimeMs: Long get() = delegate.sdkStartTimeMs
+    override val sdkInitResourceUsageTracker: SdkInitResourceUsageTracker get() = delegate.sdkInitResourceUsageTracker
     override val coreModule: CoreModule get() = delegate.coreModule
     override val configService: ConfigService get() = delegate.configService
     override val workerThreadModule: WorkerThreadModule get() = delegate.workerThreadModule
@@ -73,8 +75,10 @@ internal class ModuleInitBootstrapper(
             if (isInitialized()) {
                 return@trace false
             }
-            // stamped before anything else so that the SDK init span covers all the work below
+            // stamped before anything else so that the SDK init span covers all the work below,
+            // and the perf samples cover the same interval as the span
             val startTimeMs = initModule.clock.now()
+            val resourceUsageTracker = SdkInitResourceUsageTracker().apply { captureStart() }
             val keyValueStore = lazy { createKeyValueStore(context, initModule.jsonSerializer) }
             val persistedConfig = EmbTrace.trace(
                 sectionName = "persisted-config-load",
@@ -98,6 +102,7 @@ internal class ModuleInitBootstrapper(
                 context,
                 versionChecker,
                 startTimeMs,
+                resourceUsageTracker,
                 initModule,
                 openTelemetryModule,
                 workerThreadModule,

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.internal.instrumentation.crash.jvm.JvmCrash
 import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.NativeCrashDataSource
 import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkStateDataSource
 import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkStatusDataSource
+import io.embrace.android.embracesdk.internal.instrumentation.startup.toSdkInitDurationAttributes
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.android.embracesdk.internal.utils.Provider
@@ -206,12 +207,16 @@ internal fun ModuleGraph.triggerPayloadSend() {
 internal fun ModuleGraph.markSdkInitComplete(sdkInitDurations: Map<String, Long>) {
     val startupService = dataCaptureServiceModule.startupService
     EmbTrace.trace("startup-tracking") {
+        val resourceUsageTracker = sdkInitResourceUsageTracker
+        resourceUsageTracker.captureEnd()
         startupService.setSdkStartupInfo(
             startTimeMs = sdkStartTimeMs,
             endTimeMs = initModule.clock.now(),
             endState = essentialServiceModule.processStateTracker.getAppState(),
             threadName = Thread.currentThread().name,
-            sdkInitDurations = sdkInitDurations,
+            attributesProvider = {
+                sdkInitDurations.toSdkInitDurationAttributes() + resourceUsageTracker.buildAttributes()
+            },
         )
     }
     workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker).submit {

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UninitializedModuleGraph.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UninitializedModuleGraph.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.injection
 
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.instrumentation.startup.DataCaptureServiceModule
+import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitResourceUsageTracker
 import io.embrace.android.embracesdk.internal.instrumentation.thread.blockage.ThreadBlockageService
 import io.embrace.android.embracesdk.internal.storage.StorageService
 
@@ -12,6 +13,7 @@ internal class SdkDisabledException : IllegalStateException()
  */
 internal object UninitializedModuleGraph : ModuleGraph {
     override val sdkStartTimeMs: Long get() = throwSdkNotInitialized()
+    override val sdkInitResourceUsageTracker: SdkInitResourceUsageTracker get() = throwSdkNotInitialized()
     override val initModule: InitModule get() = throwSdkNotInitialized()
     override val openTelemetryModule: OpenTelemetryModule get() = throwSdkNotInitialized()
     override val coreModule: CoreModule get() = throwSdkNotInitialized()

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeStartupService.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeStartupService.kt
@@ -9,20 +9,20 @@ class FakeStartupService : StartupService {
     var processState: ProcessState? = null
     var threadName: String? = null
     var appVersionStartupCounterImpl: Int? = null
-    var sdkInitDurationsImpl: Map<String, Long> = emptyMap()
     var sdkInitSpanRecordedCount: Int = 0
+    var attributesProvider: (() -> Map<String, String>)? = null
 
     override fun setSdkStartupInfo(
         startTimeMs: Long,
         endTimeMs: Long,
         endState: ProcessState,
         threadName: String,
-        sdkInitDurations: Map<String, Long>,
+        attributesProvider: (() -> Map<String, String>)?,
     ) {
         sdkStartupDurationImpl = endTimeMs - startTimeMs
         this.processState = endState
         this.threadName = threadName
-        sdkInitDurationsImpl = sdkInitDurations
+        this.attributesProvider = attributesProvider
     }
 
     override fun recordSdkInitSpan() {
@@ -45,5 +45,5 @@ class FakeStartupService : StartupService {
 
     override fun getAppVersionStartupCounter(): Int? = appVersionStartupCounterImpl
 
-    override fun getSdkInitDurations(): Map<String, Long> = sdkInitDurationsImpl
+    override fun getSdkInitAttributes(): Map<String, String> = attributesProvider?.invoke() ?: emptyMap()
 }


### PR DESCRIPTION
Add metadata related to CPU utilization and blocked state as a percentage of the wall time of SDK init. Used as a proxy for approximating CPU load during SDK init.