### PR TITLE
Remote config gate activity leak detection

### DIFF
--- a/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAutoDataCaptureBehavior.kt
+++ b/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeAutoDataCaptureBehavior.kt
@@ -21,6 +21,7 @@ class FakeAutoDataCaptureBehavior(
     private val smoothnessCaptureEnabled: Boolean = false,
     private val screenLoadCaptureEnabled: Boolean = false,
     private val activityProcessLifecycleTrackerEnabled: Boolean = false,
+    private val activityLeakDetectionEnabled: Boolean = false,
 ) : AutoDataCaptureBehavior {
 
     override fun isThermalStatusCaptureEnabled(): Boolean = thermalStatusCaptureEnabled
@@ -41,4 +42,5 @@ class FakeAutoDataCaptureBehavior(
     override fun isSmoothnessCaptureEnabled(): Boolean = smoothnessCaptureEnabled
     override fun isScreenLoadCaptureEnabled(): Boolean = screenLoadCaptureEnabled
     override fun isActivityProcessLifecycleTrackerEnabled(): Boolean = activityProcessLifecycleTrackerEnabled
+    override fun isActivityLeakDetectionEnabled(): Boolean = activityLeakDetectionEnabled
 }

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehavior.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehavior.kt
@@ -95,4 +95,9 @@ interface AutoDataCaptureBehavior {
      * androidx ProcessLifecycleOwner implementation.
      */
     fun isActivityProcessLifecycleTrackerEnabled(): Boolean
+
+    /**
+     * Whether Activity leak detection is enabled.
+     */
+    fun isActivityLeakDetectionEnabled(): Boolean
 }

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImpl.kt
@@ -20,6 +20,7 @@ class AutoDataCaptureBehaviorImpl(
         const val NAVIGATION_STATE_CAPTURE_ENABLED_DEFAULT = true
         const val SMOOTHNESS_CAPTURE_ENABLED_DEFAULT = false
         const val SCREEN_LOAD_CAPTURE_ENABLED_DEFAULT = false
+        const val ACTIVITY_LEAK_DETECTION_ENABLED_DEFAULT = false
     }
 
     private val local = local.enabledFeatures
@@ -68,4 +69,8 @@ class AutoDataCaptureBehaviorImpl(
     override fun isActivityProcessLifecycleTrackerEnabled(): Boolean =
         thresholdCheck.isBehaviorEnabled(remote?.pctActivityProcessLifecycleTrackerEnabled)
             ?: local.isActivityProcessLifecycleTrackerEnabled()
+
+    override fun isActivityLeakDetectionEnabled(): Boolean =
+        thresholdCheck.isBehaviorEnabled(remote?.pctActivityLeakDetectionEnabled)
+            ?: ACTIVITY_LEAK_DETECTION_ENABLED_DEFAULT
 }

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/AutoDataCaptureBehaviorImplTest.kt
@@ -43,6 +43,7 @@ internal class AutoDataCaptureBehaviorImplTest {
             assertTrue(isNavigationStateCaptureEnabled())
             assertFalse(isSmoothnessCaptureEnabled())
             assertFalse(isActivityProcessLifecycleTrackerEnabled())
+            assertFalse(isActivityLeakDetectionEnabled())
         }
     }
 
@@ -239,6 +240,27 @@ internal class AutoDataCaptureBehaviorImplTest {
                 localActivityProcessLifecycleTrackerEnabled = true,
                 remote = RemoteConfig(pctActivityProcessLifecycleTrackerEnabled = 0.0f),
             ).isActivityProcessLifecycleTrackerEnabled(),
+        )
+    }
+
+    @Test
+    fun `activity leak detection disabled when remote field null`() {
+        assertFalse(createAutoDataCaptureBehavior(remoteCfg = null).isActivityLeakDetectionEnabled())
+    }
+
+    @Test
+    fun `activity leak detection enabled when pct is 100`() {
+        assertTrue(
+            createBehavior(remote = RemoteConfig(pctActivityLeakDetectionEnabled = 100.0f))
+                .isActivityLeakDetectionEnabled(),
+        )
+    }
+
+    @Test
+    fun `activity leak detection disabled when pct is 0`() {
+        assertFalse(
+            createBehavior(remote = RemoteConfig(pctActivityLeakDetectionEnabled = 0.0f))
+                .isActivityLeakDetectionEnabled(),
         )
     }
 

--- a/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetectionDataSource.kt
+++ b/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetectionDataSource.kt
@@ -4,24 +4,16 @@ import android.app.Application
 import io.embrace.android.embracesdk.internal.arch.InstrumentationArgs
 import io.embrace.android.embracesdk.internal.arch.SessionPartEndListener
 import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceImpl
-import io.embrace.android.embracesdk.internal.arch.limits.UpToLimitStrategy
+import io.embrace.android.embracesdk.internal.arch.limits.NoopLimitStrategy
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 
 class LeakDetectionDataSource(args: InstrumentationArgs) :
     DataSourceImpl(
         args,
-        limitStrategy = UpToLimitStrategy { MAX_LEAK_DETECTION },
+        limitStrategy = NoopLimitStrategy,
         "leak-detection",
     ),
     SessionPartEndListener {
-    companion object {
-        /**
-         * Caps how many times [captureTelemetry] is allowed to succeed for this data source per session - i.e. how many
-         * session parts' worth of [onPreSessionEnd] reports, now that reporting happens once per session part rather
-         * than once per leak.
-         */
-        const val MAX_LEAK_DETECTION = 100
-    }
 
     private val application: Application = args.application
 

--- a/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetectionInstrumentationProvider.kt
+++ b/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetectionInstrumentationProvider.kt
@@ -16,7 +16,7 @@ class LeakDetectionInstrumentationProvider : InstrumentationProvider {
         }
         return DataSourceState(
             factory = { LeakDetectionDataSource(args) },
-            configGate = { true },
+            configGate = { args.configService.autoDataCaptureBehavior.isActivityLeakDetectionEnabled() },
         )
     }
 }

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/cache/CachedConfiguration.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/cache/CachedConfiguration.kt
@@ -5,7 +5,7 @@ import io.embrace.android.embracesdk.internal.serialization.BinaryVersion
 import kotlinx.serialization.Serializable
 
 @Serializable
-@BinaryVersion(-6343163155698584460)
+@BinaryVersion(2970054080211186631)
 data class CachedConfiguration(
     val deviceId: String,
     val etag: String?,

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/RemoteConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/remote/RemoteConfig.kt
@@ -148,4 +148,10 @@ data class RemoteConfig(
      */
     @SerialName("vitals")
     val vitalsRemoteConfig: VitalsRemoteConfig? = null,
+
+    /**
+     * Percentage of devices for which activity leak detection is captured.
+     */
+    @SerialName("pct_activity_leak_detection_enabled")
+    val pctActivityLeakDetectionEnabled: Float? = null,
 )


### PR DESCRIPTION
## Goal

Gate the activity leak detection functionality behind a new `RemoteConfig` threshold: `"pct_activity_leak_detection_enabled"`.

This is a standard 0-100% threshold, with a default behaviour of "off".

## Testing
New unit tests