### PR TITLE
Write span snapshots

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
@@ -1,8 +1,10 @@
 package io.embrace.android.embracesdk.internal.injection
 
+import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.delivery.storage.StorageLocation
 import io.embrace.android.embracesdk.internal.delivery.storage.asFile
+import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.session.UserSessionMetadataStore
 import io.embrace.android.embracesdk.internal.session.id.SessionIdsProvider
 import io.embrace.android.embracesdk.internal.session.message.PayloadFactoryImpl
@@ -71,6 +73,12 @@ class UserSessionOrchestrationModuleImpl(
             payloadSourceModule.resourceSource,
             payloadSourceModule.envelopeMetadataSource,
             openTelemetryModule.currentSessionPartSpan,
+            {
+                // don't include the session part span
+                openTelemetryModule.spanRepository.getActiveEmbraceSpans()
+                    .filterNot { it.hasEmbraceAttribute(EmbType.Ux.Session) }
+                    .mapNotNull(EmbraceSdkSpan::snapshot)
+            },
         )
         essentialServiceModule.userService.addUserInfoListener(sessionPartWriter::onMetadataChanged)
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -9,11 +9,13 @@ import io.embrace.android.embracesdk.internal.envelope.session.SESSION_ENVELOPE_
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSdkSpan
+import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.session.persistence.SessionManifestWriter
 import io.embrace.android.embracesdk.internal.session.persistence.SessionMetadataWriter
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectory
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectoryStore
 import io.embrace.android.embracesdk.internal.session.persistence.SessionSpanWriter
+import io.embrace.android.embracesdk.internal.session.persistence.SpanSnapshotsWriter
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionPartSpan
 import io.embrace.android.embracesdk.internal.utils.UuidSource
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
@@ -36,6 +38,7 @@ class SessionPartWriterImpl(
     private val resourceSource: EnvelopeResourceSource,
     private val metadataSource: EnvelopeMetadataSource,
     private val currentSessionPartSpan: CurrentSessionPartSpan,
+    private val spanSnapshotSource: () -> List<Span>,
 ) : SessionPartWriter {
 
     private companion object {
@@ -75,6 +78,7 @@ class SessionPartWriterImpl(
         queueManifestWrite(writers)
         queueMetadataWrite(writers)
         queueSessionSpanWrite(writers)
+        queueSpanSnapshotsWrite(writers)
         registerResourceChangeListener()
     }
 
@@ -87,6 +91,7 @@ class SessionPartWriterImpl(
             return
         }
         queueSessionSpanWrite(writers)
+        queueSpanSnapshotsWrite(writers)
     }
 
     override fun onMetadataChanged() {
@@ -165,6 +170,24 @@ class SessionPartWriterImpl(
     }
 
     /**
+     * Writes in-flight spans to a snapshot file.
+     */
+    private fun queueSpanSnapshotsWrite(writers: PartWriters) {
+        // TODO: future: don't call this every time the listener is invoked as it's expensive to
+        // obtain _all_ the spans for every change. Currently this write only happens at session
+        // start/end
+        val spans = try {
+            spanSnapshotSource()
+        } catch (exc: Throwable) {
+            logger.trackInternalError(InternalErrorType.SpanSnapshotsWriteFail, exc)
+            return
+        }
+        execute(InternalErrorType.SpanSnapshotsWriteFail, writers.spanSnapshotWrites::submit) {
+            writers.spanSnapshots.write(spans)
+        }
+    }
+
+    /**
      * Queues [action] with [submit], or runs it on the calling thread if the process is crashing
      * and the [worker] has already been sealed by [onCrash]. Telemetry gathered inside [action] can
      * throw, so a failure is tracked here rather than escaping onto a crashing thread.
@@ -207,9 +230,16 @@ class SessionPartWriterImpl(
             logger = logger,
         )
 
+        val spanSnapshots = SpanSnapshotsWriter(
+            sessionsDir = sessionsDir,
+            sessionPartDirectorySource = { directory },
+            logger = logger,
+        )
+
         val manifestWrites = CoalescingWriteQueue(worker)
         val metadataWrites = CoalescingWriteQueue(worker)
         val sessionSpanWrites = CoalescingWriteQueue(worker)
+        val spanSnapshotWrites = CoalescingWriteQueue(worker)
     }
 
     /**

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -1238,6 +1238,7 @@ internal class SessionOrchestratorTest {
                 FakeEnvelopeResourceSource(),
                 FakeEnvelopeMetadataSource(),
                 currentSessionPartSpan,
+                { emptyList() },
             ),
         ).apply {
             start()

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterBoundaryTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterBoundaryTest.kt
@@ -88,6 +88,7 @@ internal class SessionPartWriterBoundaryTest {
             resourceSource,
             { EnvelopeMetadata(userId = "user${writeCount++}") },
             currentSessionPartSpan,
+            { emptyList() },
         )
     }
 
@@ -229,7 +230,10 @@ internal class SessionPartWriterBoundaryTest {
         startPart(SECOND_PART_ID)
         drain()
 
-        assertEquals(listOf("SessionSpanWriteFail"), logger.internalErrorMessages.map { it.msg })
+        assertEquals(
+            listOf("SessionSpanWriteFail", "SpanSnapshotsWriteFail"),
+            logger.internalErrorMessages.map { it.msg },
+        )
         assertEquals("span1", sessionSpanIn(SECOND_PART_ID)?.span?.name)
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
@@ -14,10 +14,12 @@ import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.envelope.resource.EnvelopeResourceSource
 import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
+import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.session.persistence.EnvelopeMetadataProto
 import io.embrace.android.embracesdk.internal.session.persistence.SessionManifest
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectory
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartSpan
+import io.embrace.android.embracesdk.internal.session.persistence.SpanSnapshots
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -38,6 +40,8 @@ internal class SessionPartWriterImplTest {
         private const val METADATA_FILE_NAME = "metadata.pb"
         private const val MANIFEST_FILE_NAME = "manifest.pb"
         private const val SESSION_SPAN_FILE_NAME = "session_span.pb"
+        private const val SPAN_SNAPSHOTS_FILE_NAME = "span_snapshots.pb"
+        private val IN_FLIGHT_SPAN = Span(spanId = "aaaaaaaaaaaaaaa1", name = "network-request")
         private const val ENVELOPE_VERSION = "0.1.0"
         private const val ENVELOPE_TYPE = "spans"
         private val SYMBOLS = mapOf("armeabi-v7a" to "my-symbols")
@@ -60,6 +64,7 @@ internal class SessionPartWriterImplTest {
 
     private lateinit var sessionSpan: FakeEmbraceSdkSpan
     private lateinit var currentSessionPartSpan: FakeCurrentSessionPartSpan
+    private var inFlightSpans: List<Span> = emptyList()
 
     private var resourceCount = 0
     private val resourceSource = object : EnvelopeResourceSource {
@@ -80,6 +85,7 @@ internal class SessionPartWriterImplTest {
         writeCount = 0
         resourceCount = 0
         onMetadataRead = {}
+        inFlightSpans = emptyList()
         sessionSpan = FakeEmbraceSdkSpan(name = "span0").apply { start(clock.now()) }
         currentSessionPartSpan = FakeCurrentSessionPartSpan(clock).apply { sessionPartSpan = sessionSpan }
     }
@@ -224,6 +230,7 @@ internal class SessionPartWriterImplTest {
                 "SessionManifestWriteFail",
                 "SessionMetadataWriteFail",
                 "SessionSpanWriteFail",
+                "SpanSnapshotsWriteFail",
             ),
             logger.internalErrorMessages.map { it.msg },
         )
@@ -237,6 +244,7 @@ internal class SessionPartWriterImplTest {
                 "SessionManifestWriteFail",
                 "SessionMetadataWriteFail",
                 "SessionSpanWriteFail",
+                "SpanSnapshotsWriteFail",
                 "SessionMetadataWriteFail",
             ),
             logger.internalErrorMessages.map { it.msg },
@@ -252,8 +260,10 @@ internal class SessionPartWriterImplTest {
                 "SessionManifestWriteFail",
                 "SessionMetadataWriteFail",
                 "SessionSpanWriteFail",
+                "SpanSnapshotsWriteFail",
                 "SessionMetadataWriteFail",
                 "SessionSpanWriteFail",
+                "SpanSnapshotsWriteFail",
             ),
             logger.internalErrorMessages.map { it.msg },
         )
@@ -638,6 +648,53 @@ internal class SessionPartWriterImplTest {
     }
 
     @Test
+    fun `the in-flight spans are written as soon as a session part starts`() {
+        val writer = createWriter()
+        inFlightSpans = listOf(IN_FLIGHT_SPAN)
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        assertEquals(listOf("network-request"), spanSnapshotNamesIn(SESSION_PART_ID))
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `the in-flight spans are rewritten when the session part ends`() {
+        val writer = createWriter()
+        inFlightSpans = listOf(IN_FLIGHT_SPAN)
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+
+        clock.tick(1000)
+        inFlightSpans = listOf(IN_FLIGHT_SPAN.copy(name = "view-load"))
+        endPart()
+        writer.onSessionPartEnded(SESSION_PART_ID)
+
+        assertEquals(listOf("view-load"), spanSnapshotNamesIn(SESSION_PART_ID))
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `an empty span snapshots file is written when nothing is in flight`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        assertEquals(emptyList<String>(), spanSnapshotNamesIn(SESSION_PART_ID))
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a periodic write leaves the span snapshots untouched`() {
+        val writer = createWriter()
+        inFlightSpans = listOf(IN_FLIGHT_SPAN)
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+
+        inFlightSpans = listOf(IN_FLIGHT_SPAN.copy(name = "view-load"))
+        writer.onPeriodicWrite()
+
+        assertEquals(listOf("network-request"), spanSnapshotNamesIn(SESSION_PART_ID))
+        assertNoInternalErrors()
+    }
+
+    @Test
     fun `no further writes are made once a crash has been handled`() {
         val writer = createWriter()
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
@@ -702,6 +759,7 @@ internal class SessionPartWriterImplTest {
         resourceSource,
         metadataSource,
         currentSessionPartSpan,
+        { inFlightSpans },
     )
 
     private fun configService(
@@ -756,6 +814,15 @@ internal class SessionPartWriterImplTest {
 
     private fun sessionSpanOnDisk(sessionPartId: String): SessionPartSpan? =
         partFile(sessionPartId, SESSION_SPAN_FILE_NAME)?.inputStream()?.use(SessionPartSpan.ADAPTER::decode)
+
+    private fun spanSnapshotNamesIn(sessionPartId: String): List<String?>? {
+        drain()
+        return partFile(sessionPartId, SPAN_SNAPSHOTS_FILE_NAME)
+            ?.inputStream()
+            ?.use(SpanSnapshots.ADAPTER::decode)
+            ?.spans
+            ?.map { it.name }
+    }
 
     private fun partFile(sessionPartId: String, fileName: String): File? {
         val directory = partDirs().single { it.sessionPartId == sessionPartId }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceChangeTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceChangeTest.kt
@@ -214,6 +214,7 @@ internal class SessionPartWriterResourceChangeTest {
         resourceSource,
         { EnvelopeMetadata(userId = "my-user-id") },
         currentSessionPartSpan,
+        { emptyList() },
     )
 
     private fun startPart(writer: SessionPartWriter, sessionPartId: String) {

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceReadTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceReadTest.kt
@@ -13,11 +13,11 @@ import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadataSource
 import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
+import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.session.persistence.CompletedSpans
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectory
 import io.embrace.android.embracesdk.internal.session.persistence.SessionReconstructionService
 import io.embrace.android.embracesdk.internal.session.persistence.SpanProto
-import io.embrace.android.embracesdk.internal.session.persistence.SpanSnapshots
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import okio.Buffer
 import org.junit.Assert.assertEquals
@@ -33,10 +33,8 @@ internal class SessionPartWriterResourceReadTest {
     private companion object {
         private const val USER_SESSION_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         private const val SESSION_PART_ID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-        private const val FORMAT_VERSION = 1
         private const val MANIFEST_FILE_NAME = "manifest.pb"
         private const val COMPLETED_SPANS_FILE_NAME = "completed_spans.pb"
-        private const val SPAN_SNAPSHOTS_FILE_NAME = "span_snapshots.pb"
         private val SYMBOLS = mapOf("armeabi-v7a" to "my-symbols")
 
         private val RESOURCE = EnvelopeResource(
@@ -58,10 +56,12 @@ internal class SessionPartWriterResourceReadTest {
             name = "emb-startup-moment",
         )
 
-        private val snapshotSpan = spanTemplate.copy(
-            span_id = "aaaaaaaaaaaaaaa3",
+        private val inFlightSpan = Span(
+            traceId = spanTemplate.trace_id,
+            spanId = "aaaaaaaaaaaaaaa3",
             name = "emb-network-request",
-            end_time_unix_nano = null,
+            startTimeNanos = spanTemplate.start_time_unix_nano,
+            status = Span.Status.UNSET,
         )
     }
 
@@ -76,6 +76,7 @@ internal class SessionPartWriterResourceReadTest {
     private lateinit var sessionSpan: FakeEmbraceSdkSpan
     private lateinit var currentSessionPartSpan: FakeCurrentSessionPartSpan
     private lateinit var service: SessionReconstructionService
+    private var inFlightSpans: List<Span> = emptyList()
 
     @Before
     fun setUp() {
@@ -83,6 +84,7 @@ internal class SessionPartWriterResourceReadTest {
         clock = FakeClock()
         executor = BlockingScheduledExecutorService(clock, true)
         logger = FakeInternalLogger(throwOnInternalError = false)
+        inFlightSpans = listOf(inFlightSpan)
         sessionSpan = FakeEmbraceSdkSpan(name = "emb-session").apply { start(clock.now()) }
         currentSessionPartSpan = FakeCurrentSessionPartSpan(clock).apply { sessionPartSpan = sessionSpan }
         writer = SessionPartWriterImpl(
@@ -100,6 +102,7 @@ internal class SessionPartWriterResourceReadTest {
             FakeEnvelopeResourceSource().apply { resource = RESOURCE },
             EnvelopeMetadataSource { EnvelopeMetadata(userId = "my-user-id") },
             currentSessionPartSpan,
+            { inFlightSpans },
         )
         service = SessionReconstructionService(lazy { sessionsDir }, logger)
     }
@@ -138,6 +141,13 @@ internal class SessionPartWriterResourceReadTest {
     }
 
     @Test
+    fun `the in-flight spans are reconstructed as snapshots`() {
+        val envelope = checkNotNull(writeSessionPart())
+        assertEquals(inFlightSpan, envelope.data.spanSnapshots?.first())
+        assertEquals(emptyList<FakeInternalLogger.LogMessage>(), logger.internalErrorMessages)
+    }
+
+    @Test
     fun `a session part cannot be reconstructed without the manifest`() {
         writeSessionPart()
         File(partDir(), MANIFEST_FILE_NAME).delete()
@@ -146,8 +156,8 @@ internal class SessionPartWriterResourceReadTest {
     }
 
     /**
-     * Starts a session part, then hand-writes the files that no production writer produces yet, so
-     * the directory holds everything reconstruction requires.
+     * Starts a session part, then hand-writes the completed spans, which no production writer
+     * produces yet, so the directory holds everything reconstruction requires.
      */
     private fun writeSessionPart() = run {
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
@@ -158,12 +168,6 @@ internal class SessionPartWriterResourceReadTest {
             Buffer().apply {
                 write(CompletedSpans.ADAPTER.encode(CompletedSpans(spans = listOf(completedSpan))))
             }.readByteArray(),
-        )
-        writePartFile(
-            SPAN_SNAPSHOTS_FILE_NAME,
-            SpanSnapshots.ADAPTER.encode(
-                SpanSnapshots(format_version = FORMAT_VERSION, spans = listOf(snapshotSpan)),
-            ),
         )
         service.reconstruct(directory())
     }


### PR DESCRIPTION
## Goal

Initial changeset for writing span snapshots. This hooks up all the necessary infrastructure & writes span snapshots at the start and end of a session part only. Changes within the session will be left for a future date.

## Testing

Added unit tests.
