### PR TITLE
Report confirmed leak suspects as a session attribute at session part end

### DIFF
--- a/embrace-android-instrumentation-leaks/gradle.properties
+++ b/embrace-android-instrumentation-leaks/gradle.properties
@@ -1,0 +1,1 @@
+io.embrace.android.embracesdk.semconv.optIn=true

--- a/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/ActivityLeakDetectionLifecycleCallbacks.kt
+++ b/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/ActivityLeakDetectionLifecycleCallbacks.kt
@@ -22,7 +22,7 @@ internal class ActivityLeakDetectionLifecycleCallbacks(
     }
 
     override fun onActivityDestroyed(activity: Activity) {
-        leakDetector.trackClosed(activity, activeSessionIdsProvider())
+        leakDetector.trackClosed(activity, LeakContext(OBJECT_TYPE, activeSessionIdsProvider()))
     }
 
     override fun onActivityPaused(activity: Activity) = Unit
@@ -30,4 +30,12 @@ internal class ActivityLeakDetectionLifecycleCallbacks(
     override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
     override fun onActivityStarted(activity: Activity) = Unit
     override fun onActivityStopped(activity: Activity) = Unit
+
+    private companion object {
+
+        /**
+         * Reported as [LeakContext.objectType], naming what this instrumentation tracks.
+         */
+        const val OBJECT_TYPE = "activity"
+    }
 }

--- a/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakContext.kt
+++ b/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakContext.kt
@@ -1,0 +1,20 @@
+package io.embrace.android.embracesdk.instrumentation.leaks
+
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsSnapshot
+
+/**
+ * Everything reporting a leak needs about a tracked object other than the object itself. Passed to
+ * [LeakDetector.trackClosed] as its token, and handed back, unchanged, as [LeakDetector.LeakSnapshot.token] if that object
+ * is confirmed as a leak.
+ *
+ * [objectType] is supplied by whichever instrumentation tracked the object rather than decided when the leak is reported,
+ * so that support for a new kind of object can be added without the reporting layer changing.
+ *
+ * [sessionIds] are the IDs current when the object's lifecycle ended. They are captured then rather than read when the leak
+ * is reported, because confirmation happens later - and by then the current session part may not be the one the leak
+ * belongs to.
+ */
+internal class LeakContext(
+    val objectType: String,
+    val sessionIds: SessionIdsSnapshot,
+)

--- a/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetectionDataSource.kt
+++ b/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetectionDataSource.kt
@@ -2,23 +2,34 @@ package io.embrace.android.embracesdk.instrumentation.leaks
 
 import android.app.Application
 import io.embrace.android.embracesdk.internal.arch.InstrumentationArgs
+import io.embrace.android.embracesdk.internal.arch.SessionPartEndListener
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceImpl
 import io.embrace.android.embracesdk.internal.arch.limits.UpToLimitStrategy
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 
-class LeakDetectionDataSource(args: InstrumentationArgs) : DataSourceImpl(
-    args,
-    limitStrategy = UpToLimitStrategy { MAX_LEAK_DETECTION },
-    "leak-detection",
-) {
+class LeakDetectionDataSource(args: InstrumentationArgs) :
+    DataSourceImpl(
+        args,
+        limitStrategy = UpToLimitStrategy { MAX_LEAK_DETECTION },
+        "leak-detection",
+    ),
+    SessionPartEndListener {
     companion object {
+        /**
+         * Caps how many times [captureTelemetry] is allowed to succeed for this data source per session - i.e. how many
+         * session parts' worth of [onPreSessionEnd] reports, now that reporting happens once per session part rather
+         * than once per leak.
+         */
         const val MAX_LEAK_DETECTION = 100
     }
 
     private val application: Application = args.application
 
-    // TODO: query leakDetector.suspects() (e.g. from a SessionPartEndListener.onPreSessionEnd()) and encode the dataset into
-    // a session attribute. Each entry already carries how many GC cycles it has survived since being confirmed.
-    private val leakDetector = LeakDetector(args.clock)
+    /**
+     * Visible so that tests can drive tracking and reclamation directly, rather than depending on real Activity
+     * lifecycle callbacks and real collections.
+     */
+    internal val leakDetector = LeakDetector(args.clock)
 
     private val callbacks = ActivityLeakDetectionLifecycleCallbacks(leakDetector, args::activeSessionIds)
 
@@ -30,5 +41,19 @@ class LeakDetectionDataSource(args: InstrumentationArgs) : DataSourceImpl(
     override fun onDataCaptureDisabled() {
         application.unregisterActivityLifecycleCallbacks(callbacks)
         leakDetector.stop()
+    }
+
+    /**
+     * Encodes every currently-tracked suspect into one session attribute, back-attributed to whichever session part
+     * originally tracked each one closed - see [encodeLeakSuspects]. Nothing is written when there is nothing to report,
+     * rather than setting an empty attribute on every session part.
+     */
+    override fun onPreSessionEnd() {
+        val encoded = encodeLeakSuspects(leakDetector.suspects())
+        if (encoded.isNotEmpty()) {
+            captureTelemetry {
+                addSessionPartAttribute(EmbSessionAttributes.EMB_MEMORY_LEAK_SUSPECTS, encoded)
+            }
+        }
     }
 }

--- a/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetector.kt
+++ b/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetector.kt
@@ -206,15 +206,17 @@ internal class LeakDetector(
     /**
      * A snapshot of every confirmed suspect still reachable, safe to hand outside the detector: it never carries the tracked
      * object itself, only what [trackClosed] was given, its class name read fresh from the still-live object, and how many
-     * GC cycles it has survived since being confirmed. A suspect actually collected between being read here and
-     * [onSuspectCollected] catching up to it is simply omitted, the same as if it had already been dropped.
+     * GC cycles it has survived since being confirmed.
      */
     fun suspects(): List<LeakSnapshot> {
         val cycleCount = currentGcCycleCount()
         return synchronized(trackedSuspects) {
             trackedSuspects.mapNotNull { suspect ->
                 val referent = suspect.get() ?: return@mapNotNull null
-                LeakSnapshot(suspect.trackedAtMs, suspect.token, cycleCount - suspect.suspectedAtCycle, referent.javaClass.name)
+                // The suspectedAtCycle is captured after the first GC cycle (when a TrackedReference becomes a ConfirmedSuspect).
+                // So we +1 here so that cycle is represented in the reporting (instead of reporting a confusing 0 value).
+                val cyclesSurvived = cycleCount - suspect.suspectedAtCycle + 1
+                LeakSnapshot(suspect.trackedAtMs, suspect.token, cyclesSurvived, referent.javaClass.name)
             }
         }
     }

--- a/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakSuspectEncoder.kt
+++ b/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakSuspectEncoder.kt
@@ -1,0 +1,76 @@
+package io.embrace.android.embracesdk.instrumentation.leaks
+
+/**
+ * Encodes [suspects] into a single delimited string for reporting as one session attribute, grouped by the session part
+ * each suspect was originally tracked closed in.
+ *
+ * Every currently-tracked suspect is included, regardless of which session part it originally belongs to: a suspect that
+ * survives across a session part boundary is meant to be reported again in each part it survives, with a larger
+ * [LeakDetector.LeakSnapshot.cyclesSurvived] each time - a time series of the same leak, rather than one report that has
+ * to guess which part "owns" it. Most of the time every suspect shares the same session part - the one about to end -
+ * but once something survives a boundary the live set can be a genuine mix of origins, which is why grouping is needed
+ * rather than assumed away.
+ *
+ * A suspect whose [LeakDetector.LeakSnapshot.token] is not a [LeakContext], or whose session IDs are empty, is dropped: a
+ * leak whose session is unknown is not reportable.
+ *
+ * The format is `<sessionPartId>_<userSessionId>:<objectType>|<className>|<cyclesSurvived>,...;...` - groups separated by
+ * `;`, entries within a group by `,`, fields within an entry by `|`. None of these, nor `:`, can appear in a JVM class
+ * name, so no escaping is needed.
+ *
+ * Session-part attributes are not length-truncated by the platform the way custom attributes are, so [maxLength] is
+ * enforced here - defaulting to 2000, matching `OtelLimitsConfig.getMaxInternalAttributeValueLength()`. Suspects are kept
+ * by [LeakDetector.LeakSnapshot.cyclesSurvived] descending, since the most persistent suspects are the most actionable,
+ * and the actual rendered length is checked after each tentative addition - rather than approximated from an assumed
+ * entry size - so the result never exceeds [maxLength] regardless of how long class names get. The first candidate that
+ * would not fit stops the process; a later, shorter candidate is not tried in its place.
+ */
+internal fun encodeLeakSuspects(
+    suspects: List<LeakDetector.LeakSnapshot>,
+    maxLength: Int = MAX_ENCODED_LENGTH,
+): String {
+    val candidates = suspects.mapNotNull(::toCandidate).sortedByDescending { it.cyclesSurvived }
+
+    val included = LinkedHashMap<String, List<String>>()
+    for (candidate in candidates) {
+        val attempt = LinkedHashMap(included)
+        attempt[candidate.groupKey] = (attempt[candidate.groupKey] ?: emptyList()) + candidate.entry
+
+        if (render(attempt).length > maxLength) {
+            break
+        }
+
+        included[candidate.groupKey] = attempt.getValue(candidate.groupKey)
+    }
+
+    return render(included)
+}
+
+private fun toCandidate(snapshot: LeakDetector.LeakSnapshot): Candidate? {
+    val context = snapshot.token as? LeakContext ?: return null
+    val sessionIds = context.sessionIds
+    if (sessionIds.userSessionId.isEmpty() || sessionIds.sessionPartId.isEmpty()) {
+        return null
+    }
+
+    return Candidate(
+        groupKey = "${sessionIds.sessionPartId}_${sessionIds.userSessionId}",
+        entry = "${context.objectType}|${snapshot.className}|${snapshot.cyclesSurvived}",
+        cyclesSurvived = snapshot.cyclesSurvived,
+    )
+}
+
+private fun render(groups: Map<String, List<String>>): String =
+    groups.entries.joinToString(";") { (groupKey, entries) -> "$groupKey:${entries.joinToString(",")}" }
+
+/**
+ * One suspect that survived the [toCandidate] filter. [cyclesSurvived] is carried separately from the already-built
+ * [entry] string so that [encodeLeakSuspects] can sort by it without re-parsing that string.
+ */
+private class Candidate(
+    val groupKey: String,
+    val entry: String,
+    val cyclesSurvived: Long,
+)
+
+private const val MAX_ENCODED_LENGTH = 2000

--- a/embrace-android-instrumentation-leaks/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetectionDataSourceTest.kt
+++ b/embrace-android-instrumentation-leaks/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetectionDataSourceTest.kt
@@ -1,0 +1,98 @@
+package io.embrace.android.embracesdk.instrumentation.leaks
+
+import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsSnapshot
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+internal class LeakDetectionDataSourceTest {
+
+    private lateinit var args: FakeInstrumentationArgs
+    private lateinit var dataSource: LeakDetectionDataSource
+
+    @Before
+    fun setUp() {
+        args = FakeInstrumentationArgs(RuntimeEnvironment.getApplication())
+        dataSource = LeakDetectionDataSource(args)
+
+        // nothing is tracked unless the detector is running, and this is how it is started in production
+        dataSource.onDataCaptureEnabled()
+    }
+
+    @After
+    fun tearDown() {
+        dataSource.onDataCaptureDisabled()
+    }
+
+    @Test
+    fun `a confirmed suspect is encoded into the memory leak suspects session attribute at session part end`() {
+        val leaked = Any()
+        confirmLeak(leaked, sessionIds = SESSION_IDS)
+
+        dataSource.onPreSessionEnd()
+
+        val encoded = args.destination.attributes[EmbSessionAttributes.EMB_MEMORY_LEAK_SUSPECTS]
+        assertTrue(
+            "expected the part_session group key, object type and class name; the exact cycle count isn't asserted here" +
+                " since it depends on the real GC-cycle counter - see LeakSuspectEncoderTest for that math",
+            encoded?.startsWith("part-1_session-1:activity|${leaked.javaClass.name}|") == true,
+        )
+    }
+
+    @Test
+    fun `nothing is reported when there are no confirmed suspects`() {
+        dataSource.onPreSessionEnd()
+
+        assertFalse(args.destination.attributes.containsKey(EmbSessionAttributes.EMB_MEMORY_LEAK_SUSPECTS))
+    }
+
+    @Test
+    fun `an object that has only outlived one sentinel is not reported`() {
+        val leaked = Any()
+        val detector = dataSource.leakDetector
+        detector.trackOpened(leaked)
+        val ref = checkNotNull(detector.trackClosed(leaked, LeakContext(OBJECT_TYPE, SESSION_IDS)))
+
+        detector.onSentinelReclaimed(ref)
+        dataSource.onPreSessionEnd()
+
+        assertFalse(
+            "a suspected leak is not reported until it is confirmed",
+            args.destination.attributes.containsKey(EmbSessionAttributes.EMB_MEMORY_LEAK_SUSPECTS),
+        )
+    }
+
+    @Test
+    fun `a suspect whose session is unknown is not reported`() {
+        confirmLeak(Any(), sessionIds = SessionIdsSnapshot("", ""))
+
+        dataSource.onPreSessionEnd()
+
+        assertFalse(args.destination.attributes.containsKey(EmbSessionAttributes.EMB_MEMORY_LEAK_SUSPECTS))
+    }
+
+    /**
+     * Drives both reclamations the detector thread would otherwise drive, confirming the suspect.
+     */
+    private fun confirmLeak(referent: Any, sessionIds: SessionIdsSnapshot) {
+        val detector = dataSource.leakDetector
+        detector.trackOpened(referent)
+        val ref = checkNotNull(detector.trackClosed(referent, LeakContext(OBJECT_TYPE, sessionIds)))
+
+        val confirmation = checkNotNull(detector.onSentinelReclaimed(ref))
+        detector.onSentinelReclaimed(confirmation)
+    }
+
+    private companion object {
+        const val OBJECT_TYPE = "activity"
+        val SESSION_IDS = SessionIdsSnapshot(userSessionId = "session-1", sessionPartId = "part-1")
+    }
+}

--- a/embrace-android-instrumentation-leaks/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetectorTest.kt
+++ b/embrace-android-instrumentation-leaks/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetectorTest.kt
@@ -51,7 +51,7 @@ internal class LeakDetectorTest {
         val suspect = detector.suspects().single()
         assertEquals(5000L, suspect.trackedAtMs)
         assertSame(token, suspect.token)
-        assertEquals("no cycles have passed yet at the moment of confirmation", 0L, suspect.cyclesSurvived)
+        assertEquals("surviving the sentinel that confirmed it already counts as one cycle survived", 1L, suspect.cyclesSurvived)
         assertEquals(
             "read fresh from the still-live object rather than captured at confirmation",
             leaked.javaClass.name,
@@ -59,7 +59,11 @@ internal class LeakDetectorTest {
         )
 
         gcCycleCount = 7L
-        assertEquals("4 cycles have passed since confirmation", 4L, detector.suspects().single().cyclesSurvived)
+        assertEquals(
+            "4 more cycles have passed since confirmation, on top of the 1 already counted",
+            5L,
+            detector.suspects().single().cyclesSurvived,
+        )
     }
 
     @Test

--- a/embrace-android-instrumentation-leaks/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakSuspectEncoderTest.kt
+++ b/embrace-android-instrumentation-leaks/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakSuspectEncoderTest.kt
@@ -1,0 +1,92 @@
+package io.embrace.android.embracesdk.instrumentation.leaks
+
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsSnapshot
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+internal class LeakSuspectEncoderTest {
+
+    @Test
+    fun `no suspects encodes to an empty string`() {
+        assertEquals("", encodeLeakSuspects(emptyList()))
+    }
+
+    @Test
+    fun `a single suspect encodes as one group with one entry`() {
+        val suspects = listOf(snapshot(className = "com.example.MainActivity", cyclesSurvived = 4))
+
+        assertEquals("part_sess:activity|com.example.MainActivity|4", encodeLeakSuspects(suspects))
+    }
+
+    @Test
+    fun `suspects sharing a session part are grouped, ordered by cyclesSurvived descending`() {
+        val suspects = listOf(
+            snapshot(className = "First", cyclesSurvived = 2),
+            snapshot(className = "Second", cyclesSurvived = 5),
+        )
+
+        assertEquals("part_sess:activity|Second|5,activity|First|2", encodeLeakSuspects(suspects))
+    }
+
+    @Test
+    fun `suspects from different session parts are encoded as separate groups`() {
+        val suspects = listOf(
+            snapshot(sessionPartId = "part1", objectType = "activity", className = "Foo", cyclesSurvived = 10),
+            snapshot(sessionPartId = "part2", objectType = "fragment", className = "Bar", cyclesSurvived = 20),
+        )
+
+        // groups appear in the order their first (highest-cyclesSurvived) member was reached
+        assertEquals("part2_sess:fragment|Bar|20;part1_sess:activity|Foo|10", encodeLeakSuspects(suspects))
+    }
+
+    @Test
+    fun `a suspect whose token is not a LeakContext is dropped`() {
+        val suspects =
+            listOf(LeakDetector.LeakSnapshot(trackedAtMs = 0L, token = "not a LeakContext", cyclesSurvived = 1, className = "Foo"))
+
+        assertEquals("", encodeLeakSuspects(suspects))
+    }
+
+    @Test
+    fun `a suspect with no known session part is dropped`() {
+        assertEquals("", encodeLeakSuspects(listOf(snapshot(sessionPartId = ""))))
+    }
+
+    @Test
+    fun `a suspect with no known user session is dropped`() {
+        assertEquals("", encodeLeakSuspects(listOf(snapshot(userSessionId = ""))))
+    }
+
+    @Test
+    fun `truncation keeps the highest cyclesSurvived and stops at the first candidate that does not fit`() {
+        val suspects = listOf(
+            snapshot(className = "A", cyclesSurvived = 5),
+            snapshot(className = "B", cyclesSurvived = 3),
+            // shorter than B - would fit in the remaining budget, but is never tried because B already didn't fit
+            snapshot(objectType = "x", className = "y", cyclesSurvived = 1),
+        )
+
+        assertEquals("part_sess:activity|A|5", encodeLeakSuspects(suspects, maxLength = 28))
+    }
+
+    @Test
+    fun `the encoded result never exceeds maxLength`() {
+        val suspects = (1..50).map { snapshot(className = "com.example.SomeActivity$it", cyclesSurvived = it.toLong()) }
+
+        assertTrue(encodeLeakSuspects(suspects, maxLength = 100).length <= 100)
+    }
+
+    private fun snapshot(
+        sessionPartId: String = "part",
+        userSessionId: String = "sess",
+        objectType: String = "activity",
+        className: String = "com.example.MainActivity",
+        cyclesSurvived: Long = 0L,
+    ): LeakDetector.LeakSnapshot = LeakDetector.LeakSnapshot(
+        trackedAtMs = 0L,
+        token = LeakContext(objectType, SessionIdsSnapshot(userSessionId = userSessionId, sessionPartId = sessionPartId)),
+        cyclesSurvived = cyclesSurvived,
+        className = className,
+    )
+}

--- a/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSessionAttributes.kt
+++ b/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSessionAttributes.kt
@@ -71,6 +71,12 @@ object EmbSessionAttributes {
     const val EMB_IS_FINAL_SESSION_PART: String = "emb.is_final_session_part"
 
     /**
+     * Confirmed leak suspects still reachable at the end of this session part, and how many GC cycles each has survived since being confirmed. Encoded as ';'-separated groups of '<sessionPartId>_<userSessionId>:<entries>', each naming the session part the suspects were originally tracked closed in, followed by a ','-separated list of '<objectType>|<className>|<cyclesSurvived>' entries. A suspect still alive across multiple session parts is reported again in each one, with an updated cyclesSurvived.
+     */
+    @ExperimentalSemconv
+    const val EMB_MEMORY_LEAK_SUSPECTS: String = "emb.memory_leak_suspects"
+
+    /**
      * How a signal should be delivered to the Embrace backend.
      */
     @ExperimentalSemconv

--- a/embrace-android-semconv/src/main/semconv/session.yaml
+++ b/embrace-android-semconv/src/main/semconv/session.yaml
@@ -34,6 +34,7 @@ attribute_groups:
       - ref: emb.user_session_inactivity_timeout_seconds
       - ref: emb.clock_network_drift
       - ref: emb.clock_gnss_drift
+      - ref: emb.memory_leak_suspects
 
 attributes:
   - key: emb.state
@@ -188,3 +189,8 @@ attributes:
     brief: "Drift in milliseconds. Positive = GNSS clock behind wall clock. (Wall Time - GNSS Time)"
     stability: development
     examples: ["987", "-789"]
+  - key: emb.memory_leak_suspects
+    type: string
+    brief: "Confirmed leak suspects still reachable at the end of this session part, and how many GC cycles each has survived since being confirmed. Encoded as ';'-separated groups of '<sessionPartId>_<userSessionId>:<entries>', each naming the session part the suspects were originally tracked closed in, followed by a ','-separated list of '<objectType>|<className>|<cyclesSurvived>' entries. A suspect still alive across multiple session parts is reported again in each one, with an updated cyclesSurvived."
+    stability: development
+    examples: ["part123_sess456:activity|com.example.MainActivity|4"]


### PR DESCRIPTION
## Goal
Report any known leaked references by class when the session part ends. The leaks are encoded into a single string attribute to keep the data compact, and the leaks are grouped by the `sessionId`/`sessionPartId` the object was leaked within. We report the additional ids per group of leaks because leaks may only be detected long after they object lifecycle ended.

## Testing
New unit test and manual testing with the example app.