### PR TITLE
Remove the low-signal init-maj-faults attribute

### DIFF
--- a/embrace-android-instrumentation-startup-trace/build.gradle.kts
+++ b/embrace-android-instrumentation-startup-trace/build.gradle.kts
@@ -13,5 +13,6 @@ dependencies {
     implementation(project(":embrace-android-instrumentation-api"))
 
     testImplementation(project(":embrace-android-instrumentation-api-fakes"))
+    testImplementation(libs.mockk)
     testImplementation(libs.robolectric)
 }

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitAttributeKeys.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitAttributeKeys.kt
@@ -1,6 +1,5 @@
 package io.embrace.android.embracesdk.internal.instrumentation.startup
 
-import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.INIT_MAJ_FAULTS
 import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.INIT_RUN_DELAY_PCT
 import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.THERMAL_STATUS
 
@@ -45,17 +44,10 @@ object SdkInitAttributeKeys {
     const val INIT_RUN_DELAY_PCT: String = "init-run-delay-pct"
 
     /**
-     * Major page faults taken by the process during the init window - reads that had to go
-     * to storage (cold code pages, cold files), including flash contention from concurrent
-     * installs.
-     */
-    const val INIT_MAJ_FAULTS: String = "init-maj-faults"
-
-    /**
      * Kilobytes actually read from storage by the process during the init window. Normal
      * inits read little (config file + cold pages); elevated values mark storage-bound
      * runs - cold caches after reboot/update, slow flash, or IO contention from concurrent
-     * installs - and pair with [INIT_MAJ_FAULTS] to confirm an IO-class slow run.
+     * installs.
      */
     const val INIT_DISK_READ_KB: String = "init-disk-read-kb"
 

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitAttributeKeys.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitAttributeKeys.kt
@@ -67,9 +67,11 @@ object SdkInitAttributeKeys {
 
     /**
      * The device's overall thermal throttling status at record time, as reported by
-     * [android.os.PowerManager.getCurrentThermalStatus] (API 29+): none/light/moderate/severe/
-     * critical/emergency/shutdown. Collected because heat measurably slows init, and this is a
-     * signal for that.
+     * [android.os.PowerManager.getCurrentThermalStatus] (API 29+): light/moderate/severe/
+     * critical/emergency/shutdown. Present only when the status is not none, so presence means
+     * the device was being throttled at the moment, while absence is not a strong signal
+     * because it could be due to a lag in the update or that there is no actual throttling.
+     * This is collected because heat measurably slows init, and this is a signal for that.
      */
     const val THERMAL_STATUS: String = "thermal-status"
 

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributes.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributes.kt
@@ -62,7 +62,10 @@ private fun MutableMap<String, String>.putThermalAttributes(
 ) {
     if (versionChecker.isAtLeast(VERSION_CODES.Q)) {
         val powerManager = powerManagerProvider() ?: return
-        put(THERMAL_STATUS, thermalStatusName(powerManager.currentThermalStatus))
+        val thermalStatus = powerManager.currentThermalStatus
+        if (thermalStatus != PowerManager.THERMAL_STATUS_NONE) {
+            put(THERMAL_STATUS, thermalStatusName(thermalStatus))
+        }
         if (versionChecker.isAtLeast(VERSION_CODES.R)) {
             val headroom = runCatching { powerManager.getThermalHeadroom(0) }.getOrNull()
             if (headroom != null && headroom.isFinite()) {

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitResourceUsageTracker.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitResourceUsageTracker.kt
@@ -7,7 +7,6 @@ import android.os.SystemClock
 import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.INIT_CPU_PCT
 import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.INIT_DISK_READ_KB
 import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.INIT_GC_COUNT
-import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.INIT_MAJ_FAULTS
 import io.embrace.android.embracesdk.internal.instrumentation.startup.SdkInitAttributeKeys.INIT_RUN_DELAY_PCT
 import java.io.FileInputStream
 import kotlin.math.roundToLong
@@ -57,12 +56,6 @@ class SdkInitResourceUsageTracker(
     private var endSchedstat: ByteArray? = null
 
     @Volatile
-    private var startProcStat: ByteArray? = null
-
-    @Volatile
-    private var endProcStat: ByteArray? = null
-
-    @Volatile
     private var startProcIo: ByteArray? = null
 
     @Volatile
@@ -84,7 +77,6 @@ class SdkInitResourceUsageTracker(
             val path = schedstatPathProvider()
             schedstatPath = path
             startSchedstat = procFileReader(path)
-            startProcStat = procFileReader(PROC_SELF_STAT_PATH)
             startProcIo = procFileReader(PROC_SELF_IO_PATH)
             startGcCount = runtimeStatReader(GC_COUNT_STAT)?.toLongOrNull()
         } catch (_: Throwable) {
@@ -99,7 +91,6 @@ class SdkInitResourceUsageTracker(
             endWallMs = elapsedRealtimeMs()
             endCpuMs = threadCpuTimeMs()
             endSchedstat = schedstatPath?.let(procFileReader)
-            endProcStat = procFileReader(PROC_SELF_STAT_PATH)
             endProcIo = procFileReader(PROC_SELF_IO_PATH)
             endGcCount = runtimeStatReader(GC_COUNT_STAT)?.toLongOrNull()
         } catch (_: Throwable) {
@@ -139,9 +130,6 @@ class SdkInitResourceUsageTracker(
     }
 
     private fun MutableMap<String, String>.putResourceAttributes() {
-        deltaOrNull(startProcStat?.let { parseMajFaults(it) }, endProcStat?.let { parseMajFaults(it) })?.let { faults ->
-            put(INIT_MAJ_FAULTS, faults.toString())
-        }
         deltaOrNull(startProcIo?.let { parseReadBytes(it) }, endProcIo?.let { parseReadBytes(it) })?.let { bytes ->
             put(INIT_DISK_READ_KB, (bytes / 1024L).toString())
         }
@@ -168,19 +156,6 @@ class SdkInitResourceUsageTracker(
      */
     private fun parseRunDelayNs(raw: ByteArray): Long? = try {
         raw.decodeToString().trim().split(' ').getOrNull(1)?.toLong()
-    } catch (_: Throwable) {
-        null
-    }
-
-    /**
-     * Extracts the cumulative major-fault count (field 12, 1-indexed) from raw /proc/self/stat
-     * contents. The second field (comm) is a parenthesized process name that may itself contain
-     * spaces and parentheses, so fields are counted from the substring after the LAST ')'.
-     */
-    private fun parseMajFaults(raw: ByteArray): Long? = try {
-        val afterComm = raw.decodeToString().substringAfterLast(')')
-        // post-comm tokens: state ppid pgrp session tty_nr tpgid flags minflt cminflt majflt
-        afterComm.trim().split(' ').getOrNull(MAJ_FAULTS_POST_COMM_INDEX)?.toLong()
     } catch (_: Throwable) {
         null
     }
@@ -219,9 +194,7 @@ private fun readProcFile(path: String): ByteArray? = try {
     null
 }
 
-// /proc/self/stat is ~300-350 bytes and /proc/self/io ~120, so 1024 covers both with room to spare
+// /proc/self/io is ~120 bytes, so 1024 covers it with room to spare
 private const val PROC_READ_BUFFER_BYTES = 1024
-private const val PROC_SELF_STAT_PATH = "/proc/self/stat"
 private const val PROC_SELF_IO_PATH = "/proc/self/io"
 private const val GC_COUNT_STAT = "art.gc.gc-count"
-private const val MAJ_FAULTS_POST_COMM_INDEX = 9

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributesTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributesTest.kt
@@ -5,6 +5,10 @@ import android.content.Context
 import android.os.PowerManager
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
+import io.embrace.android.embracesdk.internal.utils.VersionChecker
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Before
@@ -29,6 +33,29 @@ internal class SdkInitEnvironmentAttributesTest {
         val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
         shadowOf(powerManager).setCurrentThermalStatus(PowerManager.THERMAL_STATUS_MODERATE)
         assertEquals("moderate", environmentAttributes()[SdkInitAttributeKeys.THERMAL_STATUS])
+    }
+
+    @Test
+    fun `thermal status none is omitted since it carries no signal`() {
+        val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+        shadowOf(powerManager).setCurrentThermalStatus(PowerManager.THERMAL_STATUS_NONE)
+        assertFalse(environmentAttributes().containsKey(SdkInitAttributeKeys.THERMAL_STATUS))
+    }
+
+    @Test
+    fun `thermal headroom is still reported when thermal status is none`() {
+        // Robolectric's ShadowPowerManager has no shadow for getThermalHeadroom, so the real
+        // method throws under Robolectric and a mock is the only way to drive this branch.
+        val powerManager = mockk<PowerManager> {
+            every { currentThermalStatus } returns PowerManager.THERMAL_STATUS_NONE
+            every { getThermalHeadroom(0) } returns 0.42f
+        }
+        val attributes = environmentAttributes(
+            powerManagerProvider = { powerManager },
+            versionChecker = VersionChecker { true },
+        )
+        assertFalse(attributes.containsKey(SdkInitAttributeKeys.THERMAL_STATUS))
+        assertEquals("42", attributes[SdkInitAttributeKeys.THERMAL_HEADROOM_PCT])
     }
 
     @Test
@@ -109,11 +136,14 @@ internal class SdkInitEnvironmentAttributesTest {
 
     private fun environmentAttributes(
         prefsFileSizeProvider: () -> Long? = { null },
+        powerManagerProvider: () -> PowerManager? = { context.getSystemService(Context.POWER_SERVICE) as? PowerManager },
+        versionChecker: VersionChecker = BuildVersionChecker,
     ): Map<String, String> = sdkInitEnvironmentAttributes(
-        powerManagerProvider = { context.getSystemService(Context.POWER_SERVICE) as? PowerManager },
+        powerManagerProvider = powerManagerProvider,
         activityManagerProvider = { context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager },
         packageInfo = context.packageManager.getPackageInfo(context.packageName, 0),
         nowMs = NOW_MS,
+        versionChecker = versionChecker,
         uptimeMs = { fakeUptimeMs },
         prefsFileSizeProvider = prefsFileSizeProvider,
     )

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitResourceUsageTrackerTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitResourceUsageTrackerTest.kt
@@ -10,7 +10,6 @@ internal class SdkInitResourceUsageTrackerTest {
     private lateinit var cpuTimesMs: ArrayDeque<Long>
     private lateinit var wallTimesMs: ArrayDeque<Long>
     private lateinit var schedstatContents: ArrayDeque<ByteArray?>
-    private lateinit var procStatContents: ArrayDeque<ByteArray?>
     private lateinit var procIoContents: ArrayDeque<ByteArray?>
     private lateinit var runtimeStats: MutableMap<String, ArrayDeque<String?>>
     private lateinit var readPaths: MutableList<String>
@@ -24,14 +23,6 @@ internal class SdkInitResourceUsageTrackerTest {
             listOf(
                 "300000000 5000000 120\n".toByteArray(),
                 "800000000 12000000 150\n".toByteArray(),
-            ),
-        )
-        // comm "(fake app) 1)" deliberately contains a space and an extra ')' so field counting
-        // must start after the LAST paren; majflt (field 12) is 40 -> 55
-        procStatContents = ArrayDeque(
-            listOf(
-                "123 (fake app) 1) S 1 2 3 4 5 6 100 200 40 0 30 10".toByteArray(),
-                "123 (fake app) 1) S 1 2 3 4 5 6 150 300 55 0 60 20".toByteArray(),
             ),
         )
         procIoContents = ArrayDeque(
@@ -52,30 +43,17 @@ internal class SdkInitResourceUsageTrackerTest {
         tracker.captureStart()
         tracker.captureEnd()
         // window = 60 ms wall; cpu delta = 30 ms -> 50%; run delay = 7 ms -> 12%;
-        // majflt 55-40 = 15; read_bytes delta 49152 B -> 48 KB; gc 5-3 = 2 taking 40-12 = 28 ms
+        // read_bytes delta 49152 B -> 48 KB; gc 5-3 = 2 taking 40-12 = 28 ms
         assertEquals(
             mapOf(
                 SdkInitAttributeKeys.INIT_CPU_PCT to "50",
                 SdkInitAttributeKeys.INIT_RUN_DELAY_PCT to "12",
-                SdkInitAttributeKeys.INIT_MAJ_FAULTS to "15",
                 SdkInitAttributeKeys.INIT_DISK_READ_KB to "48",
                 SdkInitAttributeKeys.INIT_GC_COUNT to "2",
             ),
             tracker.buildAttributes(),
         )
         assertEquals(listOf(SCHEDSTAT_PATH, SCHEDSTAT_PATH), readPaths.filter { it.endsWith("schedstat") })
-    }
-
-    @Test
-    fun `missing proc stat only drops major faults`() {
-        procStatContents = ArrayDeque(listOf(null, null))
-        val tracker = createTracker()
-        tracker.captureStart()
-        tracker.captureEnd()
-        val attributes = tracker.buildAttributes()
-        assertFalse(attributes.containsKey(SdkInitAttributeKeys.INIT_MAJ_FAULTS))
-        assertEquals("50", attributes[SdkInitAttributeKeys.INIT_CPU_PCT])
-        assertEquals("48", attributes[SdkInitAttributeKeys.INIT_DISK_READ_KB])
     }
 
     @Test
@@ -206,7 +184,6 @@ internal class SdkInitResourceUsageTrackerTest {
             readPaths.add(path)
             when {
                 path.endsWith("schedstat") -> schedstatContents.removeFirst()
-                path.endsWith("/stat") -> procStatContents.removeFirst()
                 path.endsWith("/io") -> procIoContents.removeFirst()
                 else -> null
             }


### PR DESCRIPTION
This turned out to be low signal in reality after analyzing the actual collected data, so lets not record it and incur the overhead. We already record the number of bytes read during SDK startup, which will proxy I/O load - if not contention - so we this doesn't add a lot anwywa.