### PR TITLE
Memoize the `SessionIdsSnapshot` returned from `SessionIdsProviderImpl.getActiveSessionIds`

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionIdsProviderImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionIdsProviderImpl.kt
@@ -7,20 +7,37 @@ internal class SessionIdsProviderImpl(
     private val sessionPartTracker: SessionPartTracker,
 ) : SessionIdsProvider {
 
+    /**
+     * Memoized [SessionIdsSnapshot] returned by [getActiveSessionIds], reused as long as its IDs still match the active
+     * session part, so that repeated calls during the same session part return the same instance rather than each caller
+     * allocating its own.
+     */
+    @Volatile
+    private var cachedSessionIdsSnapshot: SessionIdsSnapshot? = null
+
     override fun getCurrentUserSessionId(): String =
         sessionOrchestratorProvider()?.currentUserSession()?.userSessionId ?: ""
 
     override fun getCurrentSessionPartId(): String =
         sessionPartTracker.getActiveSessionPart()?.sessionPartId ?: ""
 
-    override fun getActiveSessionIds(): SessionIdsSnapshot =
-        sessionPartTracker.getActiveSessionPart()?.let {
-            SessionIdsSnapshot(
-                userSessionId = it.userSessionId,
-                sessionPartId = it.sessionPartId,
-            )
-        } ?: SessionIdsSnapshot(
+    override fun getActiveSessionIds(): SessionIdsSnapshot {
+        val activePart = sessionPartTracker.getActiveSessionPart() ?: return SessionIdsSnapshot(
             userSessionId = sessionOrchestratorProvider()?.currentUserSession()?.userSessionId.orEmpty(),
             sessionPartId = "",
         )
+
+        val snapshot = cachedSessionIdsSnapshot
+        if (snapshot != null &&
+            snapshot.userSessionId == activePart.userSessionId &&
+            snapshot.sessionPartId == activePart.sessionPartId
+        ) {
+            return snapshot
+        }
+
+        return SessionIdsSnapshot(
+            userSessionId = activePart.userSessionId,
+            sessionPartId = activePart.sessionPartId,
+        ).also { cachedSessionIdsSnapshot = it }
+    }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionIdsProviderImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/id/SessionIdsProviderImplTest.kt
@@ -5,6 +5,8 @@ import io.embrace.android.embracesdk.fakes.FakeSessionPartTracker
 import io.embrace.android.embracesdk.fakes.fakeSessionPartToken
 import io.embrace.android.embracesdk.internal.session.UserSessionMetadata
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
 import org.junit.Before
 import org.junit.Test
 
@@ -64,6 +66,32 @@ internal class SessionIdsProviderImplTest {
             isBackgroundOnly = false,
         )
         assertEquals(SessionIdsSnapshot(token.userSessionId, token.sessionPartId), provider.getActiveSessionIds())
+    }
+
+    @Test
+    fun `getActiveSessionIds returns the same instance on every call during the same session part`() {
+        sessionPartTracker.currentSession = fakeSessionPartToken()
+
+        val first = provider.getActiveSessionIds()
+        val second = provider.getActiveSessionIds()
+
+        assertSame(
+            "every caller during the same session part should share one instance rather than each allocating its own",
+            first,
+            second,
+        )
+    }
+
+    @Test
+    fun `getActiveSessionIds returns a new instance once the session part changes`() {
+        sessionPartTracker.currentSession = fakeSessionPartToken()
+        val beforeChange = provider.getActiveSessionIds()
+
+        sessionPartTracker.currentSession = fakeSessionPartToken().copy(sessionPartId = "a-different-session-part")
+        val afterChange = provider.getActiveSessionIds()
+
+        assertNotSame(beforeChange, afterChange)
+        assertEquals("a-different-session-part", afterChange.sessionPartId)
     }
 
     @Test


### PR DESCRIPTION
## Goal
Avoid allocating a new `SessionIdsSnapshot` every time `SessionIdsProviderImpl.getActiveSessionIds` is called. These values don't change very frequently and `SessionIdsSnapshot` is immutable, so shared instances reduce our memory consumption.

## Testing
New unit tests added