### PR TITLE
Address experiments feedback

### DIFF
--- a/embrace-android-api/api/embrace-android-api.api
+++ b/embrace-android-api/api/embrace-android-api.api
@@ -96,9 +96,7 @@ public abstract interface class io/embrace/android/embracesdk/internal/api/Exper
 }
 
 public final class io/embrace/android/embracesdk/internal/api/ExperimentApi$DefaultImpls {
-	public static fun createExperiment (Lio/embrace/android/embracesdk/internal/api/ExperimentApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)Lio/embrace/android/embracesdk/experiments/TrackedExperiment;
 	public static synthetic fun createExperiment$default (Lio/embrace/android/embracesdk/internal/api/ExperimentApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/embrace/android/embracesdk/experiments/TrackedExperiment;
-	public static fun createFeatureFlag (Lio/embrace/android/embracesdk/internal/api/ExperimentApi;Ljava/lang/String;Ljava/lang/Long;)Lio/embrace/android/embracesdk/experiments/TrackedFeatureFlag;
 	public static synthetic fun createFeatureFlag$default (Lio/embrace/android/embracesdk/internal/api/ExperimentApi;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/embrace/android/embracesdk/experiments/TrackedFeatureFlag;
 	public static fun trackExperiment (Lio/embrace/android/embracesdk/internal/api/ExperimentApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)V
 	public static synthetic fun trackExperiment$default (Lio/embrace/android/embracesdk/internal/api/ExperimentApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)V
@@ -172,8 +170,6 @@ public abstract interface class io/embrace/android/embracesdk/internal/api/SdkAp
 public final class io/embrace/android/embracesdk/internal/api/SdkApi$DefaultImpls {
 	public static fun addLoadTraceChildSpan (Lio/embrace/android/embracesdk/internal/api/SdkApi;Landroid/app/Activity;Ljava/lang/String;JJ)V
 	public static fun addStartupTraceChildSpan (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;JJ)V
-	public static fun createExperiment (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)Lio/embrace/android/embracesdk/experiments/TrackedExperiment;
-	public static fun createFeatureFlag (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;Ljava/lang/Long;)Lio/embrace/android/embracesdk/experiments/TrackedFeatureFlag;
 	public static fun trackExperiment (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)V
 	public static fun trackFeatureFlag (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;Ljava/lang/Long;)V
 	public static fun untrackExperiment (Lio/embrace/android/embracesdk/internal/api/SdkApi;Ljava/lang/String;Ljava/lang/Long;)V

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/experiments/TrackedExperiment.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/experiments/TrackedExperiment.kt
@@ -21,9 +21,3 @@ public interface TrackedExperiment {
      */
     public val startedAt: Long?
 }
-
-internal class TrackedExperimentImpl(
-    override val id: String,
-    override val variant: String?,
-    override val startedAt: Long?,
-) : TrackedExperiment

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/experiments/TrackedFeatureFlag.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/experiments/TrackedFeatureFlag.kt
@@ -16,8 +16,3 @@ public interface TrackedFeatureFlag {
      */
     public val startedAt: Long?
 }
-
-internal class TrackedFeatureFlagImpl(
-    override val id: String,
-    override val startedAt: Long?,
-) : TrackedFeatureFlag

--- a/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/ExperimentApi.kt
+++ b/embrace-android-api/src/main/kotlin/io/embrace/android/embracesdk/internal/api/ExperimentApi.kt
@@ -1,9 +1,7 @@
 package io.embrace.android.embracesdk.internal.api
 
 import io.embrace.android.embracesdk.experiments.TrackedExperiment
-import io.embrace.android.embracesdk.experiments.TrackedExperimentImpl
 import io.embrace.android.embracesdk.experiments.TrackedFeatureFlag
-import io.embrace.android.embracesdk.experiments.TrackedFeatureFlagImpl
 
 /**
  * The public API used to track experiment and feature-flag state on a given device for the current app instance. IDs are unique within
@@ -16,8 +14,7 @@ public interface ExperimentApi {
      * Creates a [TrackedExperiment] with an optional [variant] and a timestamp [startedAt] in milliseconds from epoch observed from
      * the client-side that denotes when the experiment variant was first applied.
      */
-    public fun createExperiment(id: String, variant: String? = null, startedAt: Long? = null): TrackedExperiment =
-        TrackedExperimentImpl(id, variant, startedAt)
+    public fun createExperiment(id: String, variant: String? = null, startedAt: Long? = null): TrackedExperiment
 
     /**
      * Tracks a single experiment membership that this app instance has been bucketed into. A null [startedAt] means the time at which
@@ -48,8 +45,7 @@ public interface ExperimentApi {
      * Creates a [TrackedFeatureFlag] with an optional timestamp [startedAt] in milliseconds from epoch observed from the client-side
      * that denotes when the flag was first applied.
      */
-    public fun createFeatureFlag(id: String, startedAt: Long? = null): TrackedFeatureFlag =
-        TrackedFeatureFlagImpl(id, startedAt)
+    public fun createFeatureFlag(id: String, startedAt: Long? = null): TrackedFeatureFlag
 
     /**
      * Tracks a single enabled feature flag that applies to this app instance. A null [startedAt] means the time at which this call

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExperimentApiDelegate.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExperimentApiDelegate.kt
@@ -27,6 +27,9 @@ internal class ExperimentApiDelegate(
     private val pendingEvents = ConcurrentLinkedQueue<PendingEvent>()
     private val bufferedEntryCount = AtomicInteger(0)
 
+    override fun createExperiment(id: String, variant: String?, startedAt: Long?): TrackedExperiment =
+        TrackedExperimentImpl(id, variant, startedAt)
+
     override fun trackExperiments(experiments: List<TrackedExperiment>) {
         track("track_experiment", experiments.map { it.toData() })
     }
@@ -34,6 +37,9 @@ internal class ExperimentApiDelegate(
     override fun untrackExperiments(ids: List<String>, endedAt: Long?) {
         untrack("untrack_experiment", ExperimentKind.EXPERIMENT, ids, endedAt ?: now())
     }
+
+    override fun createFeatureFlag(id: String, startedAt: Long?): TrackedFeatureFlag =
+        TrackedFeatureFlagImpl(id, startedAt)
 
     override fun trackFeatureFlags(flags: List<TrackedFeatureFlag>) {
         track("track_feature_flag", flags.map { it.toData() })

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/TrackedExperimentImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/TrackedExperimentImpl.kt
@@ -1,0 +1,9 @@
+package io.embrace.android.embracesdk.internal.api.delegate
+
+import io.embrace.android.embracesdk.experiments.TrackedExperiment
+
+internal class TrackedExperimentImpl(
+    override val id: String,
+    override val variant: String?,
+    override val startedAt: Long?,
+) : TrackedExperiment

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/TrackedFeatureFlagImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/TrackedFeatureFlagImpl.kt
@@ -1,0 +1,8 @@
+package io.embrace.android.embracesdk.internal.api.delegate
+
+import io.embrace.android.embracesdk.experiments.TrackedFeatureFlag
+
+internal class TrackedFeatureFlagImpl(
+    override val id: String,
+    override val startedAt: Long?,
+) : TrackedFeatureFlag


### PR DESCRIPTION
## Goal

Addresses some feedback on the experiments API that was left in individual PRs that have since been merged down. Specifically, implementation details should remain out of `embrace-android-api`, and the experiment service has been altered for thread-safety.