### PR TITLE
Activity-leak detection as an instrumentation module

### DIFF
--- a/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/ActivityLeakDetectionLifecycleCallbacks.kt
+++ b/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/ActivityLeakDetectionLifecycleCallbacks.kt
@@ -1,0 +1,33 @@
+package io.embrace.android.embracesdk.instrumentation.leaks
+
+import android.app.Activity
+import android.app.Application
+import android.os.Build
+import android.os.Bundle
+import io.embrace.android.embracesdk.internal.session.id.SessionIdsSnapshot
+
+internal class ActivityLeakDetectionLifecycleCallbacks(
+    private val leakDetector: LeakDetector,
+    private val activeSessionIdsProvider: () -> SessionIdsSnapshot,
+) : Application.ActivityLifecycleCallbacks {
+
+    override fun onActivityPreCreated(activity: Activity, savedInstanceState: Bundle?) {
+        leakDetector.trackOpened(activity)
+    }
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            leakDetector.trackOpened(activity)
+        }
+    }
+
+    override fun onActivityDestroyed(activity: Activity) {
+        leakDetector.trackClosed(activity, activeSessionIdsProvider())
+    }
+
+    override fun onActivityPaused(activity: Activity) = Unit
+    override fun onActivityResumed(activity: Activity) = Unit
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+    override fun onActivityStarted(activity: Activity) = Unit
+    override fun onActivityStopped(activity: Activity) = Unit
+}

--- a/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetectionDataSource.kt
+++ b/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetectionDataSource.kt
@@ -1,0 +1,34 @@
+package io.embrace.android.embracesdk.instrumentation.leaks
+
+import android.app.Application
+import io.embrace.android.embracesdk.internal.arch.InstrumentationArgs
+import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceImpl
+import io.embrace.android.embracesdk.internal.arch.limits.UpToLimitStrategy
+
+class LeakDetectionDataSource(args: InstrumentationArgs) : DataSourceImpl(
+    args,
+    limitStrategy = UpToLimitStrategy { MAX_LEAK_DETECTION },
+    "leak-detection",
+) {
+    companion object {
+        const val MAX_LEAK_DETECTION = 100
+    }
+
+    private val application: Application = args.application
+
+    // TODO: query leakDetector.suspects() (e.g. from a SessionPartEndListener.onPreSessionEnd()) and encode the dataset into
+    // a session attribute. Each entry already carries how many GC cycles it has survived since being confirmed.
+    private val leakDetector = LeakDetector(args.clock)
+
+    private val callbacks = ActivityLeakDetectionLifecycleCallbacks(leakDetector, args::activeSessionIds)
+
+    override fun onDataCaptureEnabled() {
+        application.registerActivityLifecycleCallbacks(callbacks)
+        leakDetector.start()
+    }
+
+    override fun onDataCaptureDisabled() {
+        application.unregisterActivityLifecycleCallbacks(callbacks)
+        leakDetector.stop()
+    }
+}

--- a/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetectionInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetectionInstrumentationProvider.kt
@@ -1,0 +1,22 @@
+package io.embrace.android.embracesdk.instrumentation.leaks
+
+import android.os.Build
+import io.embrace.android.embracesdk.internal.arch.InstrumentationArgs
+import io.embrace.android.embracesdk.internal.arch.InstrumentationProvider
+import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceState
+
+/**
+ * SPI entry point for Activity leak detection. Registers nothing below API 23, since GC cycle tracking relies on the
+ * runtime stat `Debug.getRuntimeStat` only reports from that version onward.
+ */
+class LeakDetectionInstrumentationProvider : InstrumentationProvider {
+    override fun register(args: InstrumentationArgs): DataSourceState<*>? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return null
+        }
+        return DataSourceState(
+            factory = { LeakDetectionDataSource(args) },
+            configGate = { true },
+        )
+    }
+}

--- a/embrace-android-instrumentation-leaks/src/main/resources/META-INF/services/io.embrace.android.embracesdk.internal.arch.InstrumentationProvider
+++ b/embrace-android-instrumentation-leaks/src/main/resources/META-INF/services/io.embrace.android.embracesdk.internal.arch.InstrumentationProvider
@@ -1,0 +1,1 @@
+io.embrace.android.embracesdk.instrumentation.leaks.LeakDetectionInstrumentationProvider


### PR DESCRIPTION
## Goal
Introduce a formal instrumentation provider and data source for memory leak detection. This PR wires up the `LeakDetector` as a data source for reporting leaked `Activity` objects.

