### PR TITLE
Write session files synchronously on crash

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -280,6 +280,10 @@ internal class SessionOrchestratorImpl(
             },
             crashId = crashId,
         )
+
+        EmbTrace.trace("flush-session-part-writes") {
+            sessionPartWriter?.onCrash()
+        }
     }
 
     override fun onSessionDataUpdate() {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriter.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriter.kt
@@ -24,4 +24,10 @@ interface SessionPartWriter {
      * The periodic cache interval has elapsed. Rewrites the session span so disk reflects reality.
      */
     fun onPeriodicWrite()
+
+    /**
+     * The process is terminating due to a JVM crash. Blocks until the necessary session part info
+     * has been flushed to disk
+     */
+    fun onCrash()
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.envelope.resource.EnvelopeResourceSource
 import io.embrace.android.embracesdk.internal.envelope.session.SESSION_ENVELOPE_TYPE
 import io.embrace.android.embracesdk.internal.envelope.session.SESSION_ENVELOPE_VERSION
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.session.persistence.SessionManifestWriter
@@ -37,6 +38,10 @@ class SessionPartWriterImpl(
     private val currentSessionPartSpan: CurrentSessionPartSpan,
 ) : SessionPartWriter {
 
+    private companion object {
+        const val CRASH_DRAIN_TIMEOUT_MS: Long = 3000
+    }
+
     /**
      * The writers for the session part that telemetry is currently written to. Each targets one
      * fixed directory, so a write that was queued for a session part cannot land in a later one.
@@ -44,11 +49,13 @@ class SessionPartWriterImpl(
     @Volatile
     private var current: PartWriters? = null
 
+    @Volatile
+    private var crashing = false
+
     private val directoryStore = SessionPartDirectoryStore(sessionsDir, worker, clock, logger)
 
     override fun onSessionPartStarted(timestamp: Long, userSessionId: String, sessionPartId: String) {
         if (!enabled()) {
-            current = null
             return
         }
         val writers = PartWriters(
@@ -92,8 +99,16 @@ class SessionPartWriterImpl(
         queueSessionSpanWrite(current ?: return)
     }
 
+    override fun onCrash() {
+        if (!enabled()) {
+            return
+        }
+        crashing = true
+        worker.shutdownAndWait(CRASH_DRAIN_TIMEOUT_MS)
+    }
+
     private fun queueManifestWrite(writers: PartWriters) {
-        worker.submit {
+        execute(InternalErrorType.SessionManifestWriteFail, { worker.submit(it) }) {
             writers.manifest.write(
                 directory = writers.directory,
                 resource = resourceSource.getEnvelopeResource(),
@@ -105,7 +120,7 @@ class SessionPartWriterImpl(
     }
 
     private fun queueMetadataWrite(writers: PartWriters) {
-        writers.metadataWrites.submit {
+        execute(InternalErrorType.SessionMetadataWriteFail, writers.metadataWrites::submit) {
             writers.metadata.write()
         }
     }
@@ -115,12 +130,35 @@ class SessionPartWriterImpl(
      */
     private fun queueSessionSpanWrite(writers: PartWriters) {
         val span = writers.span?.snapshot() ?: return
-        writers.sessionSpanWrites.submit {
+        execute(InternalErrorType.SessionSpanWriteFail, writers.sessionSpanWrites::submit) {
             writers.sessionSpan.write(span)
         }
     }
 
-    private fun enabled(): Boolean = configService.persistenceBehavior.isMultiFilePersistenceEnabled()
+    /**
+     * Queues [action] with [submit], or runs it on the calling thread if the process is crashing
+     * and the [worker] has already been sealed by [onCrash]. Telemetry gathered inside [action] can
+     * throw, so a failure is tracked here rather than escaping onto a crashing thread.
+     */
+    private fun execute(
+        errorType: InternalErrorType,
+        submit: (Runnable) -> Unit,
+        action: () -> Unit,
+    ) {
+        if (crashing) {
+            try {
+                action()
+            } catch (exc: Throwable) {
+                logger.trackInternalError(errorType, exc)
+            }
+        } else {
+            submit(Runnable(action))
+        }
+    }
+
+    private fun enabled(): Boolean {
+        return configService.persistenceBehavior.isMultiFilePersistenceEnabled() && !crashing
+    }
 
     private inner class PartWriters(val directory: SessionPartDirectory) {
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -1103,7 +1103,7 @@ internal class SessionOrchestratorTest {
         clock.tick(10000)
         orchestrator.handleCrash("crash-id")
 
-        assertEquals(listOf(initial), sessionPartDirs())
+        assertEquals(listOf(initial), partDirs())
         assertNoInternalErrors()
     }
 
@@ -1121,13 +1121,13 @@ internal class SessionOrchestratorTest {
     }
 
     @Test
-    fun `a crash rewrites the session part span with its end time`() {
+    fun `a crash rewrites the session part span with its end time before the process dies`() {
         createOrchestrator(ProcessState.FOREGROUND, multiFilePersistenceConfigService())
         val sessionPartId = checkNotNull(sessionTracker.getActiveSessionPartId())
         clock.tick(10000)
         orchestrator.handleCrash("crash-id")
 
-        assertEquals(clock.now().millisToNanos(), sessionSpanIn(sessionPartId)?.span?.end_time_unix_nano)
+        assertEquals(clock.now().millisToNanos(), sessionSpanOnDisk(sessionPartId)?.span?.end_time_unix_nano)
         assertNoInternalErrors()
     }
 
@@ -2024,17 +2024,25 @@ internal class SessionOrchestratorTest {
      */
     private fun sessionPartDirs(): List<SessionPartDirectory> {
         sessionPersistenceExecutor.runCurrentlyBlocked()
-        return (sessionsDir.list() ?: emptyArray())
+        return partDirs()
+    }
+
+    private fun partDirs(): List<SessionPartDirectory> =
+        (sessionsDir.list() ?: emptyArray())
             .mapNotNull(SessionPartDirectory::fromDirName)
             .sortedWith(SessionPartDirectory.comparator)
-    }
 
     /**
      * Drains the session persistence worker and returns the session span persisted for the given
      * session part, if any.
      */
     private fun sessionSpanIn(sessionPartId: String): SessionPartSpan? {
-        val directory = sessionPartDirs().single { it.sessionPartId == sessionPartId }
+        sessionPersistenceExecutor.runCurrentlyBlocked()
+        return sessionSpanOnDisk(sessionPartId)
+    }
+
+    private fun sessionSpanOnDisk(sessionPartId: String): SessionPartSpan? {
+        val directory = partDirs().single { it.sessionPartId == sessionPartId }
         return File(File(sessionsDir, directory.dirName), "session_span.pb")
             .takeIf(File::isFile)
             ?.inputStream()

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
@@ -20,7 +20,9 @@ import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDir
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartSpan
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -571,6 +573,20 @@ internal class SessionPartWriterImplTest {
     }
 
     @Test
+    fun `a crash persists the queued session span without the worker being drained`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        clock.tick(10000)
+        endPart()
+        writer.onSessionPartEnded(SESSION_PART_ID)
+        writer.onCrash()
+
+        assertEquals(clock.now().millisToNanos(), sessionSpanOnDisk(SESSION_PART_ID)?.span?.end_time_unix_nano)
+        assertTrue(executor.isShutdown)
+        assertNoInternalErrors()
+    }
+
+    @Test
     fun `a write that has already started is not cancelled`() {
         val writer = createWriter()
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
@@ -593,6 +609,19 @@ internal class SessionPartWriterImplTest {
     }
 
     @Test
+    fun `a crash persists the telemetry queued when the session part started`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        writer.onCrash()
+
+        assertEquals(listOf(SESSION_PART_ID), partDirs().map(SessionPartDirectory::sessionPartId))
+        assertEquals("resource0", manifestOnDisk(SESSION_PART_ID)?.resource?.app_version)
+        assertEquals("user0", metadataOnDisk(SESSION_PART_ID)?.user_id)
+        assertEquals("span0", sessionSpanOnDisk(SESSION_PART_ID)?.span?.name)
+        assertNoInternalErrors()
+    }
+
+    @Test
     fun `queued writes for different files do not cancel each other`() {
         val writer = createWriter()
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
@@ -603,6 +632,53 @@ internal class SessionPartWriterImplTest {
         assertEquals("user0", metadataIn(SESSION_PART_ID)?.user_id)
         assertEquals(1, writeCount)
         assertEquals("span0", sessionSpanIn(SESSION_PART_ID)?.span?.name)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `no further writes are made once a crash has been handled`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        writer.onCrash()
+        val submitCount = executor.submitCount
+
+        clock.tick(2000)
+        sessionSpan.name = "span1"
+        writer.onPeriodicWrite()
+        writer.onUserInfoChanged()
+        endPart()
+        writer.onSessionPartEnded(SESSION_PART_ID)
+
+        // the worker is sealed by the drain, so queueing anything onto it would be silently
+        // discarded - the writer has to stop instead, leaving the crash-time state on disk
+        assertEquals(submitCount, executor.submitCount)
+        assertEquals("span0", sessionSpanOnDisk(SESSION_PART_ID)?.span?.name)
+        assertNull(sessionSpanOnDisk(SESSION_PART_ID)?.span?.end_time_unix_nano)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a session part started after a crash is not written`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        writer.onCrash()
+        val submitCount = executor.submitCount
+        clock.tick(2000)
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, OTHER_SESSION_PART_ID)
+
+        assertEquals(listOf(SESSION_PART_ID), partDirs().map(SessionPartDirectory::sessionPartId))
+        assertEquals(submitCount, executor.submitCount)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a crash does not drain the worker when multi file persistence is disabled`() {
+        val writer = createWriter(enabled = false)
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        writer.onCrash()
+
+        assertEquals(emptyList<SessionPartDirectory>(), partDirs())
+        assertFalse(executor.isShutdown)
         assertNoInternalErrors()
     }
 
@@ -665,13 +741,19 @@ internal class SessionPartWriterImplTest {
 
     private fun manifestIn(sessionPartId: String): SessionManifest? {
         drain()
-        return partFile(sessionPartId, MANIFEST_FILE_NAME)?.inputStream()?.use(SessionManifest.ADAPTER::decode)
+        return manifestOnDisk(sessionPartId)
     }
+
+    private fun manifestOnDisk(sessionPartId: String): SessionManifest? =
+        partFile(sessionPartId, MANIFEST_FILE_NAME)?.inputStream()?.use(SessionManifest.ADAPTER::decode)
 
     private fun sessionSpanIn(sessionPartId: String): SessionPartSpan? {
         drain()
-        return partFile(sessionPartId, SESSION_SPAN_FILE_NAME)?.inputStream()?.use(SessionPartSpan.ADAPTER::decode)
+        return sessionSpanOnDisk(sessionPartId)
     }
+
+    private fun sessionSpanOnDisk(sessionPartId: String): SessionPartSpan? =
+        partFile(sessionPartId, SESSION_SPAN_FILE_NAME)?.inputStream()?.use(SessionPartSpan.ADAPTER::decode)
 
     private fun partFile(sessionPartId: String, fileName: String): File? {
         val directory = partDirs().single { it.sessionPartId == sessionPartId }

--- a/embrace-android-sdk/build.gradle.kts
+++ b/embrace-android-sdk/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
     testImplementation(libs.opentelemetry.java.aliases)
     testImplementation(project(":embrace-android-otel-java"))
     testImplementation(project(":embrace-test-fakes"))
+    testImplementation(project(":embrace-android-session-persistence"))
     testImplementation(project(":embrace-android-config-fakes"))
     testImplementation(project(":embrace-android-delivery-fakes"))
     testImplementation(project(":embrace-android-instrumentation-api-fakes"))

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
@@ -7,7 +7,10 @@ import io.embrace.android.embracesdk.assertions.assertOtelLogReceived
 import io.embrace.android.embracesdk.assertions.getLastLog
 import io.embrace.android.embracesdk.assertions.getStartTime
 import io.embrace.android.embracesdk.assertions.getUserSessionId
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.FakePayloadStorageService
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
@@ -19,7 +22,10 @@ import io.embrace.android.embracesdk.internal.arch.state.ProcessState
 import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.UserSessionRemoteConfig
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.delivery.PayloadType
+import io.embrace.android.embracesdk.internal.delivery.storage.StorageLocation
+import io.embrace.android.embracesdk.internal.delivery.storage.asFile
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LegacyExceptionInfo
@@ -28,6 +34,8 @@ import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
 import io.embrace.android.embracesdk.internal.serialization.toJson
 import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
+import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectory
+import io.embrace.android.embracesdk.internal.session.persistence.SessionPartSpan
 import io.embrace.android.embracesdk.internal.utils.getSafeStackTrace
 import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.semconv.EmbAndroidAttributes
@@ -46,6 +54,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.File
 import java.util.zip.GZIPInputStream
 
 @RunWith(AndroidJUnit4::class)
@@ -58,7 +67,11 @@ internal class JvmCrashFeatureTest {
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
         EmbraceSetupInterface(
             fakeStorageLayer = true,
-            workersToFake = listOf(Worker.Background.NonIoRegWorker, Worker.Background.IoRegWorker),
+            workersToFake = listOf(
+                Worker.Background.NonIoRegWorker,
+                Worker.Background.IoRegWorker,
+                Worker.Background.SessionPersistenceWorker,
+            ),
         ).apply {
             getEmbLogger().throwOnInternalError = false
             getFakedWorkerExecutor(Worker.Background.NonIoRegWorker).blockingMode = false
@@ -99,6 +112,31 @@ internal class JvmCrashFeatureTest {
                 }
 
                 assertEquals("bar", crash.attributes?.single { it.key == "foo".toEmbraceAttributeName() }?.data)
+            }
+        )
+    }
+
+    @Test
+    fun `app crash persists the session part span even though its write was still enqueued`() {
+        testRule.runTest(
+            persistedRemoteConfig = RemoteConfig(pctMultiFilePersistenceEnabled = 100.0f),
+            testCaseAction = {
+                recordSession {
+                    crashTimeMs = clock.now()
+                    simulateJvmUncaughtException(testException)
+                }
+            },
+            assertAction = {
+                val crashLog = payloadStorageService.getPersistedCrashLog().getLastLog()
+                val sessionPartId = checkNotNull(
+                    crashLog.attributes?.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID)
+                )
+
+                // assert disk was written synchronously by the crash teardown
+                val sessionSpan = checkNotNull(readSessionSpanOnDisk(sessionPartId)) {
+                    "no session span was persisted for part $sessionPartId"
+                }
+                assertEquals(crashTimeMs.millisToNanos(), sessionSpan.span?.end_time_unix_nano)
             }
         )
     }
@@ -372,5 +410,22 @@ internal class JvmCrashFeatureTest {
             assertNotNull(foundCrashId)
         }
         assertNotNull(attributes?.findAttributeValue(EmbAndroidAttributes.EMB_ANDROID_THREADS))
+    }
+
+    private fun readSessionSpanOnDisk(sessionPartId: String): SessionPartSpan? {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        val sessionsDir = StorageLocation.SESSION_SPLIT.asFile(
+            logger = FakeInternalLogger(),
+            rootDirSupplier = { ctx.filesDir },
+            fallbackDirSupplier = { ctx.cacheDir },
+        ).value
+        val partDir = (sessionsDir.list() ?: emptyArray())
+            .mapNotNull(SessionPartDirectory::fromDirName)
+            .singleOrNull { it.sessionPartId == sessionPartId }
+            ?: return null
+        return File(File(sessionsDir, partDir.dirName), "session_span.pb")
+            .takeIf(File::isFile)
+            ?.inputStream()
+            ?.use(SessionPartSpan.ADAPTER::decode)
     }
 }


### PR DESCRIPTION
## Goal

If a JVM crash happens the process is about to terminate, so any session files should be written synchronously on disk.

## Testing

Added unit and integration tests.
