### PR TITLE
Encode session part directory version in filename

### DIFF
--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionPartDirectory.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionPartDirectory.kt
@@ -8,12 +8,14 @@ data class SessionPartDirectory(
     val uuid: String,
     val userSessionId: String = "",
     val sessionPartId: String = "",
+    val version: SessionPartDirectoryVersion = SessionPartDirectoryVersion.V1,
 ) {
-    val dirName: String = "${timestamp}_${uuid}_${encodeId(userSessionId)}_${encodeId(sessionPartId)}"
+    val dirName: String =
+        "${version.token}_${timestamp}_${uuid}_${encodeId(userSessionId)}_${encodeId(sessionPartId)}"
 
     companion object {
         private const val EMPTY_ID_TOKEN = "none"
-        private const val TOKEN_COUNT = 4
+        private const val TOKEN_COUNT = 5
 
         /**
          * Orders directories by timestamp then uuid, which is the order that session parts must
@@ -38,14 +40,37 @@ data class SessionPartDirectory(
             if (parts.size != TOKEN_COUNT) {
                 return null
             }
-            val timestamp = parts[0].toLongOrNull() ?: return null
-            val uuid = parts[1].ifEmpty { return null }
+            val version = SessionPartDirectoryVersion.fromToken(parts[0]) ?: return null
+            val timestamp = parts[1].toLongOrNull() ?: return null
+            val uuid = parts[2].ifEmpty { return null }
             return SessionPartDirectory(
                 timestamp = timestamp,
                 uuid = uuid,
-                userSessionId = decodeId(parts[2]),
-                sessionPartId = decodeId(parts[3]),
+                userSessionId = decodeId(parts[3]),
+                sessionPartId = decodeId(parts[4]),
+                version = version,
             )
         }
+    }
+}
+
+/**
+ * Version of the encoding used for a session part directory name.
+ */
+enum class SessionPartDirectoryVersion(val token: String) {
+
+    /**
+     * Initial encoding: `v1_<timestampMs>_<uuid>_<userSessionId>_<sessionPartId>`.
+     */
+    V1("v1"),
+    ;
+
+    internal companion object {
+
+        /**
+         * Returns the version that the given token identifies, or null if unrecognised.
+         */
+        fun fromToken(token: String): SessionPartDirectoryVersion? =
+            entries.firstOrNull { it.token == token }
     }
 }

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionPartDirectoryTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionPartDirectoryTest.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.internal.session.persistence
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 internal class SessionPartDirectoryTest {
@@ -16,7 +17,7 @@ internal class SessionPartDirectoryTest {
     @Test
     fun `construct dirname with session ids`() {
         assertEquals(
-            "${TIMESTAMP}_${UUID}_${USER_SESSION_ID}_$SESSION_PART_ID",
+            "v1_${TIMESTAMP}_${UUID}_${USER_SESSION_ID}_$SESSION_PART_ID",
             SessionPartDirectory(
                 timestamp = TIMESTAMP,
                 uuid = UUID,
@@ -29,7 +30,7 @@ internal class SessionPartDirectoryTest {
     @Test
     fun `construct dirname with empty session ids encodes none`() {
         assertEquals(
-            "${TIMESTAMP}_${UUID}_none_none",
+            "v1_${TIMESTAMP}_${UUID}_none_none",
             SessionPartDirectory(
                 timestamp = TIMESTAMP,
                 uuid = UUID,
@@ -40,7 +41,7 @@ internal class SessionPartDirectoryTest {
     @Test
     fun `construct dirname with only one empty session id`() {
         assertEquals(
-            "${TIMESTAMP}_${UUID}_${USER_SESSION_ID}_none",
+            "v1_${TIMESTAMP}_${UUID}_${USER_SESSION_ID}_none",
             SessionPartDirectory(
                 timestamp = TIMESTAMP,
                 uuid = UUID,
@@ -51,20 +52,44 @@ internal class SessionPartDirectoryTest {
     }
 
     @Test
+    fun `construct dirname defaults to the first version`() {
+        assertEquals(
+            SessionPartDirectoryVersion.V1,
+            SessionPartDirectory(timestamp = TIMESTAMP, uuid = UUID).version,
+        )
+    }
+
+    @Test
+    fun `construct dirname prefixes the version token`() {
+        SessionPartDirectoryVersion.entries.forEach { version ->
+            val dirName = SessionPartDirectory(
+                timestamp = TIMESTAMP,
+                uuid = UUID,
+                version = version,
+            ).dirName
+            assertTrue(
+                "Dirname should start with the version token: $dirName",
+                dirName.startsWith("${version.token}_"),
+            )
+        }
+    }
+
+    @Test
     fun `from valid dirname`() {
-        val input = "${TIMESTAMP}_${UUID}_${USER_SESSION_ID}_$SESSION_PART_ID"
+        val input = "v1_${TIMESTAMP}_${UUID}_${USER_SESSION_ID}_$SESSION_PART_ID"
         with(checkNotNull(SessionPartDirectory.fromDirName(input))) {
             assertEquals(input, dirName)
             assertEquals(TIMESTAMP, timestamp)
             assertEquals(UUID, uuid)
             assertEquals(USER_SESSION_ID, userSessionId)
             assertEquals(SESSION_PART_ID, sessionPartId)
+            assertEquals(SessionPartDirectoryVersion.V1, version)
         }
     }
 
     @Test
     fun `from valid dirname with none decodes to empty session ids`() {
-        with(checkNotNull(SessionPartDirectory.fromDirName("${TIMESTAMP}_${UUID}_none_none"))) {
+        with(checkNotNull(SessionPartDirectory.fromDirName("v1_${TIMESTAMP}_${UUID}_none_none"))) {
             assertEquals(TIMESTAMP, timestamp)
             assertEquals(UUID, uuid)
             assertEquals("", userSessionId)
@@ -92,10 +117,17 @@ internal class SessionPartDirectoryTest {
             "",
             "foo",
             "embrace_payloads",
-            "${TIMESTAMP}_$UUID",
-            "${TIMESTAMP}_${UUID}_${USER_SESSION_ID}_${SESSION_PART_ID}_extra",
-            "notATimestamp_${UUID}_none_none",
-            "${TIMESTAMP}__none_none",
+            "v1_${TIMESTAMP}_$UUID",
+            "v1_${TIMESTAMP}_${UUID}_${USER_SESSION_ID}_${SESSION_PART_ID}_extra",
+            "v1_notATimestamp_${UUID}_none_none",
+            "v1_${TIMESTAMP}__none_none",
+            // an unversioned name uses an encoding this SDK cannot interpret
+            "${TIMESTAMP}_${UUID}_${USER_SESSION_ID}_$SESSION_PART_ID",
+            "${TIMESTAMP}_${UUID}_none_none",
+            // unknown or absent version tokens
+            "v2_${TIMESTAMP}_${UUID}_none_none",
+            "_${TIMESTAMP}_${UUID}_none_none",
+            "V1_${TIMESTAMP}_${UUID}_none_none",
         )
         badDirNames.forEach { dirName ->
             assertNull("Dirname should fail: $dirName", SessionPartDirectory.fromDirName(dirName))
@@ -113,6 +145,24 @@ internal class SessionPartDirectoryTest {
         val decoded = checkNotNull(SessionPartDirectory.fromDirName(original.dirName))
         assertEquals(original, decoded)
         assertEquals(original.dirName, decoded.dirName)
+    }
+
+    @Test
+    fun `round trip preserves every version`() {
+        SessionPartDirectoryVersion.entries.forEach { version ->
+            val original = SessionPartDirectory(
+                timestamp = TIMESTAMP,
+                uuid = UUID,
+                userSessionId = USER_SESSION_ID,
+                sessionPartId = SESSION_PART_ID,
+                version = version,
+            )
+            val decoded = checkNotNull(SessionPartDirectory.fromDirName(original.dirName)) {
+                "Dirname should round trip for $version"
+            }
+            assertEquals(original, decoded)
+            assertEquals(version, decoded.version)
+        }
     }
 
     @Test


### PR DESCRIPTION
## Goal

Encodes a version for the session part directory in its filename. This will be used to indicate changes in the format that are notable enough to require modifications to our persistence/deserialization logic.

## Testing

Added unit tests.
