### PR TITLE
build(deps): bump agp from 9.3.2 to 9.4.0 in /examples/ExampleApp

### DIFF
--- a/examples/ExampleApp/gradle/libs.versions.toml
+++ b/examples/ExampleApp/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.3.2"
+agp = "9.4.0"
 kotlin = "2.4.10"
 coreKtx = "1.19.0"
 junit = "4.13.2"


### PR DESCRIPTION
Bumps `agp` from 9.3.2 to 9.4.0.

Updates `com.android.application` from 9.3.2 to 9.4.0

Updates `com.android.test` from 9.3.2 to 9.4.0

---
updated-dependencies:
- dependency-name: com.android.application dependency-version: 9.4.0 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: com.android.test dependency-version: 9.4.0 dependency-type: direct:production update-type: version-update:semver-minor ...

## Goal

<!-- Describe what this change seeks to address -->

## Testing

<!-- Describe how this change has been tested -->
