### PR TITLE
Combine buffered experiment API calls when SDK starts

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ExperimentTrackingFoundationTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/ExperimentTrackingFoundationTest.kt
@@ -28,12 +28,30 @@ internal class ExperimentTrackingFoundationTest {
         testRule.runTest(
             preSdkStartAction = {
                 bufferedExperimentStartMs = clock.now()
-                embrace.trackExperiment(id = "checkout-flow", variant = "variant-a", startedAt = bufferedExperimentStartMs)
+
+                embrace.trackExperiments(
+                    listOf(
+                        embrace.createExperiment("checkout-flow", "variant-a", bufferedExperimentStartMs),
+                        embrace.createExperiment("color-palette", "yellow", bufferedExperimentStartMs),
+                    ),
+                )
+                embrace.trackFeatureFlags(
+                    listOf(
+                        embrace.createFeatureFlag("dark-mode", bufferedExperimentStartMs),
+                        embrace.createFeatureFlag("new-ui", bufferedExperimentStartMs),
+                    ),
+                )
+                embrace.trackExperiment("color-palette", "blue")
             },
             testCaseAction = {
                 recordSession {
                     flagStartMs = clock.tick()
-                    embrace.trackFeatureFlag(id = "dark-mode", startedAt = flagStartMs)
+                    embrace.trackFeatureFlags(
+                        listOf(
+                            embrace.createFeatureFlag("dark-mode"),
+                            embrace.createFeatureFlag("http3"),
+                        ),
+                    )
 
                     // an experiment may share an id with a feature flag: they are two independent records
                     sharedIdExperimentStartMs = clock.tick()
@@ -44,10 +62,10 @@ internal class ExperimentTrackingFoundationTest {
                     embrace.trackExperiment(id = "promo")
 
                     untrackEndMs = clock.tick()
-                    embrace.untrackExperiment("checkout-flow", endedAt = untrackEndMs)
+                    embrace.untrackExperiment(id = "checkout-flow", endedAt = untrackEndMs)
 
                     embrace.trackExperiments(
-                        listOf(embrace.createExperiment(id = "checkout-flow", variant = "variant-b", startedAt = clock.tick()))
+                        listOf(embrace.createExperiment(id = "checkout-flow", variant = "variant-b", startedAt = clock.tick())),
                     )
                 }
                 recordSession()
@@ -55,27 +73,30 @@ internal class ExperimentTrackingFoundationTest {
             assertAction = {
                 val expectedRecords =
                     "e:checkout-flow:variant-a:$bufferedExperimentStartMs:$untrackEndMs;" +
-                        "f:dark-mode::$flagStartMs;" +
+                        "e:color-palette:yellow:$bufferedExperimentStartMs;" +
+                        "f:dark-mode::$bufferedExperimentStartMs;" +
+                        "f:new-ui::$bufferedExperimentStartMs;" +
+                        "f:http3::$flagStartMs;" +
                         "e:dark-mode::$sharedIdExperimentStartMs;" +
                         "e:promo::$variantlessExperimentStartMs"
                 assertEquals(
                     expectedRecords,
-                    testRule.bootstrapper.essentialServiceModule.experimentTrackingService.getRecords()
+                    testRule.bootstrapper.essentialServiceModule.experimentTrackingService.getRecords(),
                 )
 
                 val envelopes = getSessionEnvelopes(2)
                 val attrs = checkNotNull(envelopes.first().findSessionPartSpan().attributes)
-                assertEquals("4", attrs.findAttributeValue("emb.usage.track_experiment"))
+                assertEquals("5", attrs.findAttributeValue("emb.usage.track_experiment"))
                 assertEquals("1", attrs.findAttributeValue("emb.usage.untrack_experiment"))
-                assertEquals("1", attrs.findAttributeValue("emb.usage.track_feature_flag"))
+                assertEquals("2", attrs.findAttributeValue("emb.usage.track_feature_flag"))
 
                 envelopes.forEach { envelope ->
                     assertEquals(
                         expectedRecords,
-                        envelope.findSessionPartSpan().attributes?.findAttributeValue(EmbCommonAttributes.EMB_EXPERIMENTS)
+                        envelope.findSessionPartSpan().attributes?.findAttributeValue(EmbCommonAttributes.EMB_EXPERIMENTS),
                     )
                 }
-            }
+            },
         )
     }
 }

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExperimentApiDelegate.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExperimentApiDelegate.kt
@@ -49,15 +49,60 @@ internal class ExperimentApiDelegate(
         untrack("untrack_feature_flag", ExperimentKind.FEATURE_FLAG, ids, endedAt ?: now())
     }
 
+    /**
+     * Flush buffered experiment API calls by combine tracking and untracking into as few
+     * calls down to the service as possible. The ordering of tracking calls will be preserved,
+     * first writer still wins, but all untracking calls will be replayed after the tracking
+     * calls in the order they were called. Later untracking calls using the same end
+     * timestamp as a previous one will be hoisted to when that first untracking call with
+     * the same timestamp was invoked.
+     */
     fun flushPendingCalls() {
-        // The buffer can contain more experiments than the configured cap, but we'll replay all of them and let the limit enforcer
-        // log the overage and drop later calls after the cap has been reached.
+        val toTrack = mutableListOf<TrackedData>()
+        val expToUntrack = linkedMapOf<Long, List<String>>()
+        val flagsToUntrack = linkedMapOf<Long, List<String>>()
+        val apiCalls = mutableListOf<String>()
         while (true) {
             val event = pendingEvents.poll() ?: break
+            apiCalls.add(event.action)
+
             when (event) {
-                is PendingEvent.Track -> trackNow(event.action, event.data)
-                is PendingEvent.Untrack -> untrackNow(event.action, event.kind, event.ids, event.endTimeMs)
+                is PendingEvent.Track -> {
+                    toTrack += event.data
+                }
+
+                is PendingEvent.Untrack -> {
+                    when (event.kind) {
+                        ExperimentKind.EXPERIMENT -> {
+                            val existing = expToUntrack[event.endTimeMs]
+                            if (existing == null) {
+                                expToUntrack[event.endTimeMs] = event.ids
+                            } else {
+                                expToUntrack[event.endTimeMs] = existing + event.ids
+                            }
+                        }
+
+                        ExperimentKind.FEATURE_FLAG -> {
+                            val existing = flagsToUntrack[event.endTimeMs]
+                            if (existing == null) {
+                                flagsToUntrack[event.endTimeMs] = event.ids
+                            } else {
+                                flagsToUntrack[event.endTimeMs] = existing + event.ids
+                            }
+                        }
+                    }
+                }
             }
+        }
+        experimentTrackingService?.track(toTrack)
+        expToUntrack.entries.forEach {
+            experimentTrackingService?.untrack(ExperimentKind.EXPERIMENT, it.value, it.key)
+        }
+        flagsToUntrack.entries.forEach {
+            experimentTrackingService?.untrack(ExperimentKind.FEATURE_FLAG, it.value, it.key)
+        }
+        apiCalls.forEach {
+            sdkCallChecker.recordApiCall(it)
         }
     }
 
@@ -124,9 +169,11 @@ internal class ExperimentApiDelegate(
         )
 
     private sealed interface PendingEvent {
-        class Track(val action: String, val data: List<TrackedData>) : PendingEvent
+        val action: String
+
+        class Track(override val action: String, val data: List<TrackedData>) : PendingEvent
         class Untrack(
-            val action: String,
+            override val action: String,
             val kind: ExperimentKind,
             val ids: List<String>,
             val endTimeMs: Long,

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExperimentApiDelegate.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExperimentApiDelegate.kt
@@ -50,7 +50,7 @@ internal class ExperimentApiDelegate(
     }
 
     /**
-     * Flush buffered experiment API calls by combine tracking and untracking into as few
+     * Flush buffered experiment API calls by combining tracking and untracking into as few
      * calls down to the service as possible. The ordering of tracking calls will be preserved,
      * first writer still wins, but all untracking calls will be replayed after the tracking
      * calls in the order they were called. Later untracking calls using the same end
@@ -94,6 +94,11 @@ internal class ExperimentApiDelegate(
                 }
             }
         }
+
+        // Reducing the update of the session part span to one, instead of once per service call, requires a lot more complexity
+        // to be introduced to the service. But given the expected use cases, and the unlikely usage of untracking APIs pre-SDK init,
+        // the net result will likely be one session part span update anyway. As such, this implementation is acceptable for now.
+
         experimentTrackingService?.track(toTrack)
         expToUntrack.entries.forEach {
             experimentTrackingService?.untrack(ExperimentKind.EXPERIMENT, it.value, it.key)

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/SdkCallChecker.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/SdkCallChecker.kt
@@ -25,7 +25,14 @@ internal class SdkCallChecker(
         if (!isStarted && outputErrorMessage) {
             logger.logSdkNotInitialized(action)
         }
-        telemetryService?.onPublicApiCalled(action)
+        recordApiCall(action)
         return isStarted
+    }
+
+    /**
+     * Record a public API call
+     */
+    fun recordApiCall(action: String) {
+        telemetryService?.onPublicApiCalled(action)
     }
 }

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExperimentApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExperimentApiDelegateTest.kt
@@ -84,33 +84,54 @@ internal class ExperimentApiDelegateTest {
     }
 
     @Test
-    fun `buffered calls flush in FIFO order`() {
-        delegate.trackExperiment("exp1", variant = "v1", startedAt = 123456789L)
-        delegate.trackFeatureFlag("flag1", startedAt = 987654321L)
-        delegate.untrackExperiment("exp1", endedAt = 555555555L)
+    fun `buffered calls are coalesced with api usage record preserved when flushed`() {
+        delegate.trackExperiments(
+            listOf(
+                TrackedExperimentImpl("exp1", "v1", 123456789L),
+                TrackedExperimentImpl("exp2", "v1", 123456789L),
+            ),
+        )
+        delegate.trackExperiments(
+            listOf(
+                TrackedExperimentImpl("exp2", "v2", 123456789L),
+                TrackedExperimentImpl("exp3", "v1", 123456789L),
+            ),
+        )
+        delegate.trackExperiment("exp4", "v2", 123456789L)
+        delegate.trackFeatureFlags(
+            listOf(
+                TrackedFeatureFlagImpl("flag1", 987654321L),
+                TrackedFeatureFlagImpl("flag2", 987654321L),
+            ),
+        )
+        delegate.trackFeatureFlag("flag3", startedAt = 987654321L)
+        delegate.untrackExperiments(listOf("exp1", "exp2"), 555555555L)
+        delegate.untrackExperiment("exp3", 555555555L)
+        delegate.untrackExperiment("exp4", 555555566L)
+        delegate.untrackFeatureFlags(listOf("flag1", "flag3"), 555555555L)
         delegate.untrackFeatureFlag("flag1", endedAt = 666666666L)
+        delegate.untrackFeatureFlag("flag2", endedAt = 666666666L)
 
         sdkCallChecker.started.set(true)
         delegate.flushPendingCalls()
 
         assertEquals(
-            listOf("track_experiment", "track_feature_flag", "untrack_experiment", "untrack_feature_flag"),
+            listOf(
+                "track_experiment",
+                "track_experiment",
+                "track_experiment",
+                "track_feature_flag",
+                "track_feature_flag",
+                "untrack_experiment",
+                "untrack_experiment",
+                "untrack_experiment",
+                "untrack_feature_flag",
+                "untrack_feature_flag",
+                "untrack_feature_flag",
+            ),
             telemetryService.apiCalls,
         )
-        assertEquals(
-            listOf(
-                TrackedData.Experiment(id = "exp1", startTimeMs = 123456789L, variant = "v1"),
-                TrackedData.FeatureFlag(id = "flag1", startTimeMs = 987654321L),
-            ),
-            fakeExperimentTrackingService.trackedData,
-        )
-        assertEquals(
-            listOf(
-                FakeExperimentTrackingService.UntrackCall(ExperimentKind.EXPERIMENT, listOf("exp1"), 555555555L),
-                FakeExperimentTrackingService.UntrackCall(ExperimentKind.FEATURE_FLAG, listOf("flag1"), 666666666L),
-            ),
-            fakeExperimentTrackingService.untrackCalls,
-        )
+        assertEquals(5, fakeExperimentTrackingService.serviceInvocations.get())
     }
 
     @Test

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExperimentApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExperimentApiDelegateTest.kt
@@ -131,7 +131,7 @@ internal class ExperimentApiDelegateTest {
             ),
             telemetryService.apiCalls,
         )
-        assertEquals(5, fakeExperimentTrackingService.serviceInvocations.get())
+        assertEquals(5, fakeExperimentTrackingService.serviceInvocations)
     }
 
     @Test

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/SdkCallCheckerTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/SdkCallCheckerTest.kt
@@ -47,4 +47,12 @@ internal class SdkCallCheckerTest {
         assertTrue(logger.sdkNotInitializedMessages.isEmpty())
         assertEquals(action, telemetryService.apiCalls.single())
     }
+
+    @Test
+    fun `api call recorded regardless if SDK has started`() {
+        assertFalse(checker.started.get())
+        checker.recordApiCall(action)
+        assertTrue(logger.sdkNotInitializedMessages.isEmpty())
+        assertEquals(action, telemetryService.apiCalls.single())
+    }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeExperimentTrackingService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeExperimentTrackingService.kt
@@ -3,12 +3,17 @@ package io.embrace.android.embracesdk.fakes
 import io.embrace.android.embracesdk.internal.capture.experiment.ExperimentKind
 import io.embrace.android.embracesdk.internal.capture.experiment.ExperimentTrackingService
 import io.embrace.android.embracesdk.internal.capture.experiment.TrackedData
+import java.util.concurrent.atomic.AtomicInteger
 
 class FakeExperimentTrackingService : ExperimentTrackingService {
 
     val trackedData: MutableList<TrackedData> = mutableListOf()
     val untrackCalls: MutableList<UntrackCall> = mutableListOf()
     var fakeRecords: String? = null
+    val serviceInvocations: Int
+        get() = callCount.get()
+
+    private val callCount = AtomicInteger(0)
 
     data class UntrackCall(
         val kind: ExperimentKind,
@@ -18,10 +23,12 @@ class FakeExperimentTrackingService : ExperimentTrackingService {
 
     override fun track(data: List<TrackedData>) {
         trackedData.addAll(data)
+        callCount.incrementAndGet()
     }
 
     override fun untrack(kind: ExperimentKind, ids: List<String>, endTimeMs: Long) {
         untrackCalls.add(UntrackCall(kind, ids, endTimeMs))
+        callCount.incrementAndGet()
     }
 
     override fun getRecords(): String? = fakeRecords


### PR DESCRIPTION
Combine buffered experimental API calls into as few calls into the service as possible without add edit/commit transaction semantics to the internal service. Each call will generate the `emb.experiments` blob from scratch, which which should minimize.