### PR TITLE
Implement persistence layer config

### DIFF
--- a/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/Behavior.kt
+++ b/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/Behavior.kt
@@ -16,6 +16,8 @@ import io.embrace.android.embracesdk.internal.config.behavior.NetworkBehaviorImp
 import io.embrace.android.embracesdk.internal.config.behavior.NetworkSpanForwardingBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.NetworkSpanForwardingBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.OtelBehaviorImpl
+import io.embrace.android.embracesdk.internal.config.behavior.PersistenceBehavior
+import io.embrace.android.embracesdk.internal.config.behavior.PersistenceBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.SdkModeBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.SdkModeBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
@@ -143,3 +145,11 @@ fun createOtelBehavior(
     thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
     remoteCfg: RemoteConfig? = null,
 ) = OtelBehaviorImpl(thresholdCheck, InstrumentedConfigImpl, remoteCfg)
+
+/**
+ * A [PersistenceBehaviorImpl] that returns default values.
+ */
+fun createPersistenceBehavior(
+    thresholdCheck: BehaviorThresholdCheck = behaviorThresholdCheck,
+    remoteCfg: RemoteConfig? = null,
+): PersistenceBehavior = PersistenceBehaviorImpl(thresholdCheck, InstrumentedConfigImpl, remoteCfg)

--- a/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
+++ b/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeConfigService.kt
@@ -14,6 +14,7 @@ import io.embrace.android.embracesdk.internal.config.behavior.LogMessageBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.NetworkBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.NetworkSpanForwardingBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.OtelBehavior
+import io.embrace.android.embracesdk.internal.config.behavior.PersistenceBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.SdkModeBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.ThreadBlockageBehavior
@@ -47,6 +48,7 @@ class FakeConfigService(
         createNetworkSpanForwardingBehavior(traceparentInjectionBehavior),
     override var sensitiveKeysBehavior: SensitiveKeysBehavior = createSensitiveKeysBehavior(),
     override val otelBehavior: OtelBehavior = createOtelBehavior(),
+    override var persistenceBehavior: PersistenceBehavior = createPersistenceBehavior(),
     override var buildInfo: BuildInfo = BuildInfo(
         "fakeBuildId",
         "fakeBuildType",

--- a/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeEnabledFeatureConfig.kt
+++ b/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeEnabledFeatureConfig.kt
@@ -34,6 +34,7 @@ class FakeEnabledFeatureConfig(
     private val endStartupWithAppReady: Boolean = base.isEndStartupWithAppReadyEnabled(),
     private val otelKotlinSdkEnabled: Boolean = base.isOtelKotlinSdkEnabled(),
     private val activityProcessLifecycleTracker: Boolean = base.isActivityProcessLifecycleTrackerEnabled(),
+    private val multiFilePersistence: Boolean = base.isMultiFilePersistenceEnabled(),
 ) : EnabledFeatureConfig {
 
     override fun isActivityBreadcrumbCaptureEnabled(): Boolean = activityBreadcrumbCapture
@@ -63,4 +64,5 @@ class FakeEnabledFeatureConfig(
     override fun isEndStartupWithAppReadyEnabled(): Boolean = endStartupWithAppReady
     override fun isOtelKotlinSdkEnabled(): Boolean = otelKotlinSdkEnabled
     override fun isActivityProcessLifecycleTrackerEnabled(): Boolean = activityProcessLifecycleTracker
+    override fun isMultiFilePersistenceEnabled(): Boolean = multiFilePersistence
 }

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigService.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigService.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.internal.config.behavior.LogMessageBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.NetworkBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.NetworkSpanForwardingBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.OtelBehavior
+import io.embrace.android.embracesdk.internal.config.behavior.PersistenceBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.SdkModeBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehavior
 import io.embrace.android.embracesdk.internal.config.behavior.ThreadBlockageBehavior
@@ -98,6 +99,11 @@ interface ConfigService {
      * Provides behavior for OpenTelemetry configuration
      */
     val otelBehavior: OtelBehavior
+
+    /**
+     * How the persistence layer should behave when writing telemetry to disk.
+     */
+    val persistenceBehavior: PersistenceBehavior
 
     /**
      * The app framework that is currently in use.

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/ConfigServiceImpl.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.internal.config.behavior.DataCaptureEventBe
 import io.embrace.android.embracesdk.internal.config.behavior.LogMessageBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.NetworkBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.NetworkSpanForwardingBehaviorImpl
+import io.embrace.android.embracesdk.internal.config.behavior.PersistenceBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.SdkModeBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.SensitiveKeysBehaviorImpl
 import io.embrace.android.embracesdk.internal.config.behavior.ThreadBlockageBehaviorImpl
@@ -117,6 +118,8 @@ class ConfigServiceImpl(
     override val networkSpanForwardingBehavior =
         NetworkSpanForwardingBehaviorImpl(traceparentInjectionBehavior, thresholdCheck, instrumentedConfig, remoteConfig)
     override val otelBehavior = persistedConfig.otelBehavior
+    override val persistenceBehavior =
+        PersistenceBehaviorImpl(thresholdCheck, instrumentedConfig, remoteConfig)
 
     override val appId: String? = run {
         val id = instrumentedConfig.project.getAppId()

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/PersistenceBehavior.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/PersistenceBehavior.kt
@@ -1,0 +1,10 @@
+package io.embrace.android.embracesdk.internal.config.behavior
+
+interface PersistenceBehavior {
+
+    /**
+     * Whether the multi-file session persistence layer should write session telemetry in parallel
+     * with the existing single-file payload writer.
+     */
+    fun isMultiFilePersistenceEnabled(): Boolean
+}

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/PersistenceBehaviorImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/PersistenceBehaviorImpl.kt
@@ -1,0 +1,17 @@
+package io.embrace.android.embracesdk.internal.config.behavior
+
+import io.embrace.android.embracesdk.internal.config.instrumented.schema.InstrumentedConfig
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+
+class PersistenceBehaviorImpl(
+    private val thresholdCheck: BehaviorThresholdCheck,
+    local: InstrumentedConfig,
+    private val remote: RemoteConfig?,
+) : PersistenceBehavior {
+
+    private val local = local.enabledFeatures
+
+    override fun isMultiFilePersistenceEnabled(): Boolean =
+        thresholdCheck.isBehaviorEnabled(remote?.pctMultiFilePersistenceEnabled)
+            ?: local.isMultiFilePersistenceEnabled()
+}

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/PersistenceBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/PersistenceBehaviorImplTest.kt
@@ -1,0 +1,68 @@
+package io.embrace.android.embracesdk.internal.config.behavior
+
+import io.embrace.android.embracesdk.fakes.FAKE_DEVICE_ID
+import io.embrace.android.embracesdk.fakes.config.FakeEnabledFeatureConfig
+import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
+import io.embrace.android.embracesdk.fakes.createPersistenceBehavior
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+internal class PersistenceBehaviorImplTest {
+
+    @Test
+    fun `multi file persistence disabled by default`() {
+        assertFalse(createPersistenceBehavior(remoteCfg = null).isMultiFilePersistenceEnabled())
+    }
+
+    @Test
+    fun `multi file persistence uses local flag when remote absent`() {
+        assertTrue(
+            createBehavior(localMultiFilePersistenceEnabled = true, remote = null)
+                .isMultiFilePersistenceEnabled(),
+        )
+    }
+
+    @Test
+    fun `multi file persistence falls back to local flag when remote pct null`() {
+        assertTrue(
+            createBehavior(
+                localMultiFilePersistenceEnabled = true,
+                remote = RemoteConfig(pctMultiFilePersistenceEnabled = null),
+            ).isMultiFilePersistenceEnabled(),
+        )
+    }
+
+    @Test
+    fun `multi file persistence enabled when pct is 100`() {
+        assertTrue(
+            createBehavior(
+                remote = RemoteConfig(pctMultiFilePersistenceEnabled = 100.0f),
+            ).isMultiFilePersistenceEnabled(),
+        )
+    }
+
+    @Test
+    fun `multi file persistence remote pct of 0 overrides enabled local flag`() {
+        assertFalse(
+            createBehavior(
+                localMultiFilePersistenceEnabled = true,
+                remote = RemoteConfig(pctMultiFilePersistenceEnabled = 0.0f),
+            ).isMultiFilePersistenceEnabled(),
+        )
+    }
+
+    private fun createBehavior(
+        localMultiFilePersistenceEnabled: Boolean = false,
+        remote: RemoteConfig?,
+    ) = PersistenceBehaviorImpl(
+        thresholdCheck = BehaviorThresholdCheck { FAKE_DEVICE_ID },
+        local = FakeInstrumentedConfig(
+            enabledFeatures = FakeEnabledFeatureConfig(
+                multiFilePersistence = localMultiFilePersistenceEnabled,
+            ),
+        ),
+        remote = remote,
+    )
+}

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/cache/CachedConfiguration.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/cache/CachedConfiguration.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.internal.serialization.BinaryVersion
 import kotlinx.serialization.Serializable
 
 @Serializable
-@BinaryVersion(-6343163155698584460)
+@BinaryVersion(8389998782948050020)
 data class CachedConfiguration(
     val deviceId: String,
     val etag: String?,

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
@@ -194,4 +194,12 @@ interface EnabledFeatureConfig {
      * sdk_config.automatic_data_capture.activity_process_lifecycle_tracker_enabled
      */
     fun isActivityProcessLifecycleTrackerEnabled(): Boolean = false
+
+    /**
+     * Gates whether the multi-file session persistence layer writes session telemetry in parallel
+     * with the existing single-file payload writer.
+     *
+     * sdk_config.multi_file_persistence_enabled
+     */
+    fun isMultiFilePersistenceEnabled(): Boolean = false
 }

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/RemoteConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/RemoteConfig.kt
@@ -148,4 +148,11 @@ data class RemoteConfig(
      */
     @SerialName("vitals")
     val vitalsRemoteConfig: VitalsRemoteConfig? = null,
+
+    /**
+     * Percentage of devices for which the multi-file session persistence layer writes in parallel
+     * with the existing single-file payload writer.
+     */
+    @SerialName("pct_multi_file_persistence_enabled")
+    val pctMultiFilePersistenceEnabled: Float? = null,
 )

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionPartDirectory.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionPartDirectory.kt
@@ -1,0 +1,51 @@
+package io.embrace.android.embracesdk.internal.session.persistence
+
+/**
+ * Metadata about a session part that stores telemetry in a directory
+ */
+data class SessionPartDirectory(
+    val timestamp: Long,
+    val uuid: String,
+    val userSessionId: String = "",
+    val sessionPartId: String = "",
+) {
+    val dirName: String = "${timestamp}_${uuid}_${encodeId(userSessionId)}_${encodeId(sessionPartId)}"
+
+    companion object {
+        private const val EMPTY_ID_TOKEN = "none"
+        private const val TOKEN_COUNT = 4
+
+        /**
+         * Orders directories by timestamp then uuid, which is the order that session parts must
+         * be delivered in.
+         */
+        val comparator: Comparator<SessionPartDirectory> =
+            compareBy<SessionPartDirectory> { it.timestamp }.thenBy { it.uuid }
+
+        private fun encodeId(id: String): String = id.ifEmpty { EMPTY_ID_TOKEN }
+
+        private fun decodeId(token: String): String = when (token) {
+            EMPTY_ID_TOKEN -> ""
+            else -> token
+        }
+
+        /**
+         * Parses a directory name and constructs a [SessionPartDirectory] object. This returns
+         * null if the directory name is invalid.
+         */
+        fun fromDirName(dirName: String): SessionPartDirectory? {
+            val parts = dirName.split("_")
+            if (parts.size != TOKEN_COUNT) {
+                return null
+            }
+            val timestamp = parts[0].toLongOrNull() ?: return null
+            val uuid = parts[1].ifEmpty { return null }
+            return SessionPartDirectory(
+                timestamp = timestamp,
+                uuid = uuid,
+                userSessionId = decodeId(parts[2]),
+                sessionPartId = decodeId(parts[3]),
+            )
+        }
+    }
+}

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionPartDirectoryTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionPartDirectoryTest.kt
@@ -1,0 +1,146 @@
+package io.embrace.android.embracesdk.internal.session.persistence
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+internal class SessionPartDirectoryTest {
+
+    private companion object {
+        private const val TIMESTAMP = 1726739283136L
+        private const val UUID = "c2610cd1-389f-422a-bfbc-25312c7a599a"
+        private const val USER_SESSION_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        private const val SESSION_PART_ID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    }
+
+    @Test
+    fun `construct dirname with session ids`() {
+        assertEquals(
+            "${TIMESTAMP}_${UUID}_${USER_SESSION_ID}_$SESSION_PART_ID",
+            SessionPartDirectory(
+                timestamp = TIMESTAMP,
+                uuid = UUID,
+                userSessionId = USER_SESSION_ID,
+                sessionPartId = SESSION_PART_ID,
+            ).dirName,
+        )
+    }
+
+    @Test
+    fun `construct dirname with empty session ids encodes none`() {
+        assertEquals(
+            "${TIMESTAMP}_${UUID}_none_none",
+            SessionPartDirectory(
+                timestamp = TIMESTAMP,
+                uuid = UUID,
+            ).dirName,
+        )
+    }
+
+    @Test
+    fun `construct dirname with only one empty session id`() {
+        assertEquals(
+            "${TIMESTAMP}_${UUID}_${USER_SESSION_ID}_none",
+            SessionPartDirectory(
+                timestamp = TIMESTAMP,
+                uuid = UUID,
+                userSessionId = USER_SESSION_ID,
+                sessionPartId = "",
+            ).dirName,
+        )
+    }
+
+    @Test
+    fun `from valid dirname`() {
+        val input = "${TIMESTAMP}_${UUID}_${USER_SESSION_ID}_$SESSION_PART_ID"
+        with(checkNotNull(SessionPartDirectory.fromDirName(input))) {
+            assertEquals(input, dirName)
+            assertEquals(TIMESTAMP, timestamp)
+            assertEquals(UUID, uuid)
+            assertEquals(USER_SESSION_ID, userSessionId)
+            assertEquals(SESSION_PART_ID, sessionPartId)
+        }
+    }
+
+    @Test
+    fun `from valid dirname with none decodes to empty session ids`() {
+        with(checkNotNull(SessionPartDirectory.fromDirName("${TIMESTAMP}_${UUID}_none_none"))) {
+            assertEquals(TIMESTAMP, timestamp)
+            assertEquals(UUID, uuid)
+            assertEquals("", userSessionId)
+            assertEquals("", sessionPartId)
+        }
+    }
+
+    @Test
+    fun `dirname with a dashless uuid round trips`() {
+        val dashlessUuid = "1234567890ABCDEF1234567890ABCDEF"
+        val original = SessionPartDirectory(
+            timestamp = TIMESTAMP,
+            uuid = dashlessUuid,
+            userSessionId = USER_SESSION_ID,
+            sessionPartId = SESSION_PART_ID,
+        )
+        val decoded = checkNotNull(SessionPartDirectory.fromDirName(original.dirName))
+        assertEquals(original, decoded)
+        assertEquals(dashlessUuid, decoded.uuid)
+    }
+
+    @Test
+    fun `from invalid dirname`() {
+        val badDirNames = listOf(
+            "",
+            "foo",
+            "embrace_payloads",
+            "${TIMESTAMP}_$UUID",
+            "${TIMESTAMP}_${UUID}_${USER_SESSION_ID}_${SESSION_PART_ID}_extra",
+            "notATimestamp_${UUID}_none_none",
+            "${TIMESTAMP}__none_none",
+        )
+        badDirNames.forEach { dirName ->
+            assertNull("Dirname should fail: $dirName", SessionPartDirectory.fromDirName(dirName))
+        }
+    }
+
+    @Test
+    fun `round trip preserves all fields`() {
+        val original = SessionPartDirectory(
+            timestamp = TIMESTAMP,
+            uuid = UUID,
+            userSessionId = USER_SESSION_ID,
+            sessionPartId = SESSION_PART_ID,
+        )
+        val decoded = checkNotNull(SessionPartDirectory.fromDirName(original.dirName))
+        assertEquals(original, decoded)
+        assertEquals(original.dirName, decoded.dirName)
+    }
+
+    @Test
+    fun `round trip with empty ids preserves empty after decode`() {
+        val original = SessionPartDirectory(timestamp = TIMESTAMP, uuid = UUID)
+        val decoded = checkNotNull(SessionPartDirectory.fromDirName(original.dirName))
+        assertEquals("", decoded.userSessionId)
+        assertEquals("", decoded.sessionPartId)
+        assertEquals(original.dirName, decoded.dirName)
+    }
+
+    @Test
+    fun `sorting orders by timestamp then uuid`() {
+        val first = SessionPartDirectory(timestamp = 1L, uuid = "aaa")
+        val second = SessionPartDirectory(timestamp = 1L, uuid = "bbb")
+        val third = SessionPartDirectory(timestamp = 2L, uuid = "aaa")
+        val fourth = SessionPartDirectory(timestamp = 10L, uuid = "aaa")
+
+        val sorted = listOf(third, fourth, second, first).sortedWith(SessionPartDirectory.comparator)
+        assertEquals(listOf(first, second, third, fourth), sorted)
+    }
+
+    @Test
+    fun `sorting is stable when timestamp and uuid match`() {
+        val first = SessionPartDirectory(timestamp = TIMESTAMP, uuid = UUID, userSessionId = USER_SESSION_ID)
+        val second = SessionPartDirectory(timestamp = TIMESTAMP, uuid = UUID, sessionPartId = SESSION_PART_ID)
+
+        val input = listOf(first, second)
+        assertEquals(input, input.sortedWith(SessionPartDirectory.comparator))
+    }
+}

--- a/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/StorageLocation.kt
+++ b/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/StorageLocation.kt
@@ -21,4 +21,9 @@ enum class StorageLocation(val dir: String) {
      * Cached envelopes
      */
     ENVELOPE("embrace_envelopes"),
+
+    /**
+     * Session telemetry grouped under one directory per session part
+     */
+    SESSION("embrace_sessions"),
 }

--- a/embrace-config-schema.json
+++ b/embrace-config-schema.json
@@ -65,6 +65,11 @@
           },
           "minProperties": 1
         },
+        "multi_file_persistence_enabled": {
+          "description": "Persists session telemetry using the multi-file layout, written in parallel with the existing single-file payload writer. Can be overridden by remote config.",
+          "default": false,
+          "type": "boolean"
+        },
         "view_config": {
           "type": "object",
           "properties": {

--- a/embrace-gradle-plugin-integration-tests/src/test/resources/config-overrides.json
+++ b/embrace-gradle-plugin-integration-tests/src/test/resources/config-overrides.json
@@ -39,6 +39,7 @@
     "anr": {
       "capture_unity_thread": true
     },
+    "multi_file_persistence_enabled": true,
     "view_config": {
       "enable_automatic_activity_capture": false
     },

--- a/embrace-gradle-plugin-integration-tests/src/test/resources/instrumented-config-default.json
+++ b/embrace-gradle-plugin-integration-tests/src/test/resources/instrumented-config-default.json
@@ -45,6 +45,9 @@
           "signature": "isJvmCrashCaptureEnabled()Z"
         },
         {
+          "signature": "isMultiFilePersistenceEnabled()Z"
+        },
+        {
           "signature": "isNativeCrashCaptureEnabled()Z"
         },
         {

--- a/embrace-gradle-plugin-integration-tests/src/test/resources/instrumented-config-overrides.json
+++ b/embrace-gradle-plugin-integration-tests/src/test/resources/instrumented-config-overrides.json
@@ -57,6 +57,10 @@
           "returnValue": "false"
         },
         {
+          "signature": "isMultiFilePersistenceEnabled()Z",
+          "returnValue": "true"
+        },
+        {
           "signature": "isNativeCrashCaptureEnabled()Z",
           "returnValue": "false"
         },

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/EnabledFeatureConfigInstrumentation.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/EnabledFeatureConfigInstrumentation.kt
@@ -43,5 +43,6 @@ fun createEnabledFeatureConfigInstrumentation(cfg: VariantConfig) = modelSdkConf
         boolMethod("isActivityProcessLifecycleTrackerEnabled") {
             automaticDataCaptureConfig?.activityProcessLifecycleTrackerEnabled
         }
+        boolMethod("isMultiFilePersistenceEnabled") { multiFilePersistenceEnabled }
     }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/SdkLocalConfig.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/SdkLocalConfig.kt
@@ -25,6 +25,12 @@ data class SdkLocalConfig(
     val otel: OpenTelemetryLocalConfig? = null,
 
     /**
+     * Whether session telemetry should be persisted using the multi-file layout
+     */
+    @Json(name = "multi_file_persistence_enabled")
+    val multiFilePersistenceEnabled: Boolean? = null,
+
+    /**
      * View settings
      */
     @Json(name = "view_config")

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/EnabledFeatureConfigInstrumentationKtTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/EnabledFeatureConfigInstrumentationKtTest.kt
@@ -53,6 +53,7 @@ class EnabledFeatureConfigInstrumentationKtTest {
         ConfigMethod("isUiLoadTracingTraceAll", "()Z", true),
         ConfigMethod("isEndStartupWithAppReadyEnabled", "()Z", true),
         ConfigMethod("isActivityProcessLifecycleTrackerEnabled", "()Z", true),
+        ConfigMethod("isMultiFilePersistenceEnabled", "()Z", true),
     )
 
     @Test
@@ -104,6 +105,7 @@ class EnabledFeatureConfigInstrumentationKtTest {
                         otel = OpenTelemetryLocalConfig(
                             otelKotlinSdkEnabled = false,
                         ),
+                        multiFilePersistenceEnabled = true,
                         networking = NetworkLocalConfig(
                             captureRequestContentLength = true,
                             captureOkHttpResponseBodySize = true,


### PR DESCRIPTION
## Goal

Implements a config that controls how the persistence layer should behave (i.e. whether we should enable multi-file writes in parallel).

## Testing

Added unit tests.
