### PR TITLE
Optimize writing of span snapshots

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -171,9 +171,12 @@ class SessionPartWriterImpl(
      * Writes the session span as it stands right now.
      */
     private fun queueSessionSpanWrite(writers: PartWriters) {
-        val span = writers.span?.snapshot() ?: return
+        val span = writers.span ?: return
         execute(InternalErrorType.SessionSpanWriteFail, writers.sessionSpanWrites::submit) {
-            writers.sessionSpan.write(span)
+            val snapshot = span.snapshot()
+            if (snapshot != null) {
+                writers.sessionSpan.write(snapshot)
+            }
         }
     }
 
@@ -211,14 +214,17 @@ class SessionPartWriterImpl(
         submit: (Runnable) -> Unit,
         action: () -> Unit,
     ) {
-        if (crashing) {
+        val task = Runnable {
             try {
                 action()
             } catch (exc: Throwable) {
                 logger.trackInternalError(errorType, exc)
             }
+        }
+        if (crashing) {
+            task.run()
         } else {
-            submit(Runnable(action))
+            submit(task)
         }
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -1082,6 +1082,7 @@ internal class SessionOrchestratorTest {
         createOrchestrator(ProcessState.BACKGROUND, multiFilePersistenceConfigService())
         val partId = checkNotNull(sessionTracker.getActiveSessionPartId())
         sessionCacheExecutor.runCurrentlyBlocked()
+        assertEquals("emb-session", sessionSpanIn(partId)?.span?.name)
 
         clock.tick(2000)
         checkNotNull(currentSessionPartSpan.sessionPartSpan).name = "refreshed-span"

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterBoundaryTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterBoundaryTest.kt
@@ -264,7 +264,8 @@ internal class SessionPartWriterBoundaryTest {
     }
 
     private fun startPart(sessionPartId: String) {
-        sessionSpan.name = "span${spanCount++}"
+        sessionSpan = FakeEmbraceSdkSpan(name = "span${spanCount++}").apply { start(clock.now()) }
+        currentSessionPartSpan.sessionPartSpan = sessionSpan
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, sessionPartId)
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
@@ -360,7 +360,7 @@ internal class SessionPartWriterImplTest {
     }
 
     @Test
-    fun `the session span is snapshotted before the write is queued`() {
+    fun `the span bound to the part is written even if the current session span is cleared`() {
         val writer = createWriter()
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
 
@@ -369,6 +369,17 @@ internal class SessionPartWriterImplTest {
         drain()
 
         assertEquals("span0", sessionSpanIn(SESSION_PART_ID)?.span?.name)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a queued session span write persists the state at the time it runs`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        sessionSpan.name = "span1"
+        drain()
+
+        assertEquals("span1", sessionSpanIn(SESSION_PART_ID)?.span?.name)
         assertNoInternalErrors()
     }
 
@@ -432,7 +443,7 @@ internal class SessionPartWriterImplTest {
     }
 
     @Test
-    fun `the ended session span is snapshotted before the write is queued`() {
+    fun `the ended session span is written even if the current session span is cleared`() {
         val writer = createWriter()
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
         drain()


### PR DESCRIPTION
## Goal

Optimizes the writing of span snapshots by serializing on the worker thread, not the calling thread.

## Testing

<!-- Describe how this change has been tested -->
