### PR TITLE
Add skill to track publish version SDK init perf changes

### DIFF
--- a/.claude/skills/startup-longitudinal-tracking/SKILL.md
+++ b/.claude/skills/startup-longitudinal-tracking/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: startup-longitudinal-tracking
+description: >-
+  Accumulate SDK-init startup results from many runs over time into a persistent store anchored
+  to a stable reference device set, so that per-device baselines, drift, and regressions become
+  visible across weeks and releases rather than only within one campaign. Use when asked whether
+  startup has regressed or improved over time, to maintain a startup baseline for CI or release
+  gating, or to pool repeated runs into a sample large enough to judge tail behaviour. For a
+  single measurement use startup-analysis; for cross-device forensics use
+  startup-multi-device-analysis; for controlled version/condition comparisons use
+  startup-version-factor-matrix.
+---
+
+# Longitudinal startup tracking
+
+The other three skills each answer a question *inside one sitting*: how fast is it here
+(`startup-analysis`), why is it slow or variable across devices
+(`startup-multi-device-analysis`), and does a version or condition change it under controlled
+cells (`startup-version-factor-matrix`). None of them can answer **"is this getting worse?"**,
+because that question needs measurements taken at different times to be comparable — which is a
+data-management problem, not a benchmarking one.
+
+This skill owns that problem. It ingests results produced by the other three, stores them with
+enough provenance to be trusted later, maintains a **baseline per device profile**, and reports
+drift, regressions, and pooled tail statistics that no single run can supply.
+
+It assumes `startup-analysis/references/interpreting-results.md` for everything about judging a
+single run — trace query traps, which conditions to record, install-time compile state, run shape
+and tail statistics — and does not repeat it. A run that was misread on the day does not become
+correct by being stored.
+
+Two hard ideas make it work:
+
+1. **A stable reference device set.** Longitudinal comparison is only valid against devices that
+   stay the same. The set is declared once (`reference-set.json`), keyed by device profile, and
+   every ingest is checked against it. A device whose OS or hardware profile changes is treated
+   as a NEW device, not a continuation — silently comparing across an OS upgrade is the classic
+   way to invent a regression.
+2. **A fixed measurement recipe.** Runs are only poolable when the run shape, build type,
+   compile state, and instrument match. Every stored record carries them, and comparisons refuse
+   to mix incompatible records rather than averaging them into nonsense.
+
+## Bundled files
+
+- `references/store.md` — the record schema, the reference-set contract, what makes two runs
+  comparable, and how to handle device retirement, replacement, and OS upgrades.
+- `references/analysis.md` — how to read the trend output: baselines, drift vs regression,
+  pooled tail statistics, and the traps (population drift, survivorship, seasonality of device
+  state, and why a moving baseline hides slow regressions).
+- `scripts/ingest_run.py` — take a completed run directory from any of the other three skills,
+  extract per-iteration windows plus provenance, validate it against the reference set, and
+  append it to the store. Refuses non-comparable records loudly.
+- `scripts/trend_report.py` — per-device-profile baselines, run-over-run deltas with a
+  significance rule that respects the tail-heavy distribution, and a regression verdict.
+- `scripts/reference_set.py` — declare/inspect the reference set: probe attached devices, write
+  or update `reference-set.json`, and flag drift in a device's own profile.
+
+## Setting up the reference set (do this once, revisit rarely)
+
+1. Decide which devices you can commit to keeping available and unchanged for months. Fewer,
+   stable devices beat more, churning ones — the whole value is comparability over time.
+2. Choose them for coverage, not convenience: span at least two tiers (include one
+   entry/low-RAM device, where regressions bite hardest), two vendors (install-time compile
+   policy and thermal governors are OEM decisions), and two ART generations (AOT behaviour and
+   class-load accounting differ). Physical devices only. Practical floor: API 29.
+3. `python3 scripts/reference_set.py --probe --out reference-set.json` records each device's
+   profile: `api_level`, `tier`, `vendor`, `soc_family`, cluster topology, `ram_class`, plus a
+   stable `device_key` you choose (e.g. `entry-a`, `mid-b`) that is used in every later report.
+4. Freeze the measurement recipe in the same file: run shape (default 10x20 — ten passes of twenty
+   iterations), build type (benchmark/profileable), compile state, and the window instrument.
+   Changing any of these starts a new comparable series — the store keeps both and never mixes
+   them, so treat a reshape as a deliberate re-baselining with a cost, not a tweak.
+
+Keep the set small enough that you will actually re-run it on schedule. A set you skip is worse
+than a smaller set you maintain, because gaps are where regressions hide.
+
+## Procedure
+
+1. **Produce a run** with whichever skill fits (single-device check, multi-device campaign, or a
+   matrix cell). Nothing special is required beyond the profile-carrying provenance those skills
+   already write.
+2. **Ingest it**: `python3 scripts/ingest_run.py <run-dir> --store <store.jsonl>`. The script
+   pulls per-iteration windows, the device profile, SDK version, build type, compile state, run
+   shape, and instrument; it then checks the record against the reference set and the frozen
+   recipe. Mismatches are reported, not silently accepted.
+3. **Report**: `python3 scripts/trend_report.py --store <store.jsonl>` prints, per device key: the
+   baseline, the most recent runs, deltas with their significance verdict, and pooled tail
+   statistics across all comparable runs.
+4. **Act on the verdict, not the delta.** A single run that moved is a candidate; a move that
+   survives the significance rule *and* reproduces on the next run is a regression. Escalate a
+   confirmed regression into `startup-version-factor-matrix` to find which factor carries it.
+
+## What this skill deliberately does NOT do
+
+- It does not run benchmarks. Measurement stays in the other skills so there is exactly one
+  implementation of each measurement, and this layer cannot silently diverge from it.
+- It does not average across device profiles. Devices differ by multiples, so a fleet-wide mean
+  is meaningless; every number is per device key, and only pooled *within* a key.
+- It does not chase absolute targets. There are no portable reference numbers — the baseline is
+  whatever your own reference set produced, and the only meaningful statement is a change
+  relative to it.

--- a/.claude/skills/startup-longitudinal-tracking/references/analysis.md
+++ b/.claude/skills/startup-longitudinal-tracking/references/analysis.md
@@ -1,0 +1,95 @@
+# Reading the trend: baselines, drift, regressions, and the traps
+
+## Baseline
+
+A baseline is a per-`device_key`, per-recipe reference distribution, not a single number. Build it
+from the first N comparable runs (default: the earliest 3 that pass validation) and store median,
+p90, p95, max, and the run-to-run spread of those statistics. **The spread matters more than the
+centre**: it tells you how big a change has to be before it means anything on that device.
+
+Do not let the baseline float automatically. A rolling baseline that always tracks the last few
+runs will absorb a slow regression completely and report "no change" the whole way down. Re-base
+deliberately (after a known intentional change), record why in `notes`, and keep the old baseline.
+
+## Drift vs regression
+
+- **Noise**: a run inside the baseline's own run-to-run spread. Report it, act on nothing.
+- **Drift**: repeated small moves in one direction with each individual move inside the noise
+  band. This is what a rolling baseline hides and what a fixed baseline exposes — check the trend
+  across the whole series, not just the last delta.
+- **Regression**: a move beyond the significance rule that **reproduces on a re-run**. One run is
+  a candidate, two make it real. Devices have moods (thermal state, background churn, install
+  parity); a single bad run is more often the environment than the code.
+
+## Significance for tail-heavy data
+
+Startup distributions are right-skewed with real, meaningful outliers, so ordinary mean/stddev
+tests mislead in both directions. Use:
+
+- **Medians** for the central claim, compared against the baseline's run-to-run spread of medians
+  (a robust band), not against a t-test on raw samples.
+- **p90/p95 and max** as separate claims. A change that moves the tail but not the median is
+  common and important — it is exactly what users notice — and reporting only medians will miss
+  it. Conversely a max that moves alone is usually one environmental event, not a regression.
+- **Pooled percentiles within a device_key** when a single run's n is too small for the tail.
+  Pooling is only valid across comparable records (same recipe/conditions), which is why the
+  contract in `store.md` is strict.
+- Say "no p99 unless you have the samples for it" out loud; at typical run sizes p99 is one or
+  two observations wearing a statistic's clothes.
+
+## Disappearing signals: the one absence that IS a finding
+
+Everywhere else in these skills, a missing signal is a capability difference and carries no
+performance information — an OEM denies a read, an ART generation never emitted it, a version
+predates the instrument, a class cannot occur on that hardware. **This layer is the exception**,
+because it is the only one holding a baseline of what each configuration normally produces.
+
+Within a fixed `device_key` + recipe, a signal that appeared in previous runs and is absent now is
+a **change worth investigating**, and it is usually one of:
+
+- a build or packaging change that dropped an instrument (the section or attribute is simply gone)
+- a revoked capability (an OS update tightening access to a node that used to be readable)
+- a saturated or misconfigured capture (check the trace-health loss counters before anything else)
+- **event-parse errors in the capture, which is the trap specific to this check**: an atrace line
+  that failed to parse is an absent slice, indistinguishable from a signal the SDK never emitted.
+  These cluster by device (one device family in this repo's corpus produced them in 27–55% of
+  traces while another produced none), so a "disappearance" that shows up on exactly one device
+  after an OS update is more likely a parse-error cluster than a code change. `ingest_run.py`
+  therefore takes the signal inventory only from a trace with a fully clean verdict, and records
+  `signals_from_clean_trace` so an empty inventory can be told apart from a genuine absence
+- a code path that stopped running — the interesting case, and the reason this check is worth having
+
+Rules that keep it honest:
+
+- **Only compare presence within the same device_key and recipe.** Across devices, versions, or
+  recipes, presence differences are expected and mean nothing.
+- **Require a real baseline of presence** — present in at least two prior comparable runs — before
+  calling an absence a disappearance. One prior run is not a norm.
+- **Never convert a disappearance into a performance verdict.** It is a data-integrity finding: the
+  series may have become incomparable, not faster. Treat affected runs as suspect until explained.
+- The reverse — a signal that *appears* for the first time — is equally a recipe/instrument change,
+  not an improvement. Record it and re-baseline deliberately.
+
+## Traps
+
+- **Population drift**: adding, replacing, or upgrading a device changes what "the fleet" means.
+  Always report per device key; a fleet aggregate that changes composition over time is not a
+  trend, it is an artefact.
+- **Recipe drift**: a build-type, compile-state, or instrument change will dwarf most real SDK
+  effects. The store refuses to mix them; do not work around this by re-labelling.
+- **Survivorship**: runs that failed or were discarded are still information. Record failed or
+  quarantined runs with a reason, or your series will look healthier than reality.
+- **Seasonal device state**: ambient temperature, battery level, and accumulated system churn all
+  move numbers. Same recipe, same gates, ideally similar time-of-day; log what you cannot control.
+- **Version confounding**: an SDK version bump usually ships alongside app or toolchain changes.
+  Record the app build identity, and when a regression appears, confirm it in a controlled cell
+  (`startup-version-factor-matrix`) before attributing it to the SDK.
+- **Absolute targets**: there are none that transfer between device profiles. The only defensible
+  statements are relative to your own baseline.
+
+## What a good report says
+
+For each device key: the baseline (with its spread), the last few runs, the delta and its verdict
+(noise / drift / candidate regression / confirmed regression), and the pooled tail. Then one
+sentence naming the next action — re-run to confirm, escalate into a factor matrix, or nothing.
+A trend report that ends without an action is decoration.

--- a/.claude/skills/startup-longitudinal-tracking/references/store.md
+++ b/.claude/skills/startup-longitudinal-tracking/references/store.md
@@ -85,6 +85,26 @@ Two records are also refused outright, because storing them is worse than storin
   invented label passed on the command line) creates a phantom series that nothing can ever be
   compared against. Declare the device first; never mint a key at ingest time.
 
+## Archiving a closed series is a ONE-TIME, guarded move
+
+When a recipe change closes a series, the old store gets moved aside exactly once. Any automation
+that performs that move MUST guard it on the archive **not already existing** — never on "a store
+is present at the live path", because after a restart the live path holds the *new* series. On
+2026-08-16 an unguarded `store.replace(archive)` in a campaign driver ran a second time when the
+campaign was restarted mid-run: it moved the new series' six records on top of the archived series'
+eight, destroying the older store. The archive existing is itself the marker that the move already
+happened; nothing else is.
+
+Two corollaries, both paid for that night:
+
+- **Reduction is not a backup.** Pruning raw traces because "they are reduced into the store" makes
+  the store the only copy. That is sometimes a reasonable disk trade — but make it knowingly: once
+  the traces are gone, the store's loss is the data's loss, so a store that is the sole survivor of
+  its traces must be copied before any driver, migration, or cleanup is allowed near it.
+- **Same-named files across series are an overwrite hazard beyond the store itself.** The
+  reference set, notes, and store all live under fixed names; any "move the directory aside"
+  automation inherits the same runs-once requirement.
+
 ## Choosing the control version
 
 The control exists so that when BOTH versions move later you know the *measurement* changed rather

--- a/.claude/skills/startup-longitudinal-tracking/references/store.md
+++ b/.claude/skills/startup-longitudinal-tracking/references/store.md
@@ -1,0 +1,135 @@
+# The store: record schema, comparability, and device lifecycle
+
+## Why a store rather than a spreadsheet
+
+A startup number is meaningless without the conditions that produced it. Six months later, the
+only thing that distinguishes "the SDK got slower" from "we changed how we measure" is provenance
+recorded at ingest time. Everything here exists to make a record either **trustworthy and
+comparable** or **loudly rejected**.
+
+## Record schema (one JSON object per line in `store.jsonl`)
+
+```
+run_id            stable id for the run (from the producing skill, or the run dir name)
+ingested_at       ISO timestamp of ingest
+measured_at       ISO timestamp the run itself started (NOT ingest time - runs get ingested late)
+device_key        your stable key from reference-set.json (e.g. "entry-a"); the comparison axis
+device_profile    api_level, tier, vendor, soc_family, cluster topology, ram_class, storage_class
+sdk_version       resolved coordinate actually built against, not the requested string
+app_build_id      app/APK identity (sha256 or build id) - proves the host app did not change
+recipe            run_shape (passes x iterations), build_type, compile_state, instrument
+                  NOTE on run_shape: the default is 10x20 - many short passes, not a few long
+                  ones. Under clustering only the pass count buys precision (the within-pass term
+                  is sigma_within^2/N, constant at a fixed launch total) and the permutation floor
+                  is set by pass count alone. See _shared/STATISTICS.md, "Spend the budget on
+                  PASSES". Run shape is part of the series key, so changing it CLOSES the existing
+                  series: archive the old store rather than deleting it, both because those runs
+                  stay internally valid and because comparing shapes on the same devices is a
+                  useful measurement-invariance check (medians should agree; intervals should
+                  tighten).
+                  NOTE on instrument: a baseline is built from PUBLISHED versions, and a window
+                  instrument only exists from the release that introduced it - `emb-sdk-start`
+                  arrived in 9.2.0, so every earlier published version yields ZERO windows with it
+                  and the whole campaign silently collects nothing gradeable. Use "composed" for
+                  any series reaching back before the instrument: it measures first
+                  `emb-modules-init` start -> first `emb-post-services-setup` end, both present
+                  since 9.0.0. The two are NOT interchangeable (composed is a few ms narrower by
+                  construction), which is why the instrument is part of the comparability key and
+                  a series must never mix them. Verify the instrument against the OLDEST version
+                  the series will contain, not against your working-tree build
+conditions        contention, thermal band, install state, app weight (matrix vocabulary)
+signals_present   which SDK-emitted slices/attributes this run produced at all. NOT a performance
+                  measure - across devices/versions/recipes presence differences are capability
+                  differences and mean nothing. Its purpose is within one device_key + recipe over
+                  time: a signal that was always there and vanishes is a data-integrity finding
+trace_health      traces, buffer_loss, parse_errors, signals_from_clean_trace. Two counts, not
+                  one: buffer-level loss can remove the window itself (durations suspect), while
+                  event-parse errors leave surviving durations correct but make counts and
+                  absences unsafe. Collapsing them into a single "lossy" number condemns good
+                  runs - measured 88% false-alarm rate on a real corpus - and gets the check
+                  switched off
+windows_ms        the per-iteration window values (keep them ALL - tails are the point)
+derived           median, p90, p95, max, iqr, n, per-pass medians
+source_skill      which skill produced the run
+notes             free text: anything unusual the operator wants future-you to know
+```
+
+Keep raw per-iteration values, not just summaries. Every interesting longitudinal question —
+tail behaviour, bimodality, pooled percentiles — needs the distribution, and you cannot recover
+it from a median later.
+
+## The comparability contract
+
+Two records may be compared only when **all** of these match:
+
+- `device_key` (and its `device_profile` still matches the reference set)
+- `recipe.build_type`, `recipe.compile_state`, `recipe.instrument`
+- `conditions` (a quiet-cool-settled record is not comparable to a contention record)
+- host app identity (`app_build_id`), unless the question *is* about the app
+
+`ingest_run.py` enforces this; `trend_report.py` groups by the tuple and never averages across
+groups. When you deliberately change the recipe, you are starting a new series: keep the old
+records, mark the change in `notes`, and expect the baseline to reset. A silent recipe change is
+the single easiest way to manufacture a fake regression or hide a real one.
+
+Two records are also refused outright, because storing them is worse than storing nothing:
+
+- **An empty run.** A leg that aborted before collecting traces used to pass every check and land
+  in the store as `n=0`, `median=nan` — a record that looks like a measurement, plots as a gap, and
+  contaminates any baseline computed from the store. A run that produced nothing is a *failed run*;
+  record the failure in your notes, not in the series.
+- **A truncated run.** A run with materially fewer windows than its declared `run_shape` is not a
+  small run, it is a different experiment: the passes that are missing are the later, warmer ones,
+  so its median is biased cool relative to every full run it would be compared against.
+- **A `device_key` that is not in the reference set.** An unknown key (typically a typo or an
+  invented label passed on the command line) creates a phantom series that nothing can ever be
+  compared against. Declare the device first; never mint a key at ingest time.
+
+## Choosing the control version
+
+The control exists so that when BOTH versions move later you know the *measurement* changed rather
+than the SDK. Two constraints bound the choice, and the second is easy to miss:
+
+- It must be **published and immutable**, so it can be re-measured identically forever.
+- It must still **build with the current app toolchain**. The version catalog entry usually pins
+  the Embrace *gradle plugin* as well as the SDK artifacts, so an old version drags an old plugin
+  in against the current AGP. Measured: 8.3.0 fails gradle configuration in ~4 s (a toolchain
+  incompatibility, not a missing artifact), while 9.0.0 resolves cleanly. **Probe candidates
+  newest-first with `:app:dependencies` before committing a campaign to one** — how far back a
+  control can reach is set by plugin/AGP compatibility, not by what exists in the repository.
+
+## Device lifecycle
+
+Devices are not stable just because they are the same physical object.
+
+- **OS upgrade**: ART generation, compile policy, and scheduler behaviour can all shift. Treat the
+  upgraded device as a NEW `device_key` (e.g. `mid-b` becomes `mid-b-api35`). Do not carry the old
+  baseline forward; re-establish it. `reference_set.py` flags a profile drift at probe time
+  precisely so this is a decision rather than an accident.
+- **Replacement with the same model**: still a new key. Battery health, thermal paste, storage
+  wear, and accumulated system state all move numbers.
+- **Retirement**: mark the key retired in `reference-set.json` rather than deleting it; its history
+  stays interpretable and its absence from later runs is then explicit rather than mysterious.
+- **A device that has drifted physically** (swollen battery, degraded storage, permanently warm)
+  will quietly bias every future run. If a device's own baseline moves without an SDK change and
+  stays moved, suspect the device before the code.
+
+## Re-run cadence
+
+Cadence is a trade-off between machine time and detection latency. Practical guidance:
+
+- Re-run the reference set on a schedule you can actually keep, and *always* before and after a
+  release.
+- Prefer a smaller set run consistently over a larger set run sporadically: comparability comes
+  from repetition, and gaps are where slow regressions hide.
+- Repeat the same recipe even when you suspect it is not ideal. Improving the recipe is worth
+  doing deliberately and rarely, with the series break recorded — not opportunistically.
+
+## Storage hygiene
+
+- The store is append-only. Corrections are new records with a `notes` explanation, never edits;
+  an edited history cannot be audited.
+- Keep it in version control if it is small, or alongside the run artefacts if it grows; either
+  way it must outlive any individual machine, since the whole point is comparison over time.
+- Traces are large and get wiped by the next run: ingest extracts what it needs, and if you want
+  to keep traces for a run, copy them aside before the next campaign on that device.

--- a/.claude/skills/startup-longitudinal-tracking/scripts/ingest_run.py
+++ b/.claude/skills/startup-longitudinal-tracking/scripts/ingest_run.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Ingest one completed run into the longitudinal store, with validation.
+
+Accepts run directories produced by the other startup skills: it looks for provenance written by
+the version/factor matrix (cell-state.json), then for a generic run-metadata.json, and extracts
+per-iteration windows from perfetto traces via trace_processor.
+
+Validation is the point. A record that cannot be compared later is worse than no record, so this
+refuses (rather than quietly stores) runs whose device is not in the reference set, whose profile
+has drifted, or whose recipe differs from the frozen one - unless you pass --force, which stamps
+the reason into the record so future-you knows.
+
+Usage:
+  python3 ingest_run.py <run-dir> --reference-set reference-set.json --store store.jsonl
+  python3 ingest_run.py <run-dir> --reference-set ... --store ... --dry-run
+"""
+import argparse
+import json
+import pathlib
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+
+WINDOW_SQL = """
+WITH win AS (
+  SELECT s.ts AS ts, s.dur AS dur FROM slice s
+  WHERE s.name = '{slice}' AND s.dur > 0
+  ORDER BY s.ts DESC LIMIT 1
+)
+SELECT (SELECT dur / 1e6 FROM win) AS window_ms;
+"""
+
+# A baseline is built from PUBLISHED SDK versions, and the single-slice window instrument
+# (`emb-sdk-start`) only exists from 9.2.0 onwards. Every earlier published version has to be
+# measured with the composed window the analysis tooling already falls back to: first
+# `emb-modules-init` start -> first `emb-post-services-setup` end, both present since 9.0.0. Without
+# this, a longitudinal store can only ever hold versions newer than the instrument, which defeats
+# the point of having a control version.
+#
+# The two sources are NOT interchangeable - the composed window is a few ms narrower than the
+# native one by construction - so `recipe.instrument` records which produced each value and
+# `trend_report.py` must never compare across them.
+COMPOSED_WINDOW_SQL = """
+WITH m AS (
+  SELECT MIN(s.ts) AS ts FROM slice s WHERE s.name = 'emb-modules-init' AND s.dur > 0
+),
+p AS (
+  SELECT MIN(s.ts + s.dur) AS te FROM slice s
+   WHERE s.name = 'emb-post-services-setup' AND s.dur > 0
+     AND s.ts >= (SELECT ts FROM m)
+)
+SELECT CASE WHEN (SELECT ts FROM m) IS NULL OR (SELECT te FROM p) IS NULL THEN NULL
+            ELSE ((SELECT te FROM p) - (SELECT ts FROM m)) / 1e6 END AS window_ms;
+"""
+
+# Which SDK-emitted slices this run produced at all. Presence is NOT a performance measure - across
+# devices/versions/recipes it is a capability difference and means nothing. Its value is WITHIN one
+# device_key + recipe over time: a slice that was always there and vanishes is a data-integrity
+# finding (dropped instrument, revoked capability, saturated capture, or a code path that stopped
+# running), which is the one case where an absence is informative.
+SIGNALS_SQL = """
+SELECT DISTINCT name FROM slice WHERE name GLOB 'emb-*' ORDER BY name;
+"""
+
+
+def signals_in_trace(tp, trace):
+    query = pathlib.Path(tempfile.gettempdir()) / "longitudinal_signals.sql"
+    query.write_text(SIGNALS_SQL)
+    cp = subprocess.run([str(tp), "-q", str(query), str(trace)],
+                        capture_output=True, text=True, timeout=600)
+    names = []
+    for line in cp.stdout.splitlines():
+        value = line.strip().strip('"')
+        if value.startswith("emb-"):
+            names.append(value)
+    return sorted(set(names))
+
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2] / "_shared"))
+from tooling import ensure_trace_processor, tool_provenance  # noqa: E402  (path set above)
+
+
+def find_trace_processor(explicit):
+    """Shared, version-pinned cache (see _shared/tooling.py). The tool version is part of the
+    measurement recipe: an unpinned tool can shift a longitudinal series in a way that looks
+    exactly like a real regression."""
+    try:
+        return ensure_trace_processor(explicit)
+    except (RuntimeError, FileNotFoundError) as exc:
+        print(f"trace_processor unavailable: {exc}")
+        return None
+
+
+def window_from_trace(tp, trace, slice_name):
+    """Window duration in ms, or None.
+
+    `slice_name` may be the literal name of a single wrapping slice, or the sentinel
+    'composed' to use the modules-init -> post-services-setup window that pre-9.2.0 SDKs
+    require (see COMPOSED_WINDOW_SQL).
+    """
+    sql = COMPOSED_WINDOW_SQL if slice_name == "composed" else WINDOW_SQL.format(slice=slice_name)
+    query = pathlib.Path(tempfile.gettempdir()) / "longitudinal_window.sql"
+    query.write_text(sql)
+    cp = subprocess.run([str(tp), "-q", str(query), str(trace)],
+                        capture_output=True, text=True, timeout=600)
+    for line in reversed(cp.stdout.strip().splitlines()):
+        try:
+            return float(line.strip().strip('"'))
+        except ValueError:
+            continue
+    return None
+
+
+def load_provenance(run_dir):
+    """Provenance from whichever skill produced the run; None if there is none to be found."""
+    for name in ("cell-state.json", "run-metadata.json"):
+        for path in sorted(run_dir.rglob(name)):
+            return json.loads(path.read_text()), name
+    return None, None
+
+
+def record_is_published(sdk_version, forced_not_baseline=False):
+    """A record may seed the baseline only if it was built against an immutable published
+    artifact. Anything local/SNAPSHOT is a moving target and is comparison-only."""
+    if forced_not_baseline:
+        return False
+    text = (sdk_version or "").lower()
+    if not text:
+        return False
+    return not any(marker in text for marker in ("snapshot", "local", "dirty", "+"))
+
+
+def derive(windows):
+    values = sorted(windows)
+    if not values:
+        return {}
+    def pct(p):
+        return values[min(len(values) - 1, int(p * len(values)))]
+    return {"n": len(values), "median": statistics.median(values), "p90": pct(0.90),
+            "p95": pct(0.95), "max": values[-1],
+            "iqr": pct(0.75) - pct(0.25) if len(values) >= 4 else 0.0}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("run_dir")
+    ap.add_argument("--reference-set", required=True)
+    ap.add_argument("--store", required=True)
+    ap.add_argument("--device-key", help="override when provenance cannot identify the device")
+    ap.add_argument("--trace-processor")
+    ap.add_argument("--lossy-tolerance", type=float, default=2.0,
+                    help="max %% of traces allowed to report buffer-level loss before the run is "
+                         "refused (default 2%%); their windows are still used, since a lossy "
+                         "trace whose canary survived has a valid window")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--force", action="store_true",
+                    help="store despite validation failures; the reasons are recorded")
+    ap.add_argument("--not-baseline", action="store_true",
+                    help="store as comparison-only even if the version looks published")
+    args = ap.parse_args()
+
+    run_dir = pathlib.Path(args.run_dir)
+    if not run_dir.is_dir():
+        sys.exit(f"not a directory: {run_dir}")
+    ref = json.loads(pathlib.Path(args.reference_set).read_text())
+    recipe_frozen = ref.get("recipe", {})
+    devices = ref.get("devices", {})
+
+    provenance, prov_name = load_provenance(run_dir)
+    problems = []
+
+    # ---- identify the device -------------------------------------------------------------
+    device_key = args.device_key
+    serial = (provenance or {}).get("serial")
+    if not device_key and serial:
+        device_key = next((k for k, cfg in devices.items() if cfg.get("serial") == serial), None)
+    if not device_key:
+        problems.append("cannot map this run to a device_key in the reference set "
+                        "(pass --device-key, or ingest a run whose provenance records the serial)")
+    elif devices and device_key not in devices:
+        # An explicit --device-key must still be validated against the reference set. Trusting it
+        # blindly creates a phantom series under a key no device owns, and every later comparison
+        # against that key compares one run to nothing. The key must exist BEFORE runs accumulate
+        # under it.
+        problems.append(f"device_key {device_key!r} is not in the reference set (known: "
+                        f"{sorted(devices)}) - either use one of those keys, or declare this "
+                        f"device in the reference set first; do not invent a key at ingest time")
+    profile_run = (provenance or {}).get("device_profile") or {}
+    if device_key and device_key in devices and profile_run:
+        known = devices[device_key].get("profile", {})
+        drift = {f: (known.get(f), profile_run.get(f)) for f in known
+                 if f in profile_run and known.get(f) != profile_run.get(f)}
+        if drift:
+            problems.append(f"device profile drift vs reference set: {drift} - an upgraded or "
+                            f"replaced device must become a NEW device_key")
+
+    # ---- recipe -------------------------------------------------------------------------
+    instrument = recipe_frozen.get("instrument", "app-embrace-start")
+    recipe_run = {
+        "build_type": (provenance or {}).get("build_type"),
+        "compile_state": ((provenance or {}).get("cell", {}).get("levels", {}) or {}).get("compile"),
+        "instrument": instrument,
+        "run_shape": recipe_frozen.get("run_shape"),
+    }
+    for field in ("build_type", "compile_state"):
+        want, got = recipe_frozen.get(field), recipe_run.get(field)
+        if want and got and want != got:
+            problems.append(f"recipe mismatch on {field}: frozen={want!r} run={got!r} - this is a "
+                            f"different comparable series")
+
+    # ---- windows ------------------------------------------------------------------------
+    tp = find_trace_processor(args.trace_processor)
+    traces = sorted(run_dir.rglob("*.perfetto-trace")) + sorted(run_dir.rglob("*.pftrace"))
+    windows = []
+    signals = []
+    lossy = 0
+    parse_errors = 0
+    if tp and traces:
+        try:
+            from trace_health import check_trace
+        except ImportError:
+            check_trace = None
+        for trace in traces:
+            # A saturated capture still parses and still answers queries, so a window read from
+            # a lossy trace looks perfectly normal. Count them: a series silently built from
+            # partially-evicted traces is exactly the kind of slow corruption this skill exists
+            # to prevent. Buffer-level loss and event-parse errors are counted separately because
+            # they invalidate different things - see _shared/trace_health.py.
+            health = check_trace(tp, trace, instrument) if check_trace is not None else None
+            if health is not None:
+                if health["verdict"] in ("lossy", "unusable"):
+                    lossy += 1
+                elif health["verdict"] == "slices-incomplete":
+                    parse_errors += 1
+                if health["verdict"] == "unusable":
+                    continue
+            value = window_from_trace(tp, trace, instrument)
+            if value:
+                windows.append(value)
+                # Only take the signal inventory from a fully clean trace. On a trace with
+                # event-parse errors an unparsed atrace line is indistinguishable from a signal
+                # the SDK never emitted, and this field is the input to the one absence that
+                # this skill treats as a finding.
+                if not signals and (health is None or health["verdict"] == "ok"):
+                    signals = signals_in_trace(tp, trace)
+    if lossy:
+        share = 100.0 * lossy / max(1, len(traces))
+        # Tolerate a trace or two. A `lossy` verdict means buffer loss occurred but the canary
+        # SURVIVED, so that trace's window is present and usable - only whole-trace counts are
+        # unsafe, and a longitudinal record needs only the window. Blocking a 200-iteration leg
+        # over a single 0.5% trace (which is what an all-or-nothing gate did on a real run)
+        # discards 199 good measurements to avoid one imperfect one. Genuine saturation shows up
+        # as a share well above this, and `unusable` traces - canary evicted - are dropped from
+        # the windows regardless of tolerance.
+        if share > args.lossy_tolerance:
+            problems.append(f"{lossy}/{len(traces)} traces ({share:.1f}%) lost written data "
+                            f"(buffer level), above the {args.lossy_tolerance:.1f}% tolerance - "
+                            f"raise buffer size / use DISCARD / narrow the captured events; a "
+                            f"baseline built from saturated traces will drift for tooling reasons")
+        else:
+            print(f"NOTE: {lossy}/{len(traces)} traces ({share:.1f}%) reported buffer-level loss, "
+                  f"within the {args.lossy_tolerance:.1f}% tolerance - their windows are kept and "
+                  f"the count is recorded in trace_health")
+    if parse_errors and not signals:
+        problems.append(f"{parse_errors}/{len(traces)} traces had event-parse errors and none was "
+                        f"clean enough to inventory signals - window durations still stand, but "
+                        f"signals_present is empty by tooling, NOT because the SDK emitted nothing")
+    elif not tp:
+        problems.append("trace_processor not found: fetch it as the startup-analysis skill "
+                        "describes, or pass --trace-processor")
+    if traces and not windows:
+        problems.append(f"no '{instrument}' window found in {len(traces)} trace(s) - wrong "
+                        f"instrument for this SDK version, or the run did not record it")
+
+    # An EMPTY run used to sail through every check above and land in the store as n=0,
+    # median=nan: a record that looks like a measurement, plots as a gap, and quietly poisons any
+    # baseline built from the store. It happened for real on 2026-08-14, when a campaign leg
+    # aborted before collecting traces and the ingest still returned success. A run that produced
+    # nothing is a FAILED run, and a truncated run is not a small run - it is a different
+    # experiment, because the passes that are missing are the later, warmer ones.
+    shape = recipe_frozen.get("run_shape") or {}
+    expected = (shape.get("passes") or 0) * (shape.get("iterations") or 0)
+    if not windows:
+        problems.append(f"this run produced NO usable windows ({len(traces)} traces on disk) - "
+                        f"there is nothing to record; fix the run, do not store a placeholder")
+    elif expected and len(windows) < 0.9 * expected:
+        problems.append(f"truncated run: {len(windows)} windows against a declared shape of "
+                        f"{shape.get('passes')}x{shape.get('iterations')}={expected} - the missing "
+                        f"passes are the later, warmer ones, so this is not comparable to a full "
+                        f"run; re-run it or store it with --force and a reason")
+
+    record = {
+        "run_id": (provenance or {}).get("plan_run_id") or run_dir.name,
+        "ingested_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        "measured_at": (provenance or {}).get("started") or (provenance or {}).get("measured_at"),
+        "device_key": device_key,
+        "device_profile": profile_run,
+        "sdk_version": ((provenance or {}).get("checks", {}) or {}).get("sdk matches")
+                       or (provenance or {}).get("sdk_version"),
+        "app_build_id": (provenance or {}).get("apk_sha256"),
+        "recipe": {**recipe_run, **tool_provenance(tp)},
+        "conditions": ((provenance or {}).get("cell", {}) or {}).get("levels", {}),
+        # Only PUBLISHED, immutable SDK versions may form a baseline. A working-tree build is a
+        # moving target: baselining on it makes the series unreproducible and re-defines the
+        # reference every time someone commits. HEAD/SNAPSHOT runs are still stored - they are
+        # compared AGAINST the baseline ad hoc - but never folded into it.
+        "baseline_eligible": bool(record_is_published(
+            ((provenance or {}).get("checks", {}) or {}).get("sdk matches")
+            or (provenance or {}).get("sdk_version") or "", args.not_baseline)),
+        "signals_present": signals,
+        # Kept as separate counts, not one "lossy" number: buffer loss can remove the window,
+        # while parse errors only make counts and absences unsafe.
+        "trace_health": {"traces": len(traces), "buffer_loss": lossy,
+                         "parse_errors": parse_errors,
+                         "signals_from_clean_trace": bool(signals)},
+        "windows_ms": [round(w, 3) for w in windows],
+        "derived": derive(windows),
+        "source_skill": prov_name or "unknown",
+        "notes": "",
+    }
+
+    for problem in problems:
+        print(f"VALIDATION: {problem}")
+    if problems and not args.force:
+        sys.exit("\nREFUSED: fix the above, or re-run with --force to store it with these reasons "
+                 "recorded. A record that cannot be compared later is worse than no record.")
+    if problems:
+        record["notes"] = "FORCED ingest despite: " + "; ".join(problems)
+
+    summary = record["derived"]
+    print(f"\n{record['run_id']} -> device_key={record['device_key']} "
+          f"n={summary.get('n', 0)} median={summary.get('median', float('nan')):.1f} "
+          f"p90={summary.get('p90', float('nan')):.1f} max={summary.get('max', float('nan')):.1f}")
+    if args.dry_run:
+        print("dry-run: nothing written")
+        return
+    with open(args.store, "a") as fh:
+        fh.write(json.dumps(record) + "\n")
+    print(f"appended to {args.store}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/startup-longitudinal-tracking/scripts/ingest_run.py
+++ b/.claude/skills/startup-longitudinal-tracking/scripts/ingest_run.py
@@ -197,7 +197,16 @@ def main():
                             f"replaced device must become a NEW device_key")
 
     # ---- recipe -------------------------------------------------------------------------
-    instrument = recipe_frozen.get("instrument", "app-embrace-start")
+    # No default, ever. This line used to fall back to "app-embrace-start", which combined with
+    # the probe writing the same guess meant a wrong instrument could flow through BOTH layers
+    # without either flagging it (2026-08-16: every leg's ingest refused with "no window found"
+    # because neither layer had actually decided what the harness records). The probe now writes
+    # null; the decision is the operator's, made once, here enforced.
+    instrument = recipe_frozen.get("instrument")
+    if not instrument:
+        sys.exit("REFUSED: reference set has no instrument. The probe writes null deliberately - "
+                 "set recipe.instrument to what your traces actually contain (\"emb-sdk-start\" "
+                 "for SDK >= 9.2.0, \"composed\" for the fallback window) before the first ingest.")
     recipe_run = {
         "build_type": (provenance or {}).get("build_type"),
         "compile_state": ((provenance or {}).get("cell", {}).get("levels", {}) or {}).get("compile"),

--- a/.claude/skills/startup-longitudinal-tracking/scripts/reference_set.py
+++ b/.claude/skills/startup-longitudinal-tracking/scripts/reference_set.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Declare and inspect the stable reference device set that longitudinal comparison depends on.
+
+Probes every attached device for its PROFILE (not its identity), assigns each a stable
+device_key you control, and freezes the measurement recipe. Re-probing later flags profile
+DRIFT - an OS upgrade or replaced handset must become a new key, because silently comparing
+across it is the classic way to invent or hide a regression.
+
+Usage:
+  python3 reference_set.py --probe --out reference-set.json
+  python3 reference_set.py --probe --check reference-set.json      # drift check, no writes
+  python3 reference_set.py --show reference-set.json
+"""
+import argparse
+import json
+import pathlib
+import re
+import subprocess
+import sys
+import time
+
+RECIPE_DEFAULT = {
+    # Many short passes, not a few long ones. Under clustering the variance of an arm is
+    # sigma_between^2/G + sigma_within^2/(G*n); holding total launches fixed makes the second term
+    # a constant, so only the pass count G buys precision - and on startup benchmarks the
+    # between-pass term dominates heavily. Ten passes roughly halves the CI half-width versus four
+    # at the same launch count, and drops the permutation floor from 0.029 to ~1e-5, which is what
+    # lets a comparison clear alpha at all. More passes also means more independent installs, the
+    # only thing that averages down bimodal per-install effects like compile-state parity.
+    # See _shared/STATISTICS.md, "Spend the budget on PASSES, not iterations".
+    "run_shape": {"passes": 10, "iterations": 20},
+    "build_type": "benchmark",
+    "compile_state": "profile",
+    "instrument": "app-embrace-start",
+    "_comment": "Changing any of these starts a NEW comparable series; see references/store.md",
+}
+
+PROFILE_FIELDS = ["api_level", "release", "tier", "vendor", "soc_family", "clusters",
+                  "ram_class", "storage_class"]
+
+
+def adb(serial, *args, timeout=60):
+    cmd = ["adb"] + (["-s", serial] if serial else []) + list(args)
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+
+
+def prop(serial, name):
+    return adb(serial, "shell", "getprop", name).stdout.strip()
+
+
+def attached_serials():
+    out = adb(None, "devices").stdout
+    serials = []
+    for line in out.splitlines()[1:]:
+        parts = line.split()
+        if len(parts) >= 2 and parts[1] == "device":
+            serials.append(parts[0])
+    return serials
+
+
+def ram_class(serial):
+    out = adb(serial, "shell", "cat", "/proc/meminfo").stdout
+    match = re.search(r"MemTotal:\s+(\d+)", out)
+    if not match:
+        return "unknown"
+    gb = int(match.group(1)) / (1024.0 * 1024.0)
+    if gb <= 2.2:
+        return "<=2GB"
+    if gb <= 4.5:
+        return "3-4GB"
+    if gb <= 7.0:
+        return "6GB"
+    return ">=8GB"
+
+
+def tier_guess(ram, clusters):
+    """A coarse hint only - the operator should confirm it. Tier is about user-visible class,
+    which no single property captures."""
+    distinct = len(set(clusters)) if clusters else 1
+    if ram in ("<=2GB",):
+        return "entry"
+    if ram in ("3-4GB",) and distinct <= 2:
+        return "entry-mid"
+    if distinct >= 3:
+        return "flagship"
+    return "mid"
+
+
+def clusters(serial):
+    """Distinct max frequencies per cpufreq policy, ascending - the cluster topology."""
+    out = adb(serial, "shell",
+              "for p in /sys/devices/system/cpu/cpufreq/policy*; do cat $p/cpuinfo_max_freq; done"
+              ).stdout
+    freqs = sorted({int(v) for v in re.findall(r"\d{5,}", out)})
+    return freqs
+
+
+def soc_family(serial):
+    for name in ("ro.soc.model", "ro.board.platform", "ro.hardware"):
+        value = prop(serial, name)
+        if value and value.lower() not in ("unknown", ""):
+            return value
+    return "unknown"
+
+
+def probe(serial):
+    return {
+        "api_level": int(prop(serial, "ro.build.version.sdk") or 0),
+        "release": prop(serial, "ro.build.version.release"),
+        "vendor": prop(serial, "ro.product.manufacturer"),
+        "soc_family": soc_family(serial),
+        "clusters": clusters(serial),
+        "ram_class": ram_class(serial),
+        "storage_class": "unknown",  # not reliably readable unrooted; fill in by hand if known
+    }
+
+
+def coverage_warnings(devices):
+    """Say plainly what the set cannot answer - a set chosen by convenience usually cannot
+    separate the thing the operator most wants separated."""
+    warnings = []
+    apis = {d["profile"].get("api_level") for d in devices.values()}
+    vendors = {(d["profile"].get("vendor") or "").lower() for d in devices.values()}
+    tiers = {d.get("tier") or d["profile"].get("tier") for d in devices.values()}
+    if len(devices) < 2:
+        warnings.append("single device: cannot separate SDK effects from device-class effects")
+    if len(apis) < 2:
+        warnings.append("one ART/Android generation: compile-state and class-load findings may "
+                        "not transfer to other releases")
+    if len(vendors) < 2:
+        warnings.append("one vendor: cannot separate OEM policy (install-time compilation, "
+                        "thermal governors, procfs readability) from silicon")
+    if not any(t in ("entry", "entry-mid") for t in tiers):
+        warnings.append("no entry/low-RAM device: the outlier classes that hurt users most "
+                        "(memory pressure, GC competition) will be under-represented")
+    if any((d["profile"].get("api_level") or 0) < 29 for d in devices.values()):
+        warnings.append("a device below API 29 cannot be traced as a profileable non-debuggable "
+                        "target; its numbers are not comparable")
+    return warnings
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--probe", action="store_true")
+    ap.add_argument("--out")
+    ap.add_argument("--check")
+    ap.add_argument("--show")
+    args = ap.parse_args()
+
+    if args.show:
+        doc = json.loads(pathlib.Path(args.show).read_text())
+        print(json.dumps(doc, indent=1))
+        for w in coverage_warnings(doc.get("devices", {})):
+            print(f"COVERAGE GAP: {w}")
+        return
+
+    if not args.probe:
+        sys.exit("use --probe (with --out or --check), or --show <file>")
+
+    serials = attached_serials()
+    if not serials:
+        sys.exit("no attached devices (adb devices shows none in state 'device')")
+    probed = {s: probe(s) for s in serials}
+
+    if args.check:
+        doc = json.loads(pathlib.Path(args.check).read_text())
+        known = doc.get("devices", {})
+        by_serial = {cfg.get("serial"): (key, cfg) for key, cfg in known.items()}
+        for serial, profile in probed.items():
+            if serial not in by_serial:
+                print(f"NEW device attached (not in the reference set): {serial} -> {profile}")
+                continue
+            key, cfg = by_serial[serial]
+            drift = {f: (cfg["profile"].get(f), profile.get(f))
+                     for f in PROFILE_FIELDS
+                     if f in cfg.get("profile", {}) and cfg["profile"].get(f) != profile.get(f)}
+            if drift:
+                print(f"PROFILE DRIFT on '{key}' ({serial}):")
+                for field, (was, now) in drift.items():
+                    print(f"    {field}: {was!r} -> {now!r}")
+                print("    -> treat this as a NEW device_key and re-establish its baseline; do "
+                      "NOT carry the old baseline across (see references/store.md).")
+            else:
+                print(f"ok '{key}' ({serial}): profile unchanged")
+        for key, cfg in known.items():
+            if cfg.get("serial") not in probed and not cfg.get("retired"):
+                print(f"MISSING '{key}' ({cfg.get('serial')}): attach it or mark it retired - a "
+                      f"silent gap in the series is where slow regressions hide")
+        return
+
+    devices = {}
+    for i, (serial, profile) in enumerate(sorted(probed.items()), 1):
+        tier = tier_guess(profile["ram_class"], profile["clusters"])
+        key = f"{tier}-{chr(ord('a') + i - 1)}"
+        devices[key] = {"serial": serial, "tier": tier, "profile": profile,
+                        "cool_gate_c": 32.0, "retired": False}
+        print(f"{key}: {serial} api={profile['api_level']} vendor={profile['vendor']} "
+              f"soc={profile['soc_family']} ram={profile['ram_class']} tier~{tier}")
+    doc = {
+        "declared_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        "recipe": RECIPE_DEFAULT,
+        "devices": devices,
+        "_comment": ["device_key is YOUR stable label - rename these to something meaningful and "
+                     "keep them forever; they are the axis every longitudinal report uses.",
+                     "tier is a guess from RAM and cluster topology; confirm it by hand.",
+                     "cool_gate_c is per device: a plugged-in device's warm idle floor can sit "
+                     "above a naive gate, so set it from an observed idle temperature."],
+    }
+    for w in coverage_warnings(devices):
+        print(f"COVERAGE GAP: {w}")
+    if args.out:
+        pathlib.Path(args.out).write_text(json.dumps(doc, indent=1))
+        print(f"\nwrote {args.out} - review the keys and tiers before your first ingest")
+    else:
+        print(json.dumps(doc, indent=1))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/startup-longitudinal-tracking/scripts/reference_set.py
+++ b/.claude/skills/startup-longitudinal-tracking/scripts/reference_set.py
@@ -31,8 +31,17 @@ RECIPE_DEFAULT = {
     "run_shape": {"passes": 10, "iterations": 20},
     "build_type": "benchmark",
     "compile_state": "profile",
-    "instrument": "app-embrace-start",
-    "_comment": "Changing any of these starts a NEW comparable series; see references/store.md",
+    # Deliberately null: the probe cannot know which window instrument a harness actually records,
+    # and a plausible-looking default here is worse than a missing value. On 2026-08-16 this field
+    # shipped as "app-embrace-start" - a span the harness never emits - and every ingest of a
+    # 200-trace leg was refused with "no window found" until it was corrected by hand. ingest_run
+    # refuses a null instrument with a pointed message, so leaving this unset fails LOUDLY at the
+    # first ingest instead of silently poisoning the series definition. Set it to what your traces
+    # really contain: "emb-sdk-start" (SDK >= 9.2.0) or "composed" (the fallback window).
+    "instrument": None,
+    "_comment": "EVERY value above is provisional output of --probe, not just the device keys: "
+                "review the recipe field by field before the first ingest. Changing any of these "
+                "later starts a NEW comparable series; see references/store.md",
 }
 
 PROFILE_FIELDS = ["api_level", "release", "tier", "vendor", "soc_family", "clusters",

--- a/.claude/skills/startup-longitudinal-tracking/scripts/trend_report.py
+++ b/.claude/skills/startup-longitudinal-tracking/scripts/trend_report.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Report baselines, drift, and regressions per device_key from the longitudinal store.
+
+Design choices that keep this honest:
+  * groups by (device_key, build_type, compile_state, instrument, conditions) and NEVER averages
+    across groups - devices differ by multiples and recipes differ by more;
+  * the baseline is FIXED (earliest N comparable runs) rather than rolling, because a rolling
+    baseline absorbs a slow regression and reports "no change" the whole way down;
+  * significance is judged against the baseline's own run-to-run spread of medians, not a t-test
+    on right-skewed samples;
+  * median and tail are separate verdicts - a tail-only move is common, user-visible, and would be
+    missed by a median-only report.
+
+Usage:
+  python3 trend_report.py --store store.jsonl [--baseline-runs 3] [--json out.json]
+"""
+import argparse
+import json
+import pathlib
+import statistics
+import sys
+from collections import defaultdict
+
+
+def group_key(record):
+    """A series is one SDK VERSION on one device under one recipe, tracked over time.
+
+    sdk_version belongs in the key, and leaving it out produces conclusions that are wrong on
+    their face. Measured: a store holding 9.1.0 and 9.0.0 on one device grouped them into a single
+    series and, because the control happened to be measured later, reported the OLDER version as a
+    "+10.7% candidate regression" against the newer one. That is a version comparison wearing the
+    clothes of drift over time - and the sign is meaningless, since which version looks like the
+    "regression" depends only on measurement order.
+
+    Drift and version-to-version change are different questions and must not share an axis: drift
+    is the same version re-measured (anything that moves is the environment or the tooling), while
+    a version difference is deliberate. Comparing versions is `version_comparison()` below.
+    """
+    recipe = record.get("recipe") or {}
+    conditions = record.get("conditions") or {}
+    return (record.get("device_key") or "unknown",
+            record.get("sdk_version") or "?",
+            recipe.get("build_type") or "?",
+            recipe.get("compile_state") or "?",
+            recipe.get("instrument") or "?",
+            json.dumps(conditions, sort_keys=True))
+
+
+def version_comparison(records):
+    """Versions measured on the same device under the same recipe, side by side.
+
+    Kept deliberately separate from the drift report: this answers "is this version faster than
+    that one", which is a legitimate question the series axis cannot express. Reports each version
+    once with its own n, and never labels a difference a regression - with one run each, a
+    difference is a candidate finding, not a verdict.
+    """
+    by_cell = {}
+    for rec in records:
+        derived = rec.get("derived") or {}
+        if not derived.get("n"):
+            continue
+        recipe = rec.get("recipe") or {}
+        cell = (rec.get("device_key") or "unknown",
+                recipe.get("build_type") or "?",
+                recipe.get("compile_state") or "?",
+                recipe.get("instrument") or "?")
+        by_cell.setdefault(cell, {}).setdefault(rec.get("sdk_version") or "?", []).append(derived)
+    return by_cell
+
+
+def signal_changes(runs, min_prior=2):
+    """Signals that were normally present in this series and are absent in the latest run.
+
+    This is the ONLY place an absence is informative: within one device_key + recipe there is a
+    baseline of what the configuration normally emits. Across devices, versions, or recipes,
+    presence differences are capability differences and mean nothing, so this never compares
+    across series. It is a DATA-INTEGRITY finding, not a performance verdict - a vanished signal
+    means the series may have become incomparable, not that anything got faster.
+    """
+    if len(runs) < min_prior + 1:
+        return [], []
+    latest = set(runs[-1].get("signals_present") or [])
+    if not latest and not any(r.get("signals_present") for r in runs[:-1]):
+        return [], []   # this series never recorded signals; nothing to say
+    prior_counts = {}
+    for run in runs[:-1]:
+        for name in set(run.get("signals_present") or []):
+            prior_counts[name] = prior_counts.get(name, 0) + 1
+    established = {n for n, c in prior_counts.items() if c >= min_prior}
+    disappeared = sorted(established - latest)
+    appeared = sorted(latest - set(prior_counts))
+    return disappeared, appeared
+
+
+def verdict(delta_pct, band_pct, reproduced):
+    """band_pct is the baseline's own run-to-run spread; a move inside it is noise."""
+    if abs(delta_pct) <= band_pct:
+        return "noise"
+    if not reproduced:
+        return "candidate (re-run to confirm)"
+    return "REGRESSION" if delta_pct > 0 else "improvement (confirmed)"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--store", required=True)
+    ap.add_argument("--baseline-runs", type=int, default=3)
+    ap.add_argument("--json")
+    args = ap.parse_args()
+
+    path = pathlib.Path(args.store)
+    if not path.exists():
+        sys.exit(f"no store at {path}")
+    records = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if line:
+            try:
+                records.append(json.loads(line))
+            except ValueError:
+                print("skipping a malformed store line")
+
+    groups = defaultdict(list)
+    for record in records:
+        if record.get("derived", {}).get("n"):
+            groups[group_key(record)].append(record)
+
+    out = {}
+    for key, runs in sorted(groups.items()):
+        runs.sort(key=lambda r: (r.get("measured_at") or r.get("ingested_at") or ""))
+        device, sdk_version, build, compile_state, instrument, conditions = key
+        print(f"\n{'=' * 78}\n{device}  sdk={sdk_version}  [build={build} "
+              f"compile={compile_state} instrument={instrument}]\n  conditions={conditions}"
+              f"\n  runs={len(runs)}")
+        if len(runs) < 2:
+            print("  only one run in this series - no trend yet; repeat the same recipe to start "
+                  "a baseline")
+            continue
+
+        # The baseline is built ONLY from published-version runs. Working-tree runs are reported
+        # separately as ad-hoc comparisons: folding a moving target into the reference would
+        # re-define "normal" on every commit and destroy the series' reproducibility.
+        eligible = [r for r in runs if r.get("baseline_eligible", True)]
+        adhoc = [r for r in runs if not r.get("baseline_eligible", True)]
+        if not eligible:
+            print("  no published-version runs in this series - cannot form a baseline. Run the "
+                  "reference cell against a released SDK version first; working-tree runs are "
+                  "comparison-only.")
+            continue
+        runs = eligible
+        baseline_runs = runs[:max(1, min(args.baseline_runs, len(runs) - 1))]
+        base_medians = [r["derived"]["median"] for r in baseline_runs]
+        base_p90s = [r["derived"]["p90"] for r in baseline_runs]
+        base_median = statistics.median(base_medians)
+        base_p90 = statistics.median(base_p90s)
+        # run-to-run spread of the baseline statistic, as a percentage; floor it so a suspiciously
+        # tight baseline cannot make every later wobble "significant"
+        band = max(4.0, 100.0 * (max(base_medians) - min(base_medians)) / base_median
+                   if base_median else 4.0)
+        print(f"  baseline (first {len(baseline_runs)} run(s)): median {base_median:.1f} ms, "
+              f"p90 {base_p90:.1f} ms, noise band +-{band:.0f}%")
+
+        print(f"  {'measured_at':<21}{'n':>5}{'median':>9}{'p90':>8}{'max':>8}"
+              f"{'d-median':>10}{'d-p90':>8}  verdict")
+        deltas = []
+        for i, r in enumerate(runs):
+            d = r["derived"]
+            dm = 100.0 * (d["median"] - base_median) / base_median if base_median else 0.0
+            dp = 100.0 * (d["p90"] - base_p90) / base_p90 if base_p90 else 0.0
+            deltas.append(dm)
+            reproduced = (i > 0 and abs(deltas[i - 1]) > band
+                          and (deltas[i - 1] > 0) == (dm > 0) and abs(dm) > band)
+            tag = "" if i < len(baseline_runs) else verdict(dm, band, reproduced)
+            if i < len(baseline_runs):
+                tag = "baseline"
+            elif abs(dp) > band and abs(dm) <= band:
+                tag += " | TAIL-ONLY move (p90) - users feel this even when the median does not"
+            print(f"  {(r.get('measured_at') or r.get('ingested_at') or '?')[:19]:<21}"
+                  f"{d['n']:>5}{d['median']:>9.1f}{d['p90']:>8.1f}{d['max']:>8.1f}"
+                  f"{dm:>+9.1f}%{dp:>+7.1f}%  {tag}")
+
+        pooled = sorted(w for r in runs for w in r.get("windows_ms", []))
+        if pooled:
+            def pct(p):
+                return pooled[min(len(pooled) - 1, int(p * len(pooled)))]
+            print(f"  pooled across this series (n={len(pooled)}): median "
+                  f"{statistics.median(pooled):.1f}  p90 {pct(0.90):.1f}  p95 {pct(0.95):.1f}  "
+                  f"max {pooled[-1]:.1f}"
+                  + ("  p99 needs more samples than this" if len(pooled) < 500 else
+                     f"  p99 {pct(0.99):.1f}"))
+
+        if adhoc:
+            print(f"  ad-hoc comparisons vs this baseline (NOT part of it): {len(adhoc)}")
+            for r in adhoc:
+                d = r["derived"]
+                dm = 100.0 * (d["median"] - base_median) / base_median if base_median else 0.0
+                dp = 100.0 * (d["p90"] - base_p90) / base_p90 if base_p90 else 0.0
+                inside = "within" if abs(dm) <= band else "OUTSIDE"
+                print(f"    {(r.get('measured_at') or '?')[:19]}  {r.get('sdk_version') or 'local':<22}"
+                      f" median {d['median']:>7.1f} ({dm:+.1f}%)  p90 {d['p90']:>7.1f} ({dp:+.1f}%)"
+                      f"  {inside} the baseline noise band")
+            print("    (a working-tree run is judged against the published baseline, never merged "
+                  "into it; confirm any move with a second run before believing it)")
+
+        disappeared, appeared = signal_changes(runs)
+        if disappeared:
+            print(f"  SIGNALS DISAPPEARED (present in >=2 earlier runs, absent now): "
+                  f"{', '.join(disappeared)}")
+            print("    -> data-integrity finding, NOT an improvement. Check trace health/capture "
+                  "config, then the build and instrument, before trusting this run's numbers.")
+        if appeared:
+            print(f"  signals newly present: {', '.join(appeared)}")
+            print("    -> an instrument or recipe change, not a regression; re-baseline "
+                  "deliberately if this is intended.")
+
+        latest = deltas[-1]
+        if abs(latest) <= band:
+            action = "no action - within the noise band"
+        elif len(deltas) >= 2 and abs(deltas[-2]) > band and (deltas[-2] > 0) == (latest > 0):
+            action = ("CONFIRMED move: escalate into startup-version-factor-matrix to find which "
+                      "factor carries it")
+        else:
+            action = "re-run this cell with the same recipe to confirm or dismiss"
+        print(f"  next action: {action}")
+        out["|".join(key)] = {"baseline_median": base_median, "band_pct": band,
+                              "latest_delta_pct": latest, "runs": len(runs),
+                              "next_action": action}
+
+    if not groups:
+        print("store has no usable records yet")
+
+    cells = version_comparison(records)
+    multi = {cell: versions for cell, versions in cells.items() if len(versions) > 1}
+    if multi:
+        print("\n" + "=" * 78)
+        print("VERSION COMPARISON - different SDK versions on the same device and recipe.")
+        print("Separate from the drift report above: a difference here is deliberate (the SDK "
+              "changed), not drift. With one run per version it is a candidate finding, not a "
+              "verdict - repeat both versions before calling it real.")
+        for cell, versions in sorted(multi.items()):
+            device, build, compile_state, instrument = cell
+            print(f"\n{device}  [build={build} compile={compile_state} instrument={instrument}]")
+            rows = []
+            for version in sorted(versions):
+                medians = [d["median"] for d in versions[version] if d.get("median")]
+                total_n = sum(d.get("n", 0) for d in versions[version])
+                if medians:
+                    rows.append((version, statistics.median(medians), total_n,
+                                 len(versions[version])))
+            if not rows:
+                continue
+            newest = max(rows, key=lambda r: r[0])
+            for version, median, total_n, runs in rows:
+                delta = ("" if version == newest[0]
+                         else f"   {100.0 * (median - newest[1]) / newest[1]:+.1f}% vs {newest[0]}")
+                print(f"  {version:<12} median {median:7.1f} ms   n={total_n:<5} "
+                      f"runs={runs}{delta}")
+
+    print("\nReminders: baselines are fixed, not rolling (a rolling baseline hides slow drift); "
+          "one run is a candidate, two make a regression; never compare across device keys or "
+          "recipes.")
+    if args.json:
+        pathlib.Path(args.json).write_text(json.dumps(out, indent=1))
+        print(f"wrote {args.json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/startup-multi-device-analysis/references/device-gotchas.md
+++ b/.claude/skills/startup-multi-device-analysis/references/device-gotchas.md
@@ -82,6 +82,34 @@ telemetry verification fails unattended) are in
   of a pass — expected, not a foreign process.
 - Two devices of the SAME model share one `connected/` output directory name — give them
   distinct campaign dirs and never run them concurrently.
+- **A leg is verified against the DEVICE's crash buffer, never the harness exit code.** A
+  macrobenchmark leg can report rc=0 and write a complete, plausible trace set from a process that
+  crashed on every single launch: a crash in a *posted* callback fires after the activity is up, so
+  the harness's activity check passes, the window slices are present (init "completed" before the
+  crash), and nothing anywhere reads failed. Measured instance (2026-08-16): a runtime-classpath
+  conflict killed SDK 8.3.0 on every launch; the two slower devices crashed before the activity
+  check and failed honestly, while the fastest device produced 200 green-looking traces and a crash
+  buffer holding 200 `FATAL EXCEPTION`s — one per launch. Faster devices are MORE exposed, not
+  less. After every leg: `adb logcat -d -b crash` and require zero new `FATAL EXCEPTION`s before
+  the leg's data is used; a smoke pass before an unattended campaign must check the crash buffer
+  too, not just "the app launched".
+- **A hung leg emits nothing, so log monitoring cannot see it.** Watching a campaign log for
+  failure signatures catches failures, not stalls: a leg that hangs produces no lines at all and
+  looks identical to a slow leg until a driver-level timeout fires hours later (2026-08-16: one leg
+  hung for a full 4-hour outer timeout, zero passes collected, zero log lines). Give every leg its
+  own subprocess timeout sized to the LEG (~2–3× its expected duration), and make any watchdog
+  assert on *expected progress within an interval* rather than only matching failure strings.
+- **Killing a campaign does not kill its tree.** SIGTERM to a driver leaves its child benchmark
+  runner and THAT child's gradle client alive (and device-side tracers — see the tracer note in
+  "Driving a device outside macrobenchmark"). After any kill, sweep the host for survivors
+  (`pgrep -fl fleet_campaign`, `pgrep -fl connectedBenchmark`) and the device for tracers before
+  trusting the fleet is idle; a driver that spawns children should run them in a process group and
+  kill the group.
+- **The Go-tier `ddmlib ShellCommandUnresponsiveException` on install is intermittent, not a
+  device state.** Across four attempts on the same device it allowed 6, 0, 10 and 4 passes with no
+  pattern; load average ~20 is that tier's normal idle (it coexists with clean 10-pass legs), so
+  neither reboots nor cooldowns fix it. The mitigation is a bounded retry scoped to exactly that
+  failure signature — anything broader retries genuine failures into false passes.
 
 ## Driving a device outside macrobenchmark
 
@@ -138,12 +166,26 @@ compile`. So "profiled" only ever means "the broadcast was sent"; say so rather 
 verified state. The first launch after ANY recompile pays re-verification and must be held out
 like an install-aftermath iteration.
 
-## Long-running campaigns: borrowing global state
+## Long-running campaigns: DON'T borrow global state — run from a worktree
 
-A campaign that mutates something shared (above all the gradle catalog's SDK version pin) must be
-able to give it back after being killed. `try/finally` is not enough — **SIGTERM skips `finally`
-entirely**, and two killed runs in one session each left the pin at the wrong version. Three
-layers, because each covers what the others cannot:
+**The preferred pattern (2026-08-17, after four borrowed-state incidents in two days): campaigns
+that need repo mutations — the catalog's SDK version pin, benchmark iteration counts, compat
+patches for old versions — run from a dedicated `git worktree add --detach`, never from the user's
+checkout.** The worktree gets edited freely, per-version resets are a plain in-worktree
+`git checkout`, gradle builds into the worktree's own build dirs, and the whole thing is deleted
+afterwards — there is nothing to restore, so the entire class of restore-on-kill hazards below
+does not exist. `fleet_campaign.py --repo <worktree>` targets it; scripts that self-locate via
+`git rev-parse` (e.g. `compat_patch.py`) target the worktree automatically when invoked from the
+worktree's own copy of the skill. Two boundaries: the user's working tree is the *subject* only
+when benchmarking uncommitted changes (then the checkout is the point — copy the diff into the
+worktree or accept borrowing); and the host must still stay quiet-ish during legs — the worktree
+frees the *tree*, not the CPU.
+
+The borrowing discipline below remains for the cases a worktree cannot cover. When you must
+mutate something genuinely global (a device setting, mavenLocal contents, the user's checkout
+itself), a campaign must be able to give it back after being killed. `try/finally` is not enough —
+**SIGTERM skips `finally` entirely**, and two killed runs in one session each left the pin at the
+wrong version. Three layers, because each covers what the others cannot:
 
 1. **A marker file** written when the state is borrowed and deleted when returned. Its presence at
    startup means a previous run died holding it. This is the ONLY layer that survives SIGKILL or a
@@ -156,6 +198,19 @@ layers, because each covers what the others cannot:
 
 Worth testing rather than assuming: drive the real file, send a real SIGTERM, send a real SIGKILL,
 and assert the next startup recovers.
+
+Two defects measured in a real implementation of this pattern (2026-08-16), both of the kind a
+casual read passes over:
+
+- **Nested borrows half-restore on a signal.** With two borrowed states (pin wrapping a source
+  edit), each context's own handler restores *its* state and re-raises with `SIG_DFL` — so the
+  INNER context restores and the re-raised default disposition kills the process before the outer
+  handler ever runs. Normal exit and Python exceptions unwind both correctly, which is exactly why
+  the defect hides: it only manifests on the signal path. The handler must unwind a module-level
+  registry of ALL live borrows in reverse order, then re-raise once.
+- **The marker round-trip must be byte-exact.** A restore that strips a trailing newline returns a
+  source file that is one byte off — a spurious diff on an otherwise clean tree, and a lint finding
+  on Kotlin. No `strip()` anywhere on the stored value; assert `restore(capture(x)) == x` on bytes.
 
 ## Device housekeeping that silently kills campaigns
 

--- a/.claude/skills/startup-version-factor-matrix/SKILL.md
+++ b/.claude/skills/startup-version-factor-matrix/SKILL.md
@@ -146,4 +146,5 @@ checked mechanically rather than trusted to discipline.
   report p90/max alongside — outlier behaviour is often where versions actually differ.
 - **Absolute values are build-type-specific.** Debug builds can be several times slower than the
   benchmark (profileable) build and never AOT-compile; only compare like with like, and prefer the
-  benchmark build. There are no portable reference numbers — establish your own baselines.
+  benchmark build. There are no portable reference numbers — establish your own baselines, and see
+  the `startup-longitudinal-tracking` skill for keeping them comparable across runs and releases.

--- a/.claude/skills/startup-version-factor-matrix/references/version-compat.md
+++ b/.claude/skills/startup-version-factor-matrix/references/version-compat.md
@@ -43,6 +43,17 @@ channel. Two consequences specific to this skill:
 
 `compat_patch.py` encodes these as data. Apply before a cell, revert after.
 
+**Apply them in a dedicated worktree, not the user's checkout.** Version campaigns mutate the
+catalog pin, the iteration count, and (for old versions) app source — run the whole campaign from
+`git worktree add --detach`, pass the worktree to the runner (`fleet_campaign.py --repo`), invoke
+`compat_patch.py` from the *worktree's own copy* of this skill so its `git rev-parse` self-location
+targets the worktree, reset between versions with an in-worktree `git checkout`, and delete the
+worktree at the end. Nothing is borrowed, so a killed campaign leaves nothing to restore — the
+failure class that produced four incidents on 2026-08-15/17 (dirty pins after SIGTERM, a restore
+that half-applied, a tree-clean that silently reverted a fix) cannot occur. The one recipe that
+still touches shared state is `local` (publishes the working tree to mavenLocal) — there the
+working tree is the *subject*, and mavenLocal is global by design; verify what resolved, as below.
+
 - **9.x / 8.x (modern)** — no patch. `embrace = "<version>"` in
   `examples/ExampleApp/gradle/libs.versions.toml`; `local` means publish the working tree with
   `./gradlew publishToMavenLocal -q` and pin the `version=` from the repo root `gradle.properties`.

--- a/examples/ExampleApp/app/build.gradle.kts
+++ b/examples/ExampleApp/app/build.gradle.kts
@@ -101,9 +101,13 @@ dependencies {
     implementation(libs.embrace.android.otel.java)
     // opentelemetry-kotlin processor API used by TelemetryVerificationTap; the Embrace SDK already
     // ships these at runtime, this just makes them visible at compile time. Keep the version in
-    // sync with the SDK's otelKotlin version.
-    implementation("io.opentelemetry.kotlin:api:0.6.0")
-    implementation("io.opentelemetry.kotlin:sdk-api:0.6.0")
+    // sync with the SDK's otelKotlin version. compileOnly is load-bearing: as implementation these
+    // override the SDK-under-test's own otel-kotlin on the runtime classpath, which crashes any SDK
+    // built against a different version (8.3.0 died with NoSuchMethodError on Context.storeSpan in
+    // a posted Handler callback - AFTER the activity was up, so macrobenchmark still reported rc=0
+    // and produced 200 traces from a process that crashed on every launch).
+    compileOnly("io.opentelemetry.kotlin:api:0.6.0")
+    compileOnly("io.opentelemetry.kotlin:sdk-api:0.6.0")
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
 
     // uncomment to enable debugging through source contained in those modules

--- a/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/TelemetryVerificationTap.kt
+++ b/examples/ExampleApp/app/src/main/kotlin/io/embrace/android/exampleapp/TelemetryVerificationTap.kt
@@ -74,16 +74,36 @@ object TelemetryVerificationTap {
      * before [Embrace.start], since the SDK ignores processors added after it has started.
      */
     fun registerIfEnabled(context: Context) {
-        val mode = when (Settings.Global.getString(context.contentResolver, SETTING_KEY)) {
-            "all" -> Mode.ALL
-            "startup", "1" -> Mode.STARTUP
+        val setting = Settings.Global.getString(context.contentResolver, SETTING_KEY)
+        val mode = when {
+            setting == "all" -> Mode.ALL
+            setting == "startup" || setting == "1" -> Mode.STARTUP
+            setting?.startsWith("startup:") == true -> Mode.STARTUP
             else -> null
         } ?: return
         Embrace.addSpanProcessor(VerificationSpanProcessor(mode))
         if (mode == Mode.ALL) {
             Embrace.addLogRecordProcessor(VerificationLogRecordProcessor())
         } else {
-            scheduleStartupFlush()
+            scheduleStartupFlush(startupFlushDelayMs(setting))
+        }
+    }
+
+    /**
+     * `startup:<seconds>` overrides the flush delay. The default 10 s NEVER survives a
+     * macrobenchmark run: the harness force-stops the process between iterations on a shorter
+     * cadence, so every launch dies holding its queue and 50 tapped launches emit nothing at all
+     * (measured 2026-08-17). A short delay still lands well after the startup window and TTID
+     * (both < ~1 s of launch) — it only needs to beat the force-stop, not stay out of the way of
+     * the measurement. A malformed suffix falls back to the default rather than failing: this is
+     * verification plumbing inside a host app, and a bad setting must never take the app down.
+     */
+    private fun startupFlushDelayMs(setting: String): Long {
+        val seconds = setting.substringAfter("startup:", "").toLongOrNull()
+        return if (seconds != null && seconds in 1..STARTUP_FLUSH_DELAY_MS / 1000) {
+            seconds * 1000
+        } else {
+            STARTUP_FLUSH_DELAY_MS
         }
     }
 
@@ -113,6 +133,23 @@ object TelemetryVerificationTap {
                     }
                 }
             }
+            // The timer alone NEVER fires under macrobenchmark: the harness force-stops the
+            // process 1-3 s after launch, so at any delay that stays clear of the measurement the
+            // queue dies unemitted (measured 2026-08-17: 1 flush in 50 launches at 3 s with a
+            // 16 MB logcat buffer; 1 in 50 at 1 s). The sentinel is the startup trace's ROOT span
+            // ending - startup is over by definition, and every trace event that determines the
+            // window and TTID already exists, so post-hoc metric derivation cannot be perturbed
+            // by the flush's CPU. The child spans are recorded RETROSPECTIVELY after the root
+            // ends (end-call order is not timestamp order), so the flush waits a short grace for
+            // them to reach the queue rather than keying on any child's name - emitter-internal
+            // recording order is not a contract. The timer stays as the fallback for launches
+            // where no startup root ends (crashed launch, no activity); flushStartupSpans() is
+            // idempotent via startupFlushDone, so both firing is benign.
+            if (mode == Mode.STARTUP && span.name in STARTUP_SENTINEL_SPANS &&
+                !startupFlushDone.get()
+            ) {
+                flushHandler?.postDelayed({ flushStartupSpans() }, SENTINEL_FLUSH_GRACE_MS)
+            }
         }
 
         override fun isStartRequired(): Boolean = false
@@ -138,15 +175,14 @@ object TelemetryVerificationTap {
         override suspend fun shutdown(): OperationResultCode = OperationResultCode.Success
     }
 
-    private fun scheduleStartupFlush() {
+    private fun scheduleStartupFlush(delayMs: Long) {
         val thread = HandlerThread("emb-verify-flush", Process.THREAD_PRIORITY_BACKGROUND)
         thread.start()
-        Handler(thread.looper).postDelayed(
-            {
-                flushStartupSpans()
-                thread.quitSafely()
-            },
-            STARTUP_FLUSH_DELAY_MS,
+        val handler = Handler(thread.looper)
+        flushHandler = handler
+        handler.postDelayed(
+            { flushStartupSpans() },
+            delayMs,
         )
     }
 
@@ -315,12 +351,18 @@ object TelemetryVerificationTap {
         "emb-app-ready",
     )
 
+    /** The startup trace's root spans: either one ending means startup is complete. */
+    private val STARTUP_SENTINEL_SPANS = setOf("emb-app-startup-cold", "emb-app-startup-warm")
+
     private const val SETTING_KEY = "embrace_verify_telemetry"
     private const val TAG = "EmbVerify"
     private const val MARKER = "EMBV1"
     private const val MAX_CHUNK_BYTES = 3600
     private const val STARTUP_FLUSH_DELAY_MS = 10_000L
+    private const val SENTINEL_FLUSH_GRACE_MS = 150L
 
+    @Volatile
+    private var flushHandler: Handler? = null
     private val nextSeq = AtomicInteger(0)
     private val resourceEmitted = AtomicBoolean(false)
     private val startupFlushDone = AtomicBoolean(false)


### PR DESCRIPTION
Skill to benchmark released SDK versions with a controlled set of factors so that they are comparable historically.