### PR TITLE
Make post SDK startup init phases independently failable

### DIFF
--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/InternalErrorType.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/logging/InternalErrorType.kt
@@ -47,4 +47,5 @@ sealed class InternalErrorType(private val severity: Severity) {
     object NavControllerTrackingFail : InternalErrorType(ERROR)
     object UserSessionCallbackFail : InternalErrorType(ERROR)
     object HttpRequestInfoModifierFail : InternalErrorType(Severity.WARNING)
+    object SdkInitPhaseFail : InternalErrorType(ERROR)
 }

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -31,22 +31,19 @@ import io.embrace.android.embracesdk.internal.api.delegate.SdkStateApiDelegate
 import io.embrace.android.embracesdk.internal.api.delegate.UserApiDelegate
 import io.embrace.android.embracesdk.internal.api.delegate.UserSessionApiDelegate
 import io.embrace.android.embracesdk.internal.api.delegate.ViewTrackingApiDelegate
-import io.embrace.android.embracesdk.internal.arch.InstrumentationArgs
-import io.embrace.android.embracesdk.internal.config.behavior.NetworkBehavior
 import io.embrace.android.embracesdk.internal.delivery.storage.StorageLocation
 import io.embrace.android.embracesdk.internal.delivery.storage.asFile
 import io.embrace.android.embracesdk.internal.injection.InternalInterfaceModule
 import io.embrace.android.embracesdk.internal.injection.InternalInterfaceModuleImpl
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
+import io.embrace.android.embracesdk.internal.injection.flushPendingExperimentCalls
+import io.embrace.android.embracesdk.internal.injection.initializeHucInstrumentation
 import io.embrace.android.embracesdk.internal.injection.loadInstrumentation
 import io.embrace.android.embracesdk.internal.injection.markSdkInitComplete
 import io.embrace.android.embracesdk.internal.injection.postInit
 import io.embrace.android.embracesdk.internal.injection.postLoadInstrumentation
 import io.embrace.android.embracesdk.internal.injection.registerListeners
 import io.embrace.android.embracesdk.internal.injection.triggerPayloadSend
-import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkCaptureDataSource
-import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkRequestDataSource
-import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.android.embracesdk.spans.TracingApi
 import java.util.concurrent.Executors
@@ -99,7 +96,6 @@ internal class EmbraceImpl(
         EmbraceInternalApi.isStarted = sdkCallChecker.started::get
     }
 
-    private val logger get() = bootstrapper.initModule.logger
     private val clock get() = bootstrapper.initModule.clock
     private val startStopLock = Any()
 
@@ -129,10 +125,10 @@ internal class EmbraceImpl(
                         // not fully initialized, but the SDK shouldn't catastrophically throw after this point,
                         // so we allow external calls.
                         sdkCallChecker.started.set(true)
-                        experimentApiDelegate.flushPendingCalls()
+                        bootstrapper.flushPendingExperimentCalls(experimentApiDelegate)
                         bootstrapper.registerListeners()
                         bootstrapper.loadInstrumentation()
-                        initializeHucInstrumentation(bootstrapper.configService.networkBehavior)
+                        bootstrapper.initializeHucInstrumentation()
                         bootstrapper.postLoadInstrumentation()
                         bootstrapper.triggerPayloadSend()
                     }
@@ -141,35 +137,6 @@ internal class EmbraceImpl(
                     Log.w("Embrace", "Failed to initialize Embrace SDK", ignored)
                 }
             }
-        }
-    }
-
-    private fun initializeHucInstrumentation(networkBehavior: NetworkBehavior) {
-        try {
-            if (networkBehavior.isHttpUrlConnectionCaptureEnabled()) {
-                EmbTrace.trace(sectionName = "huc-init", recordDuration = true) {
-                    val trackerClass = Class.forName("io.embrace.android.embracesdk.instrumentation.huc.HttpUrlConnectionTracker")
-                    val objectField = trackerClass.getDeclaredField("INSTANCE")
-                    val trackerObject = objectField.get(null)
-                    val initMethod = trackerClass.getDeclaredMethod(
-                        "registerUrlStreamHandlerFactory",
-                        Boolean::class.java,
-                        InstrumentationArgs::class.java,
-                        NetworkRequestDataSource::class.java,
-                        NetworkCaptureDataSource::class.java,
-                    )
-                    val module = bootstrapper.instrumentationModule
-                    initMethod.invoke(
-                        trackerObject,
-                        networkBehavior.isRequestContentLengthCaptureEnabled(),
-                        module.instrumentationArgs,
-                        module.instrumentationRegistry.findByType(NetworkRequestDataSource::class),
-                        module.instrumentationRegistry.findByType(NetworkCaptureDataSource::class),
-                    )
-                }
-            }
-        } catch (t: Throwable) {
-            logger.trackInternalError(InternalErrorType.InstrumentationRegFail, t)
         }
     }
 

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/EmbraceImpl.kt
@@ -36,8 +36,7 @@ import io.embrace.android.embracesdk.internal.delivery.storage.asFile
 import io.embrace.android.embracesdk.internal.injection.InternalInterfaceModule
 import io.embrace.android.embracesdk.internal.injection.InternalInterfaceModuleImpl
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
-import io.embrace.android.embracesdk.internal.injection.flushPendingExperimentCalls
-import io.embrace.android.embracesdk.internal.injection.initializeHucInstrumentation
+import io.embrace.android.embracesdk.internal.injection.applyCustomMetadata
 import io.embrace.android.embracesdk.internal.injection.loadInstrumentation
 import io.embrace.android.embracesdk.internal.injection.markSdkInitComplete
 import io.embrace.android.embracesdk.internal.injection.postInit
@@ -125,14 +124,13 @@ internal class EmbraceImpl(
                         // not fully initialized, but the SDK shouldn't catastrophically throw after this point,
                         // so we allow external calls.
                         sdkCallChecker.started.set(true)
-                        bootstrapper.flushPendingExperimentCalls(experimentApiDelegate)
+                        bootstrapper.applyCustomMetadata(experimentApiDelegate::flushPendingCalls)
                         bootstrapper.registerListeners()
                         bootstrapper.loadInstrumentation()
-                        bootstrapper.initializeHucInstrumentation()
                         bootstrapper.postLoadInstrumentation()
                         bootstrapper.triggerPayloadSend()
                     }
-                    bootstrapper.markSdkInitComplete(EmbTrace.durationTracker.flush())
+                    bootstrapper.markSdkInitComplete(EmbTrace.durationTracker::flush)
                 } catch (ignored: Throwable) {
                     Log.w("Embrace", "Failed to initialize Embrace SDK", ignored)
                 }

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
@@ -4,10 +4,14 @@ package io.embrace.android.embracesdk.internal.injection
 
 import android.content.Context
 import io.embrace.android.embracesdk.core.BuildConfig
+import io.embrace.android.embracesdk.internal.api.delegate.ExperimentApiDelegate
+import io.embrace.android.embracesdk.internal.arch.InstrumentationArgs
 import io.embrace.android.embracesdk.internal.arch.InstrumentationProvider
 import io.embrace.android.embracesdk.internal.arch.attrs.toEmbraceAttributeName
 import io.embrace.android.embracesdk.internal.instrumentation.crash.jvm.JvmCrashDataSource
 import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.NativeCrashDataSource
+import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkCaptureDataSource
+import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkRequestDataSource
 import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkStateDataSource
 import io.embrace.android.embracesdk.internal.instrumentation.network.NetworkStatusDataSource
 import io.embrace.android.embracesdk.internal.instrumentation.startup.sdkInitEnvironmentAttributes
@@ -64,6 +68,13 @@ internal fun ModuleGraph.postInit() = EmbTrace.trace(sectionName = "post-init", 
 
     // Start the orchestrator and create the first session part once all the module dependencies have been created and wired up
     userSessionOrchestrationModule.sessionOrchestrator.start()
+}
+
+/**
+ * Replays experiment API calls that were buffered before the SDK started.
+ */
+internal fun ModuleGraph.flushPendingExperimentCalls(experimentApiDelegate: ExperimentApiDelegate) {
+    experimentApiDelegate.flushPendingCalls()
 }
 
 /**
@@ -140,6 +151,39 @@ private fun loadInstrumentationProviders(): List<InstrumentationProvider> {
         providers.add(provider)
     }
     return providers
+}
+
+/**
+ * Initializes HttpUrlConnection instrumentation via reflection, if the module is present and capture is enabled.
+ */
+internal fun ModuleGraph.initializeHucInstrumentation() {
+    val networkBehavior = configService.networkBehavior
+    try {
+        if (networkBehavior.isHttpUrlConnectionCaptureEnabled()) {
+            EmbTrace.trace(sectionName = "huc-init", recordDuration = true) {
+                val trackerClass = Class.forName("io.embrace.android.embracesdk.instrumentation.huc.HttpUrlConnectionTracker")
+                val objectField = trackerClass.getDeclaredField("INSTANCE")
+                val trackerObject = objectField.get(null)
+                val initMethod = trackerClass.getDeclaredMethod(
+                    "registerUrlStreamHandlerFactory",
+                    Boolean::class.java,
+                    InstrumentationArgs::class.java,
+                    NetworkRequestDataSource::class.java,
+                    NetworkCaptureDataSource::class.java,
+                )
+                val module = instrumentationModule
+                initMethod.invoke(
+                    trackerObject,
+                    networkBehavior.isRequestContentLengthCaptureEnabled(),
+                    module.instrumentationArgs,
+                    module.instrumentationRegistry.findByType(NetworkRequestDataSource::class),
+                    module.instrumentationRegistry.findByType(NetworkCaptureDataSource::class),
+                )
+            }
+        }
+    } catch (t: Throwable) {
+        initModule.logger.trackInternalError(InternalErrorType.InstrumentationRegFail, t)
+    }
 }
 
 /**

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
@@ -4,7 +4,6 @@ package io.embrace.android.embracesdk.internal.injection
 
 import android.content.Context
 import io.embrace.android.embracesdk.core.BuildConfig
-import io.embrace.android.embracesdk.internal.api.delegate.ExperimentApiDelegate
 import io.embrace.android.embracesdk.internal.arch.InstrumentationArgs
 import io.embrace.android.embracesdk.internal.arch.InstrumentationProvider
 import io.embrace.android.embracesdk.internal.arch.attrs.toEmbraceAttributeName
@@ -71,16 +70,18 @@ internal fun ModuleGraph.postInit() = EmbTrace.trace(sectionName = "post-init", 
 }
 
 /**
- * Replays experiment API calls that were buffered before the SDK started.
+ * Apply custom metadata by the SDK user through Embrace APIs.
+ * Should only be done after the SDK has been started successfully.
  */
-internal fun ModuleGraph.flushPendingExperimentCalls(experimentApiDelegate: ExperimentApiDelegate) {
-    experimentApiDelegate.flushPendingCalls()
-}
+internal fun ModuleGraph.applyCustomMetadata(applyMetadata: () -> Unit) =
+    safeInit {
+        applyMetadata()
+    }
 
 /**
  * Registers listeners for various lifecycle/system callbacks.
  */
-internal fun ModuleGraph.registerListeners() {
+internal fun ModuleGraph.registerListeners() = safeInit {
     EmbTrace.trace("service-registration") {
         val ctx = coreModule.application
         ctx.registerActivityLifecycleCallbacks(dataCaptureServiceModule.startupTracker)
@@ -125,17 +126,19 @@ internal fun ModuleGraph.registerListeners() {
 /**
  * Loads instrumentation via SPI and legacy methods.
  */
-internal fun ModuleGraph.loadInstrumentation() =
+internal fun ModuleGraph.loadInstrumentation() = safeInit {
     EmbTrace.trace(sectionName = "load-instrumentation", recordDuration = true) {
         val registry = instrumentationModule.instrumentationRegistry
         registry.loadInstrumentations(loadInstrumentationProviders(), instrumentationModule.instrumentationArgs)
 
         threadBlockageService?.startCapture()
-
         featureModule.lastRunCrashVerifier.readAndCleanMarkerAsync(
             workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker),
         )
     }
+
+    initializeHucInstrumentation()
+}
 
 /**
  * Loads the [InstrumentationProvider] implementations declared via SPI. Before making changes
@@ -156,7 +159,7 @@ private fun loadInstrumentationProviders(): List<InstrumentationProvider> {
 /**
  * Initializes HttpUrlConnection instrumentation via reflection, if the module is present and capture is enabled.
  */
-internal fun ModuleGraph.initializeHucInstrumentation() {
+private fun ModuleGraph.initializeHucInstrumentation() {
     val networkBehavior = configService.networkBehavior
     try {
         if (networkBehavior.isHttpUrlConnectionCaptureEnabled()) {
@@ -189,7 +192,7 @@ internal fun ModuleGraph.initializeHucInstrumentation() {
 /**
  * Performs post-load instrumentation tasks such as setting listeners.
  */
-internal fun ModuleGraph.postLoadInstrumentation() {
+internal fun ModuleGraph.postLoadInstrumentation() = safeInit {
     // setup crash teardown handlers
     val registry = instrumentationModule.instrumentationRegistry
     registry.findByType(JvmCrashDataSource::class)?.apply {
@@ -211,7 +214,7 @@ internal fun ModuleGraph.postLoadInstrumentation() {
 /**
  * Trigger sending cached data on disk.
  */
-internal fun ModuleGraph.triggerPayloadSend() {
+internal fun ModuleGraph.triggerPayloadSend() = safeInit {
     val worker = workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker)
     worker.submit {
         val resurrectionService = payloadSourceModule.payloadResurrectionService
@@ -255,9 +258,10 @@ internal fun ModuleGraph.triggerPayloadSend() {
 /**
  * Mark SDK initialization as complete.
  */
-internal fun ModuleGraph.markSdkInitComplete(sdkInitDurations: Map<String, Long>) {
+internal fun ModuleGraph.markSdkInitComplete(sdkInitDurationsProvider: () -> Map<String, Long>) = safeInit {
     val startupService = dataCaptureServiceModule.startupService
     EmbTrace.trace("startup-tracking") {
+        val sdkInitDurations = sdkInitDurationsProvider()
         val resourceUsageTracker = sdkInitResourceUsageTracker
         resourceUsageTracker.captureEnd()
         startupService.setSdkStartupInfo(
@@ -318,6 +322,19 @@ private fun ModuleGraph.eventMetadataSupplierProvider(): Provider<Map<String, St
                 put(it.key, it.value.toString())
             }
         }
+    }
+}
+
+/**
+ * Run the given initialization phase and record any failures, but allow execution to continue even if it does.
+ */
+private inline fun ModuleGraph.safeInit(
+    init: () -> Unit,
+) {
+    try {
+        init()
+    } catch (t: Throwable) {
+        initModule.logger.trackInternalError(InternalErrorType.SdkInitPhaseFail, t)
     }
 }
 


### PR DESCRIPTION
Make each phase be able to fail without effecting subsequent phases.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>