### PR TITLE
Implement initial session reconstruction service

### DIFF
--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/InternalErrorType.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/InternalErrorType.kt
@@ -36,6 +36,7 @@ sealed class InternalErrorType(private val severity: Severity) {
     object IntakeUnexpectedType : InternalErrorType(ERROR)
     object PayloadStorageFail : InternalErrorType(ERROR)
     object SessionManifestWriteFail : InternalErrorType(ERROR)
+    object SessionReconstructionFail : InternalErrorType(ERROR)
     object InternalInterfaceFail : InternalErrorType(ERROR)
     object NativeReadFail : InternalErrorType(Severity.WARNING)
     object AppLaunchTraceFail : InternalErrorType(Severity.WARNING)

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/EnvelopeResourceMapper.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/EnvelopeResourceMapper.kt
@@ -45,3 +45,44 @@ internal fun AppFramework.toProto(): EnvelopeResourceProto.AppFramework = when (
     AppFramework.UNITY -> EnvelopeResourceProto.AppFramework.UNITY
     AppFramework.FLUTTER -> EnvelopeResourceProto.AppFramework.FLUTTER
 }
+
+internal fun EnvelopeResourceProto.toPayload(): EnvelopeResource = EnvelopeResource(
+    appVersion = app_version,
+    appFramework = app_framework?.toPayload(),
+    buildId = build_id,
+    appEcosystemId = app_ecosystem_id,
+    buildType = build_type,
+    buildFlavor = build_flavor,
+    environment = environment,
+    bundleVersion = bundle_version,
+    sdkVersion = sdk_version,
+    sdkSimpleVersion = sdk_simple_version,
+    reactNativeBundleId = react_native_bundle_id,
+    reactNativeVersion = react_native_version,
+    javascriptPatchNumber = javascript_patch_number,
+    hostedPlatformVersion = hosted_platform_version,
+    hostedSdkVersion = hosted_sdk_version,
+    unityBuildId = unity_build_id,
+    deviceManufacturer = device_manufacturer,
+    deviceModel = device_model,
+    deviceArchitecture = device_architecture,
+    jailbroken = jailbroken,
+    diskTotalCapacity = disk_total_capacity,
+    osType = os_type,
+    osName = os_name,
+    osVersion = os_version,
+    osCode = os_code,
+    screenResolution = screen_resolution,
+    numCores = num_cores,
+    usesEmmcStorage = uses_emmc_storage,
+    deviceSocModel = device_soc_model,
+    extras = extras,
+)
+
+internal fun EnvelopeResourceProto.AppFramework.toPayload(): AppFramework? = when (this) {
+    EnvelopeResourceProto.AppFramework.UNSPECIFIED -> null
+    EnvelopeResourceProto.AppFramework.NATIVE -> AppFramework.NATIVE
+    EnvelopeResourceProto.AppFramework.REACT_NATIVE -> AppFramework.REACT_NATIVE
+    EnvelopeResourceProto.AppFramework.UNITY -> AppFramework.UNITY
+    EnvelopeResourceProto.AppFramework.FLUTTER -> AppFramework.FLUTTER
+}

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionManifestWriter.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionManifestWriter.kt
@@ -14,11 +14,6 @@ class SessionManifestWriter(
     private val logger: InternalLogger,
 ) {
 
-    private companion object {
-        const val FORMAT_VERSION = 1
-        const val MANIFEST_FILE_NAME = "manifest.pb"
-    }
-
     /**
      * Writes the manifest for the given session part, unless one already exists.
      *

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionPartFiles.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionPartFiles.kt
@@ -1,0 +1,9 @@
+package io.embrace.android.embracesdk.internal.session.persistence
+
+/**
+ * Version of the on-disk layout written by this SDK. Data persisted with any other version
+ * cannot be read back.
+ */
+internal const val FORMAT_VERSION = 1
+
+internal const val MANIFEST_FILE_NAME = "manifest.pb"

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionService.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionService.kt
@@ -1,0 +1,72 @@
+package io.embrace.android.embracesdk.internal.session.persistence
+
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
+import io.embrace.android.embracesdk.internal.payload.Envelope
+import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
+import java.io.File
+import java.io.IOException
+
+/**
+ * Reconstructs the telemetry persisted in a session part directory into an envelope that can be
+ * delivered.
+ */
+class SessionReconstructionService(
+    private val sessionsDir: Lazy<File>,
+    private val logger: InternalLogger,
+) {
+
+    /**
+     * Reconstructs the envelope for the given session part, or null if it cannot be read.
+     */
+    fun reconstruct(directory: SessionPartDirectory): Envelope<SessionPartPayload>? {
+        return try {
+            reconstructImpl(directory)
+        } catch (exc: Throwable) {
+            trackFailure(exc)
+            null
+        }
+    }
+
+    private fun reconstructImpl(directory: SessionPartDirectory): Envelope<SessionPartPayload>? {
+        val partDir = File(sessionsDir.value, directory.dirName)
+        if (!partDir.isDirectory) {
+            trackFailure(IOException("Not a session part directory: ${partDir.path}"))
+            return null
+        }
+
+        val src = File(partDir, MANIFEST_FILE_NAME)
+        if (!src.isFile) {
+            trackFailure(IOException("Manifest not found: ${src.path}"))
+            return null
+        }
+        val manifest = src.inputStream().buffered().use(SessionManifest.ADAPTER::decode)
+
+        if (manifest.format_version != FORMAT_VERSION) {
+            trackFailure(IOException("Unsupported manifest format version: ${manifest.format_version}"))
+            return null
+        }
+        val resource = manifest.resource
+        if (resource == null) {
+            trackFailure(IOException("Manifest has no resource: ${src.path}"))
+            return null
+        }
+
+        // various properties not persisted/deserialized yet
+        return Envelope(
+            resource = resource.toPayload(),
+            metadata = null,
+            version = manifest.envelope_version,
+            type = manifest.envelope_type,
+            data = SessionPartPayload(
+                spans = null,
+                spanSnapshots = null,
+                sharedLibSymbolMapping = manifest.shared_lib_symbol_mapping?.symbols,
+            ),
+        )
+    }
+
+    private fun trackFailure(exc: Throwable) {
+        logger.trackInternalError(InternalErrorType.SessionReconstructionFail, exc)
+    }
+}

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/EnvelopeResourceMapperTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/EnvelopeResourceMapperTest.kt
@@ -89,4 +89,77 @@ internal class EnvelopeResourceMapperTest {
             assertEquals(framework.toProto(), proto.app_framework)
         }
     }
+
+    @Test
+    fun `every proto field maps back to its payload counterpart`() {
+        assertEquals(fullyPopulatedResource, fullyPopulatedResourceProto.toPayload())
+    }
+
+    @Test
+    fun `absent proto fields map to null payload fields`() {
+        val resource = EnvelopeResourceProto().toPayload()
+        assertEquals(EnvelopeResource(), resource)
+        assertNull(resource.appVersion)
+        assertNull(resource.appFramework)
+        assertNull(resource.sdkSimpleVersion)
+        assertNull(resource.jailbroken)
+        assertNull(resource.diskTotalCapacity)
+        assertNull(resource.numCores)
+        assertNull(resource.usesEmmcStorage)
+        assertEquals(emptyMap<String, String>(), resource.extras)
+    }
+
+    @Test
+    fun `false and zero valued proto fields are preserved`() {
+        val resource = EnvelopeResourceProto(
+            app_version = "",
+            jailbroken = false,
+            uses_emmc_storage = false,
+            num_cores = 0,
+            sdk_simple_version = 0,
+            disk_total_capacity = 0L,
+        ).toPayload()
+
+        assertEquals("", resource.appVersion)
+        assertEquals(false, resource.jailbroken)
+        assertEquals(false, resource.usesEmmcStorage)
+        assertEquals(0, resource.numCores)
+        assertEquals(0, resource.sdkSimpleVersion)
+        assertEquals(0L, resource.diskTotalCapacity)
+    }
+
+    @Test
+    fun `extras are preserved when mapping back`() {
+        val extras = mapOf("a" to "1", "b" to "2")
+        assertEquals(extras, EnvelopeResourceProto(extras = extras).toPayload().extras)
+    }
+
+    @Test
+    fun `every proto app framework maps back and unspecified maps to null`() {
+        val mapped = EnvelopeResourceProto.AppFramework.entries.associateWith { it.toPayload() }
+
+        assertEquals(
+            mapOf(
+                EnvelopeResourceProto.AppFramework.UNSPECIFIED to null,
+                EnvelopeResourceProto.AppFramework.NATIVE to AppFramework.NATIVE,
+                EnvelopeResourceProto.AppFramework.REACT_NATIVE to AppFramework.REACT_NATIVE,
+                EnvelopeResourceProto.AppFramework.UNITY to AppFramework.UNITY,
+                EnvelopeResourceProto.AppFramework.FLUTTER to AppFramework.FLUTTER,
+            ),
+            mapped,
+        )
+    }
+
+    @Test
+    fun `app framework survives a full round trip`() {
+        AppFramework.entries.forEach { framework ->
+            assertEquals(framework, framework.toProto().toPayload())
+        }
+    }
+
+    @Test
+    fun `resource survives a full round trip`() {
+        assertEquals(fullyPopulatedResource, fullyPopulatedResource.toProto().toPayload())
+        assertEquals(EnvelopeResource(), EnvelopeResource().toProto().toPayload())
+    }
 }

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceManifestTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceManifestTest.kt
@@ -1,0 +1,246 @@
+package io.embrace.android.embracesdk.internal.session.persistence
+
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
+import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+internal class SessionReconstructionServiceManifestTest {
+
+    private companion object {
+        private const val MANIFEST_FILE_NAME = "manifest.pb"
+        private const val ENVELOPE_VERSION = "0.1.0"
+        private const val ENVELOPE_TYPE = "spans"
+        private const val TIMESTAMP = 1726739283136L
+        private const val UUID = "c2610cd1-389f-422a-bfbc-25312c7a599a"
+        private const val USER_SESSION_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        private const val SESSION_PART_ID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+        private val partDirectory = SessionPartDirectory(
+            timestamp = TIMESTAMP,
+            uuid = UUID,
+            userSessionId = USER_SESSION_ID,
+            sessionPartId = SESSION_PART_ID,
+        )
+    }
+
+    @get:Rule
+    val tempFolder: TemporaryFolder = TemporaryFolder()
+
+    private lateinit var sessionsDir: File
+    private lateinit var logger: FakeInternalLogger
+    private lateinit var writer: SessionManifestWriter
+    private lateinit var service: SessionReconstructionService
+
+    @Before
+    fun setUp() {
+        sessionsDir = tempFolder.newFolder("embrace_sessions")
+        logger = FakeInternalLogger(throwOnInternalError = false)
+        writer = SessionManifestWriter(lazy { sessionsDir }, logger)
+        service = SessionReconstructionService(lazy { sessionsDir }, logger)
+        createPartDir(partDirectory)
+    }
+
+    private fun createPartDir(directory: SessionPartDirectory): File =
+        File(sessionsDir, directory.dirName).apply { mkdirs() }
+
+    private fun partDir(directory: SessionPartDirectory = partDirectory): File =
+        File(sessionsDir, directory.dirName)
+
+    private fun manifestFile(directory: SessionPartDirectory = partDirectory): File =
+        File(partDir(directory), MANIFEST_FILE_NAME)
+
+    private fun write(
+        directory: SessionPartDirectory = partDirectory,
+        resource: EnvelopeResource = fullyPopulatedResource,
+        envelopeVersion: String = ENVELOPE_VERSION,
+        envelopeType: String = ENVELOPE_TYPE,
+        sharedLibSymbolMapping: Map<String, String>? = null,
+    ) {
+        assertTrue(writer.write(directory, resource, envelopeVersion, envelopeType, sharedLibSymbolMapping))
+    }
+
+    private fun writeManifestBytes(manifest: SessionManifest, directory: SessionPartDirectory = partDirectory) {
+        manifestFile(directory).writeBytes(SessionManifest.ADAPTER.encode(manifest))
+    }
+
+    private fun assertNoInternalErrors() {
+        assertEquals(emptyList<FakeInternalLogger.LogMessage>(), logger.internalErrorMessages)
+    }
+
+    private fun assertReconstructionFailureTracked() {
+        assertEquals(1, logger.internalErrorMessages.size)
+        assertEquals("SessionReconstructionFail", logger.internalErrorMessages.single().msg)
+    }
+
+    @Test
+    fun `envelope is reconstructed from the manifest`() {
+        write()
+
+        val envelope = checkNotNull(service.reconstruct(partDirectory))
+        assertEquals(fullyPopulatedResource, envelope.resource)
+        assertEquals(ENVELOPE_VERSION, envelope.version)
+        assertEquals(ENVELOPE_TYPE, envelope.type)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `telemetry that is not persisted yet is absent`() {
+        write()
+
+        val envelope = checkNotNull(service.reconstruct(partDirectory))
+        assertNull(envelope.metadata)
+        assertNull(envelope.data.spans)
+        assertNull(envelope.data.spanSnapshots)
+    }
+
+    @Test
+    fun `resource with no populated fields is reconstructed`() {
+        write(resource = EnvelopeResource())
+        assertEquals(EnvelopeResource(), service.reconstruct(partDirectory)?.resource)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `absent symbol mapping is reconstructed as null`() {
+        write(sharedLibSymbolMapping = null)
+        assertNull(service.reconstruct(partDirectory)?.data?.sharedLibSymbolMapping)
+    }
+
+    @Test
+    fun `empty symbol mapping is reconstructed as an empty map`() {
+        write(sharedLibSymbolMapping = emptyMap())
+        assertEquals(emptyMap<String, String>(), service.reconstruct(partDirectory)?.data?.sharedLibSymbolMapping)
+    }
+
+    @Test
+    fun `populated symbol mapping is reconstructed`() {
+        val symbols = mapOf("armeabi-v7a" to "my-symbols", "x86" to "other-symbols")
+        write(sharedLibSymbolMapping = symbols)
+        assertEquals(symbols, service.reconstruct(partDirectory)?.data?.sharedLibSymbolMapping)
+    }
+
+    @Test
+    fun `session part with empty ids is reconstructed`() {
+        val directory = SessionPartDirectory(timestamp = TIMESTAMP, uuid = UUID)
+        createPartDir(directory)
+        write(directory = directory)
+
+        assertNotNull(service.reconstruct(directory))
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `each session part directory is reconstructed independently`() {
+        val other = SessionPartDirectory(
+            timestamp = TIMESTAMP + 1,
+            uuid = "d3721de2-490a-533b-cacd-36423d8b6aab",
+            userSessionId = "cccccccccccccccccccccccccccccccc",
+            sessionPartId = "dddddddddddddddddddddddddddddddd",
+        )
+        createPartDir(other)
+        write()
+        write(directory = other, resource = EnvelopeResource(appVersion = "9.9.9"), envelopeType = "logs")
+
+        assertEquals(fullyPopulatedResource, service.reconstruct(partDirectory)?.resource)
+        with(checkNotNull(service.reconstruct(other))) {
+            assertEquals(EnvelopeResource(appVersion = "9.9.9"), resource)
+            assertEquals("logs", type)
+        }
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `missing session part directory is reported and does not throw`() {
+        val absent = SessionPartDirectory(timestamp = TIMESTAMP + 2, uuid = UUID)
+        assertNull(service.reconstruct(absent))
+        assertReconstructionFailureTracked()
+    }
+
+    @Test
+    fun `a file occupying the session part path is reported`() {
+        val occupied = SessionPartDirectory(timestamp = TIMESTAMP + 3, uuid = UUID)
+        partDir(occupied).writeText("not a directory")
+
+        assertNull(service.reconstruct(occupied))
+        assertReconstructionFailureTracked()
+    }
+
+    @Test
+    fun `missing manifest is reported`() {
+        assertNull(service.reconstruct(partDirectory))
+        assertReconstructionFailureTracked()
+    }
+
+    @Test
+    fun `a directory occupying the manifest path is reported`() {
+        manifestFile().mkdirs()
+
+        assertNull(service.reconstruct(partDirectory))
+        assertReconstructionFailureTracked()
+    }
+
+    @Test
+    fun `a truncated manifest is reported and does not throw`() {
+        write()
+        val bytes = manifestFile().readBytes()
+        manifestFile().writeBytes(bytes.copyOf(bytes.size / 2))
+
+        assertNull(service.reconstruct(partDirectory))
+        assertReconstructionFailureTracked()
+    }
+
+    @Test
+    fun `a manifest holding arbitrary bytes is reported and does not throw`() {
+        manifestFile().writeBytes(byteArrayOf(-1, -1, -1, -1, -1, -1))
+
+        assertNull(service.reconstruct(partDirectory))
+        assertReconstructionFailureTracked()
+    }
+
+    @Test
+    fun `an empty manifest is reported`() {
+        manifestFile().writeBytes(byteArrayOf())
+
+        assertNull(service.reconstruct(partDirectory))
+        assertReconstructionFailureTracked()
+    }
+
+    @Test
+    fun `an unsupported format version is reported`() {
+        write()
+        writeManifestBytes(
+            SessionManifest(
+                format_version = FORMAT_VERSION + 1,
+                envelope_version = ENVELOPE_VERSION,
+                envelope_type = ENVELOPE_TYPE,
+                resource = fullyPopulatedResourceProto,
+            ),
+        )
+
+        assertNull(service.reconstruct(partDirectory))
+        assertReconstructionFailureTracked()
+    }
+
+    @Test
+    fun `a manifest with no resource is reported`() {
+        write()
+        writeManifestBytes(
+            SessionManifest(
+                format_version = FORMAT_VERSION,
+                envelope_version = ENVELOPE_VERSION,
+                envelope_type = ENVELOPE_TYPE,
+            ),
+        )
+
+        assertNull(service.reconstruct(partDirectory))
+        assertReconstructionFailureTracked()
+    }
+}


### PR DESCRIPTION
## Goal

Implements the session reconstruction service, initially just deserializing the manifest file into an `Envelope<SessionPartPayload>`.

## Testing

Added unit tests.
