### PR TITLE
Invoke callback when envelope resource mutates

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/RnBundleIdTracker.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/RnBundleIdTracker.kt
@@ -9,4 +9,9 @@ interface RnBundleIdTracker {
     fun setReactNativeBundleId(jsBundleUrl: String?, forceUpdate: Boolean? = null)
 
     fun getReactNativeBundleId(): String?
+
+    /**
+     * Registers a [listener] invoked whenever the React Native bundle ID changes.
+     */
+    fun addChangeListener(listener: () -> Unit)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/RnBundleIdTrackerImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/RnBundleIdTrackerImpl.kt
@@ -9,7 +9,7 @@ import java.io.FileInputStream
 import java.io.InputStream
 import java.security.MessageDigest
 import java.util.Locale
-import java.util.concurrent.Future
+import java.util.concurrent.CopyOnWriteArrayList
 
 internal class RnBundleIdTrackerImpl(
     private val context: Context,
@@ -18,38 +18,61 @@ internal class RnBundleIdTrackerImpl(
     private val metadataBackgroundWorker: BackgroundWorker,
 ) : RnBundleIdTracker {
 
-    private var reactNativeBundleId: Future<String?> =
+    @Volatile
+    private var computedBundleId: String? = null
+
+    private val listeners = CopyOnWriteArrayList<() -> Unit>()
+
+    init {
         if (configService.appFramework == AppFramework.REACT_NATIVE) {
-            metadataBackgroundWorker.submit<String?> {
+            metadataBackgroundWorker.submit {
                 val lastKnownJsBundleUrl = javaScriptBundleURL
                 val lastKnownJsBundleId = javaScriptBundleId
-                if (!lastKnownJsBundleUrl.isNullOrEmpty() && !lastKnownJsBundleId.isNullOrEmpty()) {
+                val bundleId = if (!lastKnownJsBundleUrl.isNullOrEmpty() && !lastKnownJsBundleId.isNullOrEmpty()) {
                     // If we have a lastKnownJsBundleId, we use that as the last known bundle ID.
-                    return@submit lastKnownJsBundleId
+                    lastKnownJsBundleId
                 } else {
                     // If we don't have a lastKnownJsBundleId, we compute the bundle ID from the last known JS bundle URL.
                     // If the last known JS bundle URL is null, we set React Native bundle ID to the buildId.
-                    return@submit computeReactNativeBundleId(
+                    computeReactNativeBundleId(
                         context,
                         lastKnownJsBundleUrl,
                         configService.buildInfo.rnBundleId,
                     )
                 }
+                updateBundleId(bundleId)
             }
-        } else {
-            metadataBackgroundWorker.submit<String?> { configService.buildInfo.buildId }
         }
+    }
 
     /**
      * Return the bundle Id if it was already calculated in background or null if it's not ready yet.
      * This way, we avoid blocking the main thread to wait for the value.
      */
     override fun getReactNativeBundleId(): String? =
-        if (configService.appFramework == AppFramework.REACT_NATIVE && reactNativeBundleId.isDone) {
-            reactNativeBundleId.get()
+        if (configService.appFramework == AppFramework.REACT_NATIVE) {
+            computedBundleId
         } else {
             null
         }
+
+    override fun addChangeListener(listener: () -> Unit) {
+        listeners.add(listener)
+    }
+
+    /**
+     * Publishes a newly computed bundle ID and notifies listeners, so that they observe the new
+     * value rather than the one it replaced.
+     */
+    private fun updateBundleId(bundleId: String?) {
+        computedBundleId = bundleId
+        listeners.forEach { listener ->
+            try {
+                listener()
+            } catch (ignored: Throwable) {
+            }
+        }
+    }
 
     override fun setReactNativeBundleId(
         jsBundleUrl: String?,
@@ -62,7 +85,7 @@ internal class RnBundleIdTrackerImpl(
             javaScriptBundleURL = jsBundleUrl
 
             // Calculate the bundle ID for the new bundle URL
-            reactNativeBundleId = metadataBackgroundWorker.submit<String?> {
+            metadataBackgroundWorker.submit {
                 val bundleId = computeReactNativeBundleId(
                     context,
                     jsBundleUrl,
@@ -72,7 +95,7 @@ internal class RnBundleIdTrackerImpl(
                     // if we have a value for forceUpdate, it means the bundleId is cacheable and we should store it.
                     javaScriptBundleId = bundleId
                 }
-                bundleId
+                updateBundleId(bundleId)
             }
         }
     }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/PayloadSourceModuleImpl.kt
@@ -17,6 +17,7 @@ import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.envelope.metadata.FlutterSdkVersionInfo
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.envelope.metadata.NativeSdkVersionInfo
+import io.embrace.android.embracesdk.internal.envelope.metadata.ObservableHostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.envelope.metadata.ReactNativeSdkVersionInfo
 import io.embrace.android.embracesdk.internal.envelope.metadata.UnitySdkVersionInfo
 import io.embrace.android.embracesdk.internal.envelope.resource.DeviceImpl
@@ -66,12 +67,16 @@ class PayloadSourceModuleImpl(
 
     private val logPayloadSource = LogPayloadSourceImpl(otelModule.logSink)
 
-    override val hostedSdkVersionInfo: HostedSdkVersionInfo = when (configService.appFramework) {
-        AppFramework.REACT_NATIVE -> ReactNativeSdkVersionInfo(coreModule.store)
-        AppFramework.UNITY -> UnitySdkVersionInfo(coreModule.store)
-        AppFramework.FLUTTER -> FlutterSdkVersionInfo(coreModule.store)
-        else -> NativeSdkVersionInfo()
-    }
+    private val observableHostedSdkVersionInfo = ObservableHostedSdkVersionInfo(
+        when (configService.appFramework) {
+            AppFramework.REACT_NATIVE -> ReactNativeSdkVersionInfo(coreModule.store)
+            AppFramework.UNITY -> UnitySdkVersionInfo(coreModule.store)
+            AppFramework.FLUTTER -> FlutterSdkVersionInfo(coreModule.store)
+            else -> NativeSdkVersionInfo()
+        },
+    )
+
+    override val hostedSdkVersionInfo: HostedSdkVersionInfo = observableHostedSdkVersionInfo
 
     private val appEnvironment: AppEnvironment = AppEnvironment(
         isDebug = with(coreModule.context.applicationInfo) {
@@ -79,24 +84,35 @@ class PayloadSourceModuleImpl(
         },
     )
 
-    override val resourceSource: EnvelopeResourceSource = EmbTrace.trace("resource-source") {
+    private val device = EmbTrace.trace("deviceImpl") {
+        DeviceImpl(
+            windowManagerProvider = { coreModule.context.getSystemServiceSafe(Context.WINDOW_SERVICE) },
+            backgroundWorker = workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker),
+            systemInfo = initModule.systemInfo,
+            logger = initModule.logger,
+        )
+    }
+
+    private val resourceSourceImpl = EmbTrace.trace("resource-source") {
         EnvelopeResourceSourceImpl(
             hosted = hostedSdkVersionInfo,
             environment = appEnvironment.environment,
             configService = configService,
-            device = EmbTrace.trace("deviceImpl") {
-                DeviceImpl(
-                    windowManagerProvider = { coreModule.context.getSystemServiceSafe(Context.WINDOW_SERVICE) },
-                    backgroundWorker = workerThreadModule.backgroundWorker(Worker.Background.NonIoRegWorker),
-                    systemInfo = initModule.systemInfo,
-                    logger = initModule.logger,
-                )
-            },
+            device = device,
             rnBundleIdProvider = { rnBundleIdTracker.getReactNativeBundleId() },
             versionName = BuildConfig.VERSION_NAME,
             versionCode = BuildConfig.VERSION_CODE.toIntOrNull(),
-        )
+        ).apply {
+            device.addChangeListener(::notifyIfChanged)
+            observableHostedSdkVersionInfo.addChangeListener(::notifyIfChanged)
+
+            if (configService.appFramework == AppFramework.REACT_NATIVE) {
+                rnBundleIdTracker.addChangeListener(::notifyIfChanged)
+            }
+        }
     }
+
+    override val resourceSource: EnvelopeResourceSource = resourceSourceImpl
 
     override val envelopeMetadataSource: EnvelopeMetadataSource = EmbTrace.trace("metadata-source") {
         EnvelopeMetadataSourceImpl { essentialServiceModule.userService.getUserInfo() }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceRnBundleIdTrackerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/metadata/EmbraceRnBundleIdTrackerTest.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.capture.metadata
 import android.content.Context
 import android.content.res.AssetManager
 import android.view.WindowManager
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeKeyValueStore
 import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
@@ -11,6 +12,7 @@ import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.envelope.metadata.ReactNativeSdkVersionInfo
 import io.embrace.android.embracesdk.internal.payload.AppFramework
+import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -214,5 +216,45 @@ internal class EmbraceRnBundleIdTrackerTest {
     private companion object {
         private const val JAVA_SCRIPT_BUNDLE_URL_KEY = "io.embrace.jsbundle.url"
         private const val JAVA_SCRIPT_BUNDLE_ID_KEY = "io.embrace.jsbundle.id"
+    }
+
+    @Test
+    fun `listener is notified once the bundle ID has been computed in the background`() {
+        val executor = BlockingScheduledExecutorService(blockingMode = true)
+        val tracker = RnBundleIdTrackerImpl(context, configService, store, BackgroundWorker(executor))
+        val observed = mutableListOf<String?>()
+        tracker.addChangeListener { observed.add(tracker.getReactNativeBundleId()) }
+        assertEquals(0, observed.size)
+        assertEquals(null, tracker.getReactNativeBundleId())
+
+        // listener should see computed value
+        executor.runCurrentlyBlocked()
+        assertEquals(listOf(buildInfo.rnBundleId), observed)
+    }
+
+    @Test
+    fun `listener is notified when the JavaScript bundle URL changes`() {
+        val executor = BlockingScheduledExecutorService(blockingMode = true)
+        val tracker = RnBundleIdTrackerImpl(context, configService, store, BackgroundWorker(executor))
+        executor.runCurrentlyBlocked()
+
+        val observed = mutableListOf<String?>()
+        tracker.addChangeListener { observed.add(tracker.getReactNativeBundleId()) }
+        tracker.setReactNativeBundleId("index.android.bundle", true)
+        executor.runCurrentlyBlocked()
+
+        assertEquals(1, observed.size)
+        assertEquals(tracker.getReactNativeBundleId(), observed.single())
+    }
+
+    @Test
+    fun `setting an unchanged JavaScript bundle URL does not notify listeners`() {
+        val tracker = createRnBundleIdTracker()
+        tracker.setReactNativeBundleId("index.android.bundle", true)
+
+        var count = 0
+        tracker.addChangeListener { count++ }
+        tracker.setReactNativeBundleId("index.android.bundle")
+        assertEquals(0, count)
     }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/metadata/ObservableHostedSdkVersionInfoTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/metadata/ObservableHostedSdkVersionInfoTest.kt
@@ -1,0 +1,67 @@
+package io.embrace.android.embracesdk.internal.envelope.metadata
+
+import io.embrace.android.embracesdk.fakes.FakeKeyValueStore
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class ObservableHostedSdkVersionInfoTest {
+
+    @Test
+    fun `each setter notifies listeners`() {
+        val observable = ObservableHostedSdkVersionInfo(UnitySdkVersionInfo(FakeKeyValueStore()))
+        var count = 0
+        observable.addChangeListener { count++ }
+
+        observable.hostedSdkVersion = "1.2.0"
+        assertEquals(1, count)
+
+        observable.hostedPlatformVersion = "19"
+        assertEquals(2, count)
+
+        observable.unityBuildIdNumber = "5092abc"
+        assertEquals(3, count)
+    }
+
+    @Test
+    fun `a batch notifies once rather than once per write`() {
+        val observable = ObservableHostedSdkVersionInfo(UnitySdkVersionInfo(FakeKeyValueStore()))
+        var count = 0
+        observable.addChangeListener { count++ }
+
+        observable.batch {
+            observable.hostedPlatformVersion = "19"
+            observable.hostedSdkVersion = "1.2.0"
+            observable.unityBuildIdNumber = "5092abc"
+        }
+
+        assertEquals(1, count)
+        assertEquals("19", observable.hostedPlatformVersion)
+        assertEquals("1.2.0", observable.hostedSdkVersion)
+        assertEquals("5092abc", observable.unityBuildIdNumber)
+    }
+
+    @Test
+    fun `getters and setters pass through to the wrapped instance`() {
+        val impl = ReactNativeSdkVersionInfo(FakeKeyValueStore())
+        val observable = ObservableHostedSdkVersionInfo(impl)
+
+        observable.hostedSdkVersion = "4.1.0"
+        observable.hostedPlatformVersion = "0.72"
+        observable.javaScriptPatchNumber = "53"
+
+        assertEquals("4.1.0", impl.hostedSdkVersion)
+        assertEquals("0.72", impl.hostedPlatformVersion)
+        assertEquals("53", impl.javaScriptPatchNumber)
+    }
+
+    @Test
+    fun `a throwing listener does not prevent the others from being notified`() {
+        val observable = ObservableHostedSdkVersionInfo(NativeSdkVersionInfo())
+        var count = 0
+        observable.addChangeListener { error("listener failed") }
+        observable.addChangeListener { count++ }
+        observable.hostedSdkVersion = "1.2.0"
+
+        assertEquals(1, count)
+    }
+}

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/DeviceImplChangeListenerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/DeviceImplChangeListenerTest.kt
@@ -1,0 +1,68 @@
+package io.embrace.android.embracesdk.internal.envelope.resource
+
+import android.view.WindowManager
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
+import io.embrace.android.embracesdk.internal.SystemInfo
+import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * The values [DeviceImpl] retrieves asynchronously start out as placeholders, so anything holding
+ * a resource built before they land needs to be told when they change.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class DeviceImplChangeListenerTest {
+
+    @Test
+    fun `listeners are notified once each async value lands`() {
+        val executor = BlockingScheduledExecutorService(blockingMode = true)
+        val device = createDevice(executor)
+
+        var count = 0
+        device.addChangeListener { count++ }
+
+        // nothing has run yet, so the placeholders are still in place
+        assertEquals(0, count)
+        assertEquals("", device.screenResolution)
+
+        executor.runCurrentlyBlocked()
+        assertEquals(3, count)
+        assertEquals("0x0", device.screenResolution)
+    }
+
+    @Test
+    fun `a listener registered after the async work has run is not notified`() {
+        val executor = BlockingScheduledExecutorService(blockingMode = true)
+        val device = createDevice(executor)
+        executor.runCurrentlyBlocked()
+
+        var count = 0
+        device.addChangeListener { count++ }
+        assertEquals(0, count)
+    }
+
+    @Test
+    fun `a throwing listener does not prevent the others from being notified`() {
+        val executor = BlockingScheduledExecutorService(blockingMode = true)
+        val device = createDevice(executor)
+
+        var count = 0
+        device.addChangeListener { error("listener failed") }
+        device.addChangeListener { count++ }
+
+        executor.runCurrentlyBlocked()
+        assertEquals(3, count)
+    }
+
+    private fun createDevice(executor: BlockingScheduledExecutorService) = DeviceImpl(
+        windowManagerProvider = { mockk<WindowManager>(relaxed = true) },
+        backgroundWorker = BackgroundWorker(executor),
+        systemInfo = SystemInfo(),
+        logger = FakeInternalLogger(),
+    )
+}

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImplTest.kt
@@ -7,11 +7,14 @@ import io.embrace.android.embracesdk.fakes.FakeKeyValueStore
 import io.embrace.android.embracesdk.internal.capture.metadata.AppEnvironment
 import io.embrace.android.embracesdk.internal.envelope.metadata.UnitySdkVersionInfo
 import io.embrace.android.embracesdk.internal.payload.AppFramework
+import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
 import io.mockk.every
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.BeforeClass
 import org.junit.Test
 import java.io.File
@@ -76,4 +79,107 @@ internal class EnvelopeResourceSourceImplTest {
         assertEquals(true, envelope.usesEmmcStorage)
         assertEquals("SM8450", envelope.deviceSocModel)
     }
+
+    @Test
+    fun `listener is invoked with the current resource upon registration`() {
+        val source = createSource(FakeDevice())
+        val observed = mutableListOf<EnvelopeResource>()
+
+        source.addChangeListener(observed::add)
+
+        assertEquals(1, observed.size)
+        assertEquals(source.getEnvelopeResource(), observed.single())
+    }
+
+    @Test
+    fun `a changed value notifies listeners`() {
+        val device = FakeDevice(screenResolution = "")
+        val source = createSource(device)
+        val observed = mutableListOf<EnvelopeResource>()
+        source.addChangeListener(observed::add)
+
+        device.screenResolution = "1920x1080"
+        source.notifyIfChanged()
+
+        assertEquals(2, observed.size)
+        assertEquals("", observed.first().screenResolution)
+        assertEquals("1920x1080", observed.last().screenResolution)
+    }
+
+    @Test
+    fun `an unchanged resource does not notify listeners`() {
+        val source = createSource(FakeDevice())
+        val observed = mutableListOf<EnvelopeResource>()
+        source.addChangeListener(observed::add)
+
+        repeat(5) { source.notifyIfChanged() }
+
+        assertEquals(1, observed.size)
+    }
+
+    @Test
+    fun `adding an extra notifies listeners only when the value changes`() {
+        val source = createSource(FakeDevice())
+        val observed = mutableListOf<EnvelopeResource>()
+        source.addChangeListener(observed::add)
+
+        source.add("key", "value")
+        assertEquals(2, observed.size)
+        assertEquals(mapOf("key" to "value"), observed.last().extras)
+
+        // re-adding the same value leaves the resource untouched
+        source.add("key", "value")
+        assertEquals(2, observed.size)
+
+        source.add("key", "other")
+        assertEquals(3, observed.size)
+        assertEquals(mapOf("key" to "other"), observed.last().extras)
+    }
+
+    @Test
+    fun `every listener is notified even if one throws`() {
+        val device = FakeDevice(screenResolution = "")
+        val source = createSource(device)
+        val observed = mutableListOf<EnvelopeResource>()
+
+        source.addChangeListener { error("listener failed") }
+        source.addChangeListener(observed::add)
+
+        device.screenResolution = "1920x1080"
+        source.notifyIfChanged()
+
+        assertEquals(2, observed.size)
+        assertEquals("1920x1080", observed.last().screenResolution)
+    }
+
+    @Test
+    fun `no resource is built when nothing is listening`() {
+        var built = false
+        val device = object : Device by FakeDevice() {
+            override val screenResolution: String
+                get() {
+                    built = true
+                    return "1920x1080"
+                }
+        }
+        val source = createSource(device)
+
+        source.notifyIfChanged()
+        assertTrue(!built)
+
+        val observed = mutableListOf<EnvelopeResource>()
+        source.addChangeListener(observed::add)
+        assertTrue(built)
+        assertSame(observed.single(), observed.last())
+    }
+
+    private fun createSource(device: Device) = EnvelopeResourceSourceImpl(
+        FakeConfigService(),
+        UnitySdkVersionInfo(FakeKeyValueStore()),
+        AppEnvironment.Environment.PROD,
+        device,
+        "",
+        53,
+        { "fakeReactNativeBundleId" },
+    )
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterBoundaryTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterBoundaryTest.kt
@@ -59,6 +59,8 @@ internal class SessionPartWriterBoundaryTest {
             EnvelopeResource(appVersion = "resource${resourceCount++}")
 
         override fun add(key: String, value: String) = Unit
+
+        override fun addChangeListener(listener: (EnvelopeResource) -> Unit) = Unit
     }
 
     @Before

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
@@ -67,6 +67,8 @@ internal class SessionPartWriterImplTest {
             EnvelopeResource(appVersion = "resource${resourceCount++}")
 
         override fun add(key: String, value: String) = Unit
+
+        override fun addChangeListener(listener: (EnvelopeResource) -> Unit) = Unit
     }
 
     @Before

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/metadata/ObservableHostedSdkVersionInfo.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/metadata/ObservableHostedSdkVersionInfo.kt
@@ -1,0 +1,73 @@
+package io.embrace.android.embracesdk.internal.envelope.metadata
+
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Wraps a [HostedSdkVersionInfo] so that writes made by hosted SDKs can be observed.
+ */
+class ObservableHostedSdkVersionInfo(
+    private val impl: HostedSdkVersionInfo,
+) : HostedSdkVersionInfo {
+
+    private val listeners = CopyOnWriteArrayList<() -> Unit>()
+
+    @Volatile
+    private var batching: Boolean = false
+
+    override var hostedSdkVersion: String?
+        get() = impl.hostedSdkVersion
+        set(value) {
+            impl.hostedSdkVersion = value
+            notifyChanged()
+        }
+
+    override var hostedPlatformVersion: String?
+        get() = impl.hostedPlatformVersion
+        set(value) {
+            impl.hostedPlatformVersion = value
+            notifyChanged()
+        }
+
+    override var unityBuildIdNumber: String?
+        get() = impl.unityBuildIdNumber
+        set(value) {
+            impl.unityBuildIdNumber = value
+            notifyChanged()
+        }
+
+    override var javaScriptPatchNumber: String?
+        get() = impl.javaScriptPatchNumber
+        set(value) {
+            impl.javaScriptPatchNumber = value
+            notifyChanged()
+        }
+
+    override fun batch(action: () -> Unit) {
+        batching = true
+        try {
+            impl.batch(action)
+        } finally {
+            batching = false
+        }
+        notifyChanged()
+    }
+
+    /**
+     * Registers a [listener] invoked whenever one of the hosted SDK values is written.
+     */
+    fun addChangeListener(listener: () -> Unit) {
+        listeners.add(listener)
+    }
+
+    private fun notifyChanged() {
+        if (batching) {
+            return
+        }
+        listeners.forEach { listener ->
+            try {
+                listener()
+            } catch (ignored: Throwable) {
+            }
+        }
+    }
+}

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/DeviceImpl.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/DeviceImpl.kt
@@ -13,6 +13,7 @@ import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import java.io.File
 import java.util.Locale
+import java.util.concurrent.CopyOnWriteArrayList
 
 class DeviceImpl(
     private val windowManagerProvider: Provider<WindowManager?>,
@@ -20,9 +21,17 @@ class DeviceImpl(
     override val systemInfo: SystemInfo,
     private val logger: InternalLogger,
 ) : Device {
+
+    @Volatile
     override var isJailbroken: Boolean? = false
+
+    @Volatile
     override var screenResolution: String = ""
+
+    @Volatile
     override var usesEmmcStorage: Boolean? = null
+
+    private val listeners = CopyOnWriteArrayList<() -> Unit>()
 
     private val jailbreakLocations: List<String> = listOf(
         "/sbin/",
@@ -41,15 +50,33 @@ class DeviceImpl(
         asyncRetrieveUsesEmmcStorage()
     }
 
+    /**
+     * Registers a [listener] invoked whenever one of the asynchronously retrieved values changes.
+     */
+    fun addChangeListener(listener: () -> Unit) {
+        listeners.add(listener)
+    }
+
+    private fun notifyChanged() {
+        listeners.forEach { listener ->
+            try {
+                listener()
+            } catch (ignored: Throwable) {
+            }
+        }
+    }
+
     private fun asyncRetrieveUsesEmmcStorage() {
         backgroundWorker.submit {
             usesEmmcStorage = detectUsesEmmcStorage()
+            notifyChanged()
         }
     }
 
     private fun asyncRetrieveScreenResolution() {
         backgroundWorker.submit {
             screenResolution = getScreenResolution(windowManagerProvider())
+            notifyChanged()
         }
     }
 
@@ -74,6 +101,7 @@ class DeviceImpl(
     private fun asyncRetrieveIsJailbroken() {
         backgroundWorker.submit {
             isJailbroken = checkIfIsJailbroken()
+            notifyChanged()
         }
     }
 

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSource.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSource.kt
@@ -8,4 +8,13 @@ import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
 interface EnvelopeResourceSource {
     fun getEnvelopeResource(): EnvelopeResource
     fun add(key: String, value: String)
+
+    /**
+     * Registers a [listener] that is invoked whenever the [EnvelopeResource] changes. Most of the
+     * resource is fixed for the lifetime of the process, but some values can mutate, so the
+     * 'immutable' resource is actually mutable.
+     *
+     * The listener is invoked with the current resource upon registration.
+     */
+    fun addChangeListener(listener: (EnvelopeResource) -> Unit)
 }

--- a/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImpl.kt
+++ b/embrace-android-envelope/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/resource/EnvelopeResourceSourceImpl.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.envelope.metadata.HostedSdkVersionInfo
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
 
 class EnvelopeResourceSourceImpl(
     private val configService: ConfigService,
@@ -17,6 +18,9 @@ class EnvelopeResourceSourceImpl(
 ) : EnvelopeResourceSource {
 
     private val extras = ConcurrentHashMap<String, String>()
+    private val listeners = CopyOnWriteArrayList<(EnvelopeResource) -> Unit>()
+    private var lastEmitted: EnvelopeResource? = null
+    private val lock = Any()
 
     override fun getEnvelopeResource(): EnvelopeResource {
         val buildInfo = configService.buildInfo
@@ -56,5 +60,42 @@ class EnvelopeResourceSourceImpl(
 
     override fun add(key: String, value: String) {
         extras[key] = value
+        notifyIfChanged()
+    }
+
+    override fun addChangeListener(listener: (EnvelopeResource) -> Unit) {
+        listeners.add(listener)
+        val current = synchronized(lock) {
+            getEnvelopeResource().also { lastEmitted = it }
+        }
+        notifyListener(listener, current)
+    }
+
+    /**
+     * Rebuilds the resource and hands it to the listeners if it differs from the one they last saw.
+     * Called by whatever owns a value the resource is built from, once that value has changed.
+     */
+    fun notifyIfChanged() {
+        if (listeners.isEmpty()) {
+            return
+        }
+        val changed = synchronized(lock) {
+            val current = getEnvelopeResource()
+            when (current) {
+                lastEmitted -> null
+                else -> current.also { lastEmitted = it }
+            }
+        } ?: return
+
+        listeners.forEach { listener ->
+            notifyListener(listener, changed)
+        }
+    }
+
+    private fun notifyListener(listener: (EnvelopeResource) -> Unit, resource: EnvelopeResource) {
+        try {
+            listener(resource)
+        } catch (ignored: Throwable) {
+        }
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEnvelopeResourceSource.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEnvelopeResourceSource.kt
@@ -7,10 +7,21 @@ class FakeEnvelopeResourceSource : EnvelopeResourceSource {
 
     var resource: EnvelopeResource = EnvelopeResource()
     var customValues = mutableMapOf<String, String>()
+    val listeners = mutableListOf<(EnvelopeResource) -> Unit>()
 
     override fun getEnvelopeResource(): EnvelopeResource = resource
 
     override fun add(key: String, value: String) {
         customValues[key] = value
+    }
+
+    override fun addChangeListener(listener: (EnvelopeResource) -> Unit) {
+        listeners.add(listener)
+        listener(resource)
+    }
+
+    fun changeResource(resource: EnvelopeResource) {
+        this.resource = resource
+        listeners.forEach { it(resource) }
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeRnBundleIdTracker.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeRnBundleIdTracker.kt
@@ -6,13 +6,19 @@ class FakeRnBundleIdTracker : RnBundleIdTracker {
 
     var fakeReactNativeBundleId: String? = "fakeReactNativeBundleId"
     var forceUpdate: Boolean? = null
+    val listeners = mutableListOf<() -> Unit>()
 
     override fun setReactNativeBundleId(jsBundleUrl: String?, forceUpdate: Boolean?) {
         fakeReactNativeBundleId = jsBundleUrl
         this.forceUpdate = forceUpdate
+        listeners.forEach { it() }
     }
 
     override fun getReactNativeBundleId(): String? {
         return fakeReactNativeBundleId
+    }
+
+    override fun addChangeListener(listener: () -> Unit) {
+        listeners.add(listener)
     }
 }


### PR DESCRIPTION
## Goal

Invoke a callback when the `EnvelopeResource` mutates. This will be helpful in determining when the session part files should be rewritten to disk.

## Testing

Added unit tests.
