### PR TITLE
Identify specific leak references

### DIFF
--- a/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetector.kt
+++ b/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetector.kt
@@ -216,7 +216,13 @@ internal class LeakDetector(
                 // The suspectedAtCycle is captured after the first GC cycle (when a TrackedReference becomes a ConfirmedSuspect).
                 // So we +1 here so that cycle is represented in the reporting (instead of reporting a confusing 0 value).
                 val cyclesSurvived = cycleCount - suspect.suspectedAtCycle + 1
-                LeakSnapshot(suspect.trackedAtMs, suspect.token, cyclesSurvived, referent.javaClass.name)
+                LeakSnapshot(
+                    suspect.trackedAtMs,
+                    suspect.token,
+                    cyclesSurvived,
+                    referent.javaClass.name,
+                    System.identityHashCode(referent),
+                )
             }
         }
     }
@@ -332,12 +338,18 @@ internal class LeakDetector(
     /**
      * One entry of [suspects]: everything needed to report a confirmed suspect, read fresh at snapshot time rather than
      * retained by the [ConfirmedSuspect] itself, and nothing that could retain the object it describes.
+     *
+     * [id] is the referent's identity hashcode - stable for its lifetime regardless of when it's first read, so a
+     * suspect reported again in a later session part can be told apart from a different instance of the same class
+     * confirmed in the same one. Not guaranteed unique (identity hashcodes can collide, or be reused once an object is
+     * actually collected), but at the scale of suspects any one class accumulates here the odds are negligible.
      */
     internal data class LeakSnapshot(
         val trackedAtMs: Long,
         val token: Any?,
         val cyclesSurvived: Long,
         val className: String,
+        val id: Int,
     )
 
     internal companion object {

--- a/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakSuspectEncoder.kt
+++ b/embrace-android-instrumentation-leaks/src/main/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakSuspectEncoder.kt
@@ -14,9 +14,10 @@ package io.embrace.android.embracesdk.instrumentation.leaks
  * A suspect whose [LeakDetector.LeakSnapshot.token] is not a [LeakContext], or whose session IDs are empty, is dropped: a
  * leak whose session is unknown is not reportable.
  *
- * The format is `<sessionPartId>_<userSessionId>:<objectType>|<className>|<cyclesSurvived>,...;...` - groups separated by
- * `;`, entries within a group by `,`, fields within an entry by `|`. None of these, nor `:`, can appear in a JVM class
- * name, so no escaping is needed.
+ * The format is `<sessionPartId>_<userSessionId>:<objectType>|<className>|<cyclesSurvived>|<id>,...;...` - groups
+ * separated by `;`, entries within a group by `,`, fields within an entry by `|`. None of these, nor `:`, can appear in a
+ * JVM class name, so no escaping is needed. `<id>` is [LeakDetector.LeakSnapshot.id] rendered as hex, matching the
+ * unsigned convention `Object.toString()` already uses for identity hashcodes.
  *
  * Session-part attributes are not length-truncated by the platform the way custom attributes are, so [maxLength] is
  * enforced here - defaulting to 2000, matching `OtelLimitsConfig.getMaxInternalAttributeValueLength()`. Suspects are kept
@@ -55,7 +56,7 @@ private fun toCandidate(snapshot: LeakDetector.LeakSnapshot): Candidate? {
 
     return Candidate(
         groupKey = "${sessionIds.sessionPartId}_${sessionIds.userSessionId}",
-        entry = "${context.objectType}|${snapshot.className}|${snapshot.cyclesSurvived}",
+        entry = "${context.objectType}|${snapshot.className}|${snapshot.cyclesSurvived}|${Integer.toHexString(snapshot.id)}",
         cyclesSurvived = snapshot.cyclesSurvived,
     )
 }

--- a/embrace-android-instrumentation-leaks/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetectorTest.kt
+++ b/embrace-android-instrumentation-leaks/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakDetectorTest.kt
@@ -57,6 +57,7 @@ internal class LeakDetectorTest {
             leaked.javaClass.name,
             suspect.className,
         )
+        assertEquals(System.identityHashCode(leaked), suspect.id)
 
         gcCycleCount = 7L
         assertEquals(
@@ -64,6 +65,26 @@ internal class LeakDetectorTest {
             5L,
             detector.suspects().single().cyclesSurvived,
         )
+    }
+
+    @Test
+    fun `id identifies the referent and stays stable across repeated snapshots`() {
+        val first = Any()
+        val second = Any()
+
+        detector.trackOpened(first)
+        detector.trackOpened(second)
+        val firstRef = checkNotNull(detector.trackClosed(first, "first"))
+        val secondRef = checkNotNull(detector.trackClosed(second, "second"))
+        confirmAfterSecondSentinel(firstRef)
+        confirmAfterSecondSentinel(secondRef)
+
+        val snapshots = detector.suspects().associateBy { it.token }
+        assertEquals(System.identityHashCode(first), snapshots.getValue("first").id)
+        assertEquals(System.identityHashCode(second), snapshots.getValue("second").id)
+
+        // stable across repeated snapshots, not re-randomized per call
+        assertEquals(snapshots.getValue("first").id, detector.suspects().single { it.token == "first" }.id)
     }
 
     @Test

--- a/embrace-android-instrumentation-leaks/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakSuspectEncoderTest.kt
+++ b/embrace-android-instrumentation-leaks/src/test/kotlin/io/embrace/android/embracesdk/instrumentation/leaks/LeakSuspectEncoderTest.kt
@@ -13,37 +13,58 @@ internal class LeakSuspectEncoderTest {
     }
 
     @Test
-    fun `a single suspect encodes as one group with one entry`() {
-        val suspects = listOf(snapshot(className = "com.example.MainActivity", cyclesSurvived = 4))
+    fun `a single suspect encodes as one group with one entry, id rendered as hex`() {
+        val suspects = listOf(snapshot(className = "com.example.MainActivity", cyclesSurvived = 4, id = 255))
 
-        assertEquals("part_sess:activity|com.example.MainActivity|4", encodeLeakSuspects(suspects))
+        assertEquals("part_sess:activity|com.example.MainActivity|4|ff", encodeLeakSuspects(suspects))
+    }
+
+    @Test
+    fun `a negative id is encoded as its unsigned hex form, not a minus sign`() {
+        val suspects = listOf(snapshot(id = -1))
+
+        assertEquals("part_sess:activity|com.example.MainActivity|0|ffffffff", encodeLeakSuspects(suspects))
     }
 
     @Test
     fun `suspects sharing a session part are grouped, ordered by cyclesSurvived descending`() {
         val suspects = listOf(
-            snapshot(className = "First", cyclesSurvived = 2),
-            snapshot(className = "Second", cyclesSurvived = 5),
+            snapshot(className = "First", cyclesSurvived = 2, id = 1),
+            snapshot(className = "Second", cyclesSurvived = 5, id = 2),
         )
 
-        assertEquals("part_sess:activity|Second|5,activity|First|2", encodeLeakSuspects(suspects))
+        assertEquals("part_sess:activity|Second|5|2,activity|First|2|1", encodeLeakSuspects(suspects))
+    }
+
+    @Test
+    fun `two distinct instances of the same class in the same group are both included, told apart by id`() {
+        val suspects = listOf(
+            snapshot(className = "com.example.MainActivity", cyclesSurvived = 3, id = 1),
+            snapshot(className = "com.example.MainActivity", cyclesSurvived = 3, id = 2),
+        )
+
+        assertEquals(
+            "part_sess:activity|com.example.MainActivity|3|1,activity|com.example.MainActivity|3|2",
+            encodeLeakSuspects(suspects),
+        )
     }
 
     @Test
     fun `suspects from different session parts are encoded as separate groups`() {
         val suspects = listOf(
-            snapshot(sessionPartId = "part1", objectType = "activity", className = "Foo", cyclesSurvived = 10),
-            snapshot(sessionPartId = "part2", objectType = "fragment", className = "Bar", cyclesSurvived = 20),
+            snapshot(sessionPartId = "part1", objectType = "activity", className = "Foo", cyclesSurvived = 10, id = 1),
+            snapshot(sessionPartId = "part2", objectType = "fragment", className = "Bar", cyclesSurvived = 20, id = 2),
         )
 
         // groups appear in the order their first (highest-cyclesSurvived) member was reached
-        assertEquals("part2_sess:fragment|Bar|20;part1_sess:activity|Foo|10", encodeLeakSuspects(suspects))
+        assertEquals("part2_sess:fragment|Bar|20|2;part1_sess:activity|Foo|10|1", encodeLeakSuspects(suspects))
     }
 
     @Test
     fun `a suspect whose token is not a LeakContext is dropped`() {
-        val suspects =
-            listOf(LeakDetector.LeakSnapshot(trackedAtMs = 0L, token = "not a LeakContext", cyclesSurvived = 1, className = "Foo"))
+        val suspects = listOf(
+            LeakDetector.LeakSnapshot(trackedAtMs = 0L, token = "not a LeakContext", cyclesSurvived = 1, className = "Foo", id = 0),
+        )
 
         assertEquals("", encodeLeakSuspects(suspects))
     }
@@ -67,12 +88,14 @@ internal class LeakSuspectEncoderTest {
             snapshot(objectType = "x", className = "y", cyclesSurvived = 1),
         )
 
-        assertEquals("part_sess:activity|A|5", encodeLeakSuspects(suspects, maxLength = 28))
+        assertEquals("part_sess:activity|A|5|0", encodeLeakSuspects(suspects, maxLength = 30))
     }
 
     @Test
     fun `the encoded result never exceeds maxLength`() {
-        val suspects = (1..50).map { snapshot(className = "com.example.SomeActivity$it", cyclesSurvived = it.toLong()) }
+        val suspects = (1..50).map {
+            snapshot(className = "com.example.SomeActivity$it", cyclesSurvived = it.toLong(), id = it)
+        }
 
         assertTrue(encodeLeakSuspects(suspects, maxLength = 100).length <= 100)
     }
@@ -83,10 +106,12 @@ internal class LeakSuspectEncoderTest {
         objectType: String = "activity",
         className: String = "com.example.MainActivity",
         cyclesSurvived: Long = 0L,
+        id: Int = 0,
     ): LeakDetector.LeakSnapshot = LeakDetector.LeakSnapshot(
         trackedAtMs = 0L,
         token = LeakContext(objectType, SessionIdsSnapshot(userSessionId = userSessionId, sessionPartId = sessionPartId)),
         cyclesSurvived = cyclesSurvived,
         className = className,
+        id = id,
     )
 }

--- a/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSessionAttributes.kt
+++ b/embrace-android-semconv/src/main/kotlin/io/embrace/android/embracesdk/semconv/EmbSessionAttributes.kt
@@ -71,7 +71,7 @@ object EmbSessionAttributes {
     const val EMB_IS_FINAL_SESSION_PART: String = "emb.is_final_session_part"
 
     /**
-     * Confirmed leak suspects still reachable at the end of this session part, and how many GC cycles each has survived since being confirmed. Encoded as ';'-separated groups of '<sessionPartId>_<userSessionId>:<entries>', each naming the session part the suspects were originally tracked closed in, followed by a ','-separated list of '<objectType>|<className>|<cyclesSurvived>' entries. A suspect still alive across multiple session parts is reported again in each one, with an updated cyclesSurvived.
+     * Confirmed leak suspects still reachable at the end of this session part, as delimited entries of object type, class name, GC cycles survived, and identity hash.
      */
     @ExperimentalSemconv
     const val EMB_MEMORY_LEAK_SUSPECTS: String = "emb.memory_leak_suspects"

--- a/embrace-android-semconv/src/main/semconv/session.yaml
+++ b/embrace-android-semconv/src/main/semconv/session.yaml
@@ -191,6 +191,6 @@ attributes:
     examples: ["987", "-789"]
   - key: emb.memory_leak_suspects
     type: string
-    brief: "Confirmed leak suspects still reachable at the end of this session part, and how many GC cycles each has survived since being confirmed. Encoded as ';'-separated groups of '<sessionPartId>_<userSessionId>:<entries>', each naming the session part the suspects were originally tracked closed in, followed by a ','-separated list of '<objectType>|<className>|<cyclesSurvived>' entries. A suspect still alive across multiple session parts is reported again in each one, with an updated cyclesSurvived."
+    brief: "Confirmed leak suspects still reachable at the end of this session part, as delimited entries of object type, class name, GC cycles survived, and identity hash."
     stability: development
-    examples: ["part123_sess456:activity|com.example.MainActivity|4"]
+    examples: ["part123_sess456:activity|com.example.MainActivity|4|1a2b3c4d"]


### PR DESCRIPTION
## Goal
Allow more reasonable re-duplication & aggregation work by identifying each suspected leak reference. This adds the `identityHashCode` to each of the leak suspects reported (as a hex string) so that 2 different suspected leaks of the same class can be distinguished. 

## Testing
New unit test added.
