### PR TITLE
Create session part writer

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
@@ -11,7 +11,7 @@ import io.embrace.android.embracesdk.internal.session.orchestrator.OrchestratorB
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionOrchestrator
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionOrchestratorImpl
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionPartSpanAttrPopulatorImpl
-import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectoryStore
+import io.embrace.android.embracesdk.internal.session.orchestrator.SessionPartWriterImpl
 import io.embrace.android.embracesdk.internal.worker.Worker
 
 class UserSessionOrchestrationModuleImpl(
@@ -57,13 +57,15 @@ class UserSessionOrchestrationModuleImpl(
             payloadSourceModule.metadataService,
         )
 
-        val sessionPartDirectoryStore = SessionPartDirectoryStore(
+        val sessionPartWriter = SessionPartWriterImpl(
             StorageLocation.SESSION_SPLIT.asFile(
                 logger = initModule.logger,
                 rootDirSupplier = { coreModule.context.filesDir },
                 fallbackDirSupplier = { coreModule.context.cacheDir },
             ),
             workerThreadModule.backgroundWorker(Worker.Background.SessionPersistenceWorker),
+            configService,
+            initModule.uuidSource,
             initModule.clock,
             initModule.logger,
         )
@@ -87,7 +89,7 @@ class UserSessionOrchestrationModuleImpl(
             workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker),
             initModule.uuidSource,
             initModule.startupClassifier,
-            sessionPartDirectoryStore,
+            sessionPartWriter,
         )
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -28,8 +28,6 @@ import io.embrace.android.embracesdk.internal.session.UserSessionState
 import io.embrace.android.embracesdk.internal.session.UserSessionState.Active
 import io.embrace.android.embracesdk.internal.session.id.SessionPartTracker
 import io.embrace.android.embracesdk.internal.session.message.PayloadFactory
-import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectory
-import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectoryStore
 import io.embrace.android.embracesdk.internal.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.store.Ordinal
 import io.embrace.android.embracesdk.internal.store.OrdinalStore
@@ -63,7 +61,7 @@ internal class SessionOrchestratorImpl(
     private val backgroundWorker: BackgroundWorker,
     private val uuidSource: UuidSource,
     private val startupClassifier: StartupClassifier,
-    private val sessionPartDirectoryStore: SessionPartDirectoryStore?,
+    private val sessionPartWriter: SessionPartWriter?,
 ) : SessionOrchestrator {
 
     /**
@@ -419,7 +417,11 @@ internal class SessionOrchestratorImpl(
                         if (transitionType != TransitionType.CRASH) {
                             // create the directory that holds this session part's telemetry
                             EmbTrace.trace("create-session-part-dir") {
-                                createSessionPartDirectory(newSessionPart, userSession, timestamp)
+                                sessionPartWriter?.onSessionPartStarted(
+                                    timestamp = timestamp,
+                                    userSessionId = userSession?.userSessionId ?: "",
+                                    sessionPartId = newSessionPart.sessionPartId,
+                                )
                             }
 
                             // initiate periodic caching of the payload if a new session has started
@@ -556,28 +558,6 @@ internal class SessionOrchestratorImpl(
         return ordinalStore.incrementAndGet(Ordinal.SESSION_PART) {
             currentUserSession()?.userSessionNumber?.toInt() ?: 1
         }
-    }
-
-    /**
-     * Creates the directory that holds the telemetry for a newly started session part, if the
-     * multi-file persistence layer is enabled.
-     */
-    private fun createSessionPartDirectory(
-        newSessionPart: SessionPartToken,
-        userSession: UserSessionMetadata?,
-        timestamp: Long,
-    ) {
-        if (!configService.persistenceBehavior.isMultiFilePersistenceEnabled()) {
-            return
-        }
-        sessionPartDirectoryStore?.create(
-            SessionPartDirectory(
-                timestamp = timestamp,
-                uuid = uuidSource.createUuid(),
-                userSessionId = userSession?.userSessionId ?: "",
-                sessionPartId = newSessionPart.sessionPartId,
-            ),
-        )
     }
 
     private fun processEndMessage(envelope: Envelope<SessionPartPayload>?, transitionType: TransitionType) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriter.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriter.kt
@@ -1,0 +1,12 @@
+package io.embrace.android.embracesdk.internal.session.orchestrator
+
+/**
+ * Writes the telemetry for the active session part to its own directory on disk.
+ */
+interface SessionPartWriter {
+
+    /**
+     * A new session part has started. Creates the directory that holds its telemetry.
+     */
+    fun onSessionPartStarted(timestamp: Long, userSessionId: String, sessionPartId: String)
+}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -1,0 +1,51 @@
+package io.embrace.android.embracesdk.internal.session.orchestrator
+
+import io.embrace.android.embracesdk.internal.clock.Clock
+import io.embrace.android.embracesdk.internal.config.ConfigService
+import io.embrace.android.embracesdk.internal.logging.InternalLogger
+import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectory
+import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectoryStore
+import io.embrace.android.embracesdk.internal.utils.UuidSource
+import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import java.io.File
+
+/**
+ * Writes session part telemetry to disk, if the multi-file persistence layer is enabled.
+ * All filesystem work is queued on a single-threaded [worker].
+ */
+class SessionPartWriterImpl(
+    sessionsDir: Lazy<File>,
+    private val worker: BackgroundWorker,
+    private val configService: ConfigService,
+    private val uuidSource: UuidSource,
+    clock: Clock,
+    logger: InternalLogger,
+) : SessionPartWriter {
+
+    /**
+     * The directory that telemetry is currently written to. Only ever touched on [worker], so that
+     * a write always targets the session part it was queued for rather than a later one.
+     */
+    @Volatile
+    private var activeDirectory: SessionPartDirectory? = null
+
+    private val directoryStore = SessionPartDirectoryStore(sessionsDir, worker, clock, logger)
+
+    override fun onSessionPartStarted(timestamp: Long, userSessionId: String, sessionPartId: String) {
+        if (!enabled()) {
+            return
+        }
+        val directory = SessionPartDirectory(
+            timestamp = timestamp,
+            uuid = uuidSource.createUuid(),
+            userSessionId = userSessionId,
+            sessionPartId = sessionPartId,
+        )
+        directoryStore.create(directory)
+        worker.submit {
+            activeDirectory = directory
+        }
+    }
+
+    private fun enabled(): Boolean = configService.persistenceBehavior.isMultiFilePersistenceEnabled()
+}

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -49,7 +49,6 @@ import io.embrace.android.embracesdk.internal.session.id.SessionPartTracker
 import io.embrace.android.embracesdk.internal.session.id.SessionPartTrackerImpl
 import io.embrace.android.embracesdk.internal.session.message.PayloadFactoryImpl
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectory
-import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectoryStore
 import io.embrace.android.embracesdk.internal.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.store.KeyValueStoreEditor
 import io.embrace.android.embracesdk.internal.store.OrdinalStore
@@ -1155,9 +1154,11 @@ internal class SessionOrchestratorTest {
             BackgroundWorker(inactivityWorkerExecutor),
             TestUuidSource(),
             startupClassifier,
-            SessionPartDirectoryStore(
+            SessionPartWriterImpl(
                 lazy { sessionsDir },
                 BackgroundWorker(sessionPersistenceExecutor),
+                configService,
+                TestUuidSource(),
                 clock,
                 logger,
             ),

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
@@ -1,0 +1,126 @@
+package io.embrace.android.embracesdk.internal.session.orchestrator
+
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
+import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
+import io.embrace.android.embracesdk.fakes.TestUuidSource
+import io.embrace.android.embracesdk.fakes.createPersistenceBehavior
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectory
+import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+internal class SessionPartWriterImplTest {
+
+    private companion object {
+        private const val USER_SESSION_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        private const val SESSION_PART_ID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        private const val OTHER_SESSION_PART_ID = "cccccccccccccccccccccccccccccccc"
+    }
+
+    @get:Rule
+    val tempFolder: TemporaryFolder = TemporaryFolder()
+
+    private lateinit var sessionsDir: File
+    private lateinit var clock: FakeClock
+    private lateinit var executor: BlockingScheduledExecutorService
+    private lateinit var logger: FakeInternalLogger
+
+    @Before
+    fun setUp() {
+        sessionsDir = tempFolder.newFolder("embrace_sessions_split")
+        clock = FakeClock()
+        executor = BlockingScheduledExecutorService(clock, true)
+        logger = FakeInternalLogger(throwOnInternalError = false)
+    }
+
+    @Test
+    fun `a session part start creates a directory holding the metadata`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+
+        val directory = sessionPartDirs().single()
+        assertEquals(clock.now(), directory.timestamp)
+        assertEquals(USER_SESSION_ID, directory.userSessionId)
+        assertEquals(SESSION_PART_ID, directory.sessionPartId)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `each session part gets its own directory`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+
+        clock.tick(10000)
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, OTHER_SESSION_PART_ID)
+
+        val directories = sessionPartDirs()
+        assertEquals(listOf(SESSION_PART_ID, OTHER_SESSION_PART_ID), directories.map { it.sessionPartId })
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a queued write targets the session part it was queued for`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+
+        // start another part before the worker has had a chance to create the first directory
+        clock.tick(10000)
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, OTHER_SESSION_PART_ID)
+
+        val directories = sessionPartDirs()
+        assertEquals(listOf(SESSION_PART_ID, OTHER_SESSION_PART_ID), directories.map { it.sessionPartId })
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `nothing is written when multi file persistence is disabled`() {
+        val writer = createWriter(enabled = false)
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+
+        assertEquals(emptyList<SessionPartDirectory>(), sessionPartDirs())
+        assertNoInternalErrors()
+    }
+
+    private fun createWriter(enabled: Boolean = true) = SessionPartWriterImpl(
+        lazy { sessionsDir },
+        BackgroundWorker(executor),
+        configService(enabled),
+        TestUuidSource(),
+        clock,
+        logger,
+    )
+
+    private fun configService(enabled: Boolean) = FakeConfigService(
+        persistenceBehavior = when {
+            enabled -> createPersistenceBehavior(remoteCfg = RemoteConfig(pctMultiFilePersistenceEnabled = 100.0f))
+            else -> createPersistenceBehavior()
+        },
+    )
+
+    private fun drain() {
+        executor.runCurrentlyBlocked()
+    }
+
+    /**
+     * Drains the session persistence worker and returns the session part directories on disk, in
+     * the order they will be delivered.
+     */
+    private fun sessionPartDirs(): List<SessionPartDirectory> {
+        drain()
+        return (sessionsDir.list() ?: emptyArray())
+            .mapNotNull(SessionPartDirectory::fromDirName)
+            .sortedWith(SessionPartDirectory.comparator)
+    }
+
+    private fun assertNoInternalErrors() {
+        assertEquals(emptyList<FakeInternalLogger.LogMessage>(), logger.internalErrorMessages)
+    }
+}


### PR DESCRIPTION
## Goal

Extracts code added in #3854 to `SessionPartWriter`, which will be used to encapsulate all operations that write telemetry for the current session part.

## Testing

Added unit tests
