### PR TITLE
Implement CoalescingWriteQueue

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/CoalescingWriteQueue.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/CoalescingWriteQueue.kt
@@ -1,0 +1,84 @@
+package io.embrace.android.embracesdk.internal.session.orchestrator
+
+import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import java.util.concurrent.Future
+import java.util.concurrent.FutureTask
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Debounces the writes for one file in a session part. Each write persists the whole file, so a
+ * write that is superseded before it runs can be dropped. The intent behind this class
+ * is that a burst of changes typically only cost one write, rather than one per change.
+ *
+ * A write is held as a [FutureTask] armed with a scheduled trigger that runs it
+ * [delayMs] later. Cancelling that trigger does not cancel the [FutureTask] it wraps. This
+ * lets [shutdown] force the task to run early rather than queueing the work twice.
+ */
+internal class CoalescingWriteQueue(
+    private val worker: BackgroundWorker,
+    private val delayMs: Long = DEFAULT_DELAY_MS,
+) {
+    private val pending = AtomicReference<PendingWrite?>(null)
+
+    /**
+     * Orders writes so that concurrent calls to [submit] can be compared by age. This handles interleaving
+     * during submission.
+     */
+    private val sequence = AtomicLong()
+
+    /**
+     * Arms [runnable] to run [delayMs] from now, disarming whatever was armed before it.
+     * In-progress writes are left to finish.
+     */
+    fun submit(runnable: Runnable) {
+        val seq = sequence.incrementAndGet()
+        val task = FutureTask(runnable, Unit)
+        val trigger = runCatching {
+            worker.schedule<Unit>(task, delayMs, TimeUnit.MILLISECONDS)
+        }.getOrNull()
+        val write = PendingWrite(seq, task, trigger)
+
+        while (true) {
+            val previous = pending.get()
+            if (previous != null && previous.seq > seq) {
+                // a newer write was armed while this one was being armed. cancel this one.
+                trigger?.cancel(false)
+                return
+            }
+            if (pending.compareAndSet(previous, write)) {
+                previous?.trigger?.cancel(false)
+                return
+            }
+        }
+    }
+
+    /**
+     * Runs the pending write and blocks for up to [timeoutMs] so the newest data is on disk
+     * before the caller moves on. This is typically because the process is about to die.
+     */
+    fun shutdown(timeoutMs: Long) {
+        val write = pending.getAndSet(null) ?: return
+        write.trigger?.cancel(false)
+
+        if (runCatching { worker.submit(write.task) }.isFailure) {
+            write.task.run()
+        }
+        when (runCatching { write.task.get(timeoutMs, TimeUnit.MILLISECONDS) }.exceptionOrNull()) {
+            is TimeoutException -> write.task.run()
+            is InterruptedException -> Thread.currentThread().interrupt()
+        }
+    }
+
+    private class PendingWrite(
+        val seq: Long,
+        val task: FutureTask<Unit>,
+        val trigger: Future<*>?,
+    )
+
+    companion object {
+        const val DEFAULT_DELAY_MS = 0L
+    }
+}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -22,8 +22,6 @@ import io.embrace.android.embracesdk.internal.spans.CurrentSessionPartSpan
 import io.embrace.android.embracesdk.internal.utils.UuidSource
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import java.io.File
-import java.util.concurrent.Future
-import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Writes session part telemetry to disk, if the multi-file persistence layer is enabled.
@@ -293,18 +291,5 @@ class SessionPartWriterImpl(
         val metadataWrites = CoalescingWriteQueue(worker)
         val sessionSpanWrites = CoalescingWriteQueue(worker)
         val spanSnapshotWrites = CoalescingWriteQueue(worker)
-    }
-
-    /**
-     * Queues the writes for one file in a session part. Each write persists the whole file so
-     * we should cancel and remove any enqueued writes as they will be superseded by later ones.
-     * A write that has already started is left to finish.
-     */
-    private class CoalescingWriteQueue(private val worker: BackgroundWorker) {
-        private val pending = AtomicReference<Future<*>?>(null)
-
-        fun submit(runnable: Runnable) {
-            pending.getAndSet(worker.submit(runnable))?.cancel(false)
-        }
     }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/CoalescingWriteQueueTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/CoalescingWriteQueueTest.kt
@@ -1,0 +1,161 @@
+package io.embrace.android.embracesdk.internal.session.orchestrator
+
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
+import io.embrace.android.embracesdk.fakes.FakeClock
+import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+
+internal class CoalescingWriteQueueTest {
+
+    private companion object {
+        private const val DELAY_MS = 5000L
+        private const val TIMEOUT_MS = 1000L
+    }
+
+    private lateinit var executor: BlockingScheduledExecutorService
+    private lateinit var queue: CoalescingWriteQueue
+
+    private val writes = mutableListOf<String>()
+
+    private fun write(name: String) = Runnable { writes.add(name) }
+
+    @Before
+    fun setUp() {
+        executor = BlockingScheduledExecutorService(FakeClock(), blockingMode = false)
+        queue = CoalescingWriteQueue(BackgroundWorker(executor), DELAY_MS)
+        writes.clear()
+    }
+
+    @Test
+    fun `a write waits out its delay`() {
+        queue.submit(write("first"))
+
+        assertEquals(1, executor.scheduledTasksCount())
+        assertEquals(emptyList<String>(), writes)
+
+        executor.moveForwardAndRunBlocked(DELAY_MS)
+        assertEquals(listOf("first"), writes)
+    }
+
+    @Test
+    fun `writes submitted within the delay collapse to the last one`() {
+        queue.submit(write("first"))
+        executor.moveForwardAndRunBlocked(DELAY_MS - 1)
+        queue.submit(write("second"))
+        queue.submit(write("third"))
+
+        executor.moveForwardAndRunBlocked(DELAY_MS)
+        assertEquals(listOf("third"), writes)
+    }
+
+    @Test
+    fun `writes submitted after the delay all run`() {
+        queue.submit(write("first"))
+        executor.moveForwardAndRunBlocked(DELAY_MS)
+        queue.submit(write("second"))
+        executor.moveForwardAndRunBlocked(DELAY_MS)
+
+        assertEquals(listOf("first", "second"), writes)
+    }
+
+    @Test
+    fun `shutdown runs the pending write immediately`() {
+        queue.submit(write("first"))
+        queue.shutdown(TIMEOUT_MS)
+        assertEquals(listOf("first"), writes)
+    }
+
+    @Test
+    fun `a write forced by shutdown does not run again when its delay elapses`() {
+        queue.submit(write("first"))
+        queue.shutdown(TIMEOUT_MS)
+
+        executor.moveForwardAndRunBlocked(DELAY_MS)
+        assertEquals(listOf("first"), writes)
+        assertEquals(0, executor.scheduledTasksCount())
+    }
+
+    @Test
+    fun `shutdown with nothing pending does nothing`() {
+        queue.shutdown(TIMEOUT_MS)
+        assertEquals(emptyList<String>(), writes)
+    }
+
+    @Test
+    fun `shutdown twice runs the pending write once`() {
+        queue.submit(write("first"))
+        queue.shutdown(TIMEOUT_MS)
+        queue.shutdown(TIMEOUT_MS)
+        assertEquals(listOf("first"), writes)
+    }
+
+    @Test
+    fun `a write submitted after shutdown is armed as normal`() {
+        queue.submit(write("first"))
+        queue.shutdown(TIMEOUT_MS)
+
+        queue.submit(write("second"))
+        executor.moveForwardAndRunBlocked(DELAY_MS)
+
+        assertEquals(listOf("first", "second"), writes)
+    }
+
+    @Test
+    fun `a write that throws does not fail shutdown`() {
+        queue.submit { error("write failed") }
+        queue.shutdown(TIMEOUT_MS)
+        assertEquals(emptyList<String>(), writes)
+    }
+
+    @Test
+    fun `a write submitted to a shut down worker is flushed by shutdown`() {
+        executor.shutdown()
+        queue.submit(write("first"))
+
+        assertEquals(emptyList<String>(), writes)
+
+        queue.shutdown(TIMEOUT_MS)
+        assertEquals(listOf("first"), writes)
+    }
+
+    @Test
+    fun `a write superseded while it is being armed does not displace the newer write`() {
+        var queueRef: CoalescingWriteQueue? = null
+        val hookedExecutor = ScheduleHookExecutor(executor) {
+            checkNotNull(queueRef).submit(write("second"))
+        }
+        val reentrantQueue = CoalescingWriteQueue(BackgroundWorker(hookedExecutor), DELAY_MS)
+        queueRef = reentrantQueue
+
+        reentrantQueue.submit(write("first"))
+        executor.moveForwardAndRunBlocked(DELAY_MS)
+
+        assertEquals(listOf("second"), writes)
+    }
+
+    /**
+     * Delegates to [delegate], calling [onFirstSchedule] once after the first write is scheduled
+     * but before the caller has published it.
+     */
+    private class ScheduleHookExecutor(
+        private val delegate: ScheduledExecutorService,
+        private val onFirstSchedule: () -> Unit,
+    ) : ScheduledExecutorService by delegate {
+
+        private var hooked = false
+
+        override fun schedule(command: Runnable?, delay: Long, unit: TimeUnit?): ScheduledFuture<*> {
+            val future = delegate.schedule(command, delay, unit)
+            if (!hooked) {
+                hooked = true
+                onFirstSchedule()
+            }
+            return future
+        }
+    }
+}

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -2025,7 +2025,7 @@ internal class SessionOrchestratorTest {
      * the order they will be delivered.
      */
     private fun sessionPartDirs(): List<SessionPartDirectory> {
-        sessionPersistenceExecutor.runCurrentlyBlocked()
+        drainPersistence()
         return partDirs()
     }
 
@@ -2039,8 +2039,14 @@ internal class SessionOrchestratorTest {
      * session part, if any.
      */
     private fun sessionSpanIn(sessionPartId: String): SessionPartSpan? {
-        sessionPersistenceExecutor.runCurrentlyBlocked()
+        drainPersistence()
         return sessionSpanOnDisk(sessionPartId)
+    }
+
+    private fun drainPersistence() {
+        do {
+            sessionPersistenceExecutor.moveForwardAndRunBlocked(CoalescingWriteQueue.DEFAULT_DELAY_MS)
+        } while (sessionPersistenceExecutor.scheduledTasksCount() > 0)
     }
 
     private fun sessionSpanOnDisk(sessionPartId: String): SessionPartSpan? {

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterBoundaryTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterBoundaryTest.kt
@@ -187,13 +187,14 @@ internal class SessionPartWriterBoundaryTest {
     fun `a session span write queued at a part end lands in the session part it was queued for`() {
         startPart(FIRST_PART_ID)
         clock.tick(10000)
+        val endedAt = clock.now()
         endPart(FIRST_PART_ID)
         startPart(SECOND_PART_ID)
         drain()
 
         with(checkNotNull(sessionSpanIn(FIRST_PART_ID)?.span)) {
             assertEquals("span0", name)
-            assertEquals(clock.now().millisToNanos(), end_time_unix_nano)
+            assertEquals(endedAt.millisToNanos(), end_time_unix_nano)
         }
         with(checkNotNull(sessionSpanIn(SECOND_PART_ID)?.span)) {
             assertEquals("span1", name)
@@ -276,7 +277,9 @@ internal class SessionPartWriterBoundaryTest {
     }
 
     private fun drain() {
-        executor.runCurrentlyBlocked()
+        do {
+            executor.moveForwardAndRunBlocked(CoalescingWriteQueue.DEFAULT_DELAY_MS)
+        } while (executor.scheduledTasksCount() > 0)
     }
 
     private fun sessionPartDirs(): List<SessionPartDirectory> =

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
@@ -95,10 +95,11 @@ internal class SessionPartWriterImplTest {
     @Test
     fun `a session part start creates a directory holding the metadata`() {
         val writer = createWriter()
-        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        val startedAt = clock.now()
+        writer.onSessionPartStarted(startedAt, USER_SESSION_ID, SESSION_PART_ID)
 
         val directory = sessionPartDirs().single()
-        assertEquals(clock.now(), directory.timestamp)
+        assertEquals(startedAt, directory.timestamp)
         assertEquals(USER_SESSION_ID, directory.userSessionId)
         assertEquals(SESSION_PART_ID, directory.sessionPartId)
         assertNoInternalErrors()
@@ -226,48 +227,39 @@ internal class SessionPartWriterImplTest {
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
         drain()
 
-        assertEquals(
-            listOf(
-                "SessionPartDirectoryStoreFail",
-                "SessionManifestWriteFail",
-                "SessionMetadataWriteFail",
-                "SessionSpanWriteFail",
-                "SpanSnapshotsWriteFail",
-            ),
-            logger.internalErrorMessages.map { it.msg },
+        assertInternalErrors(
+            "SessionPartDirectoryStoreFail",
+            "SessionManifestWriteFail",
+            "SessionMetadataWriteFail",
+            "SessionSpanWriteFail",
+            "SpanSnapshotsWriteFail",
         )
 
         writer.onMetadataChanged()
         drain()
 
-        assertEquals(
-            listOf(
-                "SessionPartDirectoryStoreFail",
-                "SessionManifestWriteFail",
-                "SessionMetadataWriteFail",
-                "SessionSpanWriteFail",
-                "SpanSnapshotsWriteFail",
-                "SessionMetadataWriteFail",
-            ),
-            logger.internalErrorMessages.map { it.msg },
+        assertInternalErrors(
+            "SessionPartDirectoryStoreFail",
+            "SessionManifestWriteFail",
+            "SessionMetadataWriteFail",
+            "SessionSpanWriteFail",
+            "SpanSnapshotsWriteFail",
+            "SessionMetadataWriteFail",
         )
 
         endPart()
         writer.onSessionPartEnded(SESSION_PART_ID)
         drain()
 
-        assertEquals(
-            listOf(
-                "SessionPartDirectoryStoreFail",
-                "SessionManifestWriteFail",
-                "SessionMetadataWriteFail",
-                "SessionSpanWriteFail",
-                "SpanSnapshotsWriteFail",
-                "SessionMetadataWriteFail",
-                "SessionSpanWriteFail",
-                "SpanSnapshotsWriteFail",
-            ),
-            logger.internalErrorMessages.map { it.msg },
+        assertInternalErrors(
+            "SessionPartDirectoryStoreFail",
+            "SessionManifestWriteFail",
+            "SessionMetadataWriteFail",
+            "SessionSpanWriteFail",
+            "SpanSnapshotsWriteFail",
+            "SessionMetadataWriteFail",
+            "SessionSpanWriteFail",
+            "SpanSnapshotsWriteFail",
         )
         assertEquals(0, writeCount)
     }
@@ -415,6 +407,7 @@ internal class SessionPartWriterImplTest {
         drain()
         assertNull(sessionSpanIn(SESSION_PART_ID)?.span?.end_time_unix_nano)
         clock.tick(10000)
+        val endedAt = clock.now()
         endPart()
         writer.onSessionPartEnded(SESSION_PART_ID)
         drain()
@@ -422,7 +415,7 @@ internal class SessionPartWriterImplTest {
         val span = checkNotNull(sessionSpanIn(SESSION_PART_ID)?.span)
         assertEquals("span0", span.name)
         assertEquals(sessionSpan.spanId, span.span_id)
-        assertEquals(clock.now().millisToNanos(), span.end_time_unix_nano)
+        assertEquals(endedAt.millisToNanos(), span.end_time_unix_nano)
         assertNoInternalErrors()
     }
 
@@ -448,12 +441,13 @@ internal class SessionPartWriterImplTest {
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
         drain()
         clock.tick(10000)
+        val endedAt = clock.now()
         endPart()
         writer.onSessionPartEnded(SESSION_PART_ID)
         currentSessionPartSpan.sessionPartSpan = null
         drain()
 
-        assertEquals(clock.now().millisToNanos(), sessionSpanIn(SESSION_PART_ID)?.span?.end_time_unix_nano)
+        assertEquals(endedAt.millisToNanos(), sessionSpanIn(SESSION_PART_ID)?.span?.end_time_unix_nano)
         assertNoInternalErrors()
     }
 
@@ -620,13 +614,13 @@ internal class SessionPartWriterImplTest {
             onMetadataRead = {}
             writer.onMetadataChanged()
         }
-        drain()
+        drainOnce()
 
         assertEquals("user0", metadataOnDisk(SESSION_PART_ID)?.user_id)
         assertEquals(1, writeCount)
 
         // the write queued while the other one ran is still pending, and runs next
-        drain()
+        drainOnce()
         assertEquals("user1", metadataOnDisk(SESSION_PART_ID)?.user_id)
         assertEquals(2, writeCount)
         assertNoInternalErrors()
@@ -909,7 +903,13 @@ internal class SessionPartWriterImplTest {
     )
 
     private fun drain() {
-        executor.runCurrentlyBlocked()
+        do {
+            executor.moveForwardAndRunBlocked(CoalescingWriteQueue.DEFAULT_DELAY_MS)
+        } while (executor.scheduledTasksCount() > 0)
+    }
+
+    private fun drainOnce() {
+        executor.moveForwardAndRunBlocked(CoalescingWriteQueue.DEFAULT_DELAY_MS)
     }
 
     /**
@@ -972,6 +972,10 @@ internal class SessionPartWriterImplTest {
     private fun partFile(sessionPartId: String, fileName: String): File? {
         val directory = partDirs().single { it.sessionPartId == sessionPartId }
         return File(File(sessionsDir, directory.dirName), fileName).takeIf(File::isFile)
+    }
+
+    private fun assertInternalErrors(vararg expected: String) {
+        assertEquals(expected.sorted(), logger.internalErrorMessages.map { it.msg }.sorted())
     }
 
     private fun assertNoInternalErrors() {

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceChangeTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceChangeTest.kt
@@ -253,7 +253,9 @@ internal class SessionPartWriterResourceChangeTest {
     }
 
     private fun drain() {
-        executor.runCurrentlyBlocked()
+        do {
+            executor.moveForwardAndRunBlocked(CoalescingWriteQueue.DEFAULT_DELAY_MS)
+        } while (executor.scheduledTasksCount() > 0)
     }
 
     private fun partDirs(): List<SessionPartDirectory> =

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceReadTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceReadTest.kt
@@ -161,7 +161,7 @@ internal class SessionPartWriterResourceReadTest {
         resourceSource.changeResource(
             RESOURCE.copy(screenResolution = "1440x3120", reactNativeBundleId = "bundle-2"),
         )
-        executor.runCurrentlyBlocked()
+        drain()
 
         val envelope = checkNotNull(service.reconstruct(directory()))
         assertEquals(
@@ -186,7 +186,7 @@ internal class SessionPartWriterResourceReadTest {
      */
     private fun writeSessionPart() = run {
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
-        executor.runCurrentlyBlocked()
+        drain()
 
         writePartFile(
             COMPLETED_SPANS_FILE_NAME,
@@ -200,7 +200,7 @@ internal class SessionPartWriterResourceReadTest {
     private fun endSessionPart() {
         currentSessionPartSpan.endSession(startNewSession = true)
         writer.onSessionPartEnded(SESSION_PART_ID)
-        executor.runCurrentlyBlocked()
+        drain()
     }
 
     private fun writePartFile(fileName: String, bytes: ByteArray) {
@@ -211,4 +211,10 @@ internal class SessionPartWriterResourceReadTest {
 
     private fun directory(): SessionPartDirectory =
         (sessionsDir.list() ?: emptyArray()).mapNotNull(SessionPartDirectory::fromDirName).single()
+
+    private fun drain() {
+        do {
+            executor.moveForwardAndRunBlocked(CoalescingWriteQueue.DEFAULT_DELAY_MS)
+        } while (executor.scheduledTasksCount() > 0)
+    }
 }


### PR DESCRIPTION
## Goal

Implements `CoalescingWriteQueue`. This attempts to add debouncing to write operations so that a burst of changes does not result in a burst of writes to disk, by delaying the task by a configurable number of milliseconds.

If a write is already in-progress, it is left to execute and no attempt to cancel is made. If a write has been superseded and is not yet executing, it is removed from the queue and cancelled.

Finally, this also adds a mechanism to run the task synchronously on the calling thread. This will be beneficial for cases such as JVM crashes where the process is terminating.

This is not fully hooked up yet and will be updated to do so in a later PR.

## Testing

Added tests.
