### PR TITLE
Add initial test for multi-file persistence

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
@@ -112,6 +112,7 @@ class UserSessionOrchestrationModuleImpl(
             },
             sessionPartDirectoryStore,
             sessionPartWriteTracker,
+            onWritesComplete = { sessionPartReader?.readPersistedSessionParts() },
         )
         essentialServiceModule.userService.addUserInfoListener(sessionPartWriter::onMetadataChanged)
         openTelemetryModule.spanRepository.addCompletedOtelSpansListener { spans ->

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -44,6 +44,7 @@ class SessionPartWriterImpl(
     private val directoryStore: SessionPartDirectoryStore =
         SessionPartDirectoryStore(sessionsDir, worker, clock, logger),
     private val writeTracker: SessionPartWriteTracker = SessionPartWriteTracker(),
+    private val onWritesComplete: () -> Unit = {},
 ) : SessionPartWriter {
 
     private companion object {
@@ -96,7 +97,13 @@ class SessionPartWriterImpl(
         }
         queueSessionSpanWrite(writers)
         queueSpanSnapshotsWrite(writers)
-        worker.submit { writeTracker.markComplete(sessionPartId) }
+        worker.submit {
+            writeTracker.markComplete(sessionPartId)
+
+            if (!writesSealed) {
+                notifyWritesComplete()
+            }
+        }
     }
 
     override fun onMetadataChanged() {
@@ -228,6 +235,17 @@ class SessionPartWriterImpl(
             task.run()
         } else {
             submit(task)
+        }
+    }
+
+    /**
+     * Signals that a session part is fully written.
+     */
+    private fun notifyWritesComplete() {
+        try {
+            onWritesComplete()
+        } catch (exc: Throwable) {
+            logger.trackInternalError(InternalErrorType.SessionPartWritesCompleteFail, exc)
         }
     }
 

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/InternalErrorType.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/InternalErrorType.kt
@@ -40,6 +40,7 @@ sealed class InternalErrorType(private val severity: Severity) {
     object SessionPartDirectoryStoreFail : InternalErrorType(ERROR)
     object SessionReconstructionFail : InternalErrorType(ERROR)
     object SessionPartReadFail : InternalErrorType(ERROR)
+    object SessionPartWritesCompleteFail : InternalErrorType(ERROR)
     object DuplicateSpanIds : InternalErrorType(ERROR)
     object SessionSpanWriteFail : InternalErrorType(ERROR)
     object CompletedSpansWriteFail : InternalErrorType(ERROR)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/persistence/MultiFilePersistenceParityTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/persistence/MultiFilePersistenceParityTest.kt
@@ -1,0 +1,88 @@
+package io.embrace.android.embracesdk.testcases.persistence
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.android.embracesdk.assertions.findSessionPartSpan
+import io.embrace.android.embracesdk.assertions.getSessionPartId
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
+import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
+import io.embrace.android.embracesdk.internal.payload.Envelope
+import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
+import io.embrace.android.embracesdk.internal.worker.Worker
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
+import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
+import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Verifies that a minimal session payload reaches the server whether it was persisted by the legacy
+ * single-file layer or by the multi-file layer.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class MultiFilePersistenceParityTest {
+
+    private val multiFileEnabled = RemoteConfig(pctMultiFilePersistenceEnabled = 100.0f)
+
+    @Rule
+    @JvmField
+    val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
+        EmbraceSetupInterface(
+            workersToFake = listOf(
+                Worker.Background.SessionPersistenceWorker,
+                Worker.Background.PeriodicCacheWorker,
+                Worker.Background.NonIoRegWorker,
+                Worker.Background.IoRegWorker,
+            ),
+        ).apply {
+            getFakedWorkerExecutor(Worker.Background.SessionPersistenceWorker).blockingMode = false
+            getFakedWorkerExecutor(Worker.Background.NonIoRegWorker).blockingMode = false
+            getFakedWorkerExecutor(Worker.Background.IoRegWorker).blockingMode = false
+        }
+    }
+
+    @Test
+    fun `legacy single-file persistence delivers the session payload`() {
+        testRule.runTest(
+            testCaseAction = {
+                recordSession()
+            },
+            assertAction = {
+                assertMinimalSessionPayload(getSingleSessionEnvelope())
+            },
+        )
+    }
+
+    @Test
+    fun `multi-file persistence delivers the session payload once its writes complete`() {
+        testRule.runTest(
+            persistedRemoteConfig = multiFileEnabled,
+            testCaseAction = {
+                recordSession()
+            },
+            assertAction = {
+                // one payload comes from the legacy writer, the other after the multi-file writes have completed.
+                // this assertion waits for both.
+                val envelopes = getSessionEnvelopes(2, assertOrdering = false)
+                assertEquals(1, envelopes.map(Envelope<SessionPartPayload>::getSessionPartId).distinct().size)
+                envelopes.forEach(::assertMinimalSessionPayload)
+            },
+        )
+    }
+
+    /**
+     * Asserts the basic shape of a delivered session payload. Both persistence paths must satisfy
+     * this identically.
+     */
+    private fun assertMinimalSessionPayload(envelope: Envelope<SessionPartPayload>) {
+        assertEquals("spans", envelope.type)
+        assertEquals("2.5.1", envelope.resource?.appVersion)
+
+        val sessionSpan = envelope.findSessionPartSpan()
+        assertEquals("emb-session", sessionSpan.name)
+        assertNotNull(sessionSpan.endTimeNanos)
+        assertEquals("foreground", sessionSpan.attributes?.findAttributeValue(EmbSessionAttributes.EMB_STATE))
+    }
+}


### PR DESCRIPTION
## Goal

Adds an initial integration test that asserts multi-file persistence delivers sessions. Future changesets will enhance the actual assertions.
