### PR TITLE
Add thermal and install/update time data for sdk startup telemetry

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/InstrumentationArgsImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/InstrumentationArgsImpl.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal
 
 import android.app.Application
 import android.content.Context
+import android.content.pm.PackageInfo
 import io.embrace.android.embracesdk.internal.arch.InstrumentationArgs
 import io.embrace.android.embracesdk.internal.arch.SessionPartChangeListener
 import io.embrace.android.embracesdk.internal.arch.SessionPartEndListener
@@ -53,6 +54,10 @@ internal class InstrumentationArgsImpl(
     override val crashMarkerFile: File by lazy { crashMarkerFileProvider() }
 
     override val store: KeyValueStore by lazy { storeProvider() }
+
+    override val packageInfo: PackageInfo? by lazy {
+        runCatching { context.packageManager.getPackageInfo(context.packageName, 0) }.getOrNull()
+    }
 
     override val httpRequestInfoModifierChain: HttpRequestInfoModifierChain = HttpRequestInfoModifierChain(logger)
 

--- a/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationArgs.kt
+++ b/embrace-android-instrumentation-api-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeInstrumentationArgs.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.fakes
 
 import android.app.Application
 import android.content.Context
+import android.content.pm.PackageInfo
 import io.embrace.android.embracesdk.internal.arch.InstrumentationArgs
 import io.embrace.android.embracesdk.internal.arch.SessionPartChangeListener
 import io.embrace.android.embracesdk.internal.arch.SessionPartEndListener
@@ -31,6 +32,7 @@ class FakeInstrumentationArgs(
     override val processIdentifier: String = "fake-process-id",
     override val processStateTracker: ProcessStateTracker = FakeProcessStateTracker(),
     override val telemetryService: TelemetryService = FakeTelemetryService(),
+    override val packageInfo: PackageInfo? = null,
     val backgroundWorkerSupplier: (worker: Worker.Background) -> BackgroundWorker = { fakeBackgroundWorker() },
     val priorityWorkerSupplier: (worker: Worker.Priority) -> PriorityWorker<*> = { fakePriorityWorker<Any>() },
     val sessionPartIdSupplier: () -> String? = { null },

--- a/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationArgs.kt
+++ b/embrace-android-instrumentation-api/src/main/kotlin/io/embrace/android/embracesdk/internal/arch/InstrumentationArgs.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.arch
 
 import android.app.Application
 import android.content.Context
+import android.content.pm.PackageInfo
 import io.embrace.android.embracesdk.internal.arch.datasource.TelemetryDestination
 import io.embrace.android.embracesdk.internal.arch.navigation.NavigationTrackingService
 import io.embrace.android.embracesdk.internal.arch.state.ProcessStateTracker
@@ -107,6 +108,13 @@ interface InstrumentationArgs {
      * is unavailable.
      */
     fun <T> systemService(name: String): T?
+
+    /**
+     * Retrieves the package info for the current app. It is resolved with a single memoized
+     * PackageManager lookup shared across the SDK, and is null if that lookup failed. First
+     * access may trigger the one binder call, so avoid it on perf-sensitive paths.
+     */
+    val packageInfo: PackageInfo?
 
     /**
      * Retrieves the current session part ID, or null if there is no active session part.

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributes.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributes.kt
@@ -1,0 +1,108 @@
+package io.embrace.android.embracesdk.internal.instrumentation.startup
+
+import android.content.pm.PackageInfo
+import android.os.Build.VERSION_CODES
+import android.os.PowerManager
+import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
+import io.embrace.android.embracesdk.internal.utils.VersionChecker
+import kotlin.math.roundToLong
+
+/**
+ * Attributes describing the state of the execution environment around SDK init that are read at
+ * record time rather than captured during the init window. These attributes still have to be
+ * valid for SDK init despite the post-init retrieval. For instance, the device's thermal state
+ * changes over tens of seconds, so a momentary delay is mostly going to be correct. Meanwhile,
+ * recently the app was installed or updated is immutable during the lifetime of an app instance,
+ * so they are safe to be retrieved at any time. Some of these attributes may be OS version
+ * dependent, so attributes whose underlying data aren't available will just be dropped.
+ *
+ * Reading the raw data to inform these attributes might involve binder calls, so do not call
+ * this should not be called on the SDK init thread during startup.
+ */
+fun sdkInitEnvironmentAttributes(
+    powerManagerProvider: () -> PowerManager?,
+    packageInfo: PackageInfo?,
+    nowMs: Long,
+    versionChecker: VersionChecker = BuildVersionChecker,
+): Map<String, String> = try {
+    buildMap {
+        if (versionChecker.isAtLeast(VERSION_CODES.Q)) {
+            val powerManager = powerManagerProvider()
+            if (powerManager != null) {
+                put(THERMAL_STATUS_ATTR, thermalStatusName(powerManager.currentThermalStatus))
+                if (versionChecker.isAtLeast(VERSION_CODES.R)) {
+                    val headroom = runCatching { powerManager.getThermalHeadroom(0) }.getOrNull()
+                    if (headroom != null && headroom.isFinite()) {
+                        val headroomPct = (headroom * 100).roundToLong().coerceAtMost(MAX_THERMAL_HEADROOM_PCT)
+                        put(THERMAL_HEADROOM_PCT_ATTR, headroomPct.toString())
+                    }
+                }
+            }
+        }
+        if (packageInfo != null) {
+            secondsBetween(packageInfo.firstInstallTime, nowMs)?.let { seconds ->
+                put(SECONDS_SINCE_INSTALL_ATTR, seconds.toString())
+            }
+            secondsBetween(packageInfo.lastUpdateTime, nowMs)?.let { seconds ->
+                put(SECONDS_SINCE_UPDATE_ATTR, seconds.toString())
+            }
+        }
+    }
+} catch (_: Throwable) {
+    emptyMap()
+}
+
+/**
+ * The device's overall thermal throttling status at record time, as reported by
+ * [PowerManager.getCurrentThermalStatus] (API 29+): none/light/moderate/severe/critical/
+ * emergency/shutdown.
+ */
+const val THERMAL_STATUS_ATTR: String = "thermal-status"
+
+/**
+ * How far the device's thermal forecast is toward the severe-throttling threshold, as a whole
+ * percentage per [PowerManager.getThermalHeadroom] (API 30+). Note the polarity: 100 means AT
+ * or beyond the severe-throttling threshold and low values mean cool. Forecasts beyond severe
+ * are capped into the single 100 group - the headroom scale is uncalibrated up there, and
+ * [THERMAL_STATUS_ATTR]'s severe/critical/emergency/shutdown levels are the calibrated signal
+ * for that region. Omitted where the device does not support forecasting.
+ */
+const val THERMAL_HEADROOM_PCT_ATTR: String = "thermal-headroom-pct"
+
+/**
+ * Seconds between the app's first install and SDK init. Small values indicate init ran close
+ * to when install happened, when there could be more concurrent work vying for CPU and RAM,
+ * like dexopt or app-specific tasks.
+ */
+const val SECONDS_SINCE_INSTALL_ATTR: String = "seconds-since-install"
+
+/**
+ * Seconds between the app's last update and SDK init. Small values indicate init ran close
+ * to when app update happened, when there could be similar factors to slow down init we see
+ * in fresh installs, as well as post-update tasks like DB migrations.
+ */
+const val SECONDS_SINCE_UPDATE_ATTR: String = "seconds-since-update"
+
+private fun thermalStatusName(status: Int): String = when (status) {
+    PowerManager.THERMAL_STATUS_NONE -> "none"
+    PowerManager.THERMAL_STATUS_LIGHT -> "light"
+    PowerManager.THERMAL_STATUS_MODERATE -> "moderate"
+    PowerManager.THERMAL_STATUS_SEVERE -> "severe"
+    PowerManager.THERMAL_STATUS_CRITICAL -> "critical"
+    PowerManager.THERMAL_STATUS_EMERGENCY -> "emergency"
+    PowerManager.THERMAL_STATUS_SHUTDOWN -> "shutdown"
+    else -> status.toString()
+}
+
+private fun secondsBetween(thenMs: Long, nowMs: Long): Long? = if (thenMs in 1..nowMs) {
+    (nowMs - thenMs) / 1000L
+} else {
+    null
+}
+
+/**
+ * At and beyond the severe-throttling threshold the headroom scale is not calibrated across
+ * vendors, and the thermal-status levels carry that region instead - so everything at or past
+ * the threshold collapses into the single 100 group.
+ */
+private const val MAX_THERMAL_HEADROOM_PCT = 100L

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributesTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributesTest.kt
@@ -1,0 +1,57 @@
+package io.embrace.android.embracesdk.internal.instrumentation.startup
+
+import android.content.Context
+import android.os.PowerManager
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(AndroidJUnit4::class)
+internal class SdkInitEnvironmentAttributesTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    @Test
+    fun `thermal status is mapped to its name`() {
+        val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+        shadowOf(powerManager).setCurrentThermalStatus(PowerManager.THERMAL_STATUS_MODERATE)
+        assertEquals("moderate", environmentAttributes()[THERMAL_STATUS_ATTR])
+    }
+
+    @Test
+    fun `install and update recency computed from package info`() {
+        val packageInfo = shadowOf(context.packageManager).getInternalMutablePackageInfo(context.packageName)
+        packageInfo.firstInstallTime = NOW_MS - 90_000L
+        packageInfo.lastUpdateTime = NOW_MS - 30_000L
+        val attributes = environmentAttributes()
+        assertEquals("90", attributes[SECONDS_SINCE_INSTALL_ATTR])
+        assertEquals("30", attributes[SECONDS_SINCE_UPDATE_ATTR])
+    }
+
+    @Test
+    fun `unset package timestamps omit the recency attributes`() {
+        val attributes = environmentAttributes()
+        assertFalse(attributes.containsKey(SECONDS_SINCE_INSTALL_ATTR))
+        assertFalse(attributes.containsKey(SECONDS_SINCE_UPDATE_ATTR))
+    }
+
+    private fun environmentAttributes(): Map<String, String> = sdkInitEnvironmentAttributes(
+        powerManagerProvider = { context.getSystemService(Context.POWER_SERVICE) as? PowerManager },
+        packageInfo = context.packageManager.getPackageInfo(context.packageName, 0),
+        nowMs = NOW_MS,
+    )
+
+    private companion object {
+        const val NOW_MS = 1_700_000_000_000L
+    }
+}

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.injection
 
+import android.content.Context
 import io.embrace.android.embracesdk.core.BuildConfig
 import io.embrace.android.embracesdk.internal.arch.InstrumentationProvider
 import io.embrace.android.embracesdk.internal.arch.attrs.toEmbraceAttributeName
@@ -7,6 +8,7 @@ import io.embrace.android.embracesdk.internal.instrumentation.crash.jvm.JvmCrash
 import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.NativeCrashDataSource
 import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkStateDataSource
 import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkStatusDataSource
+import io.embrace.android.embracesdk.internal.instrumentation.startup.sdkInitEnvironmentAttributes
 import io.embrace.android.embracesdk.internal.instrumentation.startup.toSdkInitDurationAttributes
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
@@ -215,7 +217,15 @@ internal fun ModuleGraph.markSdkInitComplete(sdkInitDurations: Map<String, Long>
             endState = essentialServiceModule.processStateTracker.getAppState(),
             threadName = Thread.currentThread().name,
             attributesProvider = {
-                sdkInitDurations.toSdkInitDurationAttributes() + resourceUsageTracker.buildAttributes()
+                sdkInitDurations.toSdkInitDurationAttributes() +
+                    resourceUsageTracker.buildAttributes() +
+                    sdkInitEnvironmentAttributes(
+                        powerManagerProvider = {
+                            instrumentationModule.instrumentationArgs.systemService(Context.POWER_SERVICE)
+                        },
+                        packageInfo = instrumentationModule.instrumentationArgs.packageInfo,
+                        nowMs = initModule.clock.now(),
+                    )
             },
         )
     }


### PR DESCRIPTION
Add thermal state and thermal headroom the the SDK init span along with the number of second since app install/update (the latter should be flattened into buckets to reduce cardinality but I just want to see what the data's spread is like first before doing that. 

Note: These are not resolved until the spans are logged, which is done on a background thread, so won't increase the main thread blocking time.