### PR TITLE
Write metadata file in session part directory

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/user/EmbraceUserService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/user/EmbraceUserService.kt
@@ -190,7 +190,11 @@ internal class EmbraceUserService(
         synchronized(userInfoReference) {
             userInfoReference.set(newUserInfo)
         }
-        listeners.forEach { it() }
+        listeners.forEach { listener ->
+            runCatching(listener).onFailure {
+                logger.trackInternalError(InternalErrorType.UserInfoCallbackFail, it)
+            }
+        }
     }
 
     /**

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModule.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModule.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.injection
 import io.embrace.android.embracesdk.internal.capture.metadata.MetadataService
 import io.embrace.android.embracesdk.internal.capture.metadata.RnBundleIdTracker
 import io.embrace.android.embracesdk.internal.envelope.log.LogEnvelopeSource
+import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadataSource
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.envelope.resource.EnvelopeResourceSource
 import io.embrace.android.embracesdk.internal.envelope.session.SessionPartEnvelopeSource
@@ -19,4 +20,5 @@ interface PayloadSourceModule {
     val rnBundleIdTracker: RnBundleIdTracker
     val payloadResurrectionService: PayloadResurrectionService?
     val resourceSource: EnvelopeResourceSource
+    val envelopeMetadataSource: EnvelopeMetadataSource
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
@@ -12,6 +12,7 @@ import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.envelope.log.LogEnvelopeSource
 import io.embrace.android.embracesdk.internal.envelope.log.LogEnvelopeSourceImpl
 import io.embrace.android.embracesdk.internal.envelope.log.LogPayloadSourceImpl
+import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadataSource
 import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadataSourceImpl
 import io.embrace.android.embracesdk.internal.envelope.metadata.FlutterSdkVersionInfo
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
@@ -97,15 +98,15 @@ class PayloadSourceModuleImpl(
         )
     }
 
-    private val metadataSource = EmbTrace.trace("metadata-source") {
+    override val envelopeMetadataSource: EnvelopeMetadataSource = EmbTrace.trace("metadata-source") {
         EnvelopeMetadataSourceImpl { essentialServiceModule.userService.getUserInfo() }
     }
 
     override val sessionPartEnvelopeSource: SessionPartEnvelopeSource =
-        SessionPartEnvelopeSourceImpl(metadataSource, resourceSource, partPayloadSource)
+        SessionPartEnvelopeSourceImpl(envelopeMetadataSource, resourceSource, partPayloadSource)
 
     override val logEnvelopeSource: LogEnvelopeSource =
-        LogEnvelopeSourceImpl(metadataSource, resourceSource, logPayloadSource, deliveryModule?.cachedLogEnvelopeStore)
+        LogEnvelopeSourceImpl(envelopeMetadataSource, resourceSource, logPayloadSource, deliveryModule?.cachedLogEnvelopeStore)
 
     override val metadataService: MetadataService = EmbTrace.trace("metadata-service-init") {
         EmbraceMetadataService(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
@@ -68,7 +68,9 @@ class UserSessionOrchestrationModuleImpl(
             initModule.uuidSource,
             initModule.clock,
             initModule.logger,
+            payloadSourceModule.envelopeMetadataSource,
         )
+        essentialServiceModule.userService.addUserInfoListener(sessionPartWriter::onUserInfoChanged)
 
         SessionOrchestratorImpl(
             essentialServiceModule.processStateTracker,

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriter.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriter.kt
@@ -9,4 +9,9 @@ interface SessionPartWriter {
      * A new session part has started. Creates the directory that holds its telemetry.
      */
     fun onSessionPartStarted(timestamp: Long, userSessionId: String, sessionPartId: String)
+
+    /**
+     * User information has changed and should be persisted.
+     */
+    fun onUserInfoChanged()
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -2,50 +2,78 @@ package io.embrace.android.embracesdk.internal.session.orchestrator
 
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.config.ConfigService
+import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadataSource
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
+import io.embrace.android.embracesdk.internal.session.persistence.SessionMetadataWriter
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectory
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectoryStore
 import io.embrace.android.embracesdk.internal.utils.UuidSource
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import java.io.File
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Writes session part telemetry to disk, if the multi-file persistence layer is enabled.
  * All filesystem work is queued on a single-threaded [worker].
  */
 class SessionPartWriterImpl(
-    sessionsDir: Lazy<File>,
+    private val sessionsDir: Lazy<File>,
     private val worker: BackgroundWorker,
     private val configService: ConfigService,
     private val uuidSource: UuidSource,
     clock: Clock,
-    logger: InternalLogger,
+    private val logger: InternalLogger,
+    private val metadataSource: EnvelopeMetadataSource,
 ) : SessionPartWriter {
 
     /**
-     * The directory that telemetry is currently written to. Only ever touched on [worker], so that
-     * a write always targets the session part it was queued for rather than a later one.
+     * The writers for the session part that telemetry is currently written to. Each targets one
+     * fixed directory, so a write that was queued for a session part cannot land in a later one.
      */
-    @Volatile
-    private var activeDirectory: SessionPartDirectory? = null
-
+    private val current = AtomicReference<PartWriters?>(null)
     private val directoryStore = SessionPartDirectoryStore(sessionsDir, worker, clock, logger)
 
     override fun onSessionPartStarted(timestamp: Long, userSessionId: String, sessionPartId: String) {
         if (!enabled()) {
+            current.set(null)
             return
         }
-        val directory = SessionPartDirectory(
-            timestamp = timestamp,
-            uuid = uuidSource.createUuid(),
-            userSessionId = userSessionId,
-            sessionPartId = sessionPartId,
+        val writers = PartWriters(
+            SessionPartDirectory(
+                timestamp = timestamp,
+                uuid = uuidSource.createUuid(),
+                userSessionId = userSessionId,
+                sessionPartId = sessionPartId,
+            ),
         )
-        directoryStore.create(directory)
+
+        current.set(writers)
+        directoryStore.create(writers.directory)
+        queueMetadataWrite(writers)
+    }
+
+    override fun onUserInfoChanged() {
+        if (!enabled()) {
+            return
+        }
+        queueMetadataWrite(current.get() ?: return)
+    }
+
+    private fun queueMetadataWrite(writers: PartWriters) {
         worker.submit {
-            activeDirectory = directory
+            writers.metadata.write()
         }
     }
 
     private fun enabled(): Boolean = configService.persistenceBehavior.isMultiFilePersistenceEnabled()
+
+    private inner class PartWriters(val directory: SessionPartDirectory) {
+
+        val metadata = SessionMetadataWriter(
+            sessionsDir = sessionsDir,
+            sessionPartDirectorySource = { directory },
+            metadataSource = metadataSource::getEnvelopeMetadata,
+            logger = logger,
+        )
+    }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -10,7 +10,6 @@ import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDir
 import io.embrace.android.embracesdk.internal.utils.UuidSource
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import java.io.File
-import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Writes session part telemetry to disk, if the multi-file persistence layer is enabled.
@@ -30,12 +29,14 @@ class SessionPartWriterImpl(
      * The writers for the session part that telemetry is currently written to. Each targets one
      * fixed directory, so a write that was queued for a session part cannot land in a later one.
      */
-    private val current = AtomicReference<PartWriters?>(null)
+    @Volatile
+    private var current: PartWriters? = null
+
     private val directoryStore = SessionPartDirectoryStore(sessionsDir, worker, clock, logger)
 
     override fun onSessionPartStarted(timestamp: Long, userSessionId: String, sessionPartId: String) {
         if (!enabled()) {
-            current.set(null)
+            current = null
             return
         }
         val writers = PartWriters(
@@ -47,7 +48,7 @@ class SessionPartWriterImpl(
             ),
         )
 
-        current.set(writers)
+        current = writers
         directoryStore.create(writers.directory)
         queueMetadataWrite(writers)
     }
@@ -56,7 +57,7 @@ class SessionPartWriterImpl(
         if (!enabled()) {
             return
         }
-        queueMetadataWrite(current.get() ?: return)
+        queueMetadataWrite(current ?: return)
     }
 
     private fun queueMetadataWrite(writers: PartWriters) {

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionPartSpan
 import io.embrace.android.embracesdk.fakes.FakeDataSource
+import io.embrace.android.embracesdk.fakes.FakeEnvelopeMetadataSource
 import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakeKeyValueStore
 import io.embrace.android.embracesdk.fakes.FakeLogEnvelopeSource
@@ -1161,6 +1162,7 @@ internal class SessionOrchestratorTest {
                 TestUuidSource(),
                 clock,
                 logger,
+                FakeEnvelopeMetadataSource(),
             ),
         ).apply {
             start()

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterBoundaryTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterBoundaryTest.kt
@@ -1,0 +1,156 @@
+package io.embrace.android.embracesdk.internal.session.orchestrator
+
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
+import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
+import io.embrace.android.embracesdk.fakes.TestUuidSource
+import io.embrace.android.embracesdk.fakes.createPersistenceBehavior
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
+import io.embrace.android.embracesdk.internal.session.persistence.EnvelopeMetadataProto
+import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectory
+import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * Covers what happens to session part telemetry that is queued for writing before a session part
+ * ends, but which executes after the next session part has begun.
+ */
+internal class SessionPartWriterBoundaryTest {
+
+    private companion object {
+        private const val USER_SESSION_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        private const val FIRST_PART_ID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        private const val SECOND_PART_ID = "cccccccccccccccccccccccccccccccc"
+        private const val METADATA_FILE_NAME = "metadata.pb"
+    }
+
+    @get:Rule
+    val tempFolder: TemporaryFolder = TemporaryFolder()
+
+    private lateinit var sessionsDir: File
+    private lateinit var clock: FakeClock
+    private lateinit var executor: BlockingScheduledExecutorService
+    private lateinit var logger: FakeInternalLogger
+    private lateinit var writer: SessionPartWriter
+    private var writeCount = 0
+
+    @Before
+    fun setUp() {
+        sessionsDir = tempFolder.newFolder("embrace_sessions_split")
+        clock = FakeClock()
+        executor = BlockingScheduledExecutorService(clock, true)
+        logger = FakeInternalLogger(throwOnInternalError = false)
+        writeCount = 0
+        writer = SessionPartWriterImpl(
+            lazy { sessionsDir },
+            BackgroundWorker(executor),
+            FakeConfigService(
+                persistenceBehavior = createPersistenceBehavior(
+                    remoteCfg = RemoteConfig(pctMultiFilePersistenceEnabled = 100.0f),
+                ),
+            ),
+            TestUuidSource(),
+            clock,
+            logger,
+        ) { EnvelopeMetadata(userId = "user${writeCount++}") }
+    }
+
+    @Test
+    fun `a pending metadata write lands in the session part it was queued for`() {
+        startPart(FIRST_PART_ID)
+        drain()
+        assertEquals("user0", metadataIn(FIRST_PART_ID)?.user_id)
+        writer.onUserInfoChanged()
+        assertEquals("user0", metadataIn(FIRST_PART_ID)?.user_id)
+
+        // next part begins before write completed
+        startPart(SECOND_PART_ID)
+        drain()
+
+        // the queued write went to the first part
+        assertEquals("user1", metadataIn(FIRST_PART_ID)?.user_id)
+        assertEquals("user2", metadataIn(SECOND_PART_ID)?.user_id)
+        assertEquals(3, writeCount)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `several queued writes spanning a boundary all land in the session part they were queued for`() {
+        startPart(FIRST_PART_ID)
+        drain()
+        repeat(2) { writer.onUserInfoChanged() }
+        startPart(SECOND_PART_ID)
+        drain()
+
+        // both queued writes went to the first part
+        assertEquals("user2", metadataIn(FIRST_PART_ID)?.user_id)
+        assertEquals("user3", metadataIn(SECOND_PART_ID)?.user_id)
+        assertEquals(4, writeCount)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a user info change after a boundary targets the new session part`() {
+        startPart(FIRST_PART_ID)
+        drain()
+        startPart(SECOND_PART_ID)
+        drain()
+
+        writer.onUserInfoChanged()
+        drain()
+
+        assertEquals("user0", metadataIn(FIRST_PART_ID)?.user_id)
+        assertEquals("user2", metadataIn(SECOND_PART_ID)?.user_id)
+        assertEquals(3, writeCount)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a pending metadata write for a deleted session part is reported and does not stop the new part`() {
+        startPart(FIRST_PART_ID)
+        drain()
+        writer.onUserInfoChanged()
+        File(sessionsDir, dirFor(FIRST_PART_ID).dirName).deleteRecursively()
+
+        startPart(SECOND_PART_ID)
+        drain()
+        assertEquals(listOf("SessionMetadataWriteFail"), logger.internalErrorMessages.map { it.msg })
+        assertEquals("user1", metadataIn(SECOND_PART_ID)?.user_id)
+        assertEquals(2, writeCount)
+    }
+
+    private fun startPart(sessionPartId: String) {
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, sessionPartId)
+    }
+
+    private fun drain() {
+        executor.runCurrentlyBlocked()
+    }
+
+    private fun sessionPartDirs(): List<SessionPartDirectory> =
+        (sessionsDir.list() ?: emptyArray())
+            .mapNotNull(SessionPartDirectory::fromDirName)
+            .sortedWith(SessionPartDirectory.comparator)
+
+    private fun dirFor(sessionPartId: String): SessionPartDirectory =
+        sessionPartDirs().single { it.sessionPartId == sessionPartId }
+
+    private fun metadataIn(sessionPartId: String): EnvelopeMetadataProto? =
+        partFile(sessionPartId, METADATA_FILE_NAME)
+            ?.inputStream()
+            ?.use(EnvelopeMetadataProto.ADAPTER::decode)
+
+    private fun partFile(sessionPartId: String, fileName: String): File? =
+        File(File(sessionsDir, dirFor(sessionPartId).dirName), fileName).takeIf(File::isFile)
+
+    private fun assertNoInternalErrors() {
+        assertEquals(emptyList<FakeInternalLogger.LogMessage>(), logger.internalErrorMessages)
+    }
+}

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
@@ -7,6 +7,9 @@ import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.TestUuidSource
 import io.embrace.android.embracesdk.fakes.createPersistenceBehavior
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadataSource
+import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
+import io.embrace.android.embracesdk.internal.session.persistence.EnvelopeMetadataProto
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectory
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import org.junit.Assert.assertEquals
@@ -22,6 +25,7 @@ internal class SessionPartWriterImplTest {
         private const val USER_SESSION_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         private const val SESSION_PART_ID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         private const val OTHER_SESSION_PART_ID = "cccccccccccccccccccccccccccccccc"
+        private const val METADATA_FILE_NAME = "metadata.pb"
     }
 
     @get:Rule
@@ -32,12 +36,16 @@ internal class SessionPartWriterImplTest {
     private lateinit var executor: BlockingScheduledExecutorService
     private lateinit var logger: FakeInternalLogger
 
+    private var writeCount = 0
+    private val metadataSource = EnvelopeMetadataSource { EnvelopeMetadata(userId = "user${writeCount++}") }
+
     @Before
     fun setUp() {
         sessionsDir = tempFolder.newFolder("embrace_sessions_split")
         clock = FakeClock()
         executor = BlockingScheduledExecutorService(clock, true)
         logger = FakeInternalLogger(throwOnInternalError = false)
+        writeCount = 0
     }
 
     @Test
@@ -89,13 +97,116 @@ internal class SessionPartWriterImplTest {
         assertNoInternalErrors()
     }
 
-    private fun createWriter(enabled: Boolean = true) = SessionPartWriterImpl(
+    @Test
+    fun `metadata is written as soon as a session part starts`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+
+        assertEquals("user0", metadataIn(SESSION_PART_ID)?.user_id)
+        assertEquals(1, writeCount)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a user info change rewrites the metadata on the worker`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+        writer.onUserInfoChanged()
+        assertEquals("user0", metadataOnDisk(SESSION_PART_ID)?.user_id)
+
+        drain()
+        assertEquals("user1", metadataIn(SESSION_PART_ID)?.user_id)
+        assertEquals(2, writeCount)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `every user info change rewrites the metadata`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+
+        repeat(4) { writer.onUserInfoChanged() }
+        drain()
+
+        assertEquals("user4", metadataIn(SESSION_PART_ID)?.user_id)
+        assertEquals(5, writeCount)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a user info change is not queued when multi file persistence is disabled`() {
+        val writer = createWriter(enabled = false)
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        writer.onUserInfoChanged()
+        assertEquals(0, executor.submitCount)
+        assertEquals(0, writeCount)
+    }
+
+    @Test
+    fun `a user info change before any session part starts writes nothing`() {
+        val writer = createWriter()
+        writer.onUserInfoChanged()
+        assertEquals(emptyList<SessionPartDirectory>(), sessionPartDirs())
+        assertEquals(0, writeCount)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `nothing more is written to a session part once multi file persistence is disabled`() {
+        val configService = configService(enabled = true)
+        val writer = createWriter(configService = configService)
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+
+        configService.persistenceBehavior = createPersistenceBehavior()
+        clock.tick(10000)
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, OTHER_SESSION_PART_ID)
+        drain()
+        writer.onUserInfoChanged()
+        drain()
+
+        assertEquals(listOf(SESSION_PART_ID), sessionPartDirs().map { it.sessionPartId })
+        assertEquals("user0", metadataIn(SESSION_PART_ID)?.user_id)
+        assertEquals(1, writeCount)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a session part directory that cannot be created is reported and nothing is written`() {
+        val writer = createWriter(sessionsDir = tempFolder.newFile("not_a_dir"))
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+
+        assertEquals(
+            listOf("SessionPartDirectoryStoreFail", "SessionMetadataWriteFail"),
+            logger.internalErrorMessages.map { it.msg },
+        )
+
+        writer.onUserInfoChanged()
+        drain()
+
+        assertEquals(
+            listOf("SessionPartDirectoryStoreFail", "SessionMetadataWriteFail", "SessionMetadataWriteFail"),
+            logger.internalErrorMessages.map { it.msg },
+        )
+        assertEquals(0, writeCount)
+    }
+
+    private fun createWriter(
+        enabled: Boolean = true,
+        configService: FakeConfigService = configService(enabled),
+        sessionsDir: File = this.sessionsDir,
+    ) = SessionPartWriterImpl(
         lazy { sessionsDir },
         BackgroundWorker(executor),
-        configService(enabled),
+        configService,
         TestUuidSource(),
         clock,
         logger,
+        metadataSource,
     )
 
     private fun configService(enabled: Boolean) = FakeConfigService(
@@ -115,9 +226,26 @@ internal class SessionPartWriterImplTest {
      */
     private fun sessionPartDirs(): List<SessionPartDirectory> {
         drain()
-        return (sessionsDir.list() ?: emptyArray())
+        return partDirs()
+    }
+
+    private fun partDirs(): List<SessionPartDirectory> =
+        (sessionsDir.list() ?: emptyArray())
             .mapNotNull(SessionPartDirectory::fromDirName)
             .sortedWith(SessionPartDirectory.comparator)
+
+    private fun metadataIn(sessionPartId: String): EnvelopeMetadataProto? {
+        drain()
+        return metadataOnDisk(sessionPartId)
+    }
+
+    private fun metadataOnDisk(sessionPartId: String): EnvelopeMetadataProto? {
+        val directory = partDirs().single { it.sessionPartId == sessionPartId }
+        val file = File(File(sessionsDir, directory.dirName), METADATA_FILE_NAME)
+        return when {
+            file.isFile -> file.inputStream().use(EnvelopeMetadataProto.ADAPTER::decode)
+            else -> null
+        }
     }
 
     private fun assertNoInternalErrors() {

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/InternalErrorType.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/InternalErrorType.kt
@@ -52,5 +52,6 @@ sealed class InternalErrorType(private val severity: Severity) {
     object ClockBackwardsShift : InternalErrorType(ERROR)
     object NavControllerTrackingFail : InternalErrorType(ERROR)
     object UserSessionCallbackFail : InternalErrorType(ERROR)
+    object UserInfoCallbackFail : InternalErrorType(ERROR)
     object HttpRequestInfoModifierFail : InternalErrorType(Severity.WARNING)
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeUserService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeUserService.kt
@@ -17,6 +17,10 @@ class FakeUserService : UserService {
 
     override fun clearAllUserInfo() {
         clearedCount += 1
+        clearUserIdentifier()
+        clearUserEmail()
+        clearUsername()
+        clearAllUserPersonas()
     }
 
     override fun loadUserInfoFromDisk(): UserInfo {
@@ -25,41 +29,54 @@ class FakeUserService : UserService {
 
     override fun setUserIdentifier(userId: String?) {
         id = userId
+        notifyUserInfoChanged()
     }
 
     override fun clearUserIdentifier() {
         id = null
+        notifyUserInfoChanged()
     }
 
     override fun setUserEmail(email: String?) {
         this.email = email
+        notifyUserInfoChanged()
     }
 
     override fun clearUserEmail() {
         email = null
+        notifyUserInfoChanged()
     }
 
     override fun addUserPersona(persona: String?) {
         personas.add(checkNotNull(persona))
+        notifyUserInfoChanged()
     }
 
     override fun clearUserPersona(persona: String?) {
         personas.remove(checkNotNull(persona))
+        notifyUserInfoChanged()
     }
 
     override fun clearAllUserPersonas() {
         personas.clear()
+        notifyUserInfoChanged()
     }
 
     override fun setUsername(username: String?) {
         this.name = username
+        notifyUserInfoChanged()
     }
 
     override fun clearUsername() {
         this.name = null
+        notifyUserInfoChanged()
     }
 
     override fun addUserInfoListener(listener: () -> Unit) {
         listeners.add(listener)
+    }
+
+    fun notifyUserInfoChanged() {
+        listeners.forEach { it() }
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakePayloadSourceModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakePayloadSourceModule.kt
@@ -34,7 +34,7 @@ class FakePayloadSourceModule(
 ) : PayloadSourceModule {
 
     override val resourceSource = FakeEnvelopeResourceSource()
-    private val envelopeMetadataSource = FakeEnvelopeMetadataSource()
+    override val envelopeMetadataSource: FakeEnvelopeMetadataSource = FakeEnvelopeMetadataSource()
 
     override val sessionPartEnvelopeSource: SessionPartEnvelopeSource = FakeSessionPartEnvelopeSource(
         envelopeMetadataSource,


### PR DESCRIPTION
## Goal

Writes the metadata file in the current session part directory. This is written when the session part is created and when the user information changes.

The threading model is important as it currently enforces correctness - all session persistence happens on a dedicated background thread. If the session part ends before a enqueued write has happened, the enqueued write will still persist information to the correct directory.

## Testing

Added unit tests.
