### PR TITLE
Modify the thermal-status attribute to not write if it's none

### DIFF
--- a/embrace-android-instrumentation-startup-trace/build.gradle.kts
+++ b/embrace-android-instrumentation-startup-trace/build.gradle.kts
@@ -13,5 +13,6 @@ dependencies {
     implementation(project(":embrace-android-instrumentation-api"))
 
     testImplementation(project(":embrace-android-instrumentation-api-fakes"))
+    testImplementation(libs.mockk)
     testImplementation(libs.robolectric)
 }

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitAttributeKeys.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitAttributeKeys.kt
@@ -67,9 +67,11 @@ object SdkInitAttributeKeys {
 
     /**
      * The device's overall thermal throttling status at record time, as reported by
-     * [android.os.PowerManager.getCurrentThermalStatus] (API 29+): none/light/moderate/severe/
-     * critical/emergency/shutdown. Collected because heat measurably slows init, and this is a
-     * signal for that.
+     * [android.os.PowerManager.getCurrentThermalStatus] (API 29+): light/moderate/severe/
+     * critical/emergency/shutdown. Present only when the status is not none, so presence means
+     * the device was being throttled at the moment, while absence is not a strong signal
+     * because it could be due to a lag in the update or that there is no actual throttling.
+     * This is collected because heat measurably slows init, and this is a signal for that.
      */
     const val THERMAL_STATUS: String = "thermal-status"
 

--- a/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributes.kt
+++ b/embrace-android-instrumentation-startup-trace/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributes.kt
@@ -62,7 +62,10 @@ private fun MutableMap<String, String>.putThermalAttributes(
 ) {
     if (versionChecker.isAtLeast(VERSION_CODES.Q)) {
         val powerManager = powerManagerProvider() ?: return
-        put(THERMAL_STATUS, thermalStatusName(powerManager.currentThermalStatus))
+        val thermalStatus = powerManager.currentThermalStatus
+        if (thermalStatus != PowerManager.THERMAL_STATUS_NONE) {
+            put(THERMAL_STATUS, thermalStatusName(thermalStatus))
+        }
         if (versionChecker.isAtLeast(VERSION_CODES.R)) {
             val headroom = runCatching { powerManager.getThermalHeadroom(0) }.getOrNull()
             if (headroom != null && headroom.isFinite()) {

--- a/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributesTest.kt
+++ b/embrace-android-instrumentation-startup-trace/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/startup/SdkInitEnvironmentAttributesTest.kt
@@ -5,6 +5,10 @@ import android.content.Context
 import android.os.PowerManager
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
+import io.embrace.android.embracesdk.internal.utils.VersionChecker
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Before
@@ -29,6 +33,29 @@ internal class SdkInitEnvironmentAttributesTest {
         val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
         shadowOf(powerManager).setCurrentThermalStatus(PowerManager.THERMAL_STATUS_MODERATE)
         assertEquals("moderate", environmentAttributes()[SdkInitAttributeKeys.THERMAL_STATUS])
+    }
+
+    @Test
+    fun `thermal status none is omitted since it carries no signal`() {
+        val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+        shadowOf(powerManager).setCurrentThermalStatus(PowerManager.THERMAL_STATUS_NONE)
+        assertFalse(environmentAttributes().containsKey(SdkInitAttributeKeys.THERMAL_STATUS))
+    }
+
+    @Test
+    fun `thermal headroom is still reported when thermal status is none`() {
+        // Robolectric's ShadowPowerManager has no shadow for getThermalHeadroom, so the real
+        // method throws under Robolectric and a mock is the only way to drive this branch.
+        val powerManager = mockk<PowerManager> {
+            every { currentThermalStatus } returns PowerManager.THERMAL_STATUS_NONE
+            every { getThermalHeadroom(0) } returns 0.42f
+        }
+        val attributes = environmentAttributes(
+            powerManagerProvider = { powerManager },
+            versionChecker = VersionChecker { true },
+        )
+        assertFalse(attributes.containsKey(SdkInitAttributeKeys.THERMAL_STATUS))
+        assertEquals("42", attributes[SdkInitAttributeKeys.THERMAL_HEADROOM_PCT])
     }
 
     @Test
@@ -109,11 +136,14 @@ internal class SdkInitEnvironmentAttributesTest {
 
     private fun environmentAttributes(
         prefsFileSizeProvider: () -> Long? = { null },
+        powerManagerProvider: () -> PowerManager? = { context.getSystemService(Context.POWER_SERVICE) as? PowerManager },
+        versionChecker: VersionChecker = BuildVersionChecker,
     ): Map<String, String> = sdkInitEnvironmentAttributes(
-        powerManagerProvider = { context.getSystemService(Context.POWER_SERVICE) as? PowerManager },
+        powerManagerProvider = powerManagerProvider,
         activityManagerProvider = { context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager },
         packageInfo = context.packageManager.getPackageInfo(context.packageName, 0),
         nowMs = NOW_MS,
+        versionChecker = versionChecker,
         uptimeMs = { fakeUptimeMs },
         prefsFileSizeProvider = prefsFileSizeProvider,
     )


### PR DESCRIPTION
Thermal status is mostly never a problem - so just record it if it turns out to be anomolous.