### PR TITLE
Handle span mutation callbacks

### DIFF
--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImpl.kt
@@ -121,15 +121,17 @@ private class EmbraceSpanImpl(
     override var status: StatusData
         get() = currentStatus
         set(value) {
-            if (setSpanStatus(value)) {
+            if (setSpanStatus(value) && spanStarted()) {
                 notifyChanged()
             }
         }
 
     private fun setSpanStatus(value: StatusData): Boolean {
-        val sdkSpan = startedSpan.get() ?: return false
         synchronized(startedSpan) {
-            sdkSpan.setStatus(value)
+            if (spanStarted() && !isRecording) {
+                return false
+            }
+            startedSpan.get()?.setStatus(value)
             currentStatus = value
         }
         return true
@@ -221,6 +223,9 @@ private class EmbraceSpanImpl(
 
             deps.spanRepository.trackStartedEmbraceSpan(this)
             newSpan.setName(spanName)
+            if (currentStatus != StatusData.Unset) {
+                newSpan.setStatus(currentStatus)
+            }
 
             spanStartTimeMs = attemptedStartTimeMs
         }
@@ -345,6 +350,7 @@ private class EmbraceSpanImpl(
         val maxAttributeCount = deps.dataValidator.otelLimitsConfig.getMaxCustomAttributeCount()
         if (customAttributes.size < maxAttributeCount && key.isNotBlank()) {
             var added = false
+            var changed = false
             synchronized(customAttributes) {
                 if (customAttributes.size < maxAttributeCount && isRecording) {
                     val attribute = deps.dataValidator.truncateAttribute(
@@ -352,12 +358,14 @@ private class EmbraceSpanImpl(
                         value = value,
                         internal = internal,
                     )
-                    customAttributes[attribute.first] = attribute.second
+                    changed = customAttributes.put(attribute.first, attribute.second) != attribute.second
                     added = true
                 }
             }
             if (added) {
-                notifyChanged()
+                if (changed) {
+                    notifyChanged()
+                }
                 return true
             }
         }
@@ -377,7 +385,9 @@ private class EmbraceSpanImpl(
                 }
             }
             if (updated) {
-                notifyChanged()
+                if (spanStarted()) {
+                    notifyChanged()
+                }
                 return true
             }
         }
@@ -437,15 +447,18 @@ private class EmbraceSpanImpl(
     override fun addSystemAttribute(key: String, value: String) {
         val max = deps.dataValidator.otelLimitsConfig.getMaxSystemAttributeCount()
         if (systemAttributes.containsKey(key) || systemAttributes.size < max) {
-            var added = false
+            var written = false
+            var changed = false
             synchronized(systemAttributes) {
-                if (systemAttributes.containsKey(key) || systemAttributes.size < max) {
-                    systemAttributes[key] = value
-                    added = true
+                if ((systemAttributes.containsKey(key) || systemAttributes.size < max) && mutable()) {
+                    changed = systemAttributes.put(key, value) != value
+                    written = true
                 }
             }
-            if (added) {
-                notifyChanged()
+            if (written) {
+                if (changed && spanStarted()) {
+                    notifyChanged()
+                }
                 return
             }
         }
@@ -453,8 +466,15 @@ private class EmbraceSpanImpl(
     }
 
     override fun removeSystemAttribute(key: String) {
-        systemAttributes.remove(key)
-        notifyChanged()
+        var removed = false
+        synchronized(systemAttributes) {
+            if (mutable()) {
+                removed = systemAttributes.remove(key) != null
+            }
+        }
+        if (removed && spanStarted()) {
+            notifyChanged()
+        }
     }
 
     override fun attributes(): Map<String, Any> {
@@ -606,6 +626,13 @@ private class EmbraceSpanImpl(
         customLinks ?: ArrayList<EmbraceLinkData>(INITIAL_COLLECTION_CAPACITY).also { customLinks = it }
 
     private fun spanStarted() = startedSpan.get() != null
+
+    /**
+     * Whether this span's own data can still be changed: freely before it starts, and while it is
+     * recording. A stopped span is immutable. Mirrors the condition [updateName] applies, and is
+     * deliberately a lock-free read so callers holding another monitor never acquire [startedSpan].
+     */
+    private fun mutable() = !spanStarted() || isRecording
 
     /**
      * Tells the repository this span's data changed. Must be called after the monitor is released.

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanImplTest.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.assertions.validateSystemLink
 import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.FakeOtelKotlinClock
+import io.embrace.android.embracesdk.fakes.FakeSpanExporter
 import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.TestConstants.TESTS_DEFAULT_USE_KOTLIN_SDK
 import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
@@ -49,6 +50,7 @@ import io.opentelemetry.kotlin.context.Context
 import io.opentelemetry.kotlin.getTracer
 import io.opentelemetry.kotlin.semconv.ExceptionAttributes
 import io.opentelemetry.kotlin.tracing.SpanKind
+import io.opentelemetry.kotlin.tracing.StatusData
 import io.opentelemetry.kotlin.tracing.Tracer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -71,16 +73,31 @@ internal class EmbraceSpanImplTest {
     private lateinit var dataValidator: DataValidator
     private lateinit var tracer: Tracer
     private lateinit var telemetryService: FakeTelemetryService
+    private lateinit var spanExporter: FakeSpanExporter
     private lateinit var embraceSpanFactory: EmbraceSpanFactory
-    private var updateNotified: Boolean = false
+    private val notifications = AtomicInteger(0)
+    private val updateNotified: Boolean get() = notifications.get() > 0
     private var stoppedSpanId: String? = null
 
     @Before
     fun setup() {
         fakeClock = FakeClock()
         val otelClock = FakeOtelKotlinClock(fakeClock)
-        tracer = createSdkOtelInstance(clock = otelClock, useKotlinSdk = TESTS_DEFAULT_USE_KOTLIN_SDK).getTracer("test-tracer")
-        spanRepository = SpanRepository().apply { addSpanChangeListener { updateNotified = true } }
+        spanExporter = FakeSpanExporter()
+        tracer = createSdkOtelInstance(
+            clock = otelClock,
+            useKotlinSdk = TESTS_DEFAULT_USE_KOTLIN_SDK,
+            tracerProvider = {
+                export {
+                    EmbraceSpanProcessor(
+                        sessionIdsProvider = { null },
+                        processIdentifier = "test-process",
+                        spanExporter = spanExporter,
+                    )
+                }
+            },
+        ).getTracer("test-tracer")
+        spanRepository = SpanRepository().apply { addSpanChangeListener { notifications.incrementAndGet() } }
         serializer = TestPlatformSerializer()
         telemetryService = FakeTelemetryService()
         dataValidator = DataValidator(telemetryService = telemetryService)
@@ -727,13 +744,13 @@ internal class EmbraceSpanImplTest {
     @Test
     fun `span change listener does not run while the span holds its locks`() {
         assertTrue(embraceSpan.start())
-        val notifications = AtomicInteger(0)
+        val listenerCalls = AtomicInteger(0)
         val mutatedFromListener = CountDownLatch(1)
         val notifiedSpans = ConcurrentLinkedQueue<EmbraceSdkSpan>()
 
         spanRepository.addSpanChangeListener { span ->
             notifiedSpans.add(span)
-            if (notifications.getAndIncrement() == 0) {
+            if (listenerCalls.getAndIncrement() == 0) {
                 val mutator = Thread {
                     if (embraceSpan.addEvent("event-from-listener")) {
                         mutatedFromListener.countDown()
@@ -746,9 +763,130 @@ internal class EmbraceSpanImplTest {
 
         assertTrue(embraceSpan.addEvent(EXPECTED_EVENT_NAME))
         assertTrue(mutatedFromListener.await(0, TimeUnit.MILLISECONDS))
-        assertEquals(2, notifications.get())
+        assertEquals(2, listenerCalls.get())
         assertEquals(2, embraceSpan.events().size)
         assertTrue(notifiedSpans.all { it === embraceSpan })
+    }
+
+    @Test
+    fun `rewriting an attribute with the value it already holds does not notify`() {
+        assertTrue(embraceSpan.start())
+        val afterStart = notifications.get()
+
+        embraceSpan.addSystemAttribute("system-key", "value")
+        assertEquals(afterStart + 1, notifications.get())
+
+        embraceSpan.addSystemAttribute("system-key", "value")
+        assertEquals(afterStart + 1, notifications.get())
+        assertEquals("value", embraceSpan.getSystemAttribute("system-key"))
+        assertTrue(telemetryService.appliedLimits.isEmpty())
+
+        embraceSpan.addSystemAttribute("system-key", "different")
+        assertEquals(afterStart + 2, notifications.get())
+
+        // custom attributes behave the same way, but an unchanged write still reports success
+        assertTrue(embraceSpan.addAttribute("custom-key", "value"))
+        assertEquals(afterStart + 3, notifications.get())
+        assertTrue(embraceSpan.addAttribute("custom-key", "value"))
+        assertEquals(afterStart + 3, notifications.get())
+        assertEquals("value", embraceSpan.attributes()["custom-key"])
+    }
+
+    @Test
+    fun `removing an absent system attribute does not notify`() {
+        assertTrue(embraceSpan.start())
+        val afterStart = notifications.get()
+
+        embraceSpan.removeSystemAttribute("never-set")
+        assertEquals(afterStart, notifications.get())
+
+        embraceSpan.addSystemAttribute("system-key", "value")
+        embraceSpan.removeSystemAttribute("system-key")
+        assertNull(embraceSpan.getSystemAttribute("system-key"))
+        assertEquals(afterStart + 2, notifications.get())
+
+        embraceSpan.removeSystemAttribute("system-key")
+        assertEquals(afterStart + 2, notifications.get())
+    }
+
+    @Test
+    fun `system attributes cannot be changed once the span has stopped`() {
+        with(embraceSpan) {
+            assertTrue(start())
+            addSystemAttribute("system-key", "value")
+            assertTrue(stop())
+            val afterStop = notifications.get()
+            val dropsAfterStop = telemetryService.appliedLimits.size
+
+            addSystemAttribute("system-key", "updated")
+            addSystemAttribute("new-key", "value")
+            removeSystemAttribute("system-key")
+
+            assertEquals("value", getSystemAttribute("system-key"))
+            assertNull(getSystemAttribute("new-key"))
+            assertEquals(afterStop, notifications.get())
+
+            // the two rejected adds are tracked as drops; a rejected removal has nothing to drop
+            assertEquals(dropsAfterStop + 2, telemetryService.appliedLimits.size)
+            assertTrue(telemetryService.appliedLimits.all { it == "span_attribute" to AppliedLimitType.DROP })
+        }
+    }
+
+    @Test
+    fun `status set before the span starts is applied when it starts`() {
+        with(embraceSpan) {
+            status = StatusData.Ok
+            assertEquals(StatusData.Ok, status)
+            assertEquals(0, notifications.get())
+
+            assertTrue(start())
+            assertEquals(1, notifications.get())
+            assertEquals(Span.Status.OK, checkNotNull(snapshot()).status)
+
+            assertTrue(stop())
+            assertEquals(StatusData.Ok, spanExporter.exportedSpans.single { it.name == EXPECTED_SPAN_NAME }.status)
+        }
+    }
+
+    @Test
+    fun `status cannot be changed once the span has stopped`() {
+        with(embraceSpan) {
+            assertTrue(start())
+            status = StatusData.Ok
+            assertTrue(stop())
+            val afterStop = notifications.get()
+            status = StatusData.Error("too late")
+
+            assertEquals(StatusData.Ok, status)
+            assertEquals(Span.Status.OK, checkNotNull(snapshot()).status)
+            assertEquals(afterStop, notifications.get())
+        }
+    }
+
+    @Test
+    fun `mutating a span before it starts does not notify`() {
+        with(embraceSpan) {
+            assertTrue(updateName("new-name"))
+            status = StatusData.Ok
+            setSystemAttribute("system-key", "value")
+            assertEquals("new-name", name())
+            assertEquals("value", getSystemAttribute("system-key"))
+            assertEquals(0, notifications.get())
+
+            // a pre-start write is deferred, not rejected, so nothing is dropped
+            assertTrue(telemetryService.appliedLimits.isEmpty())
+
+            assertTrue(start())
+            assertEquals(1, notifications.get())
+
+            assertTrue(updateName("newer-name"))
+            assertEquals("newer-name", name())
+            assertEquals(2, notifications.get())
+
+            removeSystemAttribute("system-key")
+            assertNull(getSystemAttribute("system-key"))
+            assertEquals(3, notifications.get())
+        }
     }
 
     /**


### PR DESCRIPTION
## Goal

Improve where span mutation callbacks are invoked to avoid unnecessary calls before the span is started, and tighten when attributes/status can be set on a span. 

## Testing

Added unit tests.
