### PR TITLE
Add more SDK init metadata

### DIFF
--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitAttributeKeys.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitAttributeKeys.kt
@@ -1,0 +1,117 @@
+package io.embrace.android.embracesdk.internal.instrumentation.startup
+
+/**
+ * Keys of the attributes recorded on the SDK init spans to contextualize and explain
+ * performance anomalies. [SdkInitResourceUsageTracker] produces the ones measured as deltas across
+ * the init window; [sdkInitEnvironmentAttributes] produces the ones describing the ambient
+ * conditions the init ran under, read at record time.
+ *
+ * These are candidates to become proper semantic conventions once their shapes settle; until
+ * then they are deliberately kept as plain constants so nothing is locked in.
+ */
+object SdkInitAttributeKeys {
+
+    /**
+     * Percentage of the init window the init thread spent executing on a CPU, rounded to a
+     * whole number. Triage: a slow init with HIGH cpu-pct ran slowly (thermal throttling,
+     * uncompiled/interpreted code, weak silicon - the work itself took longer); a slow init
+     * with LOW cpu-pct didn't get to run (see run-delay for who to blame). Together with
+     * [INIT_RUN_DELAY_PCT] this splits every slow run into ran-slow vs was-blocked vs
+     * was-starved without needing a trace.
+     */
+    const val INIT_CPU_PCT: String = "init-cpu-pct"
+
+    /**
+     * Percentage of the init window the init thread spent runnable but waiting for a CPU,
+     * as a whole number. This is the direct measure of CPU contention: other work (other
+     * apps, system services, our own background threads, concurrent GC) held the cores
+     * while init waited. Bench-measured as the strongest single correlate of slow inits -
+     * a high value means "the device was busy", which is diagnostic (not our code) and
+     * should be excluded from regression comparisons.
+     */
+    const val INIT_RUN_DELAY_PCT: String = "init-run-delay-pct"
+
+    /**
+     * Major page faults taken by the process during the init window - reads that had to go
+     * to storage (cold code pages, cold files), including flash contention from concurrent
+     * installs.
+     */
+    const val INIT_MAJ_FAULTS: String = "init-maj-faults"
+
+    /**
+     * Kilobytes actually read from storage by the process during the init window. Normal
+     * inits read little (config file + cold pages); elevated values mark storage-bound
+     * runs - cold caches after reboot/update, slow flash, or IO contention from concurrent
+     * installs - and pair with [INIT_MAJ_FAULTS] to confirm an IO-class slow run.
+     */
+    const val INIT_DISK_READ_KB: String = "init-disk-read-kb"
+
+    /**
+     * ART garbage collections (any type, process-wide) during the init window. A
+     * deliberately imprecise, directional signal: it says there is some amount of GC
+     * and doesn't try to precisely determine how much time it took.
+     */
+    const val INIT_GC_COUNT: String = "init-gc-count"
+
+    /**
+     * Seconds between device boot and SDK init. Small values indicate a recently rebooted
+     * device: cold caches everywhere plus post-boot system activity.
+     */
+    const val SECONDS_SINCE_BOOT: String = "seconds-since-boot"
+
+    /**
+     * The device's overall thermal throttling status at record time, as reported by
+     * [android.os.PowerManager.getCurrentThermalStatus] (API 29+): none/light/moderate/severe/
+     * critical/emergency/shutdown. Collected because heat measurably slows init, and this is a
+     * signal for that.
+     */
+    const val THERMAL_STATUS: String = "thermal-status"
+
+    /**
+     * How far the device's thermal forecast is toward the severe-throttling threshold, as a whole
+     * percentage per [android.os.PowerManager.getThermalHeadroom] (API 30+). Note the polarity:
+     * 100 means AT or beyond the severe-throttling threshold and low values mean cool. Forecasts
+     * beyond severe are capped into the single 100 group - the headroom scale is uncalibrated up
+     * there, and [THERMAL_STATUS]'s severe/critical/emergency/shutdown levels are the calibrated
+     * signal for that region. Omitted where the device does not support forecasting.
+     */
+    const val THERMAL_HEADROOM_PCT: String = "thermal-headroom-pct"
+
+    /**
+     * Seconds between the app's first install and SDK init. Small values indicate init ran close
+     * to when install happened, when there could be more concurrent work vying for CPU and RAM,
+     * like dexopt or app-specific tasks.
+     */
+    const val SECONDS_SINCE_INSTALL: String = "seconds-since-install"
+
+    /**
+     * Seconds between the app's last update and SDK init. Small values indicate init ran close
+     * to when app update happened, when there could be similar factors to slow down init we see
+     * in fresh installs, as well as post-update tasks like DB migrations.
+     */
+    const val SECONDS_SINCE_UPDATE: String = "seconds-since-update"
+
+    /**
+     * Whole percentage of device RAM available at record time. Collected because memory pressure
+     * is a distinct slow-init cause on small-RAM devices: when little is available, init runs
+     * alongside our own GC and the system's reclaim/kill activity, slowing things down. Recorded
+     * as a percentage to estimate load of the device, not trying to precisely count how many
+     * bytes are left because that is often not relevant or (even more) misleading.
+     */
+    const val MEM_AVAILABLE_PCT: String = "mem-available-pct"
+
+    /**
+     * Boolean present only when it's true, when the system reports it is in a low-memory state
+     * and the OS is actively reclaiming memory. The presence of this indicates memory pressure.
+     */
+    const val LOW_MEMORY: String = "low-memory"
+
+    /**
+     * The kernel's Pressure Stall Information indicating that there is some CPU pressure over the
+     * last 10 seconds on the device, as reported in /proc/pressure/cpu, rounded to a whole
+     * percentage. Corroborates a high run-delay reading with a device-wide view that its CPUs
+     * have been busy. Not always available, so the absence of this should not be seen as
+     * evidence, but the presence is.
+     */
+    const val PSI_CPU_SOME_AVG10: String = "psi-cpu-some-avg10"
+}

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributes.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributes.kt
@@ -1,10 +1,19 @@
 package io.embrace.android.embracesdk.internal.instrumentation.startup
 
+import android.app.ActivityManager
 import android.content.pm.PackageInfo
 import android.os.Build.VERSION_CODES
 import android.os.PowerManager
+import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.LOW_MEMORY
+import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.MEM_AVAILABLE_PCT
+import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.PSI_CPU_SOME_AVG10
+import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.SECONDS_SINCE_INSTALL
+import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.SECONDS_SINCE_UPDATE
+import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.THERMAL_HEADROOM_PCT
+import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.THERMAL_STATUS
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
+import java.io.File
 import kotlin.math.roundToLong
 
 /**
@@ -21,67 +30,62 @@ import kotlin.math.roundToLong
  */
 fun sdkInitEnvironmentAttributes(
     powerManagerProvider: () -> PowerManager?,
+    activityManagerProvider: () -> ActivityManager?,
     packageInfo: PackageInfo?,
     nowMs: Long,
     versionChecker: VersionChecker = BuildVersionChecker,
 ): Map<String, String> = try {
     buildMap {
-        if (versionChecker.isAtLeast(VERSION_CODES.Q)) {
-            val powerManager = powerManagerProvider()
-            if (powerManager != null) {
-                put(THERMAL_STATUS_ATTR, thermalStatusName(powerManager.currentThermalStatus))
-                if (versionChecker.isAtLeast(VERSION_CODES.R)) {
-                    val headroom = runCatching { powerManager.getThermalHeadroom(0) }.getOrNull()
-                    if (headroom != null && headroom.isFinite()) {
-                        val headroomPct = (headroom * 100).roundToLong().coerceAtMost(MAX_THERMAL_HEADROOM_PCT)
-                        put(THERMAL_HEADROOM_PCT_ATTR, headroomPct.toString())
-                    }
-                }
-            }
-        }
-        if (packageInfo != null) {
-            secondsBetween(packageInfo.firstInstallTime, nowMs)?.let { seconds ->
-                put(SECONDS_SINCE_INSTALL_ATTR, seconds.toString())
-            }
-            secondsBetween(packageInfo.lastUpdateTime, nowMs)?.let { seconds ->
-                put(SECONDS_SINCE_UPDATE_ATTR, seconds.toString())
-            }
-        }
+        putThermalAttributes(powerManagerProvider, versionChecker)
+        putInstallRecencyAttributes(packageInfo, nowMs)
+        putMemoryAttributes(activityManagerProvider)
+        psiCpuSomeAvg10()?.let { put(PSI_CPU_SOME_AVG10, it) }
     }
 } catch (_: Throwable) {
     emptyMap()
 }
 
-/**
- * The device's overall thermal throttling status at record time, as reported by
- * [PowerManager.getCurrentThermalStatus] (API 29+): none/light/moderate/severe/critical/
- * emergency/shutdown.
- */
-const val THERMAL_STATUS_ATTR: String = "thermal-status"
+private fun MutableMap<String, String>.putThermalAttributes(
+    powerManagerProvider: () -> PowerManager?,
+    versionChecker: VersionChecker,
+) {
+    if (versionChecker.isAtLeast(VERSION_CODES.Q)) {
+        val powerManager = powerManagerProvider() ?: return
+        put(THERMAL_STATUS, thermalStatusName(powerManager.currentThermalStatus))
+        if (versionChecker.isAtLeast(VERSION_CODES.R)) {
+            val headroom = runCatching { powerManager.getThermalHeadroom(0) }.getOrNull()
+            if (headroom != null && headroom.isFinite()) {
+                val headroomPct = (headroom * 100).roundToLong().coerceAtMost(MAX_THERMAL_HEADROOM_PCT)
+                put(THERMAL_HEADROOM_PCT, headroomPct.toString())
+            }
+        }
+    }
+}
 
-/**
- * How far the device's thermal forecast is toward the severe-throttling threshold, as a whole
- * percentage per [PowerManager.getThermalHeadroom] (API 30+). Note the polarity: 100 means AT
- * or beyond the severe-throttling threshold and low values mean cool. Forecasts beyond severe
- * are capped into the single 100 group - the headroom scale is uncalibrated up there, and
- * [THERMAL_STATUS_ATTR]'s severe/critical/emergency/shutdown levels are the calibrated signal
- * for that region. Omitted where the device does not support forecasting.
- */
-const val THERMAL_HEADROOM_PCT_ATTR: String = "thermal-headroom-pct"
+private fun MutableMap<String, String>.putInstallRecencyAttributes(packageInfo: PackageInfo?, nowMs: Long) {
+    if (packageInfo != null) {
+        secondsBetween(packageInfo.firstInstallTime, nowMs)?.let { seconds ->
+            put(SECONDS_SINCE_INSTALL, seconds.toString())
+        }
+        secondsBetween(packageInfo.lastUpdateTime, nowMs)?.let { seconds ->
+            put(SECONDS_SINCE_UPDATE, seconds.toString())
+        }
+    }
+}
 
-/**
- * Seconds between the app's first install and SDK init. Small values indicate init ran close
- * to when install happened, when there could be more concurrent work vying for CPU and RAM,
- * like dexopt or app-specific tasks.
- */
-const val SECONDS_SINCE_INSTALL_ATTR: String = "seconds-since-install"
-
-/**
- * Seconds between the app's last update and SDK init. Small values indicate init ran close
- * to when app update happened, when there could be similar factors to slow down init we see
- * in fresh installs, as well as post-update tasks like DB migrations.
- */
-const val SECONDS_SINCE_UPDATE_ATTR: String = "seconds-since-update"
+private fun MutableMap<String, String>.putMemoryAttributes(activityManagerProvider: () -> ActivityManager?) {
+    val memoryInfo = runCatching {
+        activityManagerProvider()?.let { activityManager ->
+            ActivityManager.MemoryInfo().also(activityManager::getMemoryInfo)
+        }
+    }.getOrNull()
+    if (memoryInfo != null && memoryInfo.totalMem > 0) {
+        put(MEM_AVAILABLE_PCT, (100.0 * memoryInfo.availMem / memoryInfo.totalMem).roundToLong().toString())
+        if (memoryInfo.lowMemory) {
+            put(LOW_MEMORY, "true")
+        }
+    }
+}
 
 private fun thermalStatusName(status: Int): String = when (status) {
     PowerManager.THERMAL_STATUS_NONE -> "none"
@@ -99,6 +103,21 @@ private fun secondsBetween(thenMs: Long, nowMs: Long): Long? = if (thenMs in 1..
 } else {
     null
 }
+
+/**
+ * First line of /proc/pressure/cpu looks like "some avg10=1.23 avg60=0.80 avg300=0.40 total=…".
+ */
+private fun psiCpuSomeAvg10(): String? = runCatching {
+    File("/proc/pressure/cpu")
+        .readText()
+        .lineSequence()
+        .firstOrNull { it.startsWith("some") }
+        ?.substringAfter("avg10=")
+        ?.substringBefore(' ')
+        ?.toDoubleOrNull()
+        ?.roundToLong()
+        ?.toString()
+}.getOrNull()
 
 /**
  * At and beyond the severe-throttling threshold the headroom scale is not calibrated across

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitResourceUsageTracker.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitResourceUsageTracker.kt
@@ -1,9 +1,15 @@
 package io.embrace.android.embracesdk.internal.instrumentation.startup
 
+import android.os.Build
+import android.os.Debug
 import android.os.Process
 import android.os.SystemClock
-import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitResourceUsageTracker.Companion.INIT_CPU_PCT
-import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitResourceUsageTracker.Companion.INIT_RUN_DELAY_PCT
+import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.INIT_CPU_PCT
+import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.INIT_DISK_READ_KB
+import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.INIT_GC_COUNT
+import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.INIT_MAJ_FAULTS
+import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.INIT_RUN_DELAY_PCT
+import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.SECONDS_SINCE_BOOT
 import java.io.FileInputStream
 import kotlin.math.roundToLong
 
@@ -21,6 +27,13 @@ class SdkInitResourceUsageTracker(
     private val elapsedRealtimeMs: () -> Long = { SystemClock.elapsedRealtime() },
     private val schedstatPathProvider: () -> String = { "/proc/self/task/${Process.myTid()}/schedstat" },
     private val procFileReader: (path: String) -> ByteArray? = ::readProcFile,
+    private val runtimeStatReader: (statName: String) -> String? = { statName ->
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            Debug.getRuntimeStat(statName)
+        } else {
+            null
+        }
+    },
 ) {
 
     @Volatile
@@ -44,6 +57,24 @@ class SdkInitResourceUsageTracker(
     @Volatile
     private var endSchedstat: ByteArray? = null
 
+    @Volatile
+    private var startProcStat: ByteArray? = null
+
+    @Volatile
+    private var endProcStat: ByteArray? = null
+
+    @Volatile
+    private var startProcIo: ByteArray? = null
+
+    @Volatile
+    private var endProcIo: ByteArray? = null
+
+    @Volatile
+    private var startGcCount: Long? = null
+
+    @Volatile
+    private var endGcCount: Long? = null
+
     /**
      * Captures the state right before the SDK starts. Should be called as close to the SDK start call as possible.
      */
@@ -54,6 +85,9 @@ class SdkInitResourceUsageTracker(
             val path = schedstatPathProvider()
             schedstatPath = path
             startSchedstat = procFileReader(path)
+            startProcStat = procFileReader(PROC_SELF_STAT_PATH)
+            startProcIo = procFileReader(PROC_SELF_IO_PATH)
+            startGcCount = runtimeStatReader(GC_COUNT_STAT)?.toLongOrNull()
         } catch (_: Throwable) {
         }
     }
@@ -66,6 +100,9 @@ class SdkInitResourceUsageTracker(
             endWallMs = elapsedRealtimeMs()
             endCpuMs = threadCpuTimeMs()
             endSchedstat = schedstatPath?.let(procFileReader)
+            endProcStat = procFileReader(PROC_SELF_STAT_PATH)
+            endProcIo = procFileReader(PROC_SELF_IO_PATH)
+            endGcCount = runtimeStatReader(GC_COUNT_STAT)?.toLongOrNull()
         } catch (_: Throwable) {
         }
     }
@@ -85,22 +122,44 @@ class SdkInitResourceUsageTracker(
             val wallStart = startWallMs
             val wallEnd = endWallMs
             if (wallStart != null && wallEnd != null && wallEnd > wallStart) {
-                val wallMs = wallEnd - wallStart
-                val cpuStart = startCpuMs
-                val cpuEnd = endCpuMs
-                if (cpuStart != null && cpuEnd != null && cpuEnd >= cpuStart) {
-                    put(INIT_CPU_PCT, wholePercent(cpuEnd - cpuStart, wallMs).toString())
-                }
-                val runDelayStartNs = startSchedstat?.let { parseRunDelayNs(it) }
-                val runDelayEndNs = endSchedstat?.let { parseRunDelayNs(it) }
-                if (runDelayStartNs != null && runDelayEndNs != null && runDelayEndNs >= runDelayStartNs) {
-                    val runDelayMs = (runDelayEndNs - runDelayStartNs) / 1_000_000L
-                    put(INIT_RUN_DELAY_PCT, wholePercent(runDelayMs, wallMs).toString())
-                }
+                putSchedulingAttributes(wallMs = wallEnd - wallStart)
+                putResourceAttributes()
+                put(SECONDS_SINCE_BOOT, (wallStart / 1000L).toString())
             }
         }
     } catch (_: Throwable) {
         emptyMap()
+    }
+
+    private fun MutableMap<String, String>.putSchedulingAttributes(wallMs: Long) {
+        deltaOrNull(startCpuMs, endCpuMs)?.let { cpuMs ->
+            put(INIT_CPU_PCT, wholePercent(cpuMs, wallMs).toString())
+        }
+        deltaOrNull(startSchedstat?.let { parseRunDelayNs(it) }, endSchedstat?.let { parseRunDelayNs(it) })?.let { delayNs ->
+            put(INIT_RUN_DELAY_PCT, wholePercent(delayNs / 1_000_000L, wallMs).toString())
+        }
+    }
+
+    private fun MutableMap<String, String>.putResourceAttributes() {
+        deltaOrNull(startProcStat?.let { parseMajFaults(it) }, endProcStat?.let { parseMajFaults(it) })?.let { faults ->
+            put(INIT_MAJ_FAULTS, faults.toString())
+        }
+        deltaOrNull(startProcIo?.let { parseReadBytes(it) }, endProcIo?.let { parseReadBytes(it) })?.let { bytes ->
+            put(INIT_DISK_READ_KB, (bytes / 1024L).toString())
+        }
+        deltaOrNull(startGcCount, endGcCount)?.let { count ->
+            put(INIT_GC_COUNT, count.toString())
+        }
+    }
+
+    /**
+     * The delta between two samples of a cumulative counter, or null when either sample is
+     * missing or the counter went backwards.
+     */
+    private fun deltaOrNull(start: Long?, end: Long?): Long? = if (start != null && end != null && end >= start) {
+        end - start
+    } else {
+        null
     }
 
     private fun wholePercent(part: Long, whole: Long): Long = (100.0 * part / whole).roundToLong()
@@ -115,18 +174,32 @@ class SdkInitResourceUsageTracker(
         null
     }
 
-    companion object {
-        /**
-         * Percentage of the init window the init thread spent executing on a CPU, rounded to a whole
-         * number. It measures the CPU utilization rate on the init thread during SDK init.
-         */
-        const val INIT_CPU_PCT: String = "init-cpu-pct"
+    /**
+     * Extracts the cumulative major-fault count (field 12, 1-indexed) from raw /proc/self/stat
+     * contents. The second field (comm) is a parenthesized process name that may itself contain
+     * spaces and parentheses, so fields are counted from the substring after the LAST ')'.
+     */
+    private fun parseMajFaults(raw: ByteArray): Long? = try {
+        val afterComm = raw.decodeToString().substringAfterLast(')')
+        // post-comm tokens: state ppid pgrp session tty_nr tpgid flags minflt cminflt majflt
+        afterComm.trim().split(' ').getOrNull(MAJ_FAULTS_POST_COMM_INDEX)?.toLong()
+    } catch (_: Throwable) {
+        null
+    }
 
-        /**
-         * Percentage of the init window the init thread spent runnable but waiting for a CPU,
-         * as a whole number. It measures CPU contention from concurrent work.
-         */
-        const val INIT_RUN_DELAY_PCT: String = "init-run-delay-pct"
+    /**
+     * Extracts the cumulative read_bytes value from raw /proc/self/io contents (a line-keyed
+     * file; counts bytes actually fetched from the storage layer).
+     */
+    private fun parseReadBytes(raw: ByteArray): Long? = try {
+        raw.decodeToString()
+            .lineSequence()
+            .firstOrNull { it.startsWith("read_bytes:") }
+            ?.substringAfter(':')
+            ?.trim()
+            ?.toLong()
+    } catch (_: Throwable) {
+        null
     }
 }
 
@@ -148,4 +221,9 @@ private fun readProcFile(path: String): ByteArray? = try {
     null
 }
 
-private const val PROC_READ_BUFFER_BYTES = 128
+// /proc/self/stat is ~300-350 bytes and /proc/self/io ~120, so 1024 covers both with room to spare
+private const val PROC_READ_BUFFER_BYTES = 1024
+private const val PROC_SELF_STAT_PATH = "/proc/self/stat"
+private const val PROC_SELF_IO_PATH = "/proc/self/io"
+private const val GC_COUNT_STAT = "art.gc.gc-count"
+private const val MAJ_FAULTS_POST_COMM_INDEX = 9

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributesTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributesTest.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.instrumentation.startup
 
+import android.app.ActivityManager
 import android.content.Context
 import android.os.PowerManager
 import androidx.test.core.app.ApplicationProvider
@@ -25,7 +26,7 @@ internal class SdkInitEnvironmentAttributesTest {
     fun `thermal status is mapped to its name`() {
         val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
         shadowOf(powerManager).setCurrentThermalStatus(PowerManager.THERMAL_STATUS_MODERATE)
-        assertEquals("moderate", environmentAttributes()[THERMAL_STATUS_ATTR])
+        assertEquals("moderate", environmentAttributes()[SdkInitAttributeKeys.THERMAL_STATUS])
     }
 
     @Test
@@ -34,19 +35,47 @@ internal class SdkInitEnvironmentAttributesTest {
         packageInfo.firstInstallTime = NOW_MS - 90_000L
         packageInfo.lastUpdateTime = NOW_MS - 30_000L
         val attributes = environmentAttributes()
-        assertEquals("90", attributes[SECONDS_SINCE_INSTALL_ATTR])
-        assertEquals("30", attributes[SECONDS_SINCE_UPDATE_ATTR])
+        assertEquals("90", attributes[SdkInitAttributeKeys.SECONDS_SINCE_INSTALL])
+        assertEquals("30", attributes[SdkInitAttributeKeys.SECONDS_SINCE_UPDATE])
     }
 
     @Test
     fun `unset package timestamps omit the recency attributes`() {
         val attributes = environmentAttributes()
-        assertFalse(attributes.containsKey(SECONDS_SINCE_INSTALL_ATTR))
-        assertFalse(attributes.containsKey(SECONDS_SINCE_UPDATE_ATTR))
+        assertFalse(attributes.containsKey(SdkInitAttributeKeys.SECONDS_SINCE_INSTALL))
+        assertFalse(attributes.containsKey(SdkInitAttributeKeys.SECONDS_SINCE_UPDATE))
+    }
+
+    @Test
+    fun `memory availability reported as whole percentage of total`() {
+        val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        val memoryInfo = ActivityManager.MemoryInfo().apply {
+            availMem = 1_500_000_000L
+            totalMem = 4_000_000_000L
+            lowMemory = false
+        }
+        shadowOf(activityManager).setMemoryInfo(memoryInfo)
+        val attributes = environmentAttributes()
+        // 37.5% rounds to 38
+        assertEquals("38", attributes[SdkInitAttributeKeys.MEM_AVAILABLE_PCT])
+        assertFalse(attributes.containsKey(SdkInitAttributeKeys.LOW_MEMORY))
+    }
+
+    @Test
+    fun `low memory flag emitted only when the system reports it`() {
+        val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        val memoryInfo = ActivityManager.MemoryInfo().apply {
+            availMem = 200_000_000L
+            totalMem = 4_000_000_000L
+            lowMemory = true
+        }
+        shadowOf(activityManager).setMemoryInfo(memoryInfo)
+        assertEquals("true", environmentAttributes()[SdkInitAttributeKeys.LOW_MEMORY])
     }
 
     private fun environmentAttributes(): Map<String, String> = sdkInitEnvironmentAttributes(
         powerManagerProvider = { context.getSystemService(Context.POWER_SERVICE) as? PowerManager },
+        activityManagerProvider = { context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager },
         packageInfo = context.packageManager.getPackageInfo(context.packageName, 0),
         nowMs = NOW_MS,
     )

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitResourceUsageTrackerTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitResourceUsageTrackerTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.instrumentation.startup
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Test
 
@@ -9,6 +10,9 @@ internal class SdkInitResourceUsageTrackerTest {
     private lateinit var cpuTimesMs: ArrayDeque<Long>
     private lateinit var wallTimesMs: ArrayDeque<Long>
     private lateinit var schedstatContents: ArrayDeque<ByteArray?>
+    private lateinit var procStatContents: ArrayDeque<ByteArray?>
+    private lateinit var procIoContents: ArrayDeque<ByteArray?>
+    private lateinit var runtimeStats: MutableMap<String, ArrayDeque<String?>>
     private lateinit var readPaths: MutableList<String>
 
     @Before
@@ -22,25 +26,69 @@ internal class SdkInitResourceUsageTrackerTest {
                 "800000000 12000000 150\n".toByteArray(),
             ),
         )
+        // comm "(fake app) 1)" deliberately contains a space and an extra ')' so field counting
+        // must start after the LAST paren; majflt (field 12) is 40 -> 55
+        procStatContents = ArrayDeque(
+            listOf(
+                "123 (fake app) 1) S 1 2 3 4 5 6 100 200 40 0 30 10".toByteArray(),
+                "123 (fake app) 1) S 1 2 3 4 5 6 150 300 55 0 60 20".toByteArray(),
+            ),
+        )
+        procIoContents = ArrayDeque(
+            listOf(
+                "rchar: 900\nwchar: 100\nsyscr: 5\nsyscw: 2\nread_bytes: 4096\nwrite_bytes: 0\n".toByteArray(),
+                "rchar: 9000\nwchar: 400\nsyscr: 15\nsyscw: 4\nread_bytes: 53248\nwrite_bytes: 0\n".toByteArray(),
+            ),
+        )
+        runtimeStats = mutableMapOf(
+            "art.gc.gc-count" to ArrayDeque(listOf("3", "5")),
+        )
         readPaths = mutableListOf()
     }
 
     @Test
-    fun `cpu and run delay reported as whole percentages of the captured window`() {
+    fun `window metrics reported from captured deltas`() {
         val tracker = createTracker()
         tracker.captureStart()
         tracker.captureEnd()
-        // window = 60 ms wall
-        // cpu delta = 30 ms
-        // run delay = 7 ms
+        // window = 60 ms wall; cpu delta = 30 ms -> 50%; run delay = 7 ms -> 12%;
+        // majflt 55-40 = 15; read_bytes delta 49152 B -> 48 KB; gc 5-3 = 2 taking 40-12 = 28 ms;
+        // wall start 5000 ms since boot -> 5 s
         assertEquals(
             mapOf(
-                SdkInitResourceUsageTracker.INIT_CPU_PCT to "50",
-                SdkInitResourceUsageTracker.INIT_RUN_DELAY_PCT to "12",
+                SdkInitAttributeKeys.INIT_CPU_PCT to "50",
+                SdkInitAttributeKeys.INIT_RUN_DELAY_PCT to "12",
+                SdkInitAttributeKeys.INIT_MAJ_FAULTS to "15",
+                SdkInitAttributeKeys.INIT_DISK_READ_KB to "48",
+                SdkInitAttributeKeys.INIT_GC_COUNT to "2",
+                SdkInitAttributeKeys.SECONDS_SINCE_BOOT to "5",
             ),
             tracker.buildAttributes(),
         )
-        assertEquals(listOf(SCHEDSTAT_PATH, SCHEDSTAT_PATH), readPaths)
+        assertEquals(listOf(SCHEDSTAT_PATH, SCHEDSTAT_PATH), readPaths.filter { it.endsWith("schedstat") })
+    }
+
+    @Test
+    fun `missing proc stat only drops major faults`() {
+        procStatContents = ArrayDeque(listOf(null, null))
+        val tracker = createTracker()
+        tracker.captureStart()
+        tracker.captureEnd()
+        val attributes = tracker.buildAttributes()
+        assertFalse(attributes.containsKey(SdkInitAttributeKeys.INIT_MAJ_FAULTS))
+        assertEquals("50", attributes[SdkInitAttributeKeys.INIT_CPU_PCT])
+        assertEquals("48", attributes[SdkInitAttributeKeys.INIT_DISK_READ_KB])
+    }
+
+    @Test
+    fun `missing runtime stats only drops GC count`() {
+        runtimeStats = mutableMapOf()
+        val tracker = createTracker()
+        tracker.captureStart()
+        tracker.captureEnd()
+        val attributes = tracker.buildAttributes()
+        assertFalse(attributes.containsKey(SdkInitAttributeKeys.INIT_GC_COUNT))
+        assertEquals("50", attributes[SdkInitAttributeKeys.INIT_CPU_PCT])
     }
 
     @Test
@@ -49,10 +97,9 @@ internal class SdkInitResourceUsageTrackerTest {
         val tracker = createTracker()
         tracker.captureStart()
         tracker.captureEnd()
-        assertEquals(
-            mapOf(SdkInitResourceUsageTracker.INIT_CPU_PCT to "50"),
-            tracker.buildAttributes(),
-        )
+        val attributes = tracker.buildAttributes()
+        assertFalse(attributes.containsKey(SdkInitAttributeKeys.INIT_RUN_DELAY_PCT))
+        assertEquals("50", attributes[SdkInitAttributeKeys.INIT_CPU_PCT])
     }
 
     @Test
@@ -61,10 +108,9 @@ internal class SdkInitResourceUsageTrackerTest {
         val tracker = createTracker()
         tracker.captureStart()
         tracker.captureEnd()
-        assertEquals(
-            mapOf(SdkInitResourceUsageTracker.INIT_CPU_PCT to "50"),
-            tracker.buildAttributes(),
-        )
+        val attributes = tracker.buildAttributes()
+        assertFalse(attributes.containsKey(SdkInitAttributeKeys.INIT_RUN_DELAY_PCT))
+        assertEquals("50", attributes[SdkInitAttributeKeys.INIT_CPU_PCT])
     }
 
     @Test
@@ -72,10 +118,9 @@ internal class SdkInitResourceUsageTrackerTest {
         val tracker = createTracker(procFileReader = { error("SELinux says no") })
         tracker.captureStart()
         tracker.captureEnd()
-        assertEquals(
-            mapOf(SdkInitResourceUsageTracker.INIT_CPU_PCT to "50"),
-            tracker.buildAttributes(),
-        )
+        val attributes = tracker.buildAttributes()
+        assertFalse(attributes.containsKey(SdkInitAttributeKeys.INIT_RUN_DELAY_PCT))
+        assertEquals("50", attributes[SdkInitAttributeKeys.INIT_CPU_PCT])
     }
 
     @Test
@@ -89,7 +134,7 @@ internal class SdkInitResourceUsageTrackerTest {
         val tracker = createTracker()
         tracker.captureStart()
         tracker.captureEnd()
-        assertEquals("20", tracker.buildAttributes()[SdkInitResourceUsageTracker.INIT_RUN_DELAY_PCT])
+        assertEquals("20", tracker.buildAttributes()[SdkInitAttributeKeys.INIT_RUN_DELAY_PCT])
     }
 
     @Test
@@ -103,7 +148,7 @@ internal class SdkInitResourceUsageTrackerTest {
         val tracker = createTracker()
         tracker.captureStart()
         tracker.captureEnd()
-        assertEquals("12", tracker.buildAttributes()[SdkInitResourceUsageTracker.INIT_RUN_DELAY_PCT])
+        assertEquals("12", tracker.buildAttributes()[SdkInitAttributeKeys.INIT_RUN_DELAY_PCT])
     }
 
     @Test
@@ -112,10 +157,9 @@ internal class SdkInitResourceUsageTrackerTest {
         val tracker = createTracker()
         tracker.captureStart()
         tracker.captureEnd()
-        assertEquals(
-            mapOf(SdkInitResourceUsageTracker.INIT_CPU_PCT to "50"),
-            tracker.buildAttributes(),
-        )
+        val attributes = tracker.buildAttributes()
+        assertFalse(attributes.containsKey(SdkInitAttributeKeys.INIT_RUN_DELAY_PCT))
+        assertEquals("50", attributes[SdkInitAttributeKeys.INIT_CPU_PCT])
     }
 
     @Test
@@ -130,7 +174,7 @@ internal class SdkInitResourceUsageTrackerTest {
         val tracker = createTracker()
         tracker.captureStart()
         tracker.captureEnd()
-        assertEquals("20", tracker.buildAttributes()[SdkInitResourceUsageTracker.INIT_RUN_DELAY_PCT])
+        assertEquals("20", tracker.buildAttributes()[SdkInitAttributeKeys.INIT_RUN_DELAY_PCT])
     }
 
     @Test
@@ -140,7 +184,9 @@ internal class SdkInitResourceUsageTrackerTest {
         val tracker = createTracker()
         tracker.captureStart()
         tracker.captureEnd()
-        assertEquals(emptyMap<String, String>(), tracker.buildAttributes())
+        val attributes = tracker.buildAttributes()
+        assertFalse(attributes.containsKey(SdkInitAttributeKeys.INIT_CPU_PCT))
+        assertFalse(attributes.containsKey(SdkInitAttributeKeys.INIT_RUN_DELAY_PCT))
     }
 
     @Test
@@ -160,13 +206,19 @@ internal class SdkInitResourceUsageTrackerTest {
     private fun createTracker(
         procFileReader: (String) -> ByteArray? = { path ->
             readPaths.add(path)
-            schedstatContents.removeFirst()
+            when {
+                path.endsWith("schedstat") -> schedstatContents.removeFirst()
+                path.endsWith("/stat") -> procStatContents.removeFirst()
+                path.endsWith("/io") -> procIoContents.removeFirst()
+                else -> null
+            }
         },
     ) = SdkInitResourceUsageTracker(
         threadCpuTimeMs = { cpuTimesMs.removeFirst() },
         elapsedRealtimeMs = { wallTimesMs.removeFirst() },
         schedstatPathProvider = { SCHEDSTAT_PATH },
         procFileReader = procFileReader,
+        runtimeStatReader = { statName -> runtimeStats[statName]?.removeFirstOrNull() },
     )
 
     private companion object {

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/StartupServiceImplTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/startup/StartupServiceImplTest.kt
@@ -4,7 +4,7 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeTelemetryDestination
 import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.arch.state.ProcessState
-import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitResourceUsageTracker
+import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys
 import io.embrace.android.embracesdk.internal.instrumentation.startup.StartupService
 import io.embrace.android.embracesdk.internal.instrumentation.startup.StartupServiceImpl
 import io.embrace.android.embracesdk.internal.instrumentation.startup.toSdkInitDurationAttributes
@@ -47,8 +47,8 @@ internal class StartupServiceImplTest {
                 providerInvocationCount++
                 mapOf("modules-init" to 100L).toSdkInitDurationAttributes() +
                     mapOf(
-                        SdkInitResourceUsageTracker.INIT_CPU_PCT to "85",
-                        SdkInitResourceUsageTracker.INIT_RUN_DELAY_PCT to "10",
+                        SdkInitAttributeKeys.INIT_CPU_PCT to "85",
+                        SdkInitAttributeKeys.INIT_RUN_DELAY_PCT to "10",
                     )
             },
         )
@@ -66,8 +66,8 @@ internal class StartupServiceImplTest {
             assertEquals("main", attributes["thread-name"])
             assertEquals("100", attributes["modules-init-duration-ms"])
             assertEquals("3", attributes[EmbAppAttributes.EMB_APP_VERSION_STARTUP_COUNTER])
-            assertEquals("85", attributes[SdkInitResourceUsageTracker.INIT_CPU_PCT])
-            assertEquals("10", attributes[SdkInitResourceUsageTracker.INIT_RUN_DELAY_PCT])
+            assertEquals("85", attributes[SdkInitAttributeKeys.INIT_CPU_PCT])
+            assertEquals("10", attributes[SdkInitAttributeKeys.INIT_RUN_DELAY_PCT])
         }
         assertEquals(3, startupService.getAppVersionStartupCounter())
 

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
@@ -220,6 +220,9 @@ internal fun ModuleGraph.markSdkInitComplete(sdkInitDurations: Map<String, Long>
                 sdkInitDurations.toSdkInitDurationAttributes() +
                     resourceUsageTracker.buildAttributes() +
                     sdkInitEnvironmentAttributes(
+                        activityManagerProvider = {
+                            instrumentationModule.instrumentationArgs.systemService(Context.ACTIVITY_SERVICE)
+                        },
                         powerManagerProvider = {
                             instrumentationModule.instrumentationArgs.systemService(Context.POWER_SERVICE)
                         },


### PR DESCRIPTION
Add a bunch more metadata related to the environment in which the SDK startup is happening. Explanations are in the comments, but these are the factors that are correlated with slow outliers during the startup perfetto trace analysis.