### PR TITLE
Measure shared prefs first read and size

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/SharedPrefsStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/SharedPrefsStore.kt
@@ -11,6 +11,7 @@ import io.embrace.android.embracesdk.internal.store.KeyValueStoreEditor
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Creates the SDK's [KeyValueStore], backed by the default [SharedPreferences].
@@ -29,6 +30,7 @@ internal class SharedPrefsStore(
 ) : KeyValueStore {
 
     private val openBatch = ThreadLocal<Batch?>()
+    private val firstAccessTraced = AtomicBoolean(false)
 
     override fun getString(key: String): String? {
         return pending(key) { impl.getString(key, null) }
@@ -74,7 +76,7 @@ internal class SharedPrefsStore(
         if (batch != null) {
             batch.action()
         } else {
-            SharedPrefsStoreEditor(impl.edit(), serializer).use {
+            SharedPrefsStoreEditor(measureFirstAccess { impl.edit() }, serializer).use {
                 it.action()
             }
         }
@@ -98,18 +100,32 @@ internal class SharedPrefsStore(
     /**
      * Returns the value buffered by the batch open on this thread, falling back to [read] if there
      * is no open batch or the batch hasn't written [key].
+     *
+     * [read] is `noinline` so it can be handed to [measureFirstAccess]
      */
-    private inline fun <reified T> pending(key: String, read: () -> T?): T? {
-        val batch = openBatch.get() ?: return read()
-        val write = batch.writes[key] ?: return read()
+    private inline fun <reified T> pending(key: String, noinline read: () -> T?): T? {
+        val batch = openBatch.get() ?: return measureFirstAccess(read)
+        val write = batch.writes[key] ?: return measureFirstAccess(read)
         return write.value as? T
     }
+
+    /**
+     * A calling of [read] that measures the first invocation, which is the access of [SharedPreferences]
+     * from this class. That measurement should include the loading of the shared preferences file if
+     * that call was the first to load it.
+     */
+    private fun <T> measureFirstAccess(read: () -> T): T =
+        if (firstAccessTraced.compareAndSet(false, true)) {
+            EmbTrace.trace(sectionName = "prefs-first-read", recordDuration = true) { read() }
+        } else {
+            read()
+        }
 
     private fun Batch.flush() {
         if (writes.isEmpty()) {
             return
         }
-        SharedPrefsStoreEditor(impl.edit(), serializer).use { editor ->
+        SharedPrefsStoreEditor(measureFirstAccess { impl.edit() }, serializer).use { editor ->
             writes.values.forEach { it.write(editor) }
         }
     }

--- a/embrace-android-instrumentation-startup-trace/build.gradle.kts
+++ b/embrace-android-instrumentation-startup-trace/build.gradle.kts
@@ -13,5 +13,6 @@ dependencies {
     implementation(project(":embrace-android-instrumentation-api"))
 
     testImplementation(project(":embrace-android-instrumentation-api-fakes"))
+    testImplementation(libs.mockk)
     testImplementation(libs.robolectric)
 }

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitAttributeKeys.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitAttributeKeys.kt
@@ -119,4 +119,15 @@ object SdkInitAttributeKeys {
      * and the OS is actively reclaiming memory. The presence of this indicates memory pressure.
      */
     const val LOW_MEMORY: String = "low-memory"
+
+    /**
+     * Size in bytes of the HOST APP's default `SharedPreferences` file, which the SDK's key-value
+     * store is backed by, used to explain the `prefs-first-read` duration. The bigger the file,
+     * the longer it takes to load and parse its data, as Android needs to load the whole thing
+     * before reading even one value from it.
+     *
+     * This should be obtained by reading looking at the file without opening it and incurring
+     * the costs that this measurement is trying to quantify.
+     */
+    const val PREFS_FILE_BYTES: String = "prefs-file-bytes"
 }

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitAttributeKeys.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitAttributeKeys.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.instrumentation.startup
 
-import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.INIT_MAJ_FAULTS
 import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.INIT_RUN_DELAY_PCT
 import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.THERMAL_STATUS
 
@@ -45,17 +44,10 @@ object SdkInitAttributeKeys {
     const val INIT_RUN_DELAY_PCT: String = "init-run-delay-pct"
 
     /**
-     * Major page faults taken by the process during the init window - reads that had to go
-     * to storage (cold code pages, cold files), including flash contention from concurrent
-     * installs.
-     */
-    const val INIT_MAJ_FAULTS: String = "init-maj-faults"
-
-    /**
      * Kilobytes actually read from storage by the process during the init window. Normal
      * inits read little (config file + cold pages); elevated values mark storage-bound
      * runs - cold caches after reboot/update, slow flash, or IO contention from concurrent
-     * installs - and pair with [INIT_MAJ_FAULTS] to confirm an IO-class slow run.
+     * installs.
      */
     const val INIT_DISK_READ_KB: String = "init-disk-read-kb"
 
@@ -75,9 +67,11 @@ object SdkInitAttributeKeys {
 
     /**
      * The device's overall thermal throttling status at record time, as reported by
-     * [android.os.PowerManager.getCurrentThermalStatus] (API 29+): none/light/moderate/severe/
-     * critical/emergency/shutdown. Collected because heat measurably slows init, and this is a
-     * signal for that.
+     * [android.os.PowerManager.getCurrentThermalStatus] (API 29+): light/moderate/severe/
+     * critical/emergency/shutdown. Present only when the status is not none, so presence means
+     * the device was being throttled at the moment, while absence is not a strong signal
+     * because it could be due to a lag in the update or that there is no actual throttling.
+     * This is collected because heat measurably slows init, and this is a signal for that.
      */
     const val THERMAL_STATUS: String = "thermal-status"
 

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributes.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributes.kt
@@ -62,7 +62,10 @@ private fun MutableMap<String, String>.putThermalAttributes(
 ) {
     if (versionChecker.isAtLeast(VERSION_CODES.Q)) {
         val powerManager = powerManagerProvider() ?: return
-        put(THERMAL_STATUS, thermalStatusName(powerManager.currentThermalStatus))
+        val thermalStatus = powerManager.currentThermalStatus
+        if (thermalStatus != PowerManager.THERMAL_STATUS_NONE) {
+            put(THERMAL_STATUS, thermalStatusName(thermalStatus))
+        }
         if (versionChecker.isAtLeast(VERSION_CODES.R)) {
             val headroom = runCatching { powerManager.getThermalHeadroom(0) }.getOrNull()
             if (headroom != null && headroom.isFinite()) {

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributes.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributes.kt
@@ -7,6 +7,7 @@ import android.os.PowerManager
 import android.os.SystemClock
 import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.LOW_MEMORY
 import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.MEM_AVAILABLE_PCT
+import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.PREFS_FILE_BYTES
 import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.SECONDS_SINCE_BOOT
 import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.SECONDS_SINCE_INSTALL
 import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.SECONDS_SINCE_UPDATE
@@ -35,15 +36,24 @@ fun sdkInitEnvironmentAttributes(
     nowMs: Long,
     versionChecker: VersionChecker = BuildVersionChecker,
     uptimeMs: () -> Long = { SystemClock.uptimeMillis() },
+    prefsFileSizeProvider: () -> Long? = { null },
 ): Map<String, String> = try {
     buildMap {
         putThermalAttributes(powerManagerProvider, versionChecker)
         putInstallRecencyAttributes(packageInfo, nowMs)
         putMemoryAttributes(activityManagerProvider)
         put(SECONDS_SINCE_BOOT, (uptimeMs() / 1000L).toString())
+        putPrefsFileSize(prefsFileSizeProvider)
     }
 } catch (_: Throwable) {
     emptyMap()
+}
+
+private fun MutableMap<String, String>.putPrefsFileSize(prefsFileSizeProvider: () -> Long?) {
+    val bytes = runCatching { prefsFileSizeProvider() }.getOrNull()
+    if (bytes != null && bytes > 0) {
+        put(PREFS_FILE_BYTES, bytes.toString())
+    }
 }
 
 private fun MutableMap<String, String>.putThermalAttributes(

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitResourceUsageTracker.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitResourceUsageTracker.kt
@@ -7,7 +7,6 @@ import android.os.SystemClock
 import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.INIT_CPU_PCT
 import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.INIT_DISK_READ_KB
 import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.INIT_GC_COUNT
-import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.INIT_MAJ_FAULTS
 import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.INIT_RUN_DELAY_PCT
 import java.io.FileInputStream
 import kotlin.math.roundToLong
@@ -57,12 +56,6 @@ class SdkInitResourceUsageTracker(
     private var endSchedstat: ByteArray? = null
 
     @Volatile
-    private var startProcStat: ByteArray? = null
-
-    @Volatile
-    private var endProcStat: ByteArray? = null
-
-    @Volatile
     private var startProcIo: ByteArray? = null
 
     @Volatile
@@ -84,7 +77,6 @@ class SdkInitResourceUsageTracker(
             val path = schedstatPathProvider()
             schedstatPath = path
             startSchedstat = procFileReader(path)
-            startProcStat = procFileReader(PROC_SELF_STAT_PATH)
             startProcIo = procFileReader(PROC_SELF_IO_PATH)
             startGcCount = runtimeStatReader(GC_COUNT_STAT)?.toLongOrNull()
         } catch (_: Throwable) {
@@ -99,7 +91,6 @@ class SdkInitResourceUsageTracker(
             endWallMs = elapsedRealtimeMs()
             endCpuMs = threadCpuTimeMs()
             endSchedstat = schedstatPath?.let(procFileReader)
-            endProcStat = procFileReader(PROC_SELF_STAT_PATH)
             endProcIo = procFileReader(PROC_SELF_IO_PATH)
             endGcCount = runtimeStatReader(GC_COUNT_STAT)?.toLongOrNull()
         } catch (_: Throwable) {
@@ -139,9 +130,6 @@ class SdkInitResourceUsageTracker(
     }
 
     private fun MutableMap<String, String>.putResourceAttributes() {
-        deltaOrNull(startProcStat?.let { parseMajFaults(it) }, endProcStat?.let { parseMajFaults(it) })?.let { faults ->
-            put(INIT_MAJ_FAULTS, faults.toString())
-        }
         deltaOrNull(startProcIo?.let { parseReadBytes(it) }, endProcIo?.let { parseReadBytes(it) })?.let { bytes ->
             put(INIT_DISK_READ_KB, (bytes / 1024L).toString())
         }
@@ -168,19 +156,6 @@ class SdkInitResourceUsageTracker(
      */
     private fun parseRunDelayNs(raw: ByteArray): Long? = try {
         raw.decodeToString().trim().split(' ').getOrNull(1)?.toLong()
-    } catch (_: Throwable) {
-        null
-    }
-
-    /**
-     * Extracts the cumulative major-fault count (field 12, 1-indexed) from raw /proc/self/stat
-     * contents. The second field (comm) is a parenthesized process name that may itself contain
-     * spaces and parentheses, so fields are counted from the substring after the LAST ')'.
-     */
-    private fun parseMajFaults(raw: ByteArray): Long? = try {
-        val afterComm = raw.decodeToString().substringAfterLast(')')
-        // post-comm tokens: state ppid pgrp session tty_nr tpgid flags minflt cminflt majflt
-        afterComm.trim().split(' ').getOrNull(MAJ_FAULTS_POST_COMM_INDEX)?.toLong()
     } catch (_: Throwable) {
         null
     }
@@ -219,9 +194,7 @@ private fun readProcFile(path: String): ByteArray? = try {
     null
 }
 
-// /proc/self/stat is ~300-350 bytes and /proc/self/io ~120, so 1024 covers both with room to spare
+// /proc/self/io is ~120 bytes, so 1024 covers it with room to spare
 private const val PROC_READ_BUFFER_BYTES = 1024
-private const val PROC_SELF_STAT_PATH = "/proc/self/stat"
 private const val PROC_SELF_IO_PATH = "/proc/self/io"
 private const val GC_COUNT_STAT = "art.gc.gc-count"
-private const val MAJ_FAULTS_POST_COMM_INDEX = 9

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributesTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributesTest.kt
@@ -5,6 +5,10 @@ import android.content.Context
 import android.os.PowerManager
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
+import io.embrace.android.embracesdk.internal.utils.VersionChecker
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Before
@@ -29,6 +33,29 @@ internal class SdkInitEnvironmentAttributesTest {
         val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
         shadowOf(powerManager).setCurrentThermalStatus(PowerManager.THERMAL_STATUS_MODERATE)
         assertEquals("moderate", environmentAttributes()[SdkInitAttributeKeys.THERMAL_STATUS])
+    }
+
+    @Test
+    fun `thermal status none is omitted since it carries no signal`() {
+        val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+        shadowOf(powerManager).setCurrentThermalStatus(PowerManager.THERMAL_STATUS_NONE)
+        assertFalse(environmentAttributes().containsKey(SdkInitAttributeKeys.THERMAL_STATUS))
+    }
+
+    @Test
+    fun `thermal headroom is still reported when thermal status is none`() {
+        // Robolectric's ShadowPowerManager has no shadow for getThermalHeadroom, so the real
+        // method throws under Robolectric and a mock is the only way to drive this branch.
+        val powerManager = mockk<PowerManager> {
+            every { currentThermalStatus } returns PowerManager.THERMAL_STATUS_NONE
+            every { getThermalHeadroom(0) } returns 0.42f
+        }
+        val attributes = environmentAttributes(
+            powerManagerProvider = { powerManager },
+            versionChecker = VersionChecker { true },
+        )
+        assertFalse(attributes.containsKey(SdkInitAttributeKeys.THERMAL_STATUS))
+        assertEquals("42", attributes[SdkInitAttributeKeys.THERMAL_HEADROOM_PCT])
     }
 
     @Test
@@ -109,11 +136,14 @@ internal class SdkInitEnvironmentAttributesTest {
 
     private fun environmentAttributes(
         prefsFileSizeProvider: () -> Long? = { null },
+        powerManagerProvider: () -> PowerManager? = { context.getSystemService(Context.POWER_SERVICE) as? PowerManager },
+        versionChecker: VersionChecker = BuildVersionChecker,
     ): Map<String, String> = sdkInitEnvironmentAttributes(
-        powerManagerProvider = { context.getSystemService(Context.POWER_SERVICE) as? PowerManager },
+        powerManagerProvider = powerManagerProvider,
         activityManagerProvider = { context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager },
         packageInfo = context.packageManager.getPackageInfo(context.packageName, 0),
         nowMs = NOW_MS,
+        versionChecker = versionChecker,
         uptimeMs = { fakeUptimeMs },
         prefsFileSizeProvider = prefsFileSizeProvider,
     )

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributesTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributesTest.kt
@@ -80,12 +80,42 @@ internal class SdkInitEnvironmentAttributesTest {
         assertEquals("true", environmentAttributes()[SdkInitAttributeKeys.LOW_MEMORY])
     }
 
-    private fun environmentAttributes(): Map<String, String> = sdkInitEnvironmentAttributes(
+    @Test
+    fun `prefs file size reported when the host app has a default prefs file`() {
+        assertEquals(
+            "63070",
+            environmentAttributes(prefsFileSizeProvider = { 63_070L })[SdkInitAttributeKeys.PREFS_FILE_BYTES],
+        )
+    }
+
+    @Test
+    fun `prefs file size omitted when there is no file or has zero length`() {
+        assertFalse(
+            environmentAttributes(prefsFileSizeProvider = { null })
+                .containsKey(SdkInitAttributeKeys.PREFS_FILE_BYTES),
+        )
+        assertFalse(
+            environmentAttributes(prefsFileSizeProvider = { 0L })
+                .containsKey(SdkInitAttributeKeys.PREFS_FILE_BYTES),
+        )
+    }
+
+    @Test
+    fun `a failing prefs size read drops only that attribute, never the whole map`() {
+        val attributes = environmentAttributes(prefsFileSizeProvider = { error("stat failed") })
+        assertFalse(attributes.containsKey(SdkInitAttributeKeys.PREFS_FILE_BYTES))
+        assertEquals("45", attributes[SdkInitAttributeKeys.SECONDS_SINCE_BOOT])
+    }
+
+    private fun environmentAttributes(
+        prefsFileSizeProvider: () -> Long? = { null },
+    ): Map<String, String> = sdkInitEnvironmentAttributes(
         powerManagerProvider = { context.getSystemService(Context.POWER_SERVICE) as? PowerManager },
         activityManagerProvider = { context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager },
         packageInfo = context.packageManager.getPackageInfo(context.packageName, 0),
         nowMs = NOW_MS,
         uptimeMs = { fakeUptimeMs },
+        prefsFileSizeProvider = prefsFileSizeProvider,
     )
 
     private companion object {

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitResourceUsageTrackerTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitResourceUsageTrackerTest.kt
@@ -10,7 +10,6 @@ internal class SdkInitResourceUsageTrackerTest {
     private lateinit var cpuTimesMs: ArrayDeque<Long>
     private lateinit var wallTimesMs: ArrayDeque<Long>
     private lateinit var schedstatContents: ArrayDeque<ByteArray?>
-    private lateinit var procStatContents: ArrayDeque<ByteArray?>
     private lateinit var procIoContents: ArrayDeque<ByteArray?>
     private lateinit var runtimeStats: MutableMap<String, ArrayDeque<String?>>
     private lateinit var readPaths: MutableList<String>
@@ -24,14 +23,6 @@ internal class SdkInitResourceUsageTrackerTest {
             listOf(
                 "300000000 5000000 120\n".toByteArray(),
                 "800000000 12000000 150\n".toByteArray(),
-            ),
-        )
-        // comm "(fake app) 1)" deliberately contains a space and an extra ')' so field counting
-        // must start after the LAST paren; majflt (field 12) is 40 -> 55
-        procStatContents = ArrayDeque(
-            listOf(
-                "123 (fake app) 1) S 1 2 3 4 5 6 100 200 40 0 30 10".toByteArray(),
-                "123 (fake app) 1) S 1 2 3 4 5 6 150 300 55 0 60 20".toByteArray(),
             ),
         )
         procIoContents = ArrayDeque(
@@ -52,30 +43,17 @@ internal class SdkInitResourceUsageTrackerTest {
         tracker.captureStart()
         tracker.captureEnd()
         // window = 60 ms wall; cpu delta = 30 ms -> 50%; run delay = 7 ms -> 12%;
-        // majflt 55-40 = 15; read_bytes delta 49152 B -> 48 KB; gc 5-3 = 2 taking 40-12 = 28 ms
+        // read_bytes delta 49152 B -> 48 KB; gc 5-3 = 2 taking 40-12 = 28 ms
         assertEquals(
             mapOf(
                 SdkInitAttributeKeys.INIT_CPU_PCT to "50",
                 SdkInitAttributeKeys.INIT_RUN_DELAY_PCT to "12",
-                SdkInitAttributeKeys.INIT_MAJ_FAULTS to "15",
                 SdkInitAttributeKeys.INIT_DISK_READ_KB to "48",
                 SdkInitAttributeKeys.INIT_GC_COUNT to "2",
             ),
             tracker.buildAttributes(),
         )
         assertEquals(listOf(SCHEDSTAT_PATH, SCHEDSTAT_PATH), readPaths.filter { it.endsWith("schedstat") })
-    }
-
-    @Test
-    fun `missing proc stat only drops major faults`() {
-        procStatContents = ArrayDeque(listOf(null, null))
-        val tracker = createTracker()
-        tracker.captureStart()
-        tracker.captureEnd()
-        val attributes = tracker.buildAttributes()
-        assertFalse(attributes.containsKey(SdkInitAttributeKeys.INIT_MAJ_FAULTS))
-        assertEquals("50", attributes[SdkInitAttributeKeys.INIT_CPU_PCT])
-        assertEquals("48", attributes[SdkInitAttributeKeys.INIT_DISK_READ_KB])
     }
 
     @Test
@@ -206,7 +184,6 @@ internal class SdkInitResourceUsageTrackerTest {
             readPaths.add(path)
             when {
                 path.endsWith("schedstat") -> schedstatContents.removeFirst()
-                path.endsWith("/stat") -> procStatContents.removeFirst()
                 path.endsWith("/io") -> procIoContents.removeFirst()
                 else -> null
             }

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/assertions/SpanAssertions.kt
@@ -112,6 +112,7 @@ fun List<Attribute>?.assertSdkInitSectionDurationsRecorded() {
 private val expectedSdkInitSections = listOf(
     "modules-init",
     "persisted-config-load",
+    "prefs-first-read",
     "span-service-init",
     "essential-service-init",
     "delivery-init",

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
@@ -16,6 +16,7 @@ import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.opentelemetry.kotlin.semconv.UserAttributes
+import java.io.File
 import java.util.ServiceLoader
 import java.util.concurrent.TimeUnit
 
@@ -228,6 +229,7 @@ internal fun ModuleGraph.markSdkInitComplete(sdkInitDurations: Map<String, Long>
                         },
                         packageInfo = instrumentationModule.instrumentationArgs.packageInfo,
                         nowMs = initModule.clock.now(),
+                        prefsFileSizeProvider = { defaultPrefsFile(coreModule.context)?.length() },
                     )
             },
         )
@@ -269,3 +271,14 @@ private fun ModuleGraph.eventMetadataSupplierProvider(): Provider<Map<String, St
 }
 
 private const val SPAN_TIMEOUT_SWEEP_INTERVAL_MS = 30_000L
+
+/**
+ * Attempt to identify the size of the host app's default `SharedPreferences` file without actually opening it.
+ * This file currently hosts the SDK's key-value store, and the bigger it is, the more impact it will have on
+ * SDK init time if the SDK is the thing that opens it first.
+ *
+ * Returns null if the file is absent, so a missing file is not reported.
+ */
+private fun defaultPrefsFile(context: Context): File? =
+    File(File(context.applicationInfo.dataDir, "shared_prefs"), "${context.packageName}_preferences.xml")
+        .takeIf(File::exists)


### PR DESCRIPTION
Add additional measurements to the shared prefs first read load time as well as a proxy - the default prefs file size, if we can get it. If the size of the shared prefs is high, we will be dragged down by it, and seeing a long load plus a gigantic size will tell us that we should really move our store off the default shared prefs