### PR TITLE
Periodically write session part span

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -442,6 +442,7 @@ internal class SessionOrchestratorImpl(
                                             )
                                         }
                                         updatePeriodicCacheAttrs()
+                                        sessionPartWriter?.onPeriodicWrite()
                                         payloadFactory.snapshotPayload(state, timestamp, zygote)
                                     }
                                 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriter.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriter.kt
@@ -19,4 +19,9 @@ interface SessionPartWriter {
      * User information has changed and should be persisted.
      */
     fun onUserInfoChanged()
+
+    /**
+     * The periodic cache interval has elapsed. Rewrites the session span so disk reflects reality.
+     */
+    fun onPeriodicWrite()
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -82,6 +82,13 @@ class SessionPartWriterImpl(
         queueMetadataWrite(current ?: return)
     }
 
+    override fun onPeriodicWrite() {
+        if (!enabled()) {
+            return
+        }
+        queueSessionSpanWrite(current ?: return)
+    }
+
     private fun queueManifestWrite(writers: PartWriters) {
         worker.submit {
             writers.manifest.write(
@@ -99,8 +106,6 @@ class SessionPartWriterImpl(
             writers.metadata.write()
         }
     }
-
-    // TODO: the session span is not yet written on a regular interval while the part is active.
 
     /**
      * Writes the session span as it stands right now.

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -1065,6 +1065,37 @@ internal class SessionOrchestratorTest {
     }
 
     @Test
+    fun `the periodic cache tick rewrites the session span on disk`() {
+        createOrchestrator(ProcessState.FOREGROUND, multiFilePersistenceConfigService())
+        val partId = checkNotNull(sessionTracker.getActiveSessionPartId())
+        assertEquals("emb-session", sessionSpanIn(partId)?.span?.name)
+        clock.tick(2000)
+        checkNotNull(currentSessionPartSpan.sessionPartSpan).name = "refreshed-span"
+        sessionCacheExecutor.runCurrentlyBlocked()
+
+        assertEquals("refreshed-span", sessionSpanIn(partId)?.span?.name)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `the periodic cache tick only rewrites the session span in the background when session data changed`() {
+        createOrchestrator(ProcessState.BACKGROUND, multiFilePersistenceConfigService())
+        val partId = checkNotNull(sessionTracker.getActiveSessionPartId())
+        sessionCacheExecutor.runCurrentlyBlocked()
+
+        clock.tick(2000)
+        checkNotNull(currentSessionPartSpan.sessionPartSpan).name = "refreshed-span"
+        sessionCacheExecutor.runCurrentlyBlocked()
+        assertEquals("emb-session", sessionSpanIn(partId)?.span?.name)
+
+        clock.tick(2000)
+        orchestrator.onSessionDataUpdate()
+        sessionCacheExecutor.runCurrentlyBlocked()
+        assertEquals("refreshed-span", sessionSpanIn(partId)?.span?.name)
+        assertNoInternalErrors()
+    }
+
+    @Test
     fun `crash does not create a session part directory`() {
         createOrchestrator(ProcessState.FOREGROUND, multiFilePersistenceConfigService())
         val initial = sessionPartDirs().single()

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterBoundaryTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterBoundaryTest.kt
@@ -202,6 +202,23 @@ internal class SessionPartWriterBoundaryTest {
     }
 
     @Test
+    fun `a periodic write after a boundary only updates the newer session part`() {
+        startPart(FIRST_PART_ID)
+        drain()
+        startPart(SECOND_PART_ID)
+        drain()
+
+        clock.tick(2000)
+        sessionSpan.name = "span-refreshed"
+        writer.onPeriodicWrite()
+        drain()
+
+        assertEquals("span0", sessionSpanIn(FIRST_PART_ID)?.span?.name)
+        assertEquals("span-refreshed", sessionSpanIn(SECOND_PART_ID)?.span?.name)
+        assertNoInternalErrors()
+    }
+
+    @Test
     fun `a pending session span write for a deleted session part is reported and does not stop the new part`() {
         startPart(FIRST_PART_ID)
         drain()

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
@@ -395,6 +395,22 @@ internal class SessionPartWriterImplTest {
     }
 
     @Test
+    fun `a periodic write refreshes the session span for the current part`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+        assertEquals("span0", sessionSpanIn(SESSION_PART_ID)?.span?.name)
+
+        clock.tick(2000)
+        sessionSpan.name = "span1"
+        writer.onPeriodicWrite()
+        drain()
+
+        assertEquals("span1", sessionSpanIn(SESSION_PART_ID)?.span?.name)
+        assertNoInternalErrors()
+    }
+
+    @Test
     fun `the ended session span is snapshotted before the write is queued`() {
         val writer = createWriter()
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
@@ -453,6 +469,65 @@ internal class SessionPartWriterImplTest {
 
         assertEquals(submitCount, executor.submitCount)
         assertNull(sessionSpanIn(SESSION_PART_ID)?.span?.end_time_unix_nano)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `repeated periodic writes keep the latest session span`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+        repeat(4) { index ->
+            clock.tick(2000)
+            sessionSpan.name = "span${index + 1}"
+            writer.onPeriodicWrite()
+            drain()
+        }
+
+        assertEquals("span4", sessionSpanIn(SESSION_PART_ID)?.span?.name)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a periodic write before any session part starts is a no-op`() {
+        val writer = createWriter()
+        writer.onPeriodicWrite()
+        drain()
+
+        assertEquals(emptyList<SessionPartDirectory>(), sessionPartDirs())
+        assertEquals(0, executor.submitCount)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a periodic write writes nothing when the part started without a session span`() {
+        currentSessionPartSpan.sessionPartSpan = null
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+        writer.onPeriodicWrite()
+        drain()
+
+        assertNull(sessionSpanIn(SESSION_PART_ID))
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a periodic write is not made once multi file persistence is disabled`() {
+        val configService = configService(enabled = true)
+        val writer = createWriter(configService = configService)
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+        val submitCount = executor.submitCount
+
+        configService.persistenceBehavior = createPersistenceBehavior()
+        clock.tick(2000)
+        sessionSpan.name = "span1"
+        writer.onPeriodicWrite()
+        drain()
+
+        assertEquals(submitCount, executor.submitCount)
+        assertEquals("span0", sessionSpanIn(SESSION_PART_ID)?.span?.name)
         assertNoInternalErrors()
     }
 


### PR DESCRIPTION
## Goal

Hooks up the session part span so that it will be written to disk at periodic intervals. Currently this uses the same periodic caching mechanism as the monolithic payload caching.

## Testing

Added unit tests.
