### PR TITLE
Add module for telemetry limits

### DIFF
--- a/embrace-android-core/build.gradle.kts
+++ b/embrace-android-core/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation(project(":embrace-android-delivery"))
     implementation(project(":embrace-android-envelope"))
     implementation(project(":embrace-android-infra"))
+    implementation(project(":embrace-android-limits"))
     implementation(project(":embrace-android-utils"))
     implementation(project(":embrace-internal-api"))
     implementation(project(":embrace-android-otel"))

--- a/embrace-android-limits/README.md
+++ b/embrace-android-limits/README.md
@@ -1,0 +1,19 @@
+# embrace-android-limits
+
+Holds the logic that enforces upper bounds on the telemetry the SDK captures, so that a
+misbehaving app can't exhaust memory or produce payloads the backend will reject.
+
+Consumers of this module (`embrace-android-otel`, `embrace-android-session-persistence`,
+`embrace-android-core`) ask this module whether a given piece of telemetry is within limits, rather
+than each re-implementing truncation and counting rules against the raw values.
+
+## Layout
+
+Everything lives under `io.embrace.android.embracesdk.internal.limits`.
+
+## Relationship to `OtelLimitsConfig`
+
+The limit **values** deliberately stay in `OtelLimitsConfig` in `embrace-android-payload`. That
+interface is populated by the Embrace Gradle plugin's `@EmbraceInstrumented` bytecode plumbing, so
+moving it would break instrumentation. This module depends on it and owns the *enforcement* of
+those values only.

--- a/embrace-android-limits/build.gradle.kts
+++ b/embrace-android-limits/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    id("embrace-prod-jvm-conventions")
+}
+
+description = "Embrace Android SDK: Telemetry Limits"
+
+dependencies {
+    implementation(project(":embrace-android-payload"))
+    implementation(project(":embrace-android-infra"))
+
+    testImplementation(project(":embrace-test-common"))
+}

--- a/embrace-android-otel/build.gradle.kts
+++ b/embrace-android-otel/build.gradle.kts
@@ -11,6 +11,7 @@ android {
 
 dependencies {
     implementation(project(":embrace-android-infra"))
+    implementation(project(":embrace-android-limits"))
     implementation(project(":embrace-android-utils"))
     implementation(project(":embrace-android-payload"))
     implementation(project(":embrace-android-instrumentation-schema"))

--- a/embrace-android-session-persistence/build.gradle.kts
+++ b/embrace-android-session-persistence/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
 
     implementation(project(":embrace-android-payload"))
     implementation(project(":embrace-android-infra"))
+    implementation(project(":embrace-android-limits"))
     implementation(project(":embrace-android-telemetry-persistence"))
 
     testImplementation(project(":embrace-test-common"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,7 @@ include(
     ":embrace-android-config-fakes",
     ":embrace-android-envelope",
     ":embrace-android-infra",
+    ":embrace-android-limits",
     ":embrace-android-utils",
     ":embrace-android-instrumentation-vitals",
     ":embrace-android-instrumentation-api",


### PR DESCRIPTION
## Goal

Adds a module that will be used to share telemetry limits between where we write data and where we read it, so that the enforced limits are the same. Currently this module is empty.
