### PR TITLE
Activity-leak detection as a new module

### DIFF
--- a/embrace-android-instrumentation-leaks/build.gradle.kts
+++ b/embrace-android-instrumentation-leaks/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    id("embrace-prod-android-conventions")
+}
+
+description = "Embrace Android SDK: Activity Leak Detection"
+
+android {
+    namespace = "io.embrace.android.embracesdk.instrumentation.leaks"
+}
+
+dependencies {
+    implementation(project(":embrace-android-instrumentation-api"))
+    testImplementation(project(":embrace-android-instrumentation-api-fakes"))
+    testImplementation(libs.robolectric)
+}

--- a/embrace-android-instrumentation-leaks/lint-baseline.xml
+++ b/embrace-android-instrumentation-leaks/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 9.3.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.3.1)" variant="all" version="9.3.1">
+
+</issues>

--- a/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/ActivityLeakDetectionLifecycleCallbacks.kt
+++ b/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/ActivityLeakDetectionLifecycleCallbacks.kt
@@ -1,0 +1,33 @@
+package io.embrace.android.embracesdk.instrumentation.leaks
+
+import android.app.Activity
+import android.app.Application
+import android.os.Build
+import android.os.Bundle
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsSnapshot
+
+internal class ActivityLeakDetectionLifecycleCallbacks(
+    private val leakDetector: LeakDetector,
+    private val activeSessionIdsProvider: () -> SessionIdsSnapshot,
+) : Application.ActivityLifecycleCallbacks {
+
+    override fun onActivityPreCreated(activity: Activity, savedInstanceState: Bundle?) {
+        leakDetector.trackOpened(activity)
+    }
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            leakDetector.trackOpened(activity)
+        }
+    }
+
+    override fun onActivityDestroyed(activity: Activity) {
+        leakDetector.trackClosed(activity, activeSessionIdsProvider())
+    }
+
+    override fun onActivityPaused(activity: Activity) = Unit
+    override fun onActivityResumed(activity: Activity) = Unit
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+    override fun onActivityStarted(activity: Activity) = Unit
+    override fun onActivityStopped(activity: Activity) = Unit
+}

--- a/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetectionDataSource.kt
+++ b/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetectionDataSource.kt
@@ -1,0 +1,34 @@
+package io.embrace.android.embracesdk.instrumentation.leaks
+
+import android.app.Application
+import io.embrace.android.embracesdk.internal.arch.InstrumentationArgs
+import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceImpl
+import io.embrace.android.embracesdk.internal.arch.limits.UpToLimitStrategy
+
+class LeakDetectionDataSource(args: InstrumentationArgs) : DataSourceImpl(
+    args,
+    limitStrategy = UpToLimitStrategy { MAX_LEAK_DETECTION },
+    "leak-detection",
+) {
+    companion object {
+        const val MAX_LEAK_DETECTION = 100
+    }
+
+    private val application: Application = args.application
+
+    // TODO: query leakDetector.suspects() (e.g. from a SessionPartEndListener.onPreSessionEnd()) and encode the dataset into
+    // a session attribute. Each entry already carries how many GC cycles it has survived since being confirmed.
+    private val leakDetector = LeakDetector(args.clock)
+
+    private val callbacks = ActivityLeakDetectionLifecycleCallbacks(leakDetector, args::activeSessionIds)
+
+    override fun onDataCaptureEnabled() {
+        application.registerActivityLifecycleCallbacks(callbacks)
+        leakDetector.start()
+    }
+
+    override fun onDataCaptureDisabled() {
+        application.unregisterActivityLifecycleCallbacks(callbacks)
+        leakDetector.stop()
+    }
+}

--- a/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetectionInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetectionInstrumentationProvider.kt
@@ -1,0 +1,22 @@
+package io.embrace.android.embracesdk.instrumentation.leaks
+
+import android.os.Build
+import io.embrace.android.embracesdk.internal.arch.InstrumentationArgs
+import io.embrace.android.embracesdk.internal.arch.InstrumentationProvider
+import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
+
+/**
+ * SPI entry point for Activity leak detection. Registers nothing below API 23, since GC cycle tracking relies on the
+ * runtime stat `Debug.getRuntimeStat` only reports from that version onward.
+ */
+class LeakDetectionInstrumentationProvider : InstrumentationProvider {
+    override fun register(args: InstrumentationArgs): DataSourceState<*>? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return null
+        }
+        return DataSourceState(
+            factory = { LeakDetectionDataSource(args) },
+            configGate = { true },
+        )
+    }
+}

--- a/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetector.kt
+++ b/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetector.kt
@@ -1,0 +1,345 @@
+package io.embrace.android.embracesdk.instrumentation.leaks
+
+import android.os.Build
+import android.os.Debug
+import io.embrace.android.embracesdk.internal.clock.Clock
+import java.lang.ref.PhantomReference
+import java.lang.ref.Reference
+import java.lang.ref.ReferenceQueue
+import java.lang.ref.WeakReference
+import java.util.WeakHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
+
+/**
+ * Detects objects that outlive the end of their own lifecycle, and tracks how many GC cycles they go on to survive.
+ *
+ * Each tracked object is paired with a [Sentinel] allocated when its lifecycle begins and released when that lifecycle ends.
+ * The two should be reclaimed by the same collection, so a collection that reclaims the sentinel could have reclaimed the
+ * tracked object as well. Collections may be region-targeted, so the number of collections an object survives does not
+ * establish whether it could have been collected.
+ *
+ * An object still reachable at that point is suspected rather than confirmed. It is paired with a new [Sentinel] and only
+ * confirmed as a leak if it outlives that one too, which discards objects that something else was briefly holding as the
+ * lifecycle ended, such as the framework finishing its own teardown.
+ *
+ * A confirmed leak is not reported once and forgotten - it is watched, via a [ConfirmedSuspect] registered directly on it,
+ * for as long as it remains reachable. [suspects] reports how many GC cycles each one has survived since being confirmed,
+ * using [currentGcCycleCount] - a single shared reading, so that a suspect only needs to remember its own cycle count at
+ * confirmation rather than being ticked on every cycle itself. A suspect that eventually gets collected is simply
+ * discarded, since a [ConfirmedSuspect] is watched by the same queue as everything else here.
+ *
+ * The caller decides what the start and end of a lifecycle mean. Use [trackOpened] and [trackClosed] to mark them, and [start]
+ * and [stop] to control the thread that drains the queue.
+ */
+internal class LeakDetector(
+    private val clock: Clock,
+    // guarded here (rather than relying on LeakDetectionInstrumentationProvider never constructing this class below API
+    // 23) so that lint's own NewApi check, which can't trace that guard through a lazily-invoked factory in another
+    // file, can see it too
+    private val gcCycleCountReader: () -> String? = {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            Debug.getRuntimeStat(ART_GC_COUNT_STAT)
+        } else {
+            null
+        }
+    },
+) {
+    private val queue = ReferenceQueue<Any>()
+
+    /**
+     * The last cycle count successfully read from [gcCycleCountReader]. Falls back to this if a read returns null or
+     * something unparsable, rather than reporting zero, so that a single transient failure cannot make the count appear
+     * to go backwards. Starts at zero until the first successful read.
+     */
+    @Volatile
+    private var lastKnownGcCycleCount: Long = 0L
+
+    /**
+     * The number of GC cycles the runtime has performed so far, per [gcCycleCountReader]. Only meaningful as a delta
+     * between two reads - see [suspects] and [onSentinelReclaimed].
+     */
+    private fun currentGcCycleCount(): Long {
+        val value = gcCycleCountReader()?.toLongOrNull() ?: return lastKnownGcCycleCount
+        lastKnownGcCycleCount = value
+        return value
+    }
+
+    /**
+     * Sentinels for lifecycles that have begun but not yet ended. Keys are held weakly so that an object collected before its
+     * lifecycle ends drops out along with its sentinel.
+     */
+    private val sentinels = WeakHashMap<Any, Sentinel>()
+
+    /**
+     * References waiting for their sentinel to be reclaimed. Held strongly because a [Reference] that becomes unreachable is
+     * never enqueued.
+     */
+    private val watched = HashSet<TrackedReference>()
+
+    /**
+     * Confirmed suspects not yet actually collected. Held strongly for the same reason as [watched]: each entry's
+     * [ConfirmedSuspect] must stay reachable itself in order to eventually be enqueued.
+     */
+    private val trackedSuspects = HashSet<ConfirmedSuspect>()
+
+    private val running = AtomicBoolean(false)
+
+    private var detectorThread: Thread? = null
+
+    fun start() {
+        if (!running.compareAndSet(false, true)) {
+            return
+        }
+
+        val worker = thread(start = false, name = THREAD_NAME) {
+            try {
+                while (running.get()) {
+                    dispatch(queue.remove())
+
+                    // drain whatever else is already available before blocking again, rather than parking and waking
+                    // once per item
+                    var next = queue.poll()
+                    while (next != null) {
+                        dispatch(next)
+                        next = queue.poll()
+                    }
+                }
+            } catch (_: InterruptedException) {
+                // stop() interrupts the blocking queue.remove() so the thread exits without waiting for the next collection
+            }
+
+            clearTracking()
+        }
+
+        detectorThread = worker
+        worker.start()
+    }
+
+    fun stop() {
+        if (!running.compareAndSet(true, false)) {
+            return
+        }
+
+        clearTracking()
+        detectorThread?.interrupt()
+        detectorThread = null
+    }
+
+    /**
+     * Start tracking [referent] by allocating its sentinel. Call this as the lifecycle of [referent] begins, and as early in
+     * that lifecycle as possible. A sentinel allocated well after [referent] may be reclaimed by collections that could not
+     * have reclaimed [referent], which would confirm [referent] as leaked when it is not.
+     *
+     * Calling this more than once for the same object has no effect after the first call.
+     */
+    fun trackOpened(referent: Any) {
+        openSentinel(referent)
+    }
+
+    /**
+     * Release the sentinel allocated for [referent] by [trackOpened] and watch for its reclamation. Call this as the lifecycle
+     * of [referent] ends. [token] is carried through to [suspects] if [referent] is confirmed as a leak, and must not hold a
+     * reference to [referent], following the same rules as a `WeakHashMap` value.
+     *
+     * Returns the reference now being watched. Returns null if no sentinel is held for [referent], either because
+     * [trackOpened] was not called for it or because its lifecycle has already ended, in which case it is not tracked.
+     */
+    fun trackClosed(referent: Any, token: Any? = null): TrackedReference? {
+        val sentinel = releaseSentinel(referent) ?: return null
+
+        val ref = TrackedReference(sentinel, queue, WeakReference(referent), clock.now(), token)
+        watch(ref)
+        return ref
+    }
+
+    /**
+     * Pair the object tracked by [ref] with a new [Sentinel] if it is still reachable, or confirm it as a probable leak if it
+     * has already outlived one. Invoked on the detector thread as the queue delivers reclaimed sentinels, and visible so that
+     * tests can drive reclamation without relying on a real collection.
+     *
+     * A collection clears weak references before it enqueues phantom references, so the reachability of the tracked object is
+     * already settled by the time this is called.
+     *
+     * Returns the reference now watching the new sentinel. Returns null if the tracked object was confirmed as a suspect, was
+     * collected, or if [ref] was no longer being watched.
+     */
+    fun onSentinelReclaimed(ref: TrackedReference): TrackedReference? {
+        if (!stopWatching(ref)) {
+            // already handled, or dropped by stop()
+            return null
+        }
+
+        ref.clear()
+
+        val referent = ref.target.get() ?: return null
+
+        if (ref.suspected) {
+            val suspect = ConfirmedSuspect(
+                referent,
+                queue,
+                ref.trackedAtMs,
+                ref.token,
+                currentGcCycleCount(),
+            )
+
+            addSuspect(suspect)
+            return null
+        }
+
+        val confirmation = TrackedReference(Sentinel(), queue, ref.target, ref.trackedAtMs, ref.token, suspected = true)
+        watch(confirmation)
+        return confirmation
+    }
+
+    /**
+     * Invoked on the detector thread when a [ConfirmedSuspect] is dequeued, meaning the object it watches has actually been
+     * collected. There is nothing to report - it was never a persistent leak - so it is simply discarded. Visible so that
+     * tests can drive collection without relying on a real one.
+     */
+    fun onSuspectCollected(suspect: ConfirmedSuspect) {
+        synchronized(trackedSuspects) {
+            trackedSuspects.remove(suspect)
+        }
+    }
+
+    /**
+     * A snapshot of every confirmed suspect still reachable, safe to hand outside the detector: it never carries the tracked
+     * object itself, only what [trackClosed] was given, its class name read fresh from the still-live object, and how many
+     * GC cycles it has survived since being confirmed. A suspect actually collected between being read here and
+     * [onSuspectCollected] catching up to it is simply omitted, the same as if it had already been dropped.
+     */
+    fun suspects(): List<LeakSnapshot> {
+        val cycleCount = currentGcCycleCount()
+        return synchronized(trackedSuspects) {
+            trackedSuspects.mapNotNull { suspect ->
+                val referent = suspect.get() ?: return@mapNotNull null
+                LeakSnapshot(suspect.trackedAtMs, suspect.token, cycleCount - suspect.suspectedAtCycle, referent.javaClass.name)
+            }
+        }
+    }
+
+    /**
+     * The [ConfirmedSuspect] entries backing [suspects], visible so that tests can drive [onSuspectCollected] for a real
+     * entry without waiting on an actual collection.
+     */
+    fun confirmedSuspects(): Set<ConfirmedSuspect> =
+        synchronized(trackedSuspects) {
+            trackedSuspects.toSet()
+        }
+
+    /*
+     * All access to sentinels, watched and trackedSuspects goes through the functions below. All three are shared: tracking
+     * happens on the thread that begins or ends a lifecycle, and reclamation is delivered on the detector thread.
+     */
+
+    private fun openSentinel(referent: Any) {
+        synchronized(sentinels) {
+            if (!sentinels.containsKey(referent)) {
+                sentinels[referent] = Sentinel()
+            }
+        }
+    }
+
+    private fun releaseSentinel(referent: Any): Sentinel? = synchronized(sentinels) {
+        sentinels.remove(referent)
+    }
+
+    private fun watch(ref: TrackedReference) {
+        synchronized(watched) {
+            watched.add(ref)
+        }
+    }
+
+    private fun stopWatching(ref: TrackedReference): Boolean =
+        synchronized(watched) {
+            watched.remove(ref)
+        }
+
+    private fun addSuspect(suspect: ConfirmedSuspect) {
+        synchronized(trackedSuspects) {
+            trackedSuspects.add(suspect)
+        }
+    }
+
+    private fun clearTracking() {
+        synchronized(sentinels) {
+            sentinels.clear()
+        }
+
+        synchronized(watched) {
+            watched.clear()
+        }
+
+        synchronized(trackedSuspects) {
+            trackedSuspects.clear()
+        }
+    }
+
+    private fun dispatch(reclaimed: Reference<*>) {
+        when (reclaimed) {
+            is TrackedReference -> onSentinelReclaimed(reclaimed)
+            is ConfirmedSuspect -> onSuspectCollected(reclaimed)
+        }
+    }
+
+    /**
+     * Allocated alongside a tracked object and released at the same time, so that its reclamation indicates that a collection
+     * capable of reclaiming that object has run. Holds no state.
+     *
+     * This is a named type rather than an [Any] so that it can be identified in a heap dump, where anonymous objects retained
+     * by the SDK would look like a bug in it.
+     */
+    internal class Sentinel
+
+    /**
+     * Watches the [Sentinel] belonging to a tracked object, and carries what is needed to confirm or re-watch it. The tracked
+     * object is held weakly so that watching it cannot keep it in memory.
+     *
+     * [suspected] marks the second sentinel a tracked object is given, after it has already outlived one. Outliving that one
+     * as well is what confirms it as a leak, so this reference adds the object to [trackedSuspects] rather than pairing it up
+     * again.
+     */
+    internal class TrackedReference(
+        sentinel: Sentinel,
+        queue: ReferenceQueue<Any>,
+        val target: WeakReference<Any>,
+        val trackedAtMs: Long,
+        val token: Any?,
+        val suspected: Boolean = false,
+    ) : PhantomReference<Sentinel>(sentinel, queue)
+
+    /**
+     * Watches a confirmed suspect directly, rather than through a paired [Sentinel]: by this point a collection capable of
+     * reclaiming the object has already been proven twice over, so all that is left to know is exactly when it eventually
+     * stops being reachable at all - which weak reachability already answers. A [PhantomReference] would only fire after
+     * finalization as well, and would hold the referent's memory alive until explicitly cleared; neither is needed here,
+     * since nothing but bookkeeping happens once a suspect is gone.
+     *
+     * [get] doubles as the live read [suspects] uses for the class name, since unlike a [PhantomReference] a
+     * [WeakReference] hands the referent back for as long as it is still reachable.
+     */
+    internal class ConfirmedSuspect(
+        referent: Any,
+        queue: ReferenceQueue<Any>,
+        val trackedAtMs: Long,
+        val token: Any?,
+        val suspectedAtCycle: Long,
+    ) : WeakReference<Any>(referent, queue)
+
+    /**
+     * One entry of [suspects]: everything needed to report a confirmed suspect, read fresh at snapshot time rather than
+     * retained by the [ConfirmedSuspect] itself, and nothing that could retain the object it describes.
+     */
+    internal data class LeakSnapshot(
+        val trackedAtMs: Long,
+        val token: Any?,
+        val cyclesSurvived: Long,
+        val className: String,
+    )
+
+    internal companion object {
+        const val THREAD_NAME = "emb-leak-detector"
+        const val ART_GC_COUNT_STAT = "art.gc.gc-count"
+    }
+}

--- a/embrace-android-instrumentation-leaks/src/main/resources/META-INF/services/io.embrace.android.embracesdk.internal.arch.InstrumentationProvider
+++ b/embrace-android-instrumentation-leaks/src/main/resources/META-INF/services/io.embrace.android.embracesdk.internal.arch.InstrumentationProvider
@@ -1,0 +1,1 @@
+io.embrace.android.embracesdk.instrumentation.leaks.LeakDetectionInstrumentationProvider

--- a/embrace-android-instrumentation-leaks/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetectorTest.kt
+++ b/embrace-android-instrumentation-leaks/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetectorTest.kt
@@ -1,0 +1,217 @@
+package io.embrace.android.embracesdk.instrumentation.leaks
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+internal class LeakDetectorTest {
+
+    private var now: Long = 1000L
+    private var gcCycleCount: Long = 0L
+
+    private lateinit var detector: LeakDetector
+
+    @Before
+    fun setUp() {
+        now = 1000L
+        gcCycleCount = 0L
+        detector = LeakDetector(clock = { now }, gcCycleCountReader = { gcCycleCount.toString() })
+    }
+
+    @After
+    fun tearDown() {
+        // wait for the thread to exit so that it cannot be observed by the next test
+        val thread = detectorThread()
+        detector.stop()
+        thread?.join(THREAD_EXIT_TIMEOUT_MS)
+    }
+
+    @Test
+    fun `an object that outlives a second sentinel becomes a tracked suspect`() {
+        // held strongly for the duration of the test so that it cannot be collected
+        val leaked = Any()
+        val token = "Hello!"
+
+        detector.trackOpened(leaked)
+        now = 5000L
+        val ref = checkNotNull(detector.trackClosed(leaked, token))
+
+        now = 9000L
+        val confirmation = checkNotNull(detector.onSentinelReclaimed(ref))
+        assertTrue("outliving one sentinel only makes it a suspect", detector.suspects().isEmpty())
+
+        gcCycleCount = 3L
+        assertNull("confirming ends the sentinel chain", detector.onSentinelReclaimed(confirmation))
+
+        val suspect = detector.suspects().single()
+        assertEquals(5000L, suspect.trackedAtMs)
+        assertSame(token, suspect.token)
+        assertEquals("no cycles have passed yet at the moment of confirmation", 0L, suspect.cyclesSurvived)
+        assertEquals(
+            "read fresh from the still-live object rather than captured at confirmation",
+            leaked.javaClass.name,
+            suspect.className,
+        )
+
+        gcCycleCount = 7L
+        assertEquals("4 cycles have passed since confirmation", 4L, detector.suspects().single().cyclesSurvived)
+    }
+
+    @Test
+    fun `an object released before its second sentinel is reclaimed does not become a suspect`() {
+        val brieflyHeld = Any()
+        detector.trackOpened(brieflyHeld)
+        val ref = checkNotNull(detector.trackClosed(brieflyHeld))
+
+        // something was still holding it as the lifecycle ended, so it outlives the first sentinel
+        val confirmation = checkNotNull(detector.onSentinelReclaimed(ref))
+
+        // that hold is released, so the collection reclaiming the second sentinel takes it too
+        confirmation.target.clear()
+
+        assertNull(detector.onSentinelReclaimed(confirmation))
+        assertTrue("a hold that was released is not a leak", detector.suspects().isEmpty())
+    }
+
+    @Test
+    fun `the second sentinel tracks the same object as the first`() {
+        val leaked = Any()
+        detector.trackOpened(leaked)
+        val ref = checkNotNull(detector.trackClosed(leaked, "token"))
+
+        val confirmation = checkNotNull(detector.onSentinelReclaimed(ref))
+
+        assertSame("the weak reference is carried over rather than reallocated", ref.target, confirmation.target)
+        assertEquals(ref.trackedAtMs, confirmation.trackedAtMs)
+        assertSame(ref.token, confirmation.token)
+    }
+
+    @Test
+    fun `an object collected alongside its sentinel never becomes a suspect`() {
+        val collected = Any()
+        detector.trackOpened(collected)
+        val ref = checkNotNull(detector.trackClosed(collected))
+
+        // the collection that reclaimed the sentinel reclaimed the tracked object too
+        ref.target.clear()
+
+        assertNull("a collected object is never suspected", detector.onSentinelReclaimed(ref))
+        assertTrue("an object that was collected is not a leak", detector.suspects().isEmpty())
+    }
+
+    @Test
+    fun `an object with no sentinel is not tracked when its lifecycle ends`() {
+        val neverOpened = Any()
+
+        assertNull("without a sentinel there is nothing to compare against", detector.trackClosed(neverOpened))
+    }
+
+    @Test
+    fun `opening the same object twice does not create a second sentinel`() {
+        val reopened = Any()
+
+        detector.trackOpened(reopened)
+        detector.trackOpened(reopened)
+
+        assertNotNull(detector.trackClosed(reopened))
+        assertNull("the second open must not have added a sentinel of its own", detector.trackClosed(reopened))
+    }
+
+    @Test
+    fun `each tracked object becomes a suspect independently of the others`() {
+        val first = Any()
+        val second = Any()
+
+        detector.trackOpened(first)
+        detector.trackOpened(second)
+        val firstRef = checkNotNull(detector.trackClosed(first, "first"))
+        val secondRef = checkNotNull(detector.trackClosed(second, "second"))
+
+        confirmAfterSecondSentinel(firstRef)
+        assertEquals(listOf("first"), detector.suspects().map { it.token })
+
+        confirmAfterSecondSentinel(secondRef)
+        assertEquals(setOf("first", "second"), detector.suspects().map { it.token }.toSet())
+    }
+
+    @Test
+    fun `a confirmed suspect is only added once`() {
+        val leaked = Any()
+        detector.trackOpened(leaked)
+        val ref = checkNotNull(detector.trackClosed(leaked))
+
+        val confirmation = confirmAfterSecondSentinel(ref)
+        assertEquals(1, detector.suspects().size)
+
+        repeat(5) {
+            detector.onSentinelReclaimed(ref)
+            detector.onSentinelReclaimed(confirmation)
+        }
+
+        assertEquals(1, detector.suspects().size)
+    }
+
+    @Test
+    fun `a suspect that is actually collected is discarded from the dataset`() {
+        val leaked = Any()
+        detector.trackOpened(leaked)
+        val ref = checkNotNull(detector.trackClosed(leaked))
+        confirmAfterSecondSentinel(ref)
+
+        assertEquals(1, detector.suspects().size)
+
+        val suspect = detector.confirmedSuspects().single()
+        detector.onSuspectCollected(suspect)
+
+        assertTrue("an object that was actually collected is not a leak", detector.suspects().isEmpty())
+    }
+
+    @Test
+    fun `a suspect that has already cleared is omitted from a snapshot`() {
+        val leaked = Any()
+        detector.trackOpened(leaked)
+        val ref = checkNotNull(detector.trackClosed(leaked))
+        confirmAfterSecondSentinel(ref)
+
+        // simulates the object actually being collected before suspects() reads it, without waiting for a real one or
+        // for onSuspectCollected to catch up via the queue
+        detector.confirmedSuspects().single().clear()
+
+        assertTrue("a suspect with nothing left to read is not reported", detector.suspects().isEmpty())
+    }
+
+    @Test
+    fun `nothing is tracked as a suspect after the detector stops`() {
+        val leaked = Any()
+        detector.start()
+        detector.trackOpened(leaked)
+        val ref = checkNotNull(detector.trackClosed(leaked))
+
+        detector.stop()
+        detector.onSentinelReclaimed(ref)
+
+        assertTrue(detector.suspects().isEmpty())
+    }
+
+    /**
+     * Drives both reclamations the detector thread would otherwise drive, confirming the suspect. Returns the confirmation
+     * reference that was passed to the second reclamation.
+     */
+    private fun confirmAfterSecondSentinel(ref: LeakDetector.TrackedReference): LeakDetector.TrackedReference {
+        val confirmation = checkNotNull(detector.onSentinelReclaimed(ref))
+        detector.onSentinelReclaimed(confirmation)
+        return confirmation
+    }
+
+    private fun detectorThread(): Thread? =
+        Thread.getAllStackTraces().keys.firstOrNull { it.name == LeakDetector.THREAD_NAME }
+
+    private companion object {
+        const val THREAD_EXIT_TIMEOUT_MS = 5000L
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,7 @@ include(
     ":embrace-android-instrumentation-fcm",
     ":embrace-android-instrumentation-huc",
     ":embrace-android-instrumentation-huc-lite",
+    ":embrace-android-instrumentation-leaks",
     ":embrace-android-instrumentation-network-common",
     ":embrace-android-instrumentation-navigation",
     ":embrace-android-instrumentation-network-status",


### PR DESCRIPTION
## Goal
Create a generic `LeakDetector` implementation that can determine when objects with confined lifecycles (`onDestroy()`, `close()`, `destroy()`, etc.) appear to have leaked.

Uncollected references (track by the `ConfirmedSuspect` class) count the number of GC cycles that occur as long as the underlying reference remains valid. If the underlying reference is collected, the `ConfirmedSuspect` is recycled as well. The GC cycle counts are simple numeric properties that are typically captured from the runtime stats (`Debug.getRuntimeStat`) so that under most Android versions no active counting is required.

The next PR reports the "active" suspects at the end of a session part.

## Testing
New unit tests
