### PR TITLE
Add a callback for completed spans

### DIFF
--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanRepository.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanRepository.kt
@@ -11,6 +11,7 @@ import java.util.Queue
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.ConcurrentMap
+import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * Stores the spans of the current session. Two distinct representations are held:
@@ -26,6 +27,7 @@ class SpanRepository {
 
     private val completedSpanData: Queue<Span> = ConcurrentLinkedQueue()
     private val flushLock = Any()
+    private val completedSpansListeners = CopyOnWriteArrayList<(List<Span>) -> Unit>()
 
     /**
      * Track the [EmbraceSpan] if it has been started and it's not already tracked.
@@ -125,7 +127,38 @@ class SpanRepository {
         } catch (t: Throwable) {
             return StoreDataResult.FAILURE
         }
+        notifyCompletedOtelSpans(spans)
         return StoreDataResult.SUCCESS
+    }
+
+    /**
+     * Registers a [listener] invoked with each batch of completed [Span] immediately after it has
+     * been stored, so that spans can be persisted.
+     *
+     * Spans already stored when the listener registers are handed to it as one batch upon registration.
+     */
+    fun addCompletedOtelSpansListener(listener: (List<Span>) -> Unit) {
+        completedSpansListeners.add(listener)
+        val alreadyStored = completedOtelSpans()
+        if (alreadyStored.isNotEmpty()) {
+            notifyListener(listener, alreadyStored)
+        }
+    }
+
+    private fun notifyCompletedOtelSpans(spans: List<Span>) {
+        if (spans.isEmpty() || completedSpansListeners.isEmpty()) {
+            return
+        }
+        completedSpansListeners.forEach { listener ->
+            notifyListener(listener, spans)
+        }
+    }
+
+    private fun notifyListener(listener: (List<Span>) -> Unit, spans: List<Span>) {
+        try {
+            listener(spans)
+        } catch (ignored: Throwable) {
+        }
     }
 
     /**

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/DefaultSpanExporterTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/DefaultSpanExporterTest.kt
@@ -118,6 +118,20 @@ internal class DefaultSpanExporterTest {
     }
 
     @Test
+    fun `a throwing completed spans listener neither fails the export nor stops external exporters`() {
+        val spanRepository = SpanRepository()
+        spanRepository.addCompletedOtelSpansListener { error("listener failed") }
+        val externalExporter = FakeSpanExporter()
+
+        val result = exporter(spanRepository, listOf(externalExporter))
+            .exportInline(listOf(span("public-span")))
+
+        assertEquals(OperationResultCode.Success, result)
+        assertEquals(1, spanRepository.completedOtelSpans().size)
+        assertEquals("public-span", externalExporter.exportedSpans.single().name)
+    }
+
+    @Test
     fun `nothing is exported when the export check fails`() {
         val spanRepository = SpanRepository()
         val externalExporter = FakeSpanExporter()

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanRepositoryCompletedSpansListenerTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanRepositoryCompletedSpansListenerTest.kt
@@ -1,0 +1,135 @@
+package io.embrace.android.embracesdk.internal.otel.spans
+
+import io.embrace.android.embracesdk.internal.otel.sdk.StoreDataResult
+import io.embrace.android.embracesdk.internal.payload.Span
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+internal class SpanRepositoryCompletedSpansListenerTest {
+
+    private lateinit var repository: SpanRepository
+    private val observed = mutableListOf<List<Span>>()
+
+    @Before
+    fun setup() {
+        repository = SpanRepository()
+        observed.clear()
+    }
+
+    @Test
+    fun `the listener is notified with the batch that was stored`() {
+        repository.addCompletedOtelSpansListener(observed::add)
+        assertEquals(StoreDataResult.SUCCESS, repository.storeCompletedOtelSpans(listOf(span("a"), span("b"))))
+        assertEquals(listOf(listOf("a", "b")), observed.map { batch -> batch.map(Span::name) })
+    }
+
+    @Test
+    fun `each batch is notified separately and in the order it was stored`() {
+        repository.addCompletedOtelSpansListener(observed::add)
+        repository.storeCompletedOtelSpans(listOf(span("a"), span("b")))
+        repository.storeCompletedOtelSpans(listOf(span("c")))
+        assertEquals(listOf(listOf("a", "b"), listOf("c")), observed.map { batch -> batch.map(Span::name) })
+    }
+
+    @Test
+    fun `storing an empty batch does not notify`() {
+        repository.addCompletedOtelSpansListener(observed::add)
+        assertEquals(StoreDataResult.SUCCESS, repository.storeCompletedOtelSpans(emptyList()))
+        assertTrue(observed.isEmpty())
+    }
+
+    @Test
+    fun `spans stored before registration are notified as one batch on registration`() {
+        repository.storeCompletedOtelSpans(listOf(span("a")))
+        repository.storeCompletedOtelSpans(listOf(span("b")))
+        repository.addCompletedOtelSpansListener(observed::add)
+        assertEquals(listOf(listOf("a", "b")), observed.map { batch -> batch.map(Span::name) })
+    }
+
+    @Test
+    fun `registering with nothing stored does not notify`() {
+        repository.addCompletedOtelSpansListener(observed::add)
+        assertTrue(observed.isEmpty())
+    }
+
+    @Test
+    fun `spans flushed before registration are not replayed`() {
+        repository.storeCompletedOtelSpans(listOf(span("a")))
+        repository.flushOtelSpans()
+        repository.storeCompletedOtelSpans(listOf(span("b")))
+        repository.addCompletedOtelSpansListener(observed::add)
+        assertEquals(listOf(listOf("b")), observed.map { batch -> batch.map(Span::name) })
+    }
+
+    @Test
+    fun `only the listener being registered is replayed to`() {
+        repository.addCompletedOtelSpansListener(observed::add)
+        repository.storeCompletedOtelSpans(listOf(span("a")))
+
+        val other = mutableListOf<List<Span>>()
+        repository.addCompletedOtelSpansListener(other::add)
+
+        assertEquals(listOf(listOf("a")), observed.map { batch -> batch.map(Span::name) })
+        assertEquals(listOf(listOf("a")), other.map { batch -> batch.map(Span::name) })
+    }
+
+    @Test
+    fun `a listener that throws on replay does not fail registration`() {
+        repository.storeCompletedOtelSpans(listOf(span("a")))
+        repository.addCompletedOtelSpansListener { error("listener failed") }
+        repository.addCompletedOtelSpansListener(observed::add)
+        assertEquals(listOf(listOf("a")), observed.map { batch -> batch.map(Span::name) })
+    }
+
+    @Test
+    fun `every registered listener is notified`() {
+        val other = mutableListOf<List<Span>>()
+        repository.addCompletedOtelSpansListener(observed::add)
+        repository.addCompletedOtelSpansListener(other::add)
+        repository.storeCompletedOtelSpans(listOf(span("a")))
+
+        assertEquals(listOf("a"), observed.single().map(Span::name))
+        assertEquals(listOf("a"), other.single().map(Span::name))
+    }
+
+    @Test
+    fun `a throwing listener neither stops the others nor fails the store`() {
+        repository.addCompletedOtelSpansListener { error("listener failed") }
+        repository.addCompletedOtelSpansListener(observed::add)
+        assertEquals(StoreDataResult.SUCCESS, repository.storeCompletedOtelSpans(listOf(span("a"))))
+
+        assertEquals(listOf("a"), observed.single().map(Span::name))
+        assertEquals(listOf("a"), repository.completedOtelSpans().map(Span::name))
+    }
+
+    @Test
+    fun `a notified span is already readable from the repository`() {
+        val readBack = mutableListOf<String?>()
+        repository.addCompletedOtelSpansListener {
+            readBack += repository.completedOtelSpans().map(Span::name)
+        }
+        repository.storeCompletedOtelSpans(listOf(span("a")))
+        assertEquals(listOf("a"), readBack)
+    }
+
+    @Test
+    fun `flushing spans does not notify`() {
+        repository.addCompletedOtelSpansListener(observed::add)
+        repository.storeCompletedOtelSpans(listOf(span("a")))
+        assertEquals(listOf("a"), repository.flushOtelSpans().map(Span::name))
+        assertEquals(1, observed.size)
+    }
+
+    @Test
+    fun `spans stored after a flush notify only the new batch`() {
+        repository.addCompletedOtelSpansListener(observed::add)
+        repository.storeCompletedOtelSpans(listOf(span("a")))
+        repository.flushOtelSpans()
+        repository.storeCompletedOtelSpans(listOf(span("b")))
+        assertEquals(listOf(listOf("a"), listOf("b")), observed.map { batch -> batch.map(Span::name) })
+    }
+
+    private fun span(name: String) = Span(name = name)
+}


### PR DESCRIPTION
## Goal

Adds a callback for completed spans that will be used to append them to a file in the session part directory.

## Testing

Added unit tests.
