### PR TITLE
Alter span change listener

### DIFF
--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImpl.kt
@@ -125,7 +125,7 @@ private class EmbraceSpanImpl(
                 synchronized(startedSpan) {
                     sdkSpan.setStatus(value)
                     currentStatus = value
-                    deps.spanRepository.notifySpanUpdate()
+                    deps.spanRepository.notifySpanChanged(this)
                 }
             }
         }
@@ -218,7 +218,7 @@ private class EmbraceSpanImpl(
             newSpan.setName(spanName)
 
             spanStartTimeMs = attemptedStartTimeMs
-            deps.spanRepository.notifySpanUpdate()
+            deps.spanRepository.notifySpanChanged(this)
         }
 
         return true
@@ -257,7 +257,7 @@ private class EmbraceSpanImpl(
                 successful = !isRecording
                 if (successful) {
                     spanEndTimeMs = attemptedEndTimeMs
-                    deps.spanRepository.notifySpanUpdate()
+                    deps.spanRepository.notifySpanChanged(this)
                     releaseRetainedData()
                 }
             }
@@ -345,7 +345,7 @@ private class EmbraceSpanImpl(
                         internal = internal,
                     )
                     customAttributes[attribute.first] = attribute.second
-                    deps.spanRepository.notifySpanUpdate()
+                    deps.spanRepository.notifySpanChanged(this)
                     return true
                 }
             }
@@ -361,7 +361,7 @@ private class EmbraceSpanImpl(
                 if (!spanStarted() || isRecording) {
                     spanName = newName
                     startedSpan.get()?.setName(spanName)
-                    deps.spanRepository.notifySpanUpdate()
+                    deps.spanRepository.notifySpanChanged(this)
                     return true
                 }
             }
@@ -425,7 +425,7 @@ private class EmbraceSpanImpl(
             synchronized(systemAttributes) {
                 if (systemAttributes.containsKey(key) || systemAttributes.size < max) {
                     systemAttributes[key] = value
-                    deps.spanRepository.notifySpanUpdate()
+                    deps.spanRepository.notifySpanChanged(this)
                     return
                 }
             }
@@ -435,7 +435,7 @@ private class EmbraceSpanImpl(
 
     override fun removeSystemAttribute(key: String) {
         systemAttributes.remove(key)
-        deps.spanRepository.notifySpanUpdate()
+        deps.spanRepository.notifySpanChanged(this)
     }
 
     override fun attributes(): Map<String, Any> {
@@ -523,7 +523,7 @@ private class EmbraceSpanImpl(
                             customEvents().add(event)
                             customEventCount++
                         }
-                        deps.spanRepository.notifySpanUpdate()
+                        deps.spanRepository.notifySpanChanged(this)
                         return true
                     }
                 }
@@ -549,7 +549,7 @@ private class EmbraceSpanImpl(
                         customLinks().add(link)
                         customLinkCount++
                     }
-                    deps.spanRepository.notifySpanUpdate()
+                    deps.spanRepository.notifySpanChanged(this)
                     return true
                 }
             }

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanRepository.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanRepository.kt
@@ -23,7 +23,7 @@ import java.util.concurrent.CopyOnWriteArrayList
  */
 class SpanRepository {
     private val spans: ConcurrentMap<String, EmbraceSdkSpan> = ConcurrentHashMap()
-    private var spanUpdateNotifier: (() -> Unit)? = null
+    private val spanChangeListeners = CopyOnWriteArrayList<(EmbraceSdkSpan) -> Unit>()
 
     private val completedSpanData: Queue<Span> = ConcurrentLinkedQueue()
     private val flushLock = Any()
@@ -97,17 +97,22 @@ class SpanRepository {
     }
 
     /**
-     * Set a function to be invoked when a span has been updated
+     * Registers a [listener] invoked with a span immediately after any of its state has changed,
+     * including its start and stop. The caller is responsible for deriving initial state.
+     *
+     * The listener is invoked on the thread that mutated the span and must not block or perform I/O.
      */
-    fun setSpanUpdateNotifier(notifier: () -> Unit) {
-        spanUpdateNotifier = notifier
+    fun addSpanChangeListener(listener: (EmbraceSdkSpan) -> Unit) {
+        spanChangeListeners.add(listener)
     }
 
     /**
-     * Call to notify the repository that a span has been updated
+     * Call to notify the repository that the state of [span] has changed.
      */
-    fun notifySpanUpdate() {
-        spanUpdateNotifier?.invoke()
+    fun notifySpanChanged(span: EmbraceSdkSpan) {
+        spanChangeListeners.forEach { listener ->
+            notifyListener(listener, span)
+        }
     }
 
     /**
@@ -154,9 +159,9 @@ class SpanRepository {
         }
     }
 
-    private fun notifyListener(listener: (List<Span>) -> Unit, spans: List<Span>) {
+    private fun <T> notifyListener(listener: (T) -> Unit, value: T) {
         try {
-            listener(spans)
+            listener(value)
         } catch (ignored: Throwable) {
         }
     }

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImplTest.kt
@@ -30,9 +30,7 @@ internal class EmbraceSpanFactoryImplTest {
     fun setup() {
         val openTelemetryClock = FakeOtelKotlinClock(clock)
         spanRepository = SpanRepository().apply {
-            setSpanUpdateNotifier {
-                updateNotified = true
-            }
+            addSpanChangeListener { updateNotified = true }
         }
         tracer = createSdkOtelInstance(clock = openTelemetryClock, useKotlinSdk = TESTS_DEFAULT_USE_KOTLIN_SDK).getTracer("my_tracer")
         embraceSpanFactory = EmbraceSpanFactoryImpl(

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanImplTest.kt
@@ -79,7 +79,7 @@ internal class EmbraceSpanImplTest {
         fakeClock = FakeClock()
         val otelClock = FakeOtelKotlinClock(fakeClock)
         tracer = createSdkOtelInstance(clock = otelClock, useKotlinSdk = TESTS_DEFAULT_USE_KOTLIN_SDK).getTracer("test-tracer")
-        spanRepository = SpanRepository().apply { setSpanUpdateNotifier { updateNotified = true } }
+        spanRepository = SpanRepository().apply { addSpanChangeListener { updateNotified = true } }
         serializer = TestPlatformSerializer()
         telemetryService = FakeTelemetryService()
         dataValidator = DataValidator(telemetryService = telemetryService)

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanRepositorySpanChangeListenerTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanRepositorySpanChangeListenerTest.kt
@@ -1,0 +1,70 @@
+package io.embrace.android.embracesdk.internal.otel.spans
+
+import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+internal class SpanRepositorySpanChangeListenerTest {
+
+    private lateinit var repository: SpanRepository
+    private val observed = mutableListOf<EmbraceSdkSpan>()
+
+    @Before
+    fun setup() {
+        repository = SpanRepository()
+        observed.clear()
+    }
+
+    @Test
+    fun `the listener is notified with the span that changed`() {
+        val span = FakeEmbraceSdkSpan.started()
+        repository.addSpanChangeListener(observed::add)
+        repository.notifySpanChanged(span)
+        assertEquals(listOf(span), observed)
+    }
+
+    @Test
+    fun `each change is notified separately and in the order it happened`() {
+        val first = FakeEmbraceSdkSpan.started()
+        val second = FakeEmbraceSdkSpan.stopped()
+        repository.addSpanChangeListener(observed::add)
+        repository.notifySpanChanged(first)
+        repository.notifySpanChanged(second)
+        repository.notifySpanChanged(first)
+        assertEquals(listOf(first, second, first), observed)
+    }
+
+    @Test
+    fun `changes made before registration are not replayed`() {
+        repository.notifySpanChanged(FakeEmbraceSdkSpan.started())
+        repository.addSpanChangeListener(observed::add)
+        assertTrue(observed.isEmpty())
+    }
+
+    @Test
+    fun `every registered listener is notified`() {
+        val other = mutableListOf<EmbraceSdkSpan>()
+        val span = FakeEmbraceSdkSpan.started()
+        repository.addSpanChangeListener(observed::add)
+        repository.addSpanChangeListener(other::add)
+        repository.notifySpanChanged(span)
+        assertEquals(listOf(span), observed)
+        assertEquals(listOf(span), other)
+    }
+
+    @Test
+    fun `a throwing listener neither stops the others nor fails the change`() {
+        val span = FakeEmbraceSdkSpan.started()
+        repository.addSpanChangeListener { error("listener failed") }
+        repository.addSpanChangeListener(observed::add)
+        repository.notifySpanChanged(span)
+        assertEquals(listOf(span), observed)
+    }
+
+    @Test
+    fun `notifying with no listeners registered does not throw`() {
+        repository.notifySpanChanged(FakeEmbraceSdkSpan.started())
+    }
+}

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
@@ -34,9 +34,7 @@ internal fun ModuleGraph.postInit() = EmbTrace.trace(sectionName = "post-init", 
 
     initModule.logger.errorHandlerProvider = { featureModule.internalErrorDataSource.dataSource }
     deliveryModule?.payloadCachingService?.run {
-        openTelemetryModule.spanRepository.setSpanUpdateNotifier {
-            reportBackgroundActivityStateChange()
-        }
+        openTelemetryModule.spanRepository.addSpanChangeListener { reportBackgroundActivityStateChange() }
     }
 
     payloadSourceModule.metadataService.precomputeValues()


### PR DESCRIPTION
## Goal

Alter the listener that is invoked when a span changes to include a reference to the changed span (required for filtering out the session span), and additionally allow registering multiple listeners.

## Testing

Added unit tests.
