### PR TITLE
Read spans in `SessionReconstructionService`

### DIFF
--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansReader.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansReader.kt
@@ -1,0 +1,39 @@
+package io.embrace.android.embracesdk.internal.session.persistence
+
+import com.squareup.wire.ProtoReader
+import okio.BufferedSource
+import java.io.EOFException
+
+private const val SPANS_TAG = 1
+
+/**
+ * Decodes the append-only log of completed spans held in [source].
+ *
+ * Records are decoded one at a time rather than with [CompletedSpans.ADAPTER], because this avoids
+ * a single bad record taking down the entire batch.
+ *
+ * A process can die part way through an append, so a log that stops mid-record is expected and is
+ * not reported: every record written in full before it is returned. A record that is all
+ * present but does not decode is corruption and throws.
+ */
+internal fun readCompletedSpans(source: BufferedSource): List<SpanProto> {
+    val spans = mutableListOf<SpanProto>()
+    val reader = ProtoReader(source)
+    reader.beginMessage()
+
+    while (true) {
+        val record = try {
+            when (reader.nextTag()) {
+                -1 -> return spans
+                SPANS_TAG -> reader.readBytes()
+                else -> {
+                    reader.skip()
+                    continue
+                }
+            }
+        } catch (exc: EOFException) {
+            return spans
+        }
+        spans.add(SpanProto.ADAPTER.decode(record))
+    }
+}

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionPartFiles.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionPartFiles.kt
@@ -16,6 +16,8 @@ internal const val METADATA_FILE_NAME = "metadata.pb"
 
 internal const val SESSION_SPAN_FILE_NAME = "session_span.pb"
 
+internal const val COMPLETED_SPANS_FILE_NAME = "completed_spans.pb"
+
 internal const val SPAN_SNAPSHOTS_FILE_NAME = "span_snapshots.pb"
 
 /**

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionService.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionService.kt
@@ -5,6 +5,9 @@ import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
+import io.embrace.android.embracesdk.internal.payload.Span
+import okio.buffer
+import okio.source
 import java.io.File
 import java.io.IOException
 
@@ -69,10 +72,16 @@ class SessionReconstructionService(
             return null
         }
 
+        val completedSpans = readCompletedSpansFile(partDir) ?: return null
+
         // A session span with no end time never finished, so it is delivered as a snapshot rather
-        // than as a completed span. Spans other than the session span are not persisted yet.
-        val payload = span.toPayload()
-        val complete = payload.endTimeNanos != null
+        // than as a completed span. Span snapshots are not read back yet.
+        val sessionSpanPayload = span.toPayload()
+        val complete = sessionSpanPayload.endTimeNanos != null
+        val spans = when {
+            complete -> completedSpans + sessionSpanPayload
+            else -> completedSpans
+        }
 
         return Envelope(
             resource = resource.toPayload(),
@@ -80,11 +89,28 @@ class SessionReconstructionService(
             version = manifest.envelope_version,
             type = manifest.envelope_type,
             data = SessionPartPayload(
-                spans = if (complete) listOf(payload) else null,
-                spanSnapshots = if (complete) null else listOf(payload),
+                spans = spans.takeIf(List<Span>::isNotEmpty),
+                spanSnapshots = if (complete) null else listOf(sessionSpanPayload),
                 sharedLibSymbolMapping = manifest.shared_lib_symbol_mapping?.symbols,
             ),
         )
+    }
+
+    /**
+     * Decodes the completed spans logged in a session part directory, or null if the log is absent
+     * or cannot be read.
+     */
+    private fun readCompletedSpansFile(partDir: File): List<Span>? {
+        val src = File(partDir, COMPLETED_SPANS_FILE_NAME)
+        return try {
+            if (!src.isFile) {
+                throw IOException("Completed spans file not found")
+            }
+            src.source().buffer().use(::readCompletedSpans).map(SpanProto::toPayload)
+        } catch (exc: Throwable) {
+            trackFailure(exc)
+            null
+        }
     }
 
     /**

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansReaderTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansReaderTest.kt
@@ -1,0 +1,106 @@
+package io.embrace.android.embracesdk.internal.session.persistence
+
+import okio.Buffer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+import java.io.IOException
+
+internal class CompletedSpansReaderTest {
+
+    private companion object {
+        /** Field 2 as a varint, which no version of the log has ever held. */
+        private val UNKNOWN_FIELD = byteArrayOf(0x10, 0x01)
+
+        /** Field 1 tagged with wire type 6, which is not a field encoding protobuf defines. */
+        private val INVALID_FIELD_ENCODING = byteArrayOf(0x0E)
+
+        /** Field 1, length delimited, claiming more bytes than any log could hold. */
+        private val OVERSIZED_LENGTH_PREFIX = byteArrayOf(0x0A, -1, -1, -1, -1, 0x07)
+
+        private fun span(id: String) = fullyPopulatedSpanProto.copy(span_id = id)
+
+        private fun read(bytes: ByteArray): List<SpanProto> = Buffer().write(bytes).use(::readCompletedSpans)
+    }
+
+    private val first = span("aaaaaaaaaaaaaaa1")
+    private val second = span("aaaaaaaaaaaaaaa2")
+    private val third = span("aaaaaaaaaaaaaaa3")
+
+    @Test
+    fun `an empty log reads back no spans`() {
+        assertEquals(emptyList<SpanProto>(), read(byteArrayOf()))
+    }
+
+    @Test
+    fun `every field of a logged span survives the log`() {
+        assertEquals(listOf(fullyPopulatedSpanProto), read(completedSpansLog(listOf(fullyPopulatedSpanProto))))
+    }
+
+    @Test
+    fun `a span with no populated fields reads back`() {
+        assertEquals(listOf(SpanProto()), read(completedSpansLog(listOf(SpanProto()))))
+    }
+
+    @Test
+    fun `records read back in the order they were appended`() {
+        assertEquals(listOf(first, second, third), read(completedSpansLog(listOf(first, second, third))))
+    }
+
+    @Test
+    fun `a record holding several spans reads all of them back`() {
+        val batched = CompletedSpans.ADAPTER.encode(CompletedSpans(spans = listOf(first, second)))
+        assertEquals(listOf(first, second), read(batched))
+    }
+
+    @Test
+    fun `a torn final record is dropped and the records before it are kept`() {
+        val log = completedSpansLog(listOf(first, second))
+        assertEquals(listOf(first), read(log.copyOf(log.size - 1)))
+    }
+
+    @Test
+    fun `every truncation of a log reads back one of its prefixes`() {
+        val spans = listOf(first, second, third)
+        val log = completedSpansLog(spans)
+
+        (0..log.size).forEach { length ->
+            val recovered = read(log.copyOf(length))
+            assertEquals("truncated to $length bytes", spans.take(recovered.size), recovered)
+        }
+    }
+
+    @Test
+    fun `an oversized length prefix does not read past the end of the log`() {
+        val log = completedSpansLog(listOf(first)) + OVERSIZED_LENGTH_PREFIX
+        assertEquals(listOf(first), read(log))
+    }
+
+    @Test
+    fun `a malformed frame throws even with no records behind it`() {
+        try {
+            read(INVALID_FIELD_ENCODING)
+            fail("expected a malformed frame to throw")
+        } catch (expected: IOException) {
+            // a short frame is a torn append, but a malformed one is corruption at any offset
+        }
+    }
+
+    @Test
+    fun `a field a later SDK added is skipped`() {
+        val log = completedSpansLog(listOf(first)) + UNKNOWN_FIELD + completedSpansLog(listOf(second))
+        assertEquals(listOf(first, second), read(log))
+    }
+
+    @Test
+    fun `a malformed frame behind an intact record throws so the caller can report it`() {
+        val log = completedSpansLog(listOf(first)) + INVALID_FIELD_ENCODING + completedSpansLog(listOf(second))
+
+        try {
+            read(log)
+            fail("expected corruption with records behind it to throw")
+        } catch (expected: IOException) {
+            // the records before it are still lost, but reporting beats delivering a partial log
+        }
+    }
+}

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceCompletedSpansTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceCompletedSpansTest.kt
@@ -1,0 +1,267 @@
+package io.embrace.android.embracesdk.internal.session.persistence
+
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
+import io.embrace.android.embracesdk.internal.payload.Span
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+internal class SessionReconstructionServiceCompletedSpansTest {
+
+    private companion object {
+        private const val COMPLETED_SPANS_FILE_NAME = "completed_spans.pb"
+        private const val ENVELOPE_VERSION = "0.1.0"
+        private const val ENVELOPE_TYPE = "spans"
+        private const val TIMESTAMP = 1726739283136L
+        private const val UUID = "c2610cd1-389f-422a-bfbc-25312c7a599a"
+        private const val USER_SESSION_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        private const val SESSION_PART_ID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+        private val partDirectory = SessionPartDirectory(
+            timestamp = TIMESTAMP,
+            uuid = UUID,
+            userSessionId = USER_SESSION_ID,
+            sessionPartId = SESSION_PART_ID,
+        )
+
+        private val endedSpanProto = inFlightSpanProto.copy(
+            end_time_unix_nano = 1726739283900000000L,
+            status = SpanProto.Status.OK,
+        )
+
+        private val endedSpan = inFlightSpan.copy(
+            endTimeNanos = 1726739283900000000L,
+            status = Span.Status.OK,
+        )
+
+        private val secondEndedSpanProto = endedSpanProto.copy(span_id = "aaaaaaaaaaaaaaa5")
+
+        private val secondEndedSpan = endedSpan.copy(spanId = "aaaaaaaaaaaaaaa5")
+
+        /** Field 2 as a varint, which no version of the log has ever held. */
+        private val UNKNOWN_FIELD = byteArrayOf(0x10, 0x01)
+
+        /** Field 1 tagged with wire type 6, which is not a field encoding protobuf defines. */
+        private val INVALID_FIELD_ENCODING = byteArrayOf(0x0E)
+    }
+
+    @get:Rule
+    val tempFolder: TemporaryFolder = TemporaryFolder()
+
+    private lateinit var sessionsDir: File
+    private lateinit var logger: FakeInternalLogger
+    private lateinit var manifestWriter: SessionManifestWriter
+    private lateinit var metadataWriter: SessionMetadataWriter
+    private lateinit var sessionSpanWriter: SessionSpanWriter
+    private lateinit var service: SessionReconstructionService
+
+    @Volatile
+    private var sessionSpan: Span = fullyPopulatedSpan
+
+    @Volatile
+    private var activePart: SessionPartDirectory? = partDirectory
+
+    @Before
+    fun setUp() {
+        sessionsDir = tempFolder.newFolder("embrace_sessions")
+        logger = FakeInternalLogger(throwOnInternalError = false)
+        sessionSpan = fullyPopulatedSpan
+        activePart = partDirectory
+        manifestWriter = SessionManifestWriter(lazy { sessionsDir }, logger)
+        metadataWriter = SessionMetadataWriter(lazy { sessionsDir }, { activePart }, { fullyPopulatedMetadata }, logger)
+        sessionSpanWriter = SessionSpanWriter(lazy { sessionsDir }, { activePart }, logger)
+        service = SessionReconstructionService(lazy { sessionsDir }, logger)
+        createPartDir(partDirectory)
+    }
+
+    @Test
+    fun `completed spans are reconstructed in the order they were appended`() {
+        write(spans = listOf(endedSpanProto, secondEndedSpanProto))
+        val spans = checkNotNull(service.reconstruct(partDirectory)?.data?.spans)
+        assertEquals(listOf(endedSpan, secondEndedSpan, fullyPopulatedSpan), spans)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `the session span is reconstructed after the completed spans`() {
+        write(spans = listOf(endedSpanProto))
+        val spans = checkNotNull(service.reconstruct(partDirectory)?.data?.spans)
+        assertEquals(fullyPopulatedSpan, spans.last())
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `an empty completed spans log reconstructs the session span alone`() {
+        write()
+
+        val payload = checkNotNull(service.reconstruct(partDirectory)?.data)
+        assertEquals(listOf(fullyPopulatedSpan), payload.spans)
+        assertNull(payload.spanSnapshots)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `completed spans are reconstructed when the session span never ended`() {
+        val incomplete = fullyPopulatedSpan.copy(endTimeNanos = null)
+        sessionSpan = incomplete
+        write(spans = listOf(endedSpanProto))
+
+        val payload = checkNotNull(service.reconstruct(partDirectory)?.data)
+        assertEquals(listOf(endedSpan), payload.spans)
+        assertEquals(listOf(incomplete), payload.spanSnapshots)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a logged span with no end time is still reconstructed as a completed span`() {
+        write(spans = listOf(inFlightSpanProto))
+
+        val payload = checkNotNull(service.reconstruct(partDirectory)?.data)
+        assertEquals(listOf(inFlightSpan, fullyPopulatedSpan), payload.spans)
+        assertNull(payload.spanSnapshots)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `each session part directory reconstructs its own completed spans`() {
+        val other = SessionPartDirectory(
+            timestamp = TIMESTAMP + 1,
+            uuid = "d3721de2-490a-533b-cacd-36423d8b6aab",
+            userSessionId = "cccccccccccccccccccccccccccccccc",
+            sessionPartId = "dddddddddddddddddddddddddddddddd",
+        )
+        createPartDir(other)
+        write(spans = listOf(endedSpanProto))
+        write(other, spans = listOf(secondEndedSpanProto))
+
+        assertEquals(endedSpan, service.reconstruct(partDirectory)?.data?.spans?.first())
+        assertEquals(secondEndedSpan, service.reconstruct(other)?.data?.spans?.first())
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a torn final record does not lose the records before it`() {
+        write(spans = listOf(endedSpanProto, secondEndedSpanProto))
+        truncateLastByte()
+
+        val spans = checkNotNull(service.reconstruct(partDirectory)?.data?.spans)
+        assertEquals(listOf(endedSpan, fullyPopulatedSpan), spans)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a log holding nothing but a torn record reconstructs the session span alone`() {
+        write(spans = listOf(endedSpanProto))
+        truncateLastByte()
+        assertEquals(listOf(fullyPopulatedSpan), service.reconstruct(partDirectory)?.data?.spans)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a field a later SDK added is skipped rather than failing the log`() {
+        write(spans = listOf(endedSpanProto))
+        completedSpansFile().appendBytes(UNKNOWN_FIELD)
+        completedSpansFile().appendBytes(completedSpansLog(listOf(secondEndedSpanProto)))
+
+        val spans = checkNotNull(service.reconstruct(partDirectory)?.data?.spans)
+        assertEquals(listOf(endedSpan, secondEndedSpan, fullyPopulatedSpan), spans)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `an invalid field encoding behind an intact record is reported and does not throw`() {
+        write(spans = listOf(endedSpanProto))
+        completedSpansFile().appendBytes(INVALID_FIELD_ENCODING)
+        completedSpansFile().appendBytes(completedSpansLog(listOf(secondEndedSpanProto)))
+
+        assertNull(service.reconstruct(partDirectory))
+        assertReconstructionFailureTracked()
+    }
+
+    @Test
+    fun `a completed spans log holding undecodable bytes is reported and does not throw`() {
+        write()
+        completedSpansFile().writeBytes(INVALID_FIELD_ENCODING)
+        assertNull(service.reconstruct(partDirectory))
+        assertReconstructionFailureTracked()
+    }
+
+    @Test
+    fun `a missing completed spans log is reported`() {
+        writeManifest()
+        writeMetadata()
+        writeSessionSpan()
+        assertNull(service.reconstruct(partDirectory))
+        assertReconstructionFailureTracked()
+    }
+
+    @Test
+    fun `a directory occupying the completed spans path is reported`() {
+        writeManifest()
+        writeMetadata()
+        writeSessionSpan()
+        completedSpansFile().mkdirs()
+
+        assertNull(service.reconstruct(partDirectory))
+        assertReconstructionFailureTracked()
+    }
+
+    private fun createPartDir(directory: SessionPartDirectory): File =
+        File(sessionsDir, directory.dirName).apply { mkdirs() }
+
+    private fun partDir(directory: SessionPartDirectory = partDirectory): File =
+        File(sessionsDir, directory.dirName)
+
+    private fun completedSpansFile(directory: SessionPartDirectory = partDirectory): File =
+        File(partDir(directory), COMPLETED_SPANS_FILE_NAME)
+
+    private fun truncateLastByte(directory: SessionPartDirectory = partDirectory) {
+        val bytes = completedSpansFile(directory).readBytes()
+        completedSpansFile(directory).writeBytes(bytes.copyOf(bytes.size - 1))
+    }
+
+    private fun write(
+        directory: SessionPartDirectory = partDirectory,
+        spans: List<SpanProto> = emptyList(),
+    ) {
+        writeManifest(directory)
+        writeMetadata(directory)
+        writeSessionSpan(directory)
+        writeCompletedSpans(directory, spans)
+    }
+
+    private fun writeManifest(directory: SessionPartDirectory = partDirectory) {
+        assertTrue(manifestWriter.write(directory, fullyPopulatedResource, ENVELOPE_VERSION, ENVELOPE_TYPE))
+    }
+
+    private fun writeMetadata(directory: SessionPartDirectory = partDirectory) {
+        activePart = directory
+        assertTrue(metadataWriter.write())
+    }
+
+    private fun writeSessionSpan(directory: SessionPartDirectory = partDirectory) {
+        activePart = directory
+        assertTrue(sessionSpanWriter.write(sessionSpan))
+    }
+
+    private fun writeCompletedSpans(
+        directory: SessionPartDirectory = partDirectory,
+        spans: List<SpanProto> = emptyList(),
+    ) {
+        completedSpansFile(directory).writeBytes(completedSpansLog(spans))
+    }
+
+    private fun assertNoInternalErrors() {
+        assertEquals(emptyList<FakeInternalLogger.LogMessage>(), logger.internalErrorMessages)
+    }
+
+    private fun assertReconstructionFailureTracked() {
+        assertEquals(1, logger.internalErrorMessages.size)
+        assertEquals("SessionReconstructionFail", logger.internalErrorMessages.single().msg)
+    }
+}

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceManifestTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceManifestTest.kt
@@ -76,6 +76,11 @@ internal class SessionReconstructionServiceManifestTest {
         activePart = directory
         assertTrue(metadataWriter.write())
         assertTrue(sessionSpanWriter.write(fullyPopulatedSpan))
+        writeCompletedSpans(directory)
+    }
+
+    private fun writeCompletedSpans(directory: SessionPartDirectory = partDirectory) {
+        File(partDir(directory), "completed_spans.pb").writeBytes(completedSpansLog(emptyList()))
     }
 
     private fun writeManifestBytes(manifest: SessionManifest, directory: SessionPartDirectory = partDirectory) {
@@ -103,7 +108,7 @@ internal class SessionReconstructionServiceManifestTest {
     }
 
     @Test
-    fun `the session span is the only telemetry reconstructed so far`() {
+    fun `span snapshots are the only telemetry not reconstructed yet`() {
         write()
 
         val envelope = checkNotNull(service.reconstruct(partDirectory))

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceMetadataTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceMetadataTest.kt
@@ -181,6 +181,11 @@ internal class SessionReconstructionServiceMetadataTest {
         writeManifest(directory)
         writeMetadata(directory)
         writeSessionSpan(directory)
+        writeCompletedSpans(directory)
+    }
+
+    private fun writeCompletedSpans(directory: SessionPartDirectory = partDirectory) {
+        File(partDir(directory), "completed_spans.pb").writeBytes(completedSpansLog(emptyList()))
     }
 
     private fun writeManifest(directory: SessionPartDirectory = partDirectory) {

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceSessionSpanTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceSessionSpanTest.kt
@@ -225,6 +225,11 @@ internal class SessionReconstructionServiceSessionSpanTest {
         writeManifest(directory)
         writeMetadata(directory)
         writeSessionSpan(directory)
+        writeCompletedSpans(directory)
+    }
+
+    private fun writeCompletedSpans(directory: SessionPartDirectory = partDirectory) {
+        File(partDir(directory), "completed_spans.pb").writeBytes(completedSpansLog(emptyList()))
     }
 
     private fun writeManifest(directory: SessionPartDirectory = partDirectory) {

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SpanFixtures.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SpanFixtures.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Link
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
+import okio.Buffer
 
 internal val fullyPopulatedSpan = Span(
     traceId = "6c9b1f2ec1d34f3c9a7d0b8e5f2a4c11",
@@ -94,3 +95,7 @@ internal val fullyPopulatedSpanSnapshotsProto = SpanSnapshots(
     format_version = FORMAT_VERSION,
     spans = listOf(fullyPopulatedSpanProto, inFlightSpanProto),
 )
+
+internal fun completedSpansLog(spans: List<SpanProto>): ByteArray = Buffer().apply {
+    spans.forEach { write(CompletedSpans.ADAPTER.encode(CompletedSpans(spans = listOf(it)))) }
+}.readByteArray()


### PR DESCRIPTION
## Goal

Updates `SessionReconstructionService` so that it reads back persisted spans.

## Testing

Added unit tests.
