### PR TITLE
Treat missing files as empty spans

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -80,7 +80,6 @@ class SessionPartWriterImpl(
         queueMetadataWrite(writers)
         queueSessionSpanWrite(writers)
         queueSpanSnapshotsWrite(writers)
-        queueCompletedSpansWrite(writers, emptyList())
         registerResourceChangeListener()
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
@@ -233,7 +233,6 @@ internal class SessionPartWriterImplTest {
                 "SessionMetadataWriteFail",
                 "SessionSpanWriteFail",
                 "SpanSnapshotsWriteFail",
-                "CompletedSpansWriteFail",
             ),
             logger.internalErrorMessages.map { it.msg },
         )
@@ -248,7 +247,6 @@ internal class SessionPartWriterImplTest {
                 "SessionMetadataWriteFail",
                 "SessionSpanWriteFail",
                 "SpanSnapshotsWriteFail",
-                "CompletedSpansWriteFail",
                 "SessionMetadataWriteFail",
             ),
             logger.internalErrorMessages.map { it.msg },
@@ -265,7 +263,6 @@ internal class SessionPartWriterImplTest {
                 "SessionMetadataWriteFail",
                 "SessionSpanWriteFail",
                 "SpanSnapshotsWriteFail",
-                "CompletedSpansWriteFail",
                 "SessionMetadataWriteFail",
                 "SessionSpanWriteFail",
                 "SpanSnapshotsWriteFail",
@@ -787,11 +784,12 @@ internal class SessionPartWriterImplTest {
     }
 
     @Test
-    fun `a session part in which nothing completes still has an empty log`() {
+    fun `a session part in which nothing completes writes no log`() {
         val writer = createWriter()
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
 
-        assertEquals(emptyList<String>(), completedSpanNamesIn(SESSION_PART_ID))
+        assertNull(partFile(SESSION_PART_ID, COMPLETED_SPANS_FILE_NAME))
         assertNoInternalErrors()
     }
 
@@ -805,7 +803,7 @@ internal class SessionPartWriterImplTest {
         writer.onSpanCompleted(emptyList())
 
         assertEquals(submitCount, executor.submitCount)
-        assertEquals(emptyList<String>(), completedSpanNamesIn(SESSION_PART_ID))
+        assertNull(partFile(SESSION_PART_ID, COMPLETED_SPANS_FILE_NAME))
         assertNoInternalErrors()
     }
 

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansWriter.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansWriter.kt
@@ -26,8 +26,8 @@ class CompletedSpansWriter(
 
     /**
      * Appends [spans] to the log for the active session part, leaving the spans already logged in
-     * place. Writing no spans creates an empty log, so a session part in which nothing completed
-     * can still be read back.
+     * place. A session part in which nothing completed has no log at all, which reconstruction
+     * reads back as no completed spans.
      */
     fun write(spans: List<Span>): Boolean = synchronized(lock) {
         try {

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionService.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionService.kt
@@ -73,14 +73,7 @@ class SessionReconstructionService(
         }
 
         val completedSpans = readCompletedSpansFile(partDir) ?: return null
-
-        val snapshots = readPartFile(
-            partDir,
-            SPAN_SNAPSHOTS_FILE_NAME,
-            SpanSnapshots.ADAPTER,
-            SpanSnapshots::format_version,
-        ) ?: return null
-        val persistedSnapshots = snapshots.spans.map(SpanProto::toPayload)
+        val persistedSnapshots = readSpanSnapshotsFile(partDir) ?: return null
 
         // A session span with no end time never finished, so it is delivered as a snapshot rather
         // than as a completed span. The snapshots file never holds the session span itself.
@@ -109,20 +102,37 @@ class SessionReconstructionService(
     }
 
     /**
-     * Decodes the completed spans logged in a session part directory, or null if the log is absent
-     * or cannot be read.
+     * Decodes the completed spans logged in a session part directory, or null if the log cannot be
+     * read.
      */
     private fun readCompletedSpansFile(partDir: File): List<Span>? {
         val src = File(partDir, COMPLETED_SPANS_FILE_NAME)
+        if (!src.exists()) {
+            return emptyList()
+        }
         return try {
-            if (!src.isFile) {
-                throw IOException("Completed spans file not found")
-            }
             src.source().buffer().use(::readCompletedSpans).map(SpanProto::toPayload)
         } catch (exc: Throwable) {
             trackFailure(exc)
             null
         }
+    }
+
+    /**
+     * Decodes the span snapshots persisted in a session part directory, or null if the file cannot
+     * be read.
+     */
+    private fun readSpanSnapshotsFile(partDir: File): List<Span>? {
+        if (!File(partDir, SPAN_SNAPSHOTS_FILE_NAME).exists()) {
+            return emptyList()
+        }
+        val snapshots = readPartFile(
+            partDir,
+            SPAN_SNAPSHOTS_FILE_NAME,
+            SpanSnapshots.ADAPTER,
+            SpanSnapshots::format_version,
+        ) ?: return null
+        return snapshots.spans.map(SpanProto::toPayload)
     }
 
     /**

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceCompletedSpansTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceCompletedSpansTest.kt
@@ -192,12 +192,31 @@ internal class SessionReconstructionServiceCompletedSpansTest {
     }
 
     @Test
-    fun `a missing completed spans log is reported`() {
+    fun `a missing completed spans log reconstructs the session span alone`() {
         writeManifest()
         writeMetadata()
         writeSessionSpan()
-        assertNull(service.reconstruct(partDirectory))
-        assertReconstructionFailureTracked()
+        writeSpanSnapshots()
+
+        val payload = checkNotNull(service.reconstruct(partDirectory)?.data)
+        assertEquals(listOf(fullyPopulatedSpan), payload.spans)
+        assertNull(payload.spanSnapshots)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a missing completed spans log does not stop the unfinished session span being delivered`() {
+        val incomplete = fullyPopulatedSpan.copy(endTimeNanos = null)
+        sessionSpan = incomplete
+        writeManifest()
+        writeMetadata()
+        writeSessionSpan()
+        writeSpanSnapshots()
+
+        val payload = checkNotNull(service.reconstruct(partDirectory)?.data)
+        assertNull(payload.spans)
+        assertEquals(listOf(incomplete), payload.spanSnapshots)
+        assertNoInternalErrors()
     }
 
     @Test

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceSpanSnapshotsTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceSpanSnapshotsTest.kt
@@ -157,14 +157,31 @@ internal class SessionReconstructionServiceSpanSnapshotsTest {
     }
 
     @Test
-    fun `a missing snapshots file is reported`() {
+    fun `a missing snapshots file reconstructs no snapshots`() {
         writeManifest()
         writeMetadata()
         writeSessionSpan()
         writeCompletedSpans()
 
-        assertNull(service.reconstruct(partDirectory))
-        assertReconstructionFailureTracked()
+        val payload = checkNotNull(service.reconstruct(partDirectory)?.data)
+        assertNull(payload.spanSnapshots)
+        assertEquals(listOf(fullyPopulatedSpan), payload.spans)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a missing snapshots file still reconstructs the unfinished session span`() {
+        val incomplete = fullyPopulatedSpan.copy(endTimeNanos = null)
+        sessionSpan = incomplete
+        writeManifest()
+        writeMetadata()
+        writeSessionSpan()
+        writeCompletedSpans()
+
+        val payload = checkNotNull(service.reconstruct(partDirectory)?.data)
+        assertEquals(listOf(incomplete), payload.spanSnapshots)
+        assertNull(payload.spans)
+        assertNoInternalErrors()
     }
 
     @Test


### PR DESCRIPTION
## Goal

Treats missing files as empty spans instead of discarding the entire payload. This also avoids an unnecessary write when starting a session part and no spans are present.

## Testing

Added unit tests.
