### PR TITLE
Reconstruct metadata in session part payloads

### DIFF
--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/EnvelopeMetadataMapper.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/EnvelopeMetadataMapper.kt
@@ -6,10 +6,20 @@ import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
  * Maps an [EnvelopeMetadata] to its protobuf equivalent.
  */
 internal fun EnvelopeMetadata.toProto(): EnvelopeMetadataProto = EnvelopeMetadataProto(
+    format_version = FORMAT_VERSION,
     user_id = userId,
     email = email,
     username = username,
     personas = personas?.toList().orEmpty(),
     timezone_description = timezoneDescription.orEmpty(),
     locale = locale.orEmpty(),
+)
+
+internal fun EnvelopeMetadataProto.toPayload(): EnvelopeMetadata = EnvelopeMetadata(
+    userId = user_id,
+    email = email,
+    username = username,
+    personas = personas.takeIf(List<String>::isNotEmpty)?.toSet(),
+    timezoneDescription = timezone_description.takeIf(String::isNotEmpty),
+    locale = locale.takeIf(String::isNotEmpty),
 )

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionService.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionService.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.session.persistence
 
+import com.squareup.wire.ProtoAdapter
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.Envelope
@@ -35,27 +36,30 @@ class SessionReconstructionService(
             return null
         }
 
-        val src = File(partDir, MANIFEST_FILE_NAME)
-        if (!src.isFile) {
-            trackFailure(IOException("Manifest not found: ${src.path}"))
-            return null
-        }
-        val manifest = src.inputStream().buffered().use(SessionManifest.ADAPTER::decode)
+        val manifest = readPartFile(
+            partDir,
+            MANIFEST_FILE_NAME,
+            SessionManifest.ADAPTER,
+            SessionManifest::format_version,
+        ) ?: return null
 
-        if (manifest.format_version != FORMAT_VERSION) {
-            trackFailure(IOException("Unsupported manifest format version: ${manifest.format_version}"))
-            return null
-        }
         val resource = manifest.resource
         if (resource == null) {
-            trackFailure(IOException("Manifest has no resource: ${src.path}"))
+            trackFailure(IOException("Manifest has no resource: ${partDir.path}"))
             return null
         }
 
-        // various properties not persisted/deserialized yet
+        val metadata = readPartFile(
+            partDir,
+            METADATA_FILE_NAME,
+            EnvelopeMetadataProto.ADAPTER,
+            EnvelopeMetadataProto::format_version,
+        )?.toPayload() ?: return null
+
+        // spans & span snapshots not persisted/deserialized yet
         return Envelope(
             resource = resource.toPayload(),
-            metadata = null,
+            metadata = metadata,
             version = manifest.envelope_version,
             type = manifest.envelope_type,
             data = SessionPartPayload(
@@ -64,6 +68,38 @@ class SessionReconstructionService(
                 sharedLibSymbolMapping = manifest.shared_lib_symbol_mapping?.symbols,
             ),
         )
+    }
+
+    /**
+     * Decodes [fileName] from a session part directory, or null if it is absent, cannot be read,
+     * or was written by an SDK using a different on-disk layout.
+     *
+     * [formatVersion] reads the version stamped on the decoded message. Every persisted file
+     * carries one, so a file holding no data at all decodes to version 0 and is rejected rather
+     * than mistaken for a message whose fields were all left at their defaults.
+     */
+    private fun <T> readPartFile(
+        partDir: File,
+        fileName: String,
+        adapter: ProtoAdapter<T>,
+        formatVersion: (T) -> Int,
+    ): T? {
+        val src = File(partDir, fileName)
+        return try {
+            if (!src.isFile) {
+                throw IOException("File not found: ${src.path}")
+            }
+            val message = src.inputStream().buffered().use(adapter::decode)
+
+            val version = formatVersion(message)
+            if (version != FORMAT_VERSION) {
+                throw IOException("Unsupported format version in ${src.path}: $version")
+            }
+            message
+        } catch (exc: Throwable) {
+            trackFailure(exc)
+            null
+        }
     }
 
     private fun trackFailure(exc: Throwable) {

--- a/embrace-android-session-persistence/src/main/proto/embrace/session/persistence/metadata.proto
+++ b/embrace-android-session-persistence/src/main/proto/embrace/session/persistence/metadata.proto
@@ -6,13 +6,15 @@ option java_package = "io.embrace.android.embracesdk.internal.session.persistenc
 
 // Mirrors EnvelopeMetadata. Rewritten whenever user info changes.
 message EnvelopeMetadataProto {
-  optional string user_id = 1;
-  optional string email = 2;
-  optional string username = 3;
+  uint32 format_version = 1;
+
+  optional string user_id = 2;
+  optional string email = 3;
+  optional string username = 4;
 
   // a Set in the payload, so the mapper dedupes on read.
-  repeated string personas = 4;
+  repeated string personas = 5;
 
-  string timezone_description = 5;
-  string locale = 6;
+  string timezone_description = 6;
+  string locale = 7;
 }

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/EnvelopeMetadataFixtures.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/EnvelopeMetadataFixtures.kt
@@ -12,6 +12,7 @@ internal val fullyPopulatedMetadata = EnvelopeMetadata(
 )
 
 internal val fullyPopulatedMetadataProto = EnvelopeMetadataProto(
+    format_version = FORMAT_VERSION,
     user_id = "userId",
     email = "email@example.com",
     username = "username",

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/EnvelopeMetadataMapperTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/EnvelopeMetadataMapperTest.kt
@@ -13,6 +13,11 @@ internal class EnvelopeMetadataMapperTest {
     }
 
     @Test
+    fun `the format version is stamped on the proto`() {
+        assertEquals(FORMAT_VERSION, EnvelopeMetadata().toProto().format_version)
+    }
+
+    @Test
     fun `null user fields map to absent proto fields`() {
         val proto = EnvelopeMetadata(timezoneDescription = "Europe/London", locale = "en_GB").toProto()
         assertNull(proto.user_id)
@@ -55,5 +60,54 @@ internal class EnvelopeMetadataMapperTest {
     fun `fully populated metadata survives a round trip through the wire format`() {
         val proto = fullyPopulatedMetadata.toProto()
         assertEquals(proto, EnvelopeMetadataProto.ADAPTER.decode(EnvelopeMetadataProto.ADAPTER.encode(proto)))
+    }
+
+    @Test
+    fun `every proto field maps to its payload counterpart`() {
+        assertEquals(fullyPopulatedMetadata, fullyPopulatedMetadataProto.toPayload())
+    }
+
+    @Test
+    fun `absent proto user fields map to null`() {
+        val metadata = EnvelopeMetadataProto().toPayload()
+        assertNull(metadata.userId)
+        assertNull(metadata.email)
+        assertNull(metadata.username)
+    }
+
+    @Test
+    fun `empty string proto fields are preserved`() {
+        val metadata = EnvelopeMetadataProto(user_id = "", email = "", username = "").toPayload()
+        assertEquals("", metadata.userId)
+        assertEquals("", metadata.email)
+        assertEquals("", metadata.username)
+    }
+
+    @Test
+    fun `empty timezone and locale map to null`() {
+        val metadata = EnvelopeMetadataProto().toPayload()
+        assertNull(metadata.timezoneDescription)
+        assertNull(metadata.locale)
+    }
+
+    @Test
+    fun `empty proto personas map to null`() {
+        assertNull(EnvelopeMetadataProto(personas = emptyList()).toPayload().personas)
+    }
+
+    @Test
+    fun `duplicate personas are deduped on read`() {
+        val personas = listOf("payer", "first_day", "payer")
+        assertEquals(setOf("payer", "first_day"), EnvelopeMetadataProto(personas = personas).toPayload().personas)
+    }
+
+    @Test
+    fun `fully populated metadata survives a round trip through the mappers`() {
+        assertEquals(fullyPopulatedMetadata, fullyPopulatedMetadata.toProto().toPayload())
+    }
+
+    @Test
+    fun `metadata with no populated fields survives a round trip through the mappers`() {
+        assertEquals(EnvelopeMetadata(), EnvelopeMetadata().toProto().toPayload())
     }
 }

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionMetadataWriterTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionMetadataWriterTest.kt
@@ -75,6 +75,14 @@ internal class SessionMetadataWriterTest {
     }
 
     @Test
+    fun `the format version is persisted even when nothing else is populated`() {
+        metadataProvider = { EnvelopeMetadata() }
+        write()
+
+        assertEquals(FORMAT_VERSION, readMetadata().format_version)
+    }
+
+    @Test
     fun `null user fields are persisted as absent`() {
         metadataProvider = { EnvelopeMetadata(timezoneDescription = "Europe/London", locale = "en_GB") }
         write()

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceManifestTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceManifestTest.kt
@@ -37,13 +37,19 @@ internal class SessionReconstructionServiceManifestTest {
     private lateinit var sessionsDir: File
     private lateinit var logger: FakeInternalLogger
     private lateinit var writer: SessionManifestWriter
+    private lateinit var metadataWriter: SessionMetadataWriter
     private lateinit var service: SessionReconstructionService
+
+    @Volatile
+    private var activePart: SessionPartDirectory? = partDirectory
 
     @Before
     fun setUp() {
         sessionsDir = tempFolder.newFolder("embrace_sessions")
         logger = FakeInternalLogger(throwOnInternalError = false)
+        activePart = partDirectory
         writer = SessionManifestWriter(lazy { sessionsDir }, logger)
+        metadataWriter = SessionMetadataWriter(lazy { sessionsDir }, { activePart }, { fullyPopulatedMetadata }, logger)
         service = SessionReconstructionService(lazy { sessionsDir }, logger)
         createPartDir(partDirectory)
     }
@@ -65,6 +71,8 @@ internal class SessionReconstructionServiceManifestTest {
         sharedLibSymbolMapping: Map<String, String>? = null,
     ) {
         assertTrue(writer.write(directory, resource, envelopeVersion, envelopeType, sharedLibSymbolMapping))
+        activePart = directory
+        assertTrue(metadataWriter.write())
     }
 
     private fun writeManifestBytes(manifest: SessionManifest, directory: SessionPartDirectory = partDirectory) {
@@ -96,7 +104,6 @@ internal class SessionReconstructionServiceManifestTest {
         write()
 
         val envelope = checkNotNull(service.reconstruct(partDirectory))
-        assertNull(envelope.metadata)
         assertNull(envelope.data.spans)
         assertNull(envelope.data.spanSnapshots)
     }

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceMetadataTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceMetadataTest.kt
@@ -1,0 +1,204 @@
+package io.embrace.android.embracesdk.internal.session.persistence
+
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
+import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+internal class SessionReconstructionServiceMetadataTest {
+
+    private companion object {
+        private const val METADATA_FILE_NAME = "metadata.pb"
+        private const val ENVELOPE_VERSION = "0.1.0"
+        private const val ENVELOPE_TYPE = "spans"
+        private const val TIMESTAMP = 1726739283136L
+        private const val UUID = "c2610cd1-389f-422a-bfbc-25312c7a599a"
+        private const val USER_SESSION_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        private const val SESSION_PART_ID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+        private val partDirectory = SessionPartDirectory(
+            timestamp = TIMESTAMP,
+            uuid = UUID,
+            userSessionId = USER_SESSION_ID,
+            sessionPartId = SESSION_PART_ID,
+        )
+    }
+
+    @get:Rule
+    val tempFolder: TemporaryFolder = TemporaryFolder()
+
+    private lateinit var sessionsDir: File
+    private lateinit var logger: FakeInternalLogger
+    private lateinit var manifestWriter: SessionManifestWriter
+    private lateinit var metadataWriter: SessionMetadataWriter
+    private lateinit var service: SessionReconstructionService
+
+    @Volatile
+    private var metadataProvider: () -> EnvelopeMetadata = { fullyPopulatedMetadata }
+
+    @Volatile
+    private var activePart: SessionPartDirectory? = partDirectory
+
+    @Before
+    fun setUp() {
+        sessionsDir = tempFolder.newFolder("embrace_sessions")
+        logger = FakeInternalLogger(throwOnInternalError = false)
+        metadataProvider = { fullyPopulatedMetadata }
+        activePart = partDirectory
+        manifestWriter = SessionManifestWriter(lazy { sessionsDir }, logger)
+        metadataWriter = SessionMetadataWriter(lazy { sessionsDir }, { activePart }, { metadataProvider() }, logger)
+        service = SessionReconstructionService(lazy { sessionsDir }, logger)
+        createPartDir(partDirectory)
+    }
+
+    @Test
+    fun `metadata is reconstructed from the session part directory`() {
+        write()
+        assertEquals(fullyPopulatedMetadata, service.reconstruct(partDirectory)?.metadata)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `metadata with no populated fields is reconstructed`() {
+        metadataProvider = { EnvelopeMetadata() }
+        write()
+        assertEquals(EnvelopeMetadata(), service.reconstruct(partDirectory)?.metadata)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `the latest metadata is reconstructed after the user info changes`() {
+        write()
+        metadataProvider = { fullyPopulatedMetadata.copy(userId = "newUserId", personas = linkedSetOf("payer")) }
+        writeMetadata()
+
+        with(checkNotNull(service.reconstruct(partDirectory)?.metadata)) {
+            assertEquals("newUserId", userId)
+            assertEquals(setOf("payer"), personas)
+        }
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `each session part directory reconstructs its own metadata`() {
+        val other = SessionPartDirectory(
+            timestamp = TIMESTAMP + 1,
+            uuid = "d3721de2-490a-533b-cacd-36423d8b6aab",
+            userSessionId = "cccccccccccccccccccccccccccccccc",
+            sessionPartId = "dddddddddddddddddddddddddddddddd",
+        )
+        createPartDir(other)
+        write()
+        metadataProvider = { fullyPopulatedMetadata.copy(userId = "otherUserId") }
+        write(other)
+
+        assertEquals("userId", service.reconstruct(partDirectory)?.metadata?.userId)
+        assertEquals("otherUserId", service.reconstruct(other)?.metadata?.userId)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `missing metadata is reported`() {
+        writeManifest()
+
+        assertNull(service.reconstruct(partDirectory))
+        assertReconstructionFailureTracked()
+    }
+
+    @Test
+    fun `a directory occupying the metadata path is reported`() {
+        writeManifest()
+        metadataFile().mkdirs()
+
+        assertNull(service.reconstruct(partDirectory))
+        assertReconstructionFailureTracked()
+    }
+
+    @Test
+    fun `truncated metadata is reported and does not throw`() {
+        write()
+        val bytes = metadataFile().readBytes()
+        metadataFile().writeBytes(bytes.copyOf(bytes.size / 2))
+
+        assertNull(service.reconstruct(partDirectory))
+        assertReconstructionFailureTracked()
+    }
+
+    @Test
+    fun `metadata holding arbitrary bytes is reported and does not throw`() {
+        write()
+        metadataFile().writeBytes(byteArrayOf(-1, -1, -1, -1, -1, -1))
+
+        assertNull(service.reconstruct(partDirectory))
+        assertReconstructionFailureTracked()
+    }
+
+    @Test
+    fun `an empty metadata file is reported`() {
+        write()
+        metadataFile().writeBytes(byteArrayOf())
+
+        assertNull(service.reconstruct(partDirectory))
+        assertReconstructionFailureTracked()
+    }
+
+    @Test
+    fun `metadata holding no format version is reported`() {
+        write()
+        writeMetadataBytes(fullyPopulatedMetadataProto.copy(format_version = 0))
+
+        assertNull(service.reconstruct(partDirectory))
+        assertReconstructionFailureTracked()
+    }
+
+    @Test
+    fun `an unsupported metadata format version is reported`() {
+        write()
+        writeMetadataBytes(fullyPopulatedMetadataProto.copy(format_version = FORMAT_VERSION + 1))
+
+        assertNull(service.reconstruct(partDirectory))
+        assertReconstructionFailureTracked()
+    }
+
+    private fun createPartDir(directory: SessionPartDirectory): File =
+        File(sessionsDir, directory.dirName).apply { mkdirs() }
+
+    private fun partDir(directory: SessionPartDirectory = partDirectory): File =
+        File(sessionsDir, directory.dirName)
+
+    private fun metadataFile(directory: SessionPartDirectory = partDirectory): File =
+        File(partDir(directory), METADATA_FILE_NAME)
+
+    private fun write(directory: SessionPartDirectory = partDirectory) {
+        writeManifest(directory)
+        writeMetadata(directory)
+    }
+
+    private fun writeManifest(directory: SessionPartDirectory = partDirectory) {
+        assertTrue(manifestWriter.write(directory, fullyPopulatedResource, ENVELOPE_VERSION, ENVELOPE_TYPE))
+    }
+
+    private fun writeMetadata(directory: SessionPartDirectory = partDirectory) {
+        activePart = directory
+        assertTrue(metadataWriter.write())
+    }
+
+    private fun writeMetadataBytes(metadata: EnvelopeMetadataProto, directory: SessionPartDirectory = partDirectory) {
+        metadataFile(directory).writeBytes(EnvelopeMetadataProto.ADAPTER.encode(metadata))
+    }
+
+    private fun assertNoInternalErrors() {
+        assertEquals(emptyList<FakeInternalLogger.LogMessage>(), logger.internalErrorMessages)
+    }
+
+    private fun assertReconstructionFailureTracked() {
+        assertEquals(1, logger.internalErrorMessages.size)
+        assertEquals("SessionReconstructionFail", logger.internalErrorMessages.single().msg)
+    }
+}


### PR DESCRIPTION
## Goal

Alters the `SessionReconstructionService` so that it deserializes metadata and adds it to session part payloads.

## Testing

Added unit tests.
