### PR TITLE
Resolve test failures in persistence implementation

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
@@ -92,6 +92,7 @@ class UserSessionOrchestrationModuleImpl(
             appVersionStartupCounterProvider,
             logModule.logLimitingService,
             payloadSourceModule.metadataService,
+            openTelemetryModule.otelSdkConfig.processIdentifier,
         )
 
         val sessionPartWriter = SessionPartWriterImpl(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImpl.kt
@@ -17,6 +17,7 @@ internal class SessionPartSpanAttrPopulatorImpl(
     private val appVersionStartupCounterProvider: () -> Int?,
     private val logLimitingService: LogLimitingService,
     private val metadataService: MetadataService,
+    private val processIdentifier: String,
 ) : SessionPartSpanAttrPopulator {
 
     override fun populateSessionPartSpanStartAttrs(sessionPart: SessionPartToken, userSession: UserSessionMetadata?) {
@@ -25,6 +26,7 @@ internal class SessionPartSpanAttrPopulatorImpl(
             addSessionPartAttribute(EmbSessionAttributes.EMB_STATE, sessionPart.processState.name.lowercase(Locale.US))
             addSessionPartAttribute(EmbSessionAttributes.EMB_CLEAN_EXIT, false.toString())
             addSessionPartAttribute(EmbSessionAttributes.EMB_TERMINATED, true.toString())
+            addSessionPartAttribute(EmbSessionAttributes.EMB_PROCESS_IDENTIFIER, processIdentifier)
 
             sessionPart.startType.toString().lowercase(Locale.US).let {
                 addSessionPartAttribute(EmbSessionAttributes.EMB_SESSION_START_TYPE, it)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/SessionPartReaderTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/SessionPartReaderTest.kt
@@ -62,10 +62,12 @@ internal class SessionPartReaderTest {
             startTimeNanos = 1726739283136000000L,
             endTimeNanos = 1726739284136000000L,
             status = Span.Status.UNSET,
+            events = emptyList(),
             attributes = listOfNotNull(
                 Attribute(key = "emb.type", data = "ux.session"),
                 processIdentifier?.let { Attribute(key = EmbSessionAttributes.EMB_PROCESS_IDENTIFIER, data = it) },
             ),
+            links = emptyList(),
         )
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorListenerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorListenerTest.kt
@@ -406,6 +406,7 @@ internal class SessionOrchestratorListenerTest {
                 { null },
                 FakeLogLimitingService(),
                 FakeMetadataService(),
+                "process-id",
             ),
             ordinalStoreOverride ?: FakeOrdinalStore(),
             FakeKeyValueStore(),

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -1221,6 +1221,7 @@ internal class SessionOrchestratorTest {
                 { null },
                 FakeLogLimitingService(),
                 FakeMetadataService(),
+                "process-id",
             ),
             ordinalStoreOverride ?: FakeOrdinalStore(),
             keyValueStoreOverride ?: FakeKeyValueStore(),

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartSpanAttrPopulatorImplTest.kt
@@ -42,6 +42,7 @@ internal class SessionPartSpanAttrPopulatorImplTest {
             { 7 },
             FakeLogLimitingService(),
             FakeMetadataService(),
+            PROCESS_ID,
         )
     }
 
@@ -63,6 +64,7 @@ internal class SessionPartSpanAttrPopulatorImplTest {
         assertEquals("43200", attrs[EmbSessionAttributes.EMB_USER_SESSION_MAX_DURATION_SECONDS])
         assertEquals("1800", attrs[EmbSessionAttributes.EMB_USER_SESSION_INACTIVITY_TIMEOUT_SECONDS])
         assertEquals("id", attrs[EmbSessionAttributes.EMB_SESSION_PART_ID])
+        assertEquals(PROCESS_ID, attrs[EmbSessionAttributes.EMB_PROCESS_IDENTIFIER])
         assertFalse(attrs.containsKey(EmbSessionAttributes.EMB_IS_BACKGROUND_ONLY_PART))
     }
 
@@ -168,6 +170,7 @@ internal class SessionPartSpanAttrPopulatorImplTest {
             { 7 },
             FakeLogLimitingService(),
             metadataService,
+            PROCESS_ID,
         )
 
         populator.populateSessionPartSpanEndAttrs(LifeEventType.STATE, "crashId", false, emptyMap())
@@ -184,6 +187,10 @@ internal class SessionPartSpanAttrPopulatorImplTest {
             EmbSessionAttributes.EMB_CLOCK_GNSS_DRIFT to "10",
         )
         assertEquals(expected, attrs)
+    }
+
+    private companion object {
+        const val PROCESS_ID = "process-id"
     }
 
     private fun testClassifiedUserSession(isBackgroundOnly: Boolean) = UserSessionMetadata.Classified(

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceReadTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceReadTest.kt
@@ -66,6 +66,9 @@ internal class SessionPartWriterResourceReadTest {
             name = "emb-network-request",
             startTimeNanos = spanTemplate.start_time_unix_nano,
             status = Span.Status.UNSET,
+            events = emptyList(),
+            attributes = emptyList(),
+            links = emptyList(),
         )
     }
 
@@ -127,7 +130,7 @@ internal class SessionPartWriterResourceReadTest {
     @Test
     fun `the session span written at the start of the part is reconstructed as a snapshot`() {
         val envelope = checkNotNull(writeSessionPart())
-        val expected = checkNotNull(sessionSpan.snapshot()).copy(events = null, links = null)
+        val expected = checkNotNull(sessionSpan.snapshot())
         assertEquals(expected, envelope.data.spanSnapshots?.last())
         assertNull(envelope.data.spans?.find { it.spanId == sessionSpan.spanId })
         assertEquals(emptyList<FakeInternalLogger.LogMessage>(), logger.internalErrorMessages)
@@ -140,7 +143,7 @@ internal class SessionPartWriterResourceReadTest {
         endSessionPart()
 
         val envelope = checkNotNull(service.reconstruct(directory()))
-        val expected = checkNotNull(sessionSpan.snapshot()).copy(events = null, links = null)
+        val expected = checkNotNull(sessionSpan.snapshot())
         assertEquals(expected, envelope.data.spans?.last())
         assertNull(envelope.data.spanSnapshots?.find { it.spanId == sessionSpan.spanId })
         assertEquals(emptyList<FakeInternalLogger.LogMessage>(), logger.internalErrorMessages)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/persistence/MultiFilePersistenceParityTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/persistence/MultiFilePersistenceParityTest.kt
@@ -366,7 +366,6 @@ internal class MultiFilePersistenceParityTest {
         )
     }
 
-    @Ignore("Empty span collections read back as absent ones")
     @Test
     fun `empty span collections are persisted identically`() {
         testRule.runTest(
@@ -400,7 +399,6 @@ internal class MultiFilePersistenceParityTest {
         )
     }
 
-    @Ignore("The session span's emb.process_identifier is not persisted")
     @Test
     fun `the session span process identifier is persisted identically`() {
         testRule.runTest(
@@ -562,28 +560,18 @@ internal class MultiFilePersistenceParityTest {
 
     private fun Span.normalised(): Span {
         val span = copy(
-            events = events?.map { it.normalised() }?.nullIfEmpty(),
-            attributes = attributes?.sorted()?.nullIfEmpty(),
-            links = links?.map { it.normalised() }?.nullIfEmpty(),
+            events = events?.map { it.normalised() },
+            attributes = attributes?.sorted(),
+            links = links?.map { it.normalised() },
         )
-        if (span.name != SESSION_SPAN_NAME) {
-            return span
-        }
-        return span.copy(
-            links = null,
-            attributes = span.attributes
-                ?.filterNot { it.key == EmbSessionAttributes.EMB_PROCESS_IDENTIFIER }
-                ?.nullIfEmpty(),
-        )
+        return if (span.name == SESSION_SPAN_NAME) span.copy(links = null) else span
     }
 
-    private fun SpanEvent.normalised(): SpanEvent = copy(attributes = attributes?.sorted()?.nullIfEmpty())
+    private fun SpanEvent.normalised(): SpanEvent = copy(attributes = attributes?.sorted())
 
-    private fun Link.normalised(): Link = copy(attributes = attributes?.sorted()?.nullIfEmpty())
+    private fun Link.normalised(): Link = copy(attributes = attributes?.sorted())
 
     private fun List<Attribute>.sorted(): List<Attribute> = sortedWith(compareBy({ it.key }, { it.data }))
-
-    private fun <T> List<T>.nullIfEmpty(): List<T>? = takeIf(List<T>::isNotEmpty)
 
     private companion object {
         const val SESSION_SPAN_NAME = "emb-session"

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionService.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionService.kt
@@ -103,8 +103,8 @@ class SessionReconstructionService(
             version = manifest.envelope_version,
             type = manifest.envelope_type,
             data = SessionPartPayload(
-                spans = deduped.spans.takeIf(List<Span>::isNotEmpty),
-                spanSnapshots = deduped.spanSnapshots.takeIf(List<Span>::isNotEmpty),
+                spans = deduped.spans,
+                spanSnapshots = deduped.spanSnapshots,
                 sharedLibSymbolMapping = manifest.shared_lib_symbol_mapping?.symbols,
             ),
         )

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SpanMapper.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SpanMapper.kt
@@ -50,9 +50,9 @@ internal fun SpanProto.toPayload(): Span = Span(
     startTimeNanos = start_time_unix_nano.takeIf { it != 0L },
     endTimeNanos = end_time_unix_nano,
     status = status.toPayload(),
-    events = events.takeIf(List<SpanEventProto>::isNotEmpty)?.map(SpanEventProto::toPayload),
-    attributes = attributes.takeIf(List<AttributeProto>::isNotEmpty)?.map(AttributeProto::toPayload),
-    links = links.takeIf(List<LinkProto>::isNotEmpty)?.map(LinkProto::toPayload),
+    events = events.map(SpanEventProto::toPayload),
+    attributes = attributes.map(AttributeProto::toPayload),
+    links = links.map(LinkProto::toPayload),
 )
 
 internal fun SpanProto.Status.toPayload(): Span.Status = when (this) {
@@ -64,17 +64,14 @@ internal fun SpanProto.Status.toPayload(): Span.Status = when (this) {
 internal fun SpanEventProto.toPayload(): SpanEvent = SpanEvent(
     name = name.takeIf(String::isNotEmpty),
     timestampNanos = time_unix_nano.takeIf { it != 0L },
-    attributes = attributes.takeIf(List<AttributeProto>::isNotEmpty)?.map(AttributeProto::toPayload),
+    attributes = attributes.map(AttributeProto::toPayload),
 )
 
-internal fun AttributeProto.toPayload(): Attribute = Attribute(
-    key = key.takeIf(String::isNotEmpty),
-    data = value_.takeIf(String::isNotEmpty),
-)
+internal fun AttributeProto.toPayload(): Attribute = Attribute(key = key, data = value_)
 
 internal fun LinkProto.toPayload(): Link = Link(
     spanId = span_id.takeIf(String::isNotEmpty),
     traceId = trace_id.takeIf(String::isNotEmpty),
-    attributes = attributes.takeIf(List<AttributeProto>::isNotEmpty)?.map(AttributeProto::toPayload),
+    attributes = attributes.map(AttributeProto::toPayload),
     isRemote = is_remote,
 )

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceCompletedSpansTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceCompletedSpansTest.kt
@@ -107,7 +107,7 @@ internal class SessionReconstructionServiceCompletedSpansTest {
 
         val payload = checkNotNull(service.reconstruct(partDirectory)?.data)
         assertEquals(listOf(fullyPopulatedSpan), payload.spans)
-        assertNull(payload.spanSnapshots)
+        assertEquals(emptyList<Span>(), payload.spanSnapshots)
         assertNoInternalErrors()
     }
 
@@ -129,7 +129,7 @@ internal class SessionReconstructionServiceCompletedSpansTest {
 
         val payload = checkNotNull(service.reconstruct(partDirectory)?.data)
         assertEquals(listOf(inFlightSpan, fullyPopulatedSpan), payload.spans)
-        assertNull(payload.spanSnapshots)
+        assertEquals(emptyList<Span>(), payload.spanSnapshots)
         assertNoInternalErrors()
     }
 
@@ -206,7 +206,7 @@ internal class SessionReconstructionServiceCompletedSpansTest {
 
         val payload = checkNotNull(service.reconstruct(partDirectory)?.data)
         assertEquals(listOf(fullyPopulatedSpan), payload.spans)
-        assertNull(payload.spanSnapshots)
+        assertEquals(emptyList<Span>(), payload.spanSnapshots)
         assertNoInternalErrors()
     }
 
@@ -220,7 +220,7 @@ internal class SessionReconstructionServiceCompletedSpansTest {
         writeSpanSnapshots()
 
         val payload = checkNotNull(service.reconstruct(partDirectory)?.data)
-        assertNull(payload.spans)
+        assertEquals(emptyList<Span>(), payload.spans)
         assertEquals(listOf(incomplete), payload.spanSnapshots)
         assertNoInternalErrors()
     }

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceDedupeTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceDedupeTest.kt
@@ -3,7 +3,6 @@ package io.embrace.android.embracesdk.internal.session.persistence
 import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.internal.payload.Span
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -93,7 +92,7 @@ internal class SessionReconstructionServiceDedupeTest {
 
         val payload = checkNotNull(service.reconstruct(partDirectory)?.data)
         assertEquals(listOf(earlySpan, fullyPopulatedSpan), payload.spans)
-        assertNull(payload.spanSnapshots)
+        assertEquals(emptyList<Span>(), payload.spanSnapshots)
         assertDuplicatesTracked()
     }
 
@@ -103,7 +102,7 @@ internal class SessionReconstructionServiceDedupeTest {
 
         val payload = checkNotNull(service.reconstruct(partDirectory)?.data)
         assertEquals(listOf(earlySpan, fullyPopulatedSpan), payload.spans)
-        assertNull(payload.spanSnapshots)
+        assertEquals(emptyList<Span>(), payload.spanSnapshots)
         assertDuplicatesTracked()
     }
 

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceSessionSpanTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceSessionSpanTest.kt
@@ -76,7 +76,7 @@ internal class SessionReconstructionServiceSessionSpanTest {
     @Test
     fun `a complete session span is not reconstructed as a span snapshot`() {
         write()
-        assertNull(service.reconstruct(partDirectory)?.data?.spanSnapshots)
+        assertEquals(emptyList<Span>(), service.reconstruct(partDirectory)?.data?.spanSnapshots)
         assertNoInternalErrors()
     }
 
@@ -88,7 +88,7 @@ internal class SessionReconstructionServiceSessionSpanTest {
 
         val payload = checkNotNull(service.reconstruct(partDirectory)?.data)
         assertEquals(listOf(incomplete), payload.spanSnapshots)
-        assertNull(payload.spans)
+        assertEquals(emptyList<Span>(), payload.spans)
         assertNoInternalErrors()
     }
 
@@ -100,7 +100,7 @@ internal class SessionReconstructionServiceSessionSpanTest {
 
         val payload = checkNotNull(service.reconstruct(partDirectory)?.data)
         assertEquals(listOf(ended), payload.spans)
-        assertNull(payload.spanSnapshots)
+        assertEquals(emptyList<Span>(), payload.spanSnapshots)
         assertNoInternalErrors()
     }
 
@@ -110,8 +110,11 @@ internal class SessionReconstructionServiceSessionSpanTest {
         write()
 
         val payload = checkNotNull(service.reconstruct(partDirectory)?.data)
-        assertEquals(listOf(Span(status = Span.Status.UNSET)), payload.spanSnapshots)
-        assertNull(payload.spans)
+        assertEquals(
+            listOf(Span(status = Span.Status.UNSET, events = emptyList(), attributes = emptyList(), links = emptyList())),
+            payload.spanSnapshots,
+        )
+        assertEquals(emptyList<Span>(), payload.spans)
         assertNoInternalErrors()
     }
 

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceSpanSnapshotsTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceSpanSnapshotsTest.kt
@@ -102,7 +102,7 @@ internal class SessionReconstructionServiceSpanSnapshotsTest {
 
         val payload = checkNotNull(service.reconstruct(partDirectory)?.data)
         assertEquals(listOf(inFlightSpan, incomplete), payload.spanSnapshots)
-        assertNull(payload.spans)
+        assertEquals(emptyList<Span>(), payload.spans)
         assertNoInternalErrors()
     }
 
@@ -111,7 +111,7 @@ internal class SessionReconstructionServiceSpanSnapshotsTest {
         write()
 
         val payload = checkNotNull(service.reconstruct(partDirectory)?.data)
-        assertNull(payload.spanSnapshots)
+        assertEquals(emptyList<Span>(), payload.spanSnapshots)
         assertEquals(listOf(fullyPopulatedSpan), payload.spans)
         assertNoInternalErrors()
     }
@@ -170,7 +170,7 @@ internal class SessionReconstructionServiceSpanSnapshotsTest {
         writeCompletedSpans()
 
         val payload = checkNotNull(service.reconstruct(partDirectory)?.data)
-        assertNull(payload.spanSnapshots)
+        assertEquals(emptyList<Span>(), payload.spanSnapshots)
         assertEquals(listOf(fullyPopulatedSpan), payload.spans)
         assertNoInternalErrors()
     }
@@ -186,7 +186,7 @@ internal class SessionReconstructionServiceSpanSnapshotsTest {
 
         val payload = checkNotNull(service.reconstruct(partDirectory)?.data)
         assertEquals(listOf(incomplete), payload.spanSnapshots)
-        assertNull(payload.spans)
+        assertEquals(emptyList<Span>(), payload.spans)
         assertNoInternalErrors()
     }
 

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SpanFixtures.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SpanFixtures.kt
@@ -77,7 +77,9 @@ internal val inFlightSpan = Span(
     startTimeNanos = 1726739283200000000L,
     endTimeNanos = null,
     status = Span.Status.UNSET,
+    events = emptyList(),
     attributes = listOf(Attribute(key = "url.full", data = "https://example.com")),
+    links = emptyList(),
 )
 
 internal val inFlightSpanProto = SpanProto(

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SpanMapperTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SpanMapperTest.kt
@@ -133,11 +133,11 @@ internal class SpanMapperTest {
     }
 
     @Test
-    fun `empty proto collections are mapped back to null`() {
+    fun `empty proto collections are mapped back to empty collections`() {
         val span = SpanProto(events = emptyList(), attributes = emptyList(), links = emptyList()).toPayload()
-        assertNull(span.events)
-        assertNull(span.attributes)
-        assertNull(span.links)
+        assertEquals(emptyList<SpanEvent>(), span.events)
+        assertEquals(emptyList<Attribute>(), span.attributes)
+        assertEquals(emptyList<Link>(), span.links)
     }
 
     @Test
@@ -159,18 +159,18 @@ internal class SpanMapperTest {
     }
 
     @Test
-    fun `attribute proto defaults are mapped back to null`() {
-        assertEquals(Attribute(key = null, data = null), AttributeProto().toPayload())
+    fun `an empty attribute key and value survive the round trip`() {
+        assertEquals(Attribute(key = "", data = ""), AttributeProto().toPayload())
     }
 
     @Test
-    fun `span event proto defaults are mapped back to null`() {
-        assertEquals(SpanEvent(name = null, timestampNanos = null, attributes = null), SpanEventProto().toPayload())
+    fun `span event proto defaults are mapped back to null, other than its attributes`() {
+        assertEquals(SpanEvent(name = null, timestampNanos = null, attributes = emptyList()), SpanEventProto().toPayload())
     }
 
     @Test
-    fun `link proto defaults are mapped back to null, other than is remote`() {
-        assertEquals(Link(spanId = null, traceId = null, attributes = null, isRemote = false), LinkProto().toPayload())
+    fun `link proto defaults are mapped back to null, other than is remote and its attributes`() {
+        assertEquals(Link(spanId = null, traceId = null, attributes = emptyList(), isRemote = false), LinkProto().toPayload())
         assertEquals(true, LinkProto(is_remote = true).toPayload().isRemote)
     }
 }


### PR DESCRIPTION
## Goal

Resolves a couple of test failures in the persistence implementation by specifying the `processIdentifier` attribute correctly and altering how empty span collections are handled.