### PR TITLE
Remove the PSI-based CPU contention attribute

### DIFF
--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitAttributeKeys.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitAttributeKeys.kt
@@ -28,6 +28,15 @@ object SdkInitAttributeKeys {
      * while init waited. Bench-measured as the strongest single correlate of slow inits -
      * a high value means "the device was busy", which is diagnostic (not our code) and
      * should be excluded from regression comparisons.
+     *
+     * This is the only CPU-contention signal available to us, so do not expect to corroborate it
+     * with a device-wide one. The kernel's PSI counters (/proc/pressure/cpu) are the obvious
+     * candidate and are unreachable: AOSP labels them with their own SELinux types and grants read
+     * access to lmkd and system_server only - no app domain has it, on any Android version since
+     * the types were introduced in Android 10. An attribute reading them was implemented, measured
+     * across 12 launches on 4 devices spanning API 29-35 and two vendors, populated zero times,
+     * and removed. Note that it reads fine from `adb shell`, whose domain has broad legacy /proc
+     * access an app never gets - so verify any such idea with `run-as <pkg>`, never a plain shell.
      */
     const val INIT_RUN_DELAY_PCT: String = "init-run-delay-pct"
 
@@ -105,13 +114,4 @@ object SdkInitAttributeKeys {
      * and the OS is actively reclaiming memory. The presence of this indicates memory pressure.
      */
     const val LOW_MEMORY: String = "low-memory"
-
-    /**
-     * The kernel's Pressure Stall Information indicating that there is some CPU pressure over the
-     * last 10 seconds on the device, as reported in /proc/pressure/cpu, rounded to a whole
-     * percentage. Corroborates a high run-delay reading with a device-wide view that its CPUs
-     * have been busy. Not always available, so the absence of this should not be seen as
-     * evidence, but the presence is.
-     */
-    const val PSI_CPU_SOME_AVG10: String = "psi-cpu-some-avg10"
 }

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributes.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributes.kt
@@ -6,14 +6,12 @@ import android.os.Build.VERSION_CODES
 import android.os.PowerManager
 import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.LOW_MEMORY
 import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.MEM_AVAILABLE_PCT
-import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.PSI_CPU_SOME_AVG10
 import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.SECONDS_SINCE_INSTALL
 import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.SECONDS_SINCE_UPDATE
 import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.THERMAL_HEADROOM_PCT
 import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.THERMAL_STATUS
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
-import java.io.File
 import kotlin.math.roundToLong
 
 /**
@@ -39,7 +37,6 @@ fun sdkInitEnvironmentAttributes(
         putThermalAttributes(powerManagerProvider, versionChecker)
         putInstallRecencyAttributes(packageInfo, nowMs)
         putMemoryAttributes(activityManagerProvider)
-        psiCpuSomeAvg10()?.let { put(PSI_CPU_SOME_AVG10, it) }
     }
 } catch (_: Throwable) {
     emptyMap()
@@ -103,21 +100,6 @@ private fun secondsBetween(thenMs: Long, nowMs: Long): Long? = if (thenMs in 1..
 } else {
     null
 }
-
-/**
- * First line of /proc/pressure/cpu looks like "some avg10=1.23 avg60=0.80 avg300=0.40 total=…".
- */
-private fun psiCpuSomeAvg10(): String? = runCatching {
-    File("/proc/pressure/cpu")
-        .readText()
-        .lineSequence()
-        .firstOrNull { it.startsWith("some") }
-        ?.substringAfter("avg10=")
-        ?.substringBefore(' ')
-        ?.toDoubleOrNull()
-        ?.roundToLong()
-        ?.toString()
-}.getOrNull()
 
 /**
  * At and beyond the severe-throttling threshold the headroom scale is not calibrated across

--- a/embrace-android-sdk/src/androidTest/kotlin/io/embrace/android/embracesdk/strictmode/KnownViolations.kt
+++ b/embrace-android-sdk/src/androidTest/kotlin/io/embrace/android/embracesdk/strictmode/KnownViolations.kt
@@ -28,6 +28,16 @@ internal val KNOWN_VIOLATIONS: List<KnownViolation> = listOf(
             "stats the directory on every call",
     ),
     KnownViolation(
+        signature = "internal.instrumentation.startup.SdkInitResourceUsageTrackerKt.readProcFile",
+        violation = DiskReadViolation::class,
+        reason = "SdkInitResourceUsageTracker samples /proc/self/task/<tid>/schedstat, /proc/self/stat and " +
+            "/proc/self/io at both edges of the init window. These cannot be moved off the main thread: " +
+            "schedstat is per-TID and only means anything when read from the thread being measured, and the " +
+            "other two have to be sampled at the window's edges to give a delta across it. procfs is " +
+            "memory-backed, so the cost is microseconds rather than real disk I/O — StrictMode instruments " +
+            "the syscall and cannot tell the two apart",
+    ),
+    KnownViolation(
         signature = "internal.config.store.RemoteConfigStoreImpl.loadFromCache",
         violation = DiskReadViolation::class,
         reason = "PersistedConfig's ctor loads the persisted response from the config store",


### PR DESCRIPTION
Further investigation yielded that not only is this not gettable for some OEMs, but Android's version of Linux doesn't provide this at all for external access, so we're SOL.