### PR TITLE
Add leak detection instrumentation as default

### DIFF
--- a/embrace-android-sdk/build.gradle.kts
+++ b/embrace-android-sdk/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation(project(":embrace-android-instrumentation-crash-ndk"))
     implementation(project(":embrace-android-instrumentation-fcm"))
     implementation(project(":embrace-android-instrumentation-huc-lite"))
+    implementation(project(":embrace-android-instrumentation-leaks"))
     implementation(project(":embrace-android-instrumentation-navigation"))
     implementation(project(":embrace-android-instrumentation-network-status"))
     implementation(project(":embrace-android-instrumentation-okhttp"))


### PR DESCRIPTION
## Goal
Add `embrace-android-instrumentation-leaks` as a default dependency in the `embrace-android-sdk` module, so that memory leak detection is a default (remotely configured) instrumentation.