### PR TITLE
Coalesce session part file writes

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -17,10 +17,13 @@ import io.embrace.android.embracesdk.internal.spans.CurrentSessionPartSpan
 import io.embrace.android.embracesdk.internal.utils.UuidSource
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import java.io.File
+import java.util.concurrent.Future
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Writes session part telemetry to disk, if the multi-file persistence layer is enabled.
- * All filesystem work is queued on a single-threaded [worker].
+ * All filesystem work is queued on a single-threaded [worker]. A queued write that is superseded
+ * before it runs is cancelled to avoid duplicate work.
  */
 class SessionPartWriterImpl(
     private val sessionsDir: Lazy<File>,
@@ -102,7 +105,7 @@ class SessionPartWriterImpl(
     }
 
     private fun queueMetadataWrite(writers: PartWriters) {
-        worker.submit {
+        writers.metadataWrites.submit {
             writers.metadata.write()
         }
     }
@@ -112,7 +115,7 @@ class SessionPartWriterImpl(
      */
     private fun queueSessionSpanWrite(writers: PartWriters) {
         val span = writers.span?.snapshot() ?: return
-        worker.submit {
+        writers.sessionSpanWrites.submit {
             writers.sessionSpan.write(span)
         }
     }
@@ -122,7 +125,6 @@ class SessionPartWriterImpl(
     private inner class PartWriters(val directory: SessionPartDirectory) {
 
         val span: EmbraceSdkSpan? = currentSessionPartSpan.current()
-
         val manifest = SessionManifestWriter(sessionsDir, logger)
 
         val metadata = SessionMetadataWriter(
@@ -137,5 +139,21 @@ class SessionPartWriterImpl(
             sessionPartDirectorySource = { directory },
             logger = logger,
         )
+
+        val metadataWrites = CoalescingWriteQueue(worker)
+        val sessionSpanWrites = CoalescingWriteQueue(worker)
+    }
+
+    /**
+     * Queues the writes for one file in a session part. Each write persists the whole file so
+     * we should cancel and remove any enqueued writes as they will be superseded by later ones.
+     * A write that has already started is left to finish.
+     */
+    private class CoalescingWriteQueue(private val worker: BackgroundWorker) {
+        private val pending = AtomicReference<Future<*>?>(null)
+
+        fun submit(runnable: Runnable) {
+            pending.getAndSet(worker.submit(runnable))?.cancel(false)
+        }
     }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterBoundaryTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterBoundaryTest.kt
@@ -10,7 +10,6 @@ import io.embrace.android.embracesdk.fakes.TestUuidSource
 import io.embrace.android.embracesdk.fakes.createPersistenceBehavior
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
-import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadataSource
 import io.embrace.android.embracesdk.internal.envelope.resource.EnvelopeResourceSource
 import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
@@ -85,7 +84,7 @@ internal class SessionPartWriterBoundaryTest {
             clock,
             logger,
             resourceSource,
-            EnvelopeMetadataSource { EnvelopeMetadata(userId = "user${writeCount++}") },
+            { EnvelopeMetadata(userId = "user${writeCount++}") },
             currentSessionPartSpan,
         )
     }
@@ -110,17 +109,17 @@ internal class SessionPartWriterBoundaryTest {
     }
 
     @Test
-    fun `several queued writes spanning a boundary all land in the session part they were queued for`() {
+    fun `only the last metadata write queued before a boundary lands in the older part`() {
         startPart(FIRST_PART_ID)
         drain()
         repeat(2) { writer.onUserInfoChanged() }
         startPart(SECOND_PART_ID)
         drain()
 
-        // both queued writes went to the first part
-        assertEquals("user2", metadataIn(FIRST_PART_ID)?.user_id)
-        assertEquals("user3", metadataIn(SECOND_PART_ID)?.user_id)
-        assertEquals(4, writeCount)
+        // the first of the queued writes was superseded, and the one that ran went to the first part
+        assertEquals("user1", metadataIn(FIRST_PART_ID)?.user_id)
+        assertEquals("user2", metadataIn(SECOND_PART_ID)?.user_id)
+        assertEquals(3, writeCount)
         assertNoInternalErrors()
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
@@ -50,7 +50,11 @@ internal class SessionPartWriterImplTest {
     private lateinit var logger: FakeInternalLogger
 
     private var writeCount = 0
-    private val metadataSource = EnvelopeMetadataSource { EnvelopeMetadata(userId = "user${writeCount++}") }
+    private var onMetadataRead: () -> Unit = {}
+    private val metadataSource = EnvelopeMetadataSource {
+        onMetadataRead()
+        EnvelopeMetadata(userId = "user${writeCount++}")
+    }
 
     private lateinit var sessionSpan: FakeEmbraceSdkSpan
     private lateinit var currentSessionPartSpan: FakeCurrentSessionPartSpan
@@ -71,6 +75,7 @@ internal class SessionPartWriterImplTest {
         logger = FakeInternalLogger(throwOnInternalError = false)
         writeCount = 0
         resourceCount = 0
+        onMetadataRead = {}
         sessionSpan = FakeEmbraceSdkSpan(name = "span0").apply { start(clock.now()) }
         currentSessionPartSpan = FakeCurrentSessionPartSpan(clock).apply { sessionPartSpan = sessionSpan }
     }
@@ -151,7 +156,7 @@ internal class SessionPartWriterImplTest {
     }
 
     @Test
-    fun `every user info change rewrites the metadata`() {
+    fun `queued metadata writes for a session part are coalesced into one write`() {
         val writer = createWriter()
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
         drain()
@@ -159,8 +164,9 @@ internal class SessionPartWriterImplTest {
         repeat(4) { writer.onUserInfoChanged() }
         drain()
 
-        assertEquals("user4", metadataIn(SESSION_PART_ID)?.user_id)
-        assertEquals(5, writeCount)
+        // the queued writes were superseded before they ran, so only the last one wrote
+        assertEquals("user1", metadataIn(SESSION_PART_ID)?.user_id)
+        assertEquals(2, writeCount)
         assertNoInternalErrors()
     }
 
@@ -527,6 +533,75 @@ internal class SessionPartWriterImplTest {
         drain()
 
         assertEquals(submitCount, executor.submitCount)
+        assertEquals("span0", sessionSpanIn(SESSION_PART_ID)?.span?.name)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `queued session span writes are coalesced into one write`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+
+        File(sessionsDir, partDirs().single().dirName).deleteRecursively()
+        repeat(4) {
+            clock.tick(2000)
+            writer.onPeriodicWrite()
+        }
+        drain()
+
+        assertEquals(listOf("SessionSpanWriteFail"), logger.internalErrorMessages.map { it.msg })
+    }
+
+    @Test
+    fun `a coalesced session span write persists the latest snapshot`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+
+        repeat(4) { index ->
+            clock.tick(2000)
+            sessionSpan.name = "span${index + 1}"
+            writer.onPeriodicWrite()
+        }
+        drain()
+
+        assertEquals("span4", sessionSpanIn(SESSION_PART_ID)?.span?.name)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a write that has already started is not cancelled`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+
+        // supersede the metadata write from inside the metadata write itself
+        onMetadataRead = {
+            onMetadataRead = {}
+            writer.onUserInfoChanged()
+        }
+        drain()
+
+        assertEquals("user0", metadataOnDisk(SESSION_PART_ID)?.user_id)
+        assertEquals(1, writeCount)
+
+        // the write queued while the other one ran is still pending, and runs next
+        drain()
+        assertEquals("user1", metadataOnDisk(SESSION_PART_ID)?.user_id)
+        assertEquals(2, writeCount)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `queued writes for different files do not cancel each other`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        writer.onUserInfoChanged()
+        drain()
+
+        assertEquals("resource0", manifestIn(SESSION_PART_ID)?.resource?.app_version)
+        assertEquals("user0", metadataIn(SESSION_PART_ID)?.user_id)
+        assertEquals(1, writeCount)
         assertEquals("span0", sessionSpanIn(SESSION_PART_ID)?.span?.name)
         assertNoInternalErrors()
     }


### PR DESCRIPTION
## Goal

Coalesce writes to the session part directory so that there is never more than one enqueued for each session part file, thus preventing unnecessary backpressure.

## Testing

Added unit tests.
