### PR TITLE
Move bulk commit logic into service

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/ExperimentApiCall.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/ExperimentApiCall.kt
@@ -1,0 +1,15 @@
+package io.embrace.android.embracesdk.internal.capture.experiment
+
+/**
+ * An experiment API call made before the SDK started
+ */
+sealed class ExperimentApiCall {
+
+    data class Track(val data: List<TrackedData>) : ExperimentApiCall()
+
+    data class Untrack(
+        val kind: ExperimentKind,
+        val ids: List<String>,
+        val endTimeMs: Long,
+    ) : ExperimentApiCall()
+}

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/ExperimentTrackingService.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/ExperimentTrackingService.kt
@@ -20,32 +20,13 @@ interface ExperimentTrackingService {
     fun untrack(kind: ExperimentKind, ids: List<String>, endTimeMs: Long)
 
     /**
+     * Applies experiment API calls that were buffered before the SDK started, in the order given, exactly as if each had
+     * been made via [track] or [untrack] after startup. The only difference is that they are applied as a single update.
+     */
+    fun bulkModify(events: List<ExperimentApiCall>)
+
+    /**
      * Returns the serialized experiment records as a blob, or null if nothing has been tracked.
      */
     fun getRecords(): String?
-}
-
-/**
- * Internal representation of a single tracked experiment or feature flag.
- */
-sealed class TrackedData {
-    abstract val id: String
-    abstract val startTimeMs: Long
-
-    /**
-     * An association with an experiment, optionally including the variant in which this app instance is bucketed into.
-     */
-    data class Experiment(
-        override val id: String,
-        override val startTimeMs: Long,
-        val variant: String?,
-    ) : TrackedData()
-
-    /**
-     * An association with an enabled feature flag.
-     */
-    data class FeatureFlag(
-        override val id: String,
-        override val startTimeMs: Long,
-    ) : TrackedData()
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/ExperimentTrackingServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/ExperimentTrackingServiceImpl.kt
@@ -25,33 +25,27 @@ internal class ExperimentTrackingServiceImpl(
     private var cacheValid = false
     private var cachedRecords: String? = null
 
-    override fun track(data: List<TrackedData>) {
-        var updated = false
-        synchronized(lock) {
-            data.forEach { entry ->
-                if (trackRecord(entry.toRecord())) {
-                    updated = true
-                }
-            }
-        }
-        if (updated) {
-            publishRecords()
-        }
-    }
+    override fun track(data: List<TrackedData>) = modifyAndPublish { trackRecords(data) }
 
-    override fun untrack(kind: ExperimentKind, ids: List<String>, endTimeMs: Long) {
-        var updated = false
-        synchronized(lock) {
-            ids.forEach { id ->
-                if (untrackRecord(RecordKey(kind, id.stripWhitespace()), endTimeMs)) {
-                    updated = true
+    override fun untrack(kind: ExperimentKind, ids: List<String>, endTimeMs: Long) =
+        modifyAndPublish {
+            untrackRecords(kind, ids, endTimeMs)
+        }
+
+    override fun bulkModify(events: List<ExperimentApiCall>) =
+        modifyAndPublish {
+            var changed = false
+            events.forEach { event ->
+                val applied = when (event) {
+                    is ExperimentApiCall.Track -> trackRecords(event.data)
+                    is ExperimentApiCall.Untrack -> untrackRecords(event.kind, event.ids, event.endTimeMs)
+                }
+                if (applied) {
+                    changed = true
                 }
             }
+            changed
         }
-        if (updated) {
-            publishRecords()
-        }
-    }
 
     override fun getRecords(): String? = synchronized(lock) {
         if (!cacheValid) {
@@ -65,6 +59,22 @@ internal class ExperimentTrackingServiceImpl(
         cachedRecords
     }
 
+    /**
+     * Must be called while holding [lock]. Returns true if any record was added.
+     */
+    private fun trackRecords(data: List<TrackedData>): Boolean {
+        var updated = false
+        data.forEach { entry ->
+            if (trackRecord(entry.toRecord())) {
+                updated = true
+            }
+        }
+        return updated
+    }
+
+    /**
+     * Must be called while holding [lock]. Returns true if the record was added.
+     */
     private fun trackRecord(record: ExperimentRecord): Boolean {
         val key = RecordKey(record.kind, record.id)
         if (!isValid(record) || records.containsKey(key)) {
@@ -80,6 +90,22 @@ internal class ExperimentTrackingServiceImpl(
         return true
     }
 
+    /**
+     * Must be called while holding [lock]. Returns true if any record was modified.
+     */
+    private fun untrackRecords(kind: ExperimentKind, ids: List<String>, endTimeMs: Long): Boolean {
+        var updated = false
+        ids.forEach { id ->
+            if (untrackRecord(RecordKey(kind, id.stripWhitespace()), endTimeMs)) {
+                updated = true
+            }
+        }
+        return updated
+    }
+
+    /**
+     * Must be called while holding [lock]. Returns true if the given record was modified.
+     */
     private fun untrackRecord(key: RecordKey, endTimeMs: Long): Boolean {
         val record = records[key]
         if (record == null || record.endTimeMs != null) {
@@ -88,6 +114,18 @@ internal class ExperimentTrackingServiceImpl(
         records[key] = record.copy(endTimeMs = endTimeMs)
         cacheValid = false
         return true
+    }
+
+    /**
+     * Runs [modify] while holding [lock], then publishes the records outside the lock if it reports that any changed.
+     */
+    private inline fun modifyAndPublish(modify: () -> Boolean) {
+        val updated = synchronized(lock) {
+            modify()
+        }
+        if (updated) {
+            publishRecords()
+        }
     }
 
     private fun publishRecords() {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/TrackedData.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/TrackedData.kt
@@ -1,0 +1,26 @@
+package io.embrace.android.embracesdk.internal.capture.experiment
+
+/**
+ * Internal representation of a single tracked experiment or feature flag.
+ */
+sealed class TrackedData {
+    abstract val id: String
+    abstract val startTimeMs: Long
+
+    /**
+     * An association with an experiment, optionally including the variant in which this app instance is bucketed into.
+     */
+    data class Experiment(
+        override val id: String,
+        override val startTimeMs: Long,
+        val variant: String?,
+    ) : TrackedData()
+
+    /**
+     * An association with an enabled feature flag.
+     */
+    data class FeatureFlag(
+        override val id: String,
+        override val startTimeMs: Long,
+    ) : TrackedData()
+}

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/ExperimentTrackingServiceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/capture/experiment/ExperimentTrackingServiceImplTest.kt
@@ -277,6 +277,89 @@ internal class ExperimentTrackingServiceImplTest {
     }
 
     @Test
+    fun `making multiple calls in bulk results in one attribute write`() {
+        service.bulkModify(
+            listOf(
+                ExperimentApiCall.Track(
+                    listOf(
+                        TrackedData.Experiment(id = "a", variant = null, startTimeMs = 100L),
+                        TrackedData.Experiment(id = "b", variant = null, startTimeMs = 200L),
+                    ),
+                ),
+                ExperimentApiCall.Untrack(ExperimentKind.EXPERIMENT, listOf("a"), 300L),
+                ExperimentApiCall.Track(
+                    listOf(TrackedData.FeatureFlag(id = "f", startTimeMs = 150L)),
+                ),
+                ExperimentApiCall.Untrack(ExperimentKind.FEATURE_FLAG, listOf("f"), 400L),
+            ),
+        )
+        service.assertRecordState("e:a::100:300;e:b::200;f:f::150:400")
+        assertEquals(1, experimentAttributeWriteCount())
+    }
+
+    @Test
+    fun `bulk calls dedupes and invokes methods in the expected order`() {
+        val replayed = serviceWithRemoteConfig(RemoteConfig())
+        val events = listOf(
+            // untracking before tracking is dropped, as it would be live
+            ExperimentApiCall.Untrack(ExperimentKind.EXPERIMENT, listOf("id1"), 50L),
+            ExperimentApiCall.Track(
+                listOf(TrackedData.Experiment(id = "id1", variant = "v1", startTimeMs = 100L)),
+            ),
+            ExperimentApiCall.Track(
+                listOf(TrackedData.Experiment(id = "id1", variant = "v2", startTimeMs = 200L)),
+            ),
+            ExperimentApiCall.Untrack(ExperimentKind.EXPERIMENT, listOf("id1"), 300L),
+            ExperimentApiCall.Untrack(ExperimentKind.EXPERIMENT, listOf("id1"), 250L),
+        )
+        replayed.bulkModify(events)
+
+        events.forEach { event ->
+            when (event) {
+                is ExperimentApiCall.Track -> service.track(event.data)
+                is ExperimentApiCall.Untrack -> service.untrack(event.kind, event.ids, event.endTimeMs)
+            }
+        }
+
+        assertEquals("e:id1:v1:100:300", replayed.getRecords())
+        assertEquals(service.getRecords(), replayed.getRecords())
+    }
+
+    @Test
+    fun `bulk calls validates and enforces limits`() {
+        val service = serviceWithRemoteConfig(RemoteConfig(experimentMaxCount = 2))
+        service.bulkModify(
+            listOf(
+                ExperimentApiCall.Track(
+                    listOf(
+                        TrackedData.Experiment(id = "id1", variant = null, startTimeMs = 100L),
+                        TrackedData.Experiment(id = "", variant = null, startTimeMs = 150L),
+                        TrackedData.Experiment(id = "id2", variant = null, startTimeMs = 200L),
+                        TrackedData.Experiment(id = "id3", variant = null, startTimeMs = 300L),
+                    ),
+                ),
+            ),
+        )
+        service.assertRecordState("e:id1::100;e:id2::200")
+        assertEquals(listOf("experiments" to AppliedLimitType.DROP), telemetryService.appliedLimits)
+    }
+
+    @Test
+    fun `bulk calls only updates experiments attributes if one of the calls actually changed something`() {
+        service.bulkModify(emptyList())
+        service.bulkModify(
+            listOf(
+                ExperimentApiCall.Track(
+                    listOf(TrackedData.Experiment(id = " ", variant = null, startTimeMs = 100L)),
+                ),
+                ExperimentApiCall.Untrack(ExperimentKind.EXPERIMENT, listOf("unknown"), 200L),
+            ),
+        )
+        service.assertRecordState(null)
+        assertEquals(0, experimentAttributeWriteCount())
+    }
+
+    @Test
     fun `serialization order follows tracking order irrespective of kind`() {
         service.track(
             listOf(TrackedData.Experiment(id = "id1", variant = null, startTimeMs = 100L)),

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/CollectionExtensions.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/CollectionExtensions.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.utils
 
+import java.util.Queue
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -53,3 +54,9 @@ fun <T> MutableMap<String, AtomicInteger>.lockAndRun(key: String, code: () -> T)
 fun <T> Collection<T>.threadSafeToList(): List<T> {
     return ArrayList(this)
 }
+
+/**
+ * Removes and returns the contents of the queue as a list, one element at a time via [Queue.poll], until a poll returns null.
+ * This method is threadsafe as long as the implementation's [poll] method is threadsafe.
+ */
+fun <T : Any> Queue<T>.drain(): List<T> = generateSequence(::poll).toList()

--- a/embrace-android-infra/src/test/kotlin/io/embrace/android/embracesdk/internal/utils/CollectionExtensionsKtTest.kt
+++ b/embrace-android-infra/src/test/kotlin/io/embrace/android/embracesdk/internal/utils/CollectionExtensionsKtTest.kt
@@ -2,8 +2,10 @@ package io.embrace.android.embracesdk.internal.utils
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
@@ -67,5 +69,41 @@ internal class CollectionExtensionsKtTest {
         completedTasks.forEachIndexed { index, task ->
             assertEquals("Execution order wrong. Order found: $completedTasks", expectedOrder[index], task)
         }
+    }
+
+    @Test
+    fun `drain removes and returns all elements in queue order`() {
+        val queue = ConcurrentLinkedQueue(listOf("a", "b", "c"))
+
+        assertEquals(listOf("a", "b", "c"), queue.drain())
+        assertTrue(queue.isEmpty())
+        assertEquals(emptyList<String>(), queue.drain())
+
+        queue.add("d")
+        assertEquals(listOf("d"), queue.drain())
+    }
+
+    @Test
+    fun `elements added during a drain are returned or retained but never dropped`() {
+        // Add logic to the polling to modify the queue to ensure modifications during iteration and processed in the expected way.
+        var addedOnEmpty = false
+        val queue = object : ConcurrentLinkedQueue<String>(listOf("a", "b")) {
+            override fun poll(): String? {
+                val polled = super.poll()
+                if (polled == "a") {
+                    add("c")
+                } else if (polled == null && !addedOnEmpty) {
+                    addedOnEmpty = true
+                    add("d")
+                }
+                return polled
+            }
+        }
+
+        // "c" is enqueued before the drain is finished, so it is part of this drain
+        assertEquals(listOf("a", "b", "c"), queue.drain())
+
+        // "d" is enqueued right after the drains sees the queue being empty, so it is retained for the next one rather than dropped
+        assertEquals(listOf("d"), queue.toList())
     }
 }

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExperimentApiDelegate.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExperimentApiDelegate.kt
@@ -3,11 +3,13 @@ package io.embrace.android.embracesdk.internal.api.delegate
 import io.embrace.android.embracesdk.experiments.TrackedExperiment
 import io.embrace.android.embracesdk.experiments.TrackedFeatureFlag
 import io.embrace.android.embracesdk.internal.api.ExperimentApi
+import io.embrace.android.embracesdk.internal.capture.experiment.ExperimentApiCall
 import io.embrace.android.embracesdk.internal.capture.experiment.ExperimentKind
 import io.embrace.android.embracesdk.internal.capture.experiment.TrackedData
 import io.embrace.android.embracesdk.internal.config.behavior.ExperimentBehaviorImpl
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.injection.embraceImplInject
+import io.embrace.android.embracesdk.internal.utils.drain
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -24,7 +26,16 @@ internal class ExperimentApiDelegate(
         bootstrapper.essentialServiceModule.experimentTrackingService
     }
 
-    private val pendingEvents = ConcurrentLinkedQueue<PendingEvent>()
+    /**
+     * List of track and untrack calls to this API made prior to SDK init
+     */
+    private val pendingCalls = ConcurrentLinkedQueue<PendingCall>()
+
+    /**
+     * Ceiling of the count of experiment records that could be created from the buffered calls.
+     * This does not dedupe, validate, or take into account untracking doesn't actually add a record, as it just provides a reasonable
+     * ceiling to ensure that the number of pending calls is not unbounded.
+     */
     private val bufferedEntryCount = AtomicInteger(0)
 
     override fun createExperiment(id: String, variant: String?, startedAt: Long?): TrackedExperiment =
@@ -50,71 +61,22 @@ internal class ExperimentApiDelegate(
     }
 
     /**
-     * Flush buffered experiment API calls by combining tracking and untracking into as few
-     * calls down to the service as possible. The ordering of tracking calls will be preserved,
-     * first writer still wins, but all untracking calls will be replayed after the tracking
-     * calls in the order they were called. Later untracking calls using the same end
-     * timestamp as a previous one will be hoisted to when that first untracking call with
-     * the same timestamp was invoked.
+     * Flush the buffered calls and commit them in one go in the service, then record the API calls.
      */
     fun flushPendingCalls() {
-        val toTrack = mutableListOf<TrackedData>()
-        val expToUntrack = linkedMapOf<Long, List<String>>()
-        val flagsToUntrack = linkedMapOf<Long, List<String>>()
-        val apiCalls = mutableListOf<String>()
-        while (true) {
-            val event = pendingEvents.poll() ?: break
-            apiCalls.add(event.action)
-
-            when (event) {
-                is PendingEvent.Track -> {
-                    toTrack += event.data
-                }
-
-                is PendingEvent.Untrack -> {
-                    when (event.kind) {
-                        ExperimentKind.EXPERIMENT -> {
-                            val existing = expToUntrack[event.endTimeMs]
-                            if (existing == null) {
-                                expToUntrack[event.endTimeMs] = event.ids
-                            } else {
-                                expToUntrack[event.endTimeMs] = existing + event.ids
-                            }
-                        }
-
-                        ExperimentKind.FEATURE_FLAG -> {
-                            val existing = flagsToUntrack[event.endTimeMs]
-                            if (existing == null) {
-                                flagsToUntrack[event.endTimeMs] = event.ids
-                            } else {
-                                flagsToUntrack[event.endTimeMs] = existing + event.ids
-                            }
-                        }
-                    }
-                }
+        val calls = pendingCalls.drain()
+        if (calls.isNotEmpty()) {
+            experimentTrackingService?.bulkModify(calls.map { it.event })
+            calls.forEach {
+                sdkCallChecker.recordApiCall(it.action)
             }
-        }
-
-        // Reducing the update of the session part span to one, instead of once per service call, requires a lot more complexity
-        // to be introduced to the service. But given the expected use cases, and the unlikely usage of untracking APIs pre-SDK init,
-        // the net result will likely be one session part span update anyway. As such, this implementation is acceptable for now.
-
-        experimentTrackingService?.track(toTrack)
-        expToUntrack.entries.forEach {
-            experimentTrackingService?.untrack(ExperimentKind.EXPERIMENT, it.value, it.key)
-        }
-        flagsToUntrack.entries.forEach {
-            experimentTrackingService?.untrack(ExperimentKind.FEATURE_FLAG, it.value, it.key)
-        }
-        apiCalls.forEach {
-            sdkCallChecker.recordApiCall(it)
         }
     }
 
     private fun track(action: String, data: List<TrackedData>) {
         if (!sdkCallChecker.started.get()) {
             val admitted = admitEntries(data) ?: return
-            pendingEvents.add(PendingEvent.Track(action, admitted))
+            pendingCalls.add(PendingCall(action, ExperimentApiCall.Track(admitted)))
         } else {
             trackNow(action, data)
         }
@@ -123,7 +85,7 @@ internal class ExperimentApiDelegate(
     private fun untrack(action: String, kind: ExperimentKind, ids: List<String>, endTimeMs: Long) {
         if (!sdkCallChecker.started.get()) {
             val admitted = admitEntries(ids) ?: return
-            pendingEvents.add(PendingEvent.Untrack(action, kind, admitted, endTimeMs))
+            pendingCalls.add(PendingCall(action, ExperimentApiCall.Untrack(kind, admitted, endTimeMs)))
         } else {
             untrackNow(action, kind, ids, endTimeMs)
         }
@@ -173,17 +135,10 @@ internal class ExperimentApiDelegate(
             startTimeMs = startedAt ?: now(),
         )
 
-    private sealed interface PendingEvent {
-        val action: String
-
-        class Track(override val action: String, val data: List<TrackedData>) : PendingEvent
-        class Untrack(
-            override val action: String,
-            val kind: ExperimentKind,
-            val ids: List<String>,
-            val endTimeMs: Long,
-        ) : PendingEvent
-    }
+    /**
+     * A buffered API call made prior to SDK init completion.
+     */
+    private class PendingCall(val action: String, val event: ExperimentApiCall)
 
     private companion object {
         // The buffer stores entries up to the record cap's maximum settable value because it can't resolve the configured cap

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExperimentApiDelegateTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ExperimentApiDelegateTest.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.createExperimentBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeEssentialServiceModule
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
+import io.embrace.android.embracesdk.internal.capture.experiment.ExperimentApiCall
 import io.embrace.android.embracesdk.internal.capture.experiment.ExperimentKind
 import io.embrace.android.embracesdk.internal.capture.experiment.TrackedData
 import io.embrace.android.embracesdk.internal.config.behavior.ExperimentBehaviorImpl
@@ -84,7 +85,7 @@ internal class ExperimentApiDelegateTest {
     }
 
     @Test
-    fun `buffered calls are coalesced with api usage record preserved when flushed`() {
+    fun `buffered calls are replayed in one service call with api usage recorded when flushed`() {
         delegate.trackExperiments(
             listOf(
                 TrackedExperimentImpl("exp1", "v1", 123456789L),
@@ -131,7 +132,38 @@ internal class ExperimentApiDelegateTest {
             ),
             telemetryService.apiCalls,
         )
-        assertEquals(5, fakeExperimentTrackingService.serviceInvocations)
+        assertEquals(1, fakeExperimentTrackingService.serviceInvocations)
+        assertEquals(
+            listOf(
+                ExperimentApiCall.Track(
+                    listOf(
+                        TrackedData.Experiment("exp1", 123456789L, "v1"),
+                        TrackedData.Experiment("exp2", 123456789L, "v1"),
+                    ),
+                ),
+                ExperimentApiCall.Track(
+                    listOf(
+                        TrackedData.Experiment("exp2", 123456789L, "v2"),
+                        TrackedData.Experiment("exp3", 123456789L, "v1"),
+                    ),
+                ),
+                ExperimentApiCall.Track(listOf(TrackedData.Experiment("exp4", 123456789L, "v2"))),
+                ExperimentApiCall.Track(
+                    listOf(
+                        TrackedData.FeatureFlag("flag1", 987654321L),
+                        TrackedData.FeatureFlag("flag2", 987654321L),
+                    ),
+                ),
+                ExperimentApiCall.Track(listOf(TrackedData.FeatureFlag("flag3", 987654321L))),
+                ExperimentApiCall.Untrack(ExperimentKind.EXPERIMENT, listOf("exp1", "exp2"), 555555555L),
+                ExperimentApiCall.Untrack(ExperimentKind.EXPERIMENT, listOf("exp3"), 555555555L),
+                ExperimentApiCall.Untrack(ExperimentKind.EXPERIMENT, listOf("exp4"), 555555566L),
+                ExperimentApiCall.Untrack(ExperimentKind.FEATURE_FLAG, listOf("flag1", "flag3"), 555555555L),
+                ExperimentApiCall.Untrack(ExperimentKind.FEATURE_FLAG, listOf("flag1"), 666666666L),
+                ExperimentApiCall.Untrack(ExperimentKind.FEATURE_FLAG, listOf("flag2"), 666666666L),
+            ),
+            fakeExperimentTrackingService.bulkApiCalls,
+        )
     }
 
     @Test
@@ -279,6 +311,7 @@ internal class ExperimentApiDelegateTest {
 
         sdkCallChecker.started.set(true)
         delegate.flushPendingCalls()
+        assertEquals(0, fakeExperimentTrackingService.serviceInvocations)
 
         delegate.trackExperiments(emptyList())
         delegate.untrackExperiments(emptyList(), endedAt = 0L)

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeExperimentTrackingService.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeExperimentTrackingService.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.fakes
 
+import io.embrace.android.embracesdk.internal.capture.experiment.ExperimentApiCall
 import io.embrace.android.embracesdk.internal.capture.experiment.ExperimentKind
 import io.embrace.android.embracesdk.internal.capture.experiment.ExperimentTrackingService
 import io.embrace.android.embracesdk.internal.capture.experiment.TrackedData
@@ -9,6 +10,7 @@ class FakeExperimentTrackingService : ExperimentTrackingService {
 
     val trackedData: MutableList<TrackedData> = mutableListOf()
     val untrackCalls: MutableList<UntrackCall> = mutableListOf()
+    val bulkApiCalls: MutableList<ExperimentApiCall> = mutableListOf()
     var fakeRecords: String? = null
     val serviceInvocations: Int
         get() = callCount.get()
@@ -22,14 +24,33 @@ class FakeExperimentTrackingService : ExperimentTrackingService {
     )
 
     override fun track(data: List<TrackedData>) {
-        trackedData.addAll(data)
+        trackInternal(data)
         callCount.incrementAndGet()
     }
 
     override fun untrack(kind: ExperimentKind, ids: List<String>, endTimeMs: Long) {
-        untrackCalls.add(UntrackCall(kind, ids, endTimeMs))
+        untrackInternal(kind, ids, endTimeMs)
+        callCount.incrementAndGet()
+    }
+
+    override fun bulkModify(events: List<ExperimentApiCall>) {
+        bulkApiCalls.addAll(events)
+        events.forEach { event ->
+            when (event) {
+                is ExperimentApiCall.Track -> trackInternal(event.data)
+                is ExperimentApiCall.Untrack -> untrackInternal(event.kind, event.ids, event.endTimeMs)
+            }
+        }
         callCount.incrementAndGet()
     }
 
     override fun getRecords(): String? = fakeRecords
+
+    private fun trackInternal(data: List<TrackedData>) {
+        trackedData.addAll(data)
+    }
+
+    private fun untrackInternal(kind: ExperimentKind, ids: List<String>, endTimeMs: Long) {
+        untrackCalls.add(UntrackCall(kind, ids, endTimeMs))
+    }
 }


### PR DESCRIPTION
Move logic to combine various experiment API calls into the internal service and make the delegate only keep track of the API calls which can be replayed in order when the SDK initializes.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>