### PR TITLE
Rewrite manifest on state change

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -52,6 +52,9 @@ class SessionPartWriterImpl(
     @Volatile
     private var crashing = false
 
+    @Volatile
+    private var resourceListenerRegistered = false
+
     private val directoryStore = SessionPartDirectoryStore(sessionsDir, worker, clock, logger)
 
     override fun onSessionPartStarted(timestamp: Long, userSessionId: String, sessionPartId: String) {
@@ -72,6 +75,7 @@ class SessionPartWriterImpl(
         queueManifestWrite(writers)
         queueMetadataWrite(writers)
         queueSessionSpanWrite(writers)
+        registerResourceChangeListener()
     }
 
     override fun onSessionPartEnded(sessionPartId: String) {
@@ -92,6 +96,13 @@ class SessionPartWriterImpl(
         queueMetadataWrite(current ?: return)
     }
 
+    private fun onResourceChanged() {
+        if (!enabled()) {
+            return
+        }
+        queueManifestWrite(current ?: return)
+    }
+
     override fun onPeriodicWrite() {
         if (!enabled()) {
             return
@@ -107,8 +118,26 @@ class SessionPartWriterImpl(
         worker.shutdownAndWait(CRASH_DRAIN_TIMEOUT_MS)
     }
 
-    private fun queueManifestWrite(writers: PartWriters) {
+    /**
+     * Subscribes to resource changes so the manifest on disk keeps up with them. Registration
+     * happens at most once as the listener outlives any one session part, and is deferred to the
+     * [worker] because building a resource can touch the filesystem.
+     *
+     * The resource handed to the listener is discarded: each write rebuilds it, so the newest
+     * resource wins even if two changes are delivered out of order.
+     */
+    private fun registerResourceChangeListener() {
+        if (resourceListenerRegistered) {
+            return
+        }
+        resourceListenerRegistered = true
         execute(InternalErrorType.SessionManifestWriteFail, { worker.submit(it) }) {
+            resourceSource.addChangeListener { _ -> onResourceChanged() }
+        }
+    }
+
+    private fun queueManifestWrite(writers: PartWriters) {
+        execute(InternalErrorType.SessionManifestWriteFail, writers.manifestWrites::submit) {
             writers.manifest.write(
                 directory = writers.directory,
                 resource = resourceSource.getEnvelopeResource(),
@@ -178,6 +207,7 @@ class SessionPartWriterImpl(
             logger = logger,
         )
 
+        val manifestWrites = CoalescingWriteQueue(worker)
         val metadataWrites = CoalescingWriteQueue(worker)
         val sessionSpanWrites = CoalescingWriteQueue(worker)
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceChangeTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceChangeTest.kt
@@ -1,0 +1,255 @@
+package io.embrace.android.embracesdk.internal.session.orchestrator
+
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
+import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.fakes.FakeConfigService
+import io.embrace.android.embracesdk.fakes.FakeCurrentSessionPartSpan
+import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
+import io.embrace.android.embracesdk.fakes.FakeInternalLogger
+import io.embrace.android.embracesdk.fakes.TestUuidSource
+import io.embrace.android.embracesdk.fakes.createPersistenceBehavior
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.envelope.resource.EnvelopeResourceSource
+import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
+import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
+import io.embrace.android.embracesdk.internal.session.persistence.SessionManifest
+import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectory
+import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * Covers rewriting the manifest when the envelope resource changes. Most of the resource is fixed
+ * for the lifetime of the process, but values such as the React Native bundle id can mutate.
+ */
+internal class SessionPartWriterResourceChangeTest {
+
+    private companion object {
+        private const val USER_SESSION_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        private const val FIRST_PART_ID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        private const val SECOND_PART_ID = "cccccccccccccccccccccccccccccccc"
+        private const val MANIFEST_FILE_NAME = "manifest.pb"
+        private const val INITIAL_VERSION = "1.0.0"
+        private const val CHANGED_VERSION = "2.0.0"
+    }
+
+    @get:Rule
+    val tempFolder: TemporaryFolder = TemporaryFolder()
+
+    private lateinit var sessionsDir: File
+    private lateinit var clock: FakeClock
+    private lateinit var executor: BlockingScheduledExecutorService
+    private lateinit var logger: FakeInternalLogger
+    private lateinit var currentSessionPartSpan: FakeCurrentSessionPartSpan
+
+    private var appVersion = INITIAL_VERSION
+    private var resourceReads = 0
+    private val resourceListeners = mutableListOf<(EnvelopeResource) -> Unit>()
+
+    private val resourceSource = object : EnvelopeResourceSource {
+        override fun getEnvelopeResource(): EnvelopeResource {
+            resourceReads++
+            return EnvelopeResource(appVersion = appVersion)
+        }
+
+        override fun add(key: String, value: String) = Unit
+
+        override fun addChangeListener(listener: (EnvelopeResource) -> Unit) {
+            resourceListeners.add(listener)
+            listener(getEnvelopeResource())
+        }
+    }
+
+    @Before
+    fun setUp() {
+        sessionsDir = tempFolder.newFolder("embrace_sessions_split")
+        clock = FakeClock()
+        executor = BlockingScheduledExecutorService(clock, true)
+        logger = FakeInternalLogger(throwOnInternalError = false)
+        appVersion = INITIAL_VERSION
+        resourceReads = 0
+        resourceListeners.clear()
+        currentSessionPartSpan = FakeCurrentSessionPartSpan(clock).apply {
+            sessionPartSpan = FakeEmbraceSdkSpan().apply { start(clock.now()) }
+        }
+    }
+
+    @Test
+    fun `a resource change rewrites the manifest for the active session part`() {
+        val writer = createWriter()
+        startPart(writer, FIRST_PART_ID)
+        drain()
+        assertEquals(INITIAL_VERSION, manifestOnDisk(FIRST_PART_ID)?.resource?.app_version)
+
+        changeResource(CHANGED_VERSION)
+        drain()
+
+        with(checkNotNull(manifestOnDisk(FIRST_PART_ID))) {
+            assertEquals(CHANGED_VERSION, resource?.app_version)
+            assertEquals(USER_SESSION_ID, user_session_id)
+            assertEquals(FIRST_PART_ID, session_part_id)
+        }
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a resource change before any session part starts writes nothing`() {
+        createWriter()
+        changeResource(CHANGED_VERSION)
+        drain()
+
+        assertTrue(resourceListeners.isEmpty())
+        assertEquals(emptyList<SessionPartDirectory>(), partDirs())
+        assertEquals(0, resourceReads)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `no listener is registered when multi file persistence is disabled`() {
+        val writer = createWriter(enabled = false)
+        startPart(writer, FIRST_PART_ID)
+        drain()
+        changeResource(CHANGED_VERSION)
+        drain()
+
+        assertTrue(resourceListeners.isEmpty())
+        assertEquals(emptyList<SessionPartDirectory>(), partDirs())
+        assertEquals(0, resourceReads)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a resource change after a boundary rewrites only the newer manifest`() {
+        val writer = createWriter()
+        startPart(writer, FIRST_PART_ID)
+        drain()
+        endPart(writer, FIRST_PART_ID)
+        startPart(writer, SECOND_PART_ID)
+        drain()
+
+        changeResource(CHANGED_VERSION)
+        drain()
+
+        assertEquals(INITIAL_VERSION, manifestOnDisk(FIRST_PART_ID)?.resource?.app_version)
+        assertEquals(CHANGED_VERSION, manifestOnDisk(SECOND_PART_ID)?.resource?.app_version)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a burst of resource changes is coalesced into one manifest write`() {
+        val writer = createWriter()
+        startPart(writer, FIRST_PART_ID)
+        drain()
+        assertEquals(2, resourceReads)
+
+        repeat(3) { changeResource("2.0.$it") }
+        drain()
+
+        assertEquals(3, resourceReads)
+        assertEquals("2.0.2", manifestOnDisk(FIRST_PART_ID)?.resource?.app_version)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `the resource listener is registered once across session parts`() {
+        val writer = createWriter()
+        startPart(writer, FIRST_PART_ID)
+        drain()
+        endPart(writer, FIRST_PART_ID)
+        startPart(writer, SECOND_PART_ID)
+        drain()
+
+        assertEquals(1, resourceListeners.size)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a resource change after a crash does not write`() {
+        val writer = createWriter()
+        startPart(writer, FIRST_PART_ID)
+        drain()
+        writer.onCrash()
+
+        val readsBeforeChange = resourceReads
+        changeResource(CHANGED_VERSION)
+
+        assertEquals(readsBeforeChange, resourceReads)
+        assertEquals(INITIAL_VERSION, manifestOnDisk(FIRST_PART_ID)?.resource?.app_version)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a rewrite into a deleted session part directory is reported`() {
+        val writer = createWriter()
+        startPart(writer, FIRST_PART_ID)
+        drain()
+        assertTrue(File(sessionsDir, dirFor(FIRST_PART_ID).dirName).deleteRecursively())
+
+        changeResource(CHANGED_VERSION)
+        drain()
+
+        assertEquals(1, logger.internalErrorMessages.size)
+        assertEquals("SessionManifestWriteFail", logger.internalErrorMessages.single().msg)
+    }
+
+    private fun createWriter(enabled: Boolean = true) = SessionPartWriterImpl(
+        lazy { sessionsDir },
+        BackgroundWorker(executor),
+        FakeConfigService(
+            persistenceBehavior = when {
+                enabled -> createPersistenceBehavior(
+                    remoteCfg = RemoteConfig(pctMultiFilePersistenceEnabled = 100.0f),
+                )
+                else -> createPersistenceBehavior()
+            },
+        ),
+        TestUuidSource(),
+        clock,
+        logger,
+        resourceSource,
+        { EnvelopeMetadata(userId = "my-user-id") },
+        currentSessionPartSpan,
+    )
+
+    private fun startPart(writer: SessionPartWriter, sessionPartId: String) {
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, sessionPartId)
+    }
+
+    private fun endPart(writer: SessionPartWriter, sessionPartId: String) {
+        currentSessionPartSpan.endSession(startNewSession = true)
+        writer.onSessionPartEnded(sessionPartId)
+    }
+
+    private fun changeResource(version: String) {
+        appVersion = version
+        val resource = EnvelopeResource(appVersion = version)
+        resourceListeners.forEach { listener -> listener(resource) }
+    }
+
+    private fun drain() {
+        executor.runCurrentlyBlocked()
+    }
+
+    private fun partDirs(): List<SessionPartDirectory> =
+        (sessionsDir.list() ?: emptyArray())
+            .mapNotNull(SessionPartDirectory::fromDirName)
+            .sortedWith(SessionPartDirectory.comparator)
+
+    private fun dirFor(sessionPartId: String): SessionPartDirectory =
+        partDirs().single { it.sessionPartId == sessionPartId }
+
+    private fun manifestOnDisk(sessionPartId: String): SessionManifest? =
+        File(File(sessionsDir, dirFor(sessionPartId).dirName), MANIFEST_FILE_NAME)
+            .takeIf(File::isFile)
+            ?.inputStream()
+            ?.use(SessionManifest.ADAPTER::decode)
+
+    private fun assertNoInternalErrors() {
+        assertEquals(emptyList<FakeInternalLogger.LogMessage>(), logger.internalErrorMessages)
+    }
+}

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionManifestWriter.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionManifestWriter.kt
@@ -7,7 +7,11 @@ import java.io.File
 import java.io.IOException
 
 /**
- * Writes the data that is immutable for the lifetime of a session part to its directory.
+ * Writes the envelope resource and the identity of a session part to its directory.
+ *
+ * This file is overwritten in place. [write] is called when a session part starts and again
+ * whenever the [EnvelopeResource] changes, as some of the values it is built from are retrieved
+ * asynchronously or supplied by a hosted SDK after the session part began.
  */
 class SessionManifestWriter(
     private val sessionsDir: Lazy<File>,
@@ -15,7 +19,7 @@ class SessionManifestWriter(
 ) {
 
     /**
-     * Writes the manifest for the given session part, unless one already exists.
+     * Writes the manifest for the given session part, replacing any manifest already on disk.
      *
      * Returns true if a manifest is on disk for this session part
      */
@@ -45,10 +49,6 @@ class SessionManifestWriter(
         if (!partDir.isDirectory) {
             trackFailure(IOException("Not a session part directory"))
             return false
-        }
-
-        if (File(partDir, MANIFEST_FILE_NAME).exists()) {
-            return true
         }
 
         // build the message before touching the filesystem

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionManifestWriterTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionManifestWriterTest.kt
@@ -161,7 +161,7 @@ internal class SessionManifestWriterTest {
     }
 
     @Test
-    fun `manifest is not rewritten on a second call`() {
+    fun `manifest is rewritten on a second call`() {
         assertTrue(write(sharedLibSymbolMapping = mapOf("armeabi-v7a" to "my-symbols")))
         assertTrue(
             write(
@@ -173,13 +173,13 @@ internal class SessionManifestWriterTest {
         )
 
         with(readManifest()) {
-            assertEquals(fullyPopulatedResourceProto, resource)
-            assertEquals(ENVELOPE_VERSION, envelope_version)
-            assertEquals(ENVELOPE_TYPE, envelope_type)
-            assertEquals(
-                SharedLibSymbolMapping(symbols = mapOf("armeabi-v7a" to "my-symbols")),
-                shared_lib_symbol_mapping,
-            )
+            assertEquals("9.9.9", resource?.app_version)
+            assertEquals(EnvelopeResourceProto.AppFramework.FLUTTER, resource?.app_framework)
+            assertEquals("9.9.9", envelope_version)
+            assertEquals("logs", envelope_type)
+            assertNull(shared_lib_symbol_mapping)
+            assertEquals(USER_SESSION_ID, user_session_id)
+            assertEquals(SESSION_PART_ID, session_part_id)
         }
         assertEquals(listOf(MANIFEST_FILE_NAME), partDir().list()?.toList())
         assertNoInternalErrors()


### PR DESCRIPTION
## Goal

Overwrites the session part manifest file whenever one of the properties in `EnvelopeResource` change.

## Testing

Added unit tests.
