### PR TITLE
Write session part span

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
@@ -70,6 +70,7 @@ class UserSessionOrchestrationModuleImpl(
             initModule.logger,
             payloadSourceModule.resourceSource,
             payloadSourceModule.envelopeMetadataSource,
+            openTelemetryModule.currentSessionPartSpan,
         )
         essentialServiceModule.userService.addUserInfoListener(sessionPartWriter::onUserInfoChanged)
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -11,6 +11,8 @@ import io.embrace.android.embracesdk.internal.session.persistence.SessionManifes
 import io.embrace.android.embracesdk.internal.session.persistence.SessionMetadataWriter
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectory
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectoryStore
+import io.embrace.android.embracesdk.internal.session.persistence.SessionSpanWriter
+import io.embrace.android.embracesdk.internal.spans.CurrentSessionPartSpan
 import io.embrace.android.embracesdk.internal.utils.UuidSource
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import java.io.File
@@ -28,6 +30,7 @@ class SessionPartWriterImpl(
     private val logger: InternalLogger,
     private val resourceSource: EnvelopeResourceSource,
     private val metadataSource: EnvelopeMetadataSource,
+    private val currentSessionPartSpan: CurrentSessionPartSpan,
 ) : SessionPartWriter {
 
     /**
@@ -57,6 +60,7 @@ class SessionPartWriterImpl(
         directoryStore.create(writers.directory)
         queueManifestWrite(writers)
         queueMetadataWrite(writers)
+        queueSessionSpanWrite(writers)
     }
 
     override fun onUserInfoChanged() {
@@ -84,6 +88,18 @@ class SessionPartWriterImpl(
         }
     }
 
+    // TODO: the session span is not yet written on a regular interval while the part is active.
+
+    /**
+     * Writes the session span as it stands right now.
+     */
+    private fun queueSessionSpanWrite(writers: PartWriters) {
+        val span = currentSessionPartSpan.current()?.snapshot() ?: return
+        worker.submit {
+            writers.sessionSpan.write(span)
+        }
+    }
+
     private fun enabled(): Boolean = configService.persistenceBehavior.isMultiFilePersistenceEnabled()
 
     private inner class PartWriters(val directory: SessionPartDirectory) {
@@ -94,6 +110,12 @@ class SessionPartWriterImpl(
             sessionsDir = sessionsDir,
             sessionPartDirectorySource = { directory },
             metadataSource = metadataSource::getEnvelopeMetadata,
+            logger = logger,
+        )
+
+        val sessionSpan = SessionSpanWriter(
+            sessionsDir = sessionsDir,
+            sessionPartDirectorySource = { directory },
             logger = logger,
         )
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -1165,6 +1165,7 @@ internal class SessionOrchestratorTest {
                 logger,
                 FakeEnvelopeResourceSource(),
                 FakeEnvelopeMetadataSource(),
+                currentSessionPartSpan,
             ),
         ).apply {
             start()

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterBoundaryTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterBoundaryTest.kt
@@ -3,16 +3,20 @@ package io.embrace.android.embracesdk.internal.session.orchestrator
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeCurrentSessionPartSpan
+import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.TestUuidSource
 import io.embrace.android.embracesdk.fakes.createPersistenceBehavior
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadataSource
 import io.embrace.android.embracesdk.internal.envelope.resource.EnvelopeResourceSource
 import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
 import io.embrace.android.embracesdk.internal.session.persistence.EnvelopeMetadataProto
 import io.embrace.android.embracesdk.internal.session.persistence.SessionManifest
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectory
+import io.embrace.android.embracesdk.internal.session.persistence.SessionPartSpan
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -33,6 +37,7 @@ internal class SessionPartWriterBoundaryTest {
         private const val SECOND_PART_ID = "cccccccccccccccccccccccccccccccc"
         private const val METADATA_FILE_NAME = "metadata.pb"
         private const val MANIFEST_FILE_NAME = "manifest.pb"
+        private const val SESSION_SPAN_FILE_NAME = "session_span.pb"
     }
 
     @get:Rule
@@ -45,6 +50,9 @@ internal class SessionPartWriterBoundaryTest {
     private lateinit var writer: SessionPartWriter
     private var writeCount = 0
     private var resourceCount = 0
+    private var spanCount = 0
+    private lateinit var sessionSpan: FakeEmbraceSdkSpan
+    private lateinit var currentSessionPartSpan: FakeCurrentSessionPartSpan
     private val resourceSource = object : EnvelopeResourceSource {
         override fun getEnvelopeResource(): EnvelopeResource =
             EnvelopeResource(appVersion = "resource${resourceCount++}")
@@ -60,6 +68,9 @@ internal class SessionPartWriterBoundaryTest {
         logger = FakeInternalLogger(throwOnInternalError = false)
         writeCount = 0
         resourceCount = 0
+        spanCount = 0
+        sessionSpan = FakeEmbraceSdkSpan().apply { start(clock.now()) }
+        currentSessionPartSpan = FakeCurrentSessionPartSpan(clock).apply { sessionPartSpan = sessionSpan }
         writer = SessionPartWriterImpl(
             lazy { sessionsDir },
             BackgroundWorker(executor),
@@ -72,7 +83,9 @@ internal class SessionPartWriterBoundaryTest {
             clock,
             logger,
             resourceSource,
-        ) { EnvelopeMetadata(userId = "user${writeCount++}") }
+            EnvelopeMetadataSource { EnvelopeMetadata(userId = "user${writeCount++}") },
+            currentSessionPartSpan,
+        )
     }
 
     @Test
@@ -140,6 +153,33 @@ internal class SessionPartWriterBoundaryTest {
     }
 
     @Test
+    fun `a pending session span write lands in the session part it was queued for`() {
+        startPart(FIRST_PART_ID)
+        startPart(SECOND_PART_ID)
+        drain()
+
+        assertEquals("span0", sessionSpanIn(FIRST_PART_ID)?.span?.name)
+        assertEquals("span1", sessionSpanIn(SECOND_PART_ID)?.span?.name)
+        assertEquals(2, spanCount)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a user info change after a boundary does not rewrite either session span`() {
+        startPart(FIRST_PART_ID)
+        drain()
+        startPart(SECOND_PART_ID)
+        drain()
+        writer.onUserInfoChanged()
+        drain()
+
+        assertEquals("span0", sessionSpanIn(FIRST_PART_ID)?.span?.name)
+        assertEquals("span1", sessionSpanIn(SECOND_PART_ID)?.span?.name)
+        assertEquals(2, spanCount)
+        assertNoInternalErrors()
+    }
+
+    @Test
     fun `a pending manifest write lands in the session part it was queued for`() {
         startPart(FIRST_PART_ID)
         startPart(SECOND_PART_ID)
@@ -167,6 +207,7 @@ internal class SessionPartWriterBoundaryTest {
     }
 
     private fun startPart(sessionPartId: String) {
+        sessionSpan.name = "span${spanCount++}"
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, sessionPartId)
     }
 
@@ -186,6 +227,11 @@ internal class SessionPartWriterBoundaryTest {
         partFile(sessionPartId, METADATA_FILE_NAME)
             ?.inputStream()
             ?.use(EnvelopeMetadataProto.ADAPTER::decode)
+
+    private fun sessionSpanIn(sessionPartId: String): SessionPartSpan? =
+        partFile(sessionPartId, SESSION_SPAN_FILE_NAME)
+            ?.inputStream()
+            ?.use(SessionPartSpan.ADAPTER::decode)
 
     private fun manifestIn(sessionPartId: String): SessionManifest? =
         partFile(sessionPartId, MANIFEST_FILE_NAME)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
@@ -3,6 +3,8 @@ package io.embrace.android.embracesdk.internal.session.orchestrator
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeCurrentSessionPartSpan
+import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.TestUuidSource
 import io.embrace.android.embracesdk.fakes.createPersistenceBehavior
@@ -14,6 +16,7 @@ import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
 import io.embrace.android.embracesdk.internal.session.persistence.EnvelopeMetadataProto
 import io.embrace.android.embracesdk.internal.session.persistence.SessionManifest
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectory
+import io.embrace.android.embracesdk.internal.session.persistence.SessionPartSpan
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -31,6 +34,7 @@ internal class SessionPartWriterImplTest {
         private const val OTHER_SESSION_PART_ID = "cccccccccccccccccccccccccccccccc"
         private const val METADATA_FILE_NAME = "metadata.pb"
         private const val MANIFEST_FILE_NAME = "manifest.pb"
+        private const val SESSION_SPAN_FILE_NAME = "session_span.pb"
         private const val ENVELOPE_VERSION = "0.1.0"
         private const val ENVELOPE_TYPE = "spans"
         private val SYMBOLS = mapOf("armeabi-v7a" to "my-symbols")
@@ -46,6 +50,9 @@ internal class SessionPartWriterImplTest {
 
     private var writeCount = 0
     private val metadataSource = EnvelopeMetadataSource { EnvelopeMetadata(userId = "user${writeCount++}") }
+
+    private lateinit var sessionSpan: FakeEmbraceSdkSpan
+    private lateinit var currentSessionPartSpan: FakeCurrentSessionPartSpan
 
     private var resourceCount = 0
     private val resourceSource = object : EnvelopeResourceSource {
@@ -63,6 +70,8 @@ internal class SessionPartWriterImplTest {
         logger = FakeInternalLogger(throwOnInternalError = false)
         writeCount = 0
         resourceCount = 0
+        sessionSpan = FakeEmbraceSdkSpan(name = "span0").apply { start(clock.now()) }
+        currentSessionPartSpan = FakeCurrentSessionPartSpan(clock).apply { sessionPartSpan = sessionSpan }
     }
 
     @Test
@@ -199,7 +208,12 @@ internal class SessionPartWriterImplTest {
         drain()
 
         assertEquals(
-            listOf("SessionPartDirectoryStoreFail", "SessionManifestWriteFail", "SessionMetadataWriteFail"),
+            listOf(
+                "SessionPartDirectoryStoreFail",
+                "SessionManifestWriteFail",
+                "SessionMetadataWriteFail",
+                "SessionSpanWriteFail",
+            ),
             logger.internalErrorMessages.map { it.msg },
         )
 
@@ -211,6 +225,7 @@ internal class SessionPartWriterImplTest {
                 "SessionPartDirectoryStoreFail",
                 "SessionManifestWriteFail",
                 "SessionMetadataWriteFail",
+                "SessionSpanWriteFail",
                 "SessionMetadataWriteFail",
             ),
             logger.internalErrorMessages.map { it.msg },
@@ -277,6 +292,73 @@ internal class SessionPartWriterImplTest {
         assertNoInternalErrors()
     }
 
+    @Test
+    fun `the session span is written as soon as a session part starts`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+
+        val span = checkNotNull(sessionSpanIn(SESSION_PART_ID)?.span)
+        assertEquals("span0", span.name)
+        assertEquals(sessionSpan.traceId, span.trace_id)
+        assertEquals(sessionSpan.spanId, span.span_id)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `each session part gets its own session span`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+
+        clock.tick(10000)
+        sessionSpan.name = "span1"
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, OTHER_SESSION_PART_ID)
+        drain()
+
+        assertEquals("span0", sessionSpanIn(SESSION_PART_ID)?.span?.name)
+        assertEquals("span1", sessionSpanIn(OTHER_SESSION_PART_ID)?.span?.name)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `the session span is snapshotted before the write is queued`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+
+        // the part ends before the worker drains, so the span captured at the start is the one written
+        currentSessionPartSpan.sessionPartSpan = null
+        drain()
+
+        assertEquals("span0", sessionSpanIn(SESSION_PART_ID)?.span?.name)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `no session span is written when there is no active session span`() {
+        currentSessionPartSpan.sessionPartSpan = null
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+
+        assertNull(sessionSpanIn(SESSION_PART_ID))
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a user info change leaves the session span untouched`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+
+        sessionSpan.name = "span1"
+        repeat(4) { writer.onUserInfoChanged() }
+        drain()
+
+        assertEquals("span0", sessionSpanIn(SESSION_PART_ID)?.span?.name)
+        assertNoInternalErrors()
+    }
+
     private fun createWriter(
         enabled: Boolean = true,
         configService: FakeConfigService = configService(enabled),
@@ -290,6 +372,7 @@ internal class SessionPartWriterImplTest {
         logger,
         resourceSource,
         metadataSource,
+        currentSessionPartSpan,
     )
 
     private fun configService(
@@ -332,6 +415,11 @@ internal class SessionPartWriterImplTest {
     private fun manifestIn(sessionPartId: String): SessionManifest? {
         drain()
         return partFile(sessionPartId, MANIFEST_FILE_NAME)?.inputStream()?.use(SessionManifest.ADAPTER::decode)
+    }
+
+    private fun sessionSpanIn(sessionPartId: String): SessionPartSpan? {
+        drain()
+        return partFile(sessionPartId, SESSION_SPAN_FILE_NAME)?.inputStream()?.use(SessionPartSpan.ADAPTER::decode)
     }
 
     private fun partFile(sessionPartId: String, fileName: String): File? {

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceReadTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceReadTest.kt
@@ -3,16 +3,18 @@ package io.embrace.android.embracesdk.internal.session.orchestrator
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeCurrentSessionPartSpan
+import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
 import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.TestUuidSource
 import io.embrace.android.embracesdk.fakes.createPersistenceBehavior
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadataSource
 import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
 import io.embrace.android.embracesdk.internal.session.persistence.CompletedSpans
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectory
-import io.embrace.android.embracesdk.internal.session.persistence.SessionPartSpan
 import io.embrace.android.embracesdk.internal.session.persistence.SessionReconstructionService
 import io.embrace.android.embracesdk.internal.session.persistence.SpanProto
 import io.embrace.android.embracesdk.internal.session.persistence.SpanSnapshots
@@ -33,7 +35,6 @@ internal class SessionPartWriterResourceReadTest {
         private const val SESSION_PART_ID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         private const val FORMAT_VERSION = 1
         private const val MANIFEST_FILE_NAME = "manifest.pb"
-        private const val SESSION_SPAN_FILE_NAME = "session_span.pb"
         private const val COMPLETED_SPANS_FILE_NAME = "completed_spans.pb"
         private const val SPAN_SNAPSHOTS_FILE_NAME = "span_snapshots.pb"
         private val SYMBOLS = mapOf("armeabi-v7a" to "my-symbols")
@@ -44,7 +45,7 @@ internal class SessionPartWriterResourceReadTest {
             sdkVersion = "7.0.0",
         )
 
-        private val sessionSpan = SpanProto(
+        private val spanTemplate = SpanProto(
             trace_id = "6c9b1f2ec1d34f3c9a7d0b8e5f2a4c11",
             span_id = "aaaaaaaaaaaaaaa1",
             name = "emb-session",
@@ -52,12 +53,12 @@ internal class SessionPartWriterResourceReadTest {
             end_time_unix_nano = 1726739284136000000L,
         )
 
-        private val completedSpan = sessionSpan.copy(
+        private val completedSpan = spanTemplate.copy(
             span_id = "aaaaaaaaaaaaaaa2",
             name = "emb-startup-moment",
         )
 
-        private val snapshotSpan = sessionSpan.copy(
+        private val snapshotSpan = spanTemplate.copy(
             span_id = "aaaaaaaaaaaaaaa3",
             name = "emb-network-request",
             end_time_unix_nano = null,
@@ -72,6 +73,7 @@ internal class SessionPartWriterResourceReadTest {
     private lateinit var executor: BlockingScheduledExecutorService
     private lateinit var logger: FakeInternalLogger
     private lateinit var writer: SessionPartWriter
+    private lateinit var sessionSpan: FakeEmbraceSdkSpan
     private lateinit var service: SessionReconstructionService
 
     @Before
@@ -80,6 +82,10 @@ internal class SessionPartWriterResourceReadTest {
         clock = FakeClock()
         executor = BlockingScheduledExecutorService(clock, true)
         logger = FakeInternalLogger(throwOnInternalError = false)
+        sessionSpan = FakeEmbraceSdkSpan(name = "emb-session").apply {
+            start(clock.now())
+            stop(endTimeMs = clock.now() + 1000)
+        }
         writer = SessionPartWriterImpl(
             lazy { sessionsDir },
             BackgroundWorker(executor),
@@ -93,7 +99,9 @@ internal class SessionPartWriterResourceReadTest {
             clock,
             logger,
             FakeEnvelopeResourceSource().apply { resource = RESOURCE },
-        ) { EnvelopeMetadata(userId = "my-user-id") }
+            EnvelopeMetadataSource { EnvelopeMetadata(userId = "my-user-id") },
+            FakeCurrentSessionPartSpan(clock).apply { sessionPartSpan = sessionSpan },
+        )
         service = SessionReconstructionService(lazy { sessionsDir }, logger)
     }
 
@@ -105,6 +113,14 @@ internal class SessionPartWriterResourceReadTest {
         assertEquals(RESOURCE, envelope.resource)
         assertEquals("my-user-id", envelope.metadata?.userId)
         assertEquals(SYMBOLS, envelope.data.sharedLibSymbolMapping)
+        assertEquals(emptyList<FakeInternalLogger.LogMessage>(), logger.internalErrorMessages)
+    }
+
+    @Test
+    fun `the session span written at the start of the part is reconstructed`() {
+        val envelope = checkNotNull(writeSessionPart())
+        val expected = checkNotNull(sessionSpan.snapshot()).copy(events = null, links = null)
+        assertEquals(expected, envelope.data.spans?.last())
         assertEquals(emptyList<FakeInternalLogger.LogMessage>(), logger.internalErrorMessages)
     }
 
@@ -124,12 +140,6 @@ internal class SessionPartWriterResourceReadTest {
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
         executor.runCurrentlyBlocked()
 
-        writePartFile(
-            SESSION_SPAN_FILE_NAME,
-            SessionPartSpan.ADAPTER.encode(
-                SessionPartSpan(format_version = FORMAT_VERSION, span = sessionSpan),
-            ),
-        )
         writePartFile(
             COMPLETED_SPANS_FILE_NAME,
             Buffer().apply {


### PR DESCRIPTION
## Goal

Writes the session part span when the session part is initially created. I have not altered the implementation to write on the session part end or at regular intervals during the session - that will come in future changesets.

## Testing

Added unit tests.
