### PR TITLE
build(deps): bump agp from 9.3.1 to 9.3.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 
 # Some dependencies are pinned to old versions because of an unpatched AGP issue in 7.x: https://issuetracker.google.com/issues/377760847
 binaryCompatibilityValidator = "0.18.1"
-agp = "9.3.1"
+agp = "9.3.2"
 junit = "4.13.2"
 dokka = "2.2.0"
 kotlinGradlePlugin = "2.4.10"


### PR DESCRIPTION
Bumps `agp` from 9.3.1 to 9.3.2.

Updates `com.android.tools.build:gradle` from 9.3.1 to 9.3.2

Updates `com.android.library` from 9.3.1 to 9.3.2

---
updated-dependencies:
- dependency-name: com.android.tools.build:gradle dependency-version: 9.3.2 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: com.android.library dependency-version: 9.3.2 dependency-type: direct:production update-type: version-update:semver-patch ...

## Goal

<!-- Describe what this change seeks to address -->

## Testing

<!-- Describe how this change has been tested -->
