### PR TITLE
Resolve test failures in persistence implementation

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -77,6 +77,11 @@ class SessionPartWriterImpl(
 
         current = writers
         writeTracker.markWriting(sessionPartId)
+
+        // the session span is snapshotted after it has stopped, so it must hold on to its events and
+        // links until this part's writes have completed
+        writers.span?.retainDataAfterStop()
+
         directoryStore.create(writers.directory)
         queueManifestWrite(writers)
         queueMetadataWrite(writers)
@@ -101,6 +106,7 @@ class SessionPartWriterImpl(
             if (!writesSealed) {
                 notifyWritesComplete()
             }
+            writers.span?.releaseRetainedData()
         }
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
@@ -862,6 +862,33 @@ internal class SessionPartWriterImplTest {
         assertNoInternalErrors()
     }
 
+    @Test
+    fun `the session span retains its data until the part's writes have completed`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+        assertTrue(sessionSpan.dataRetainedAfterStop)
+        assertFalse(sessionSpan.retainedDataReleased)
+
+        endPart()
+        writer.onSessionPartEnded(SESSION_PART_ID)
+        assertFalse(sessionSpan.retainedDataReleased)
+
+        drain()
+        assertTrue(sessionSpan.retainedDataReleased)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `the session span is not asked to retain its data when multi file persistence is disabled`() {
+        val writer = createWriter(enabled = false)
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+
+        assertFalse(sessionSpan.dataRetainedAfterStop)
+        assertNoInternalErrors()
+    }
+
     private fun completedSpan(name: String) = Span(
         traceId = "6c9b1f2ec1d34f3c9a7d0b8e5f2a4c11",
         spanId = "aaaaaaaaaaaaaaa2",

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
@@ -59,6 +59,12 @@ class FakeEmbraceSdkSpan(
     val events: ConcurrentLinkedQueue<EmbraceSpanEvent> = ConcurrentLinkedQueue()
     val links: ConcurrentLinkedQueue<EmbraceLinkData> = ConcurrentLinkedQueue()
 
+    var dataRetainedAfterStop: Boolean = false
+        private set
+
+    var retainedDataReleased: Boolean = false
+        private set
+
     override val parent: EmbraceSpan?
         get() = parentContext.getEmbraceSpan(openTelemetry)
 
@@ -186,6 +192,16 @@ class FakeEmbraceSdkSpan(
                 links = links.toList().map { it.toEmbracePayload() }
             )
         }
+    }
+
+    override fun retainDataAfterStop() {
+        dataRetainedAfterStop = true
+    }
+
+    override fun releaseRetainedData() {
+        retainedDataReleased = true
+        events.clear()
+        links.clear()
     }
 
     override fun hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean =

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSdkSpan.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSdkSpan.kt
@@ -50,6 +50,18 @@ interface EmbraceSdkSpan : EmbraceSpan {
     fun snapshot(): Span?
 
     /**
+     * Keeps the events and links this span records once it stops, rather than releasing them after
+     * export. [releaseRetainedData] must be called when owners are finished with the collections.
+     */
+    fun retainDataAfterStop()
+
+    /**
+     * Drops references to internal data this span recorded that are already copied onto the
+     * underlying opentelemetry span.
+     */
+    fun releaseRetainedData()
+
+    /**
      * Checks to see if the given span has a particular [EmbraceAttribute]
      */
     fun hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImpl.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanFactoryImpl.kt
@@ -161,6 +161,9 @@ private class EmbraceSpanImpl(
 
     private var customLinks: MutableList<EmbraceLinkData>? = null
 
+    @Volatile
+    private var retainDataAfterStop = false
+
     private val systemAttributes = ConcurrentHashMap<String, String>(otelSpanStartArgs.embraceAttributes.size).apply {
         otelSpanStartArgs.embraceAttributes.forEach { put(it.key, it.value) }
     }
@@ -267,7 +270,9 @@ private class EmbraceSpanImpl(
                 successful = !isRecording
                 if (successful) {
                     spanEndTimeMs = attemptedEndTimeMs
-                    releaseRetainedData()
+                    if (!retainDataAfterStop) {
+                        releaseRetainedData()
+                    }
                 }
             }
         }
@@ -278,12 +283,16 @@ private class EmbraceSpanImpl(
         return successful
     }
 
+    override fun retainDataAfterStop() {
+        retainDataAfterStop = true
+    }
+
     /**
      * Once a span has stopped it has been exported to an independent [Span] payload, so its own
      * event/link collections are redundant. Drop the references to allow GC on the collections during
      * the remainder of the session part.
      */
-    private fun releaseRetainedData() {
+    override fun releaseRetainedData() {
         synchronized(collectionLock) {
             systemEvents = null
             customEvents = null

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/NoopEmbraceSdkSpan.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/spans/NoopEmbraceSdkSpan.kt
@@ -56,6 +56,10 @@ object NoopEmbraceSdkSpan : EmbraceSdkSpan {
 
     override fun snapshot(): Span? = null
 
+    override fun retainDataAfterStop() = Unit
+
+    override fun releaseRetainedData() = Unit
+
     override fun hasEmbraceAttribute(embraceAttribute: EmbraceAttribute): Boolean = false
 
     override fun getSystemAttribute(key: String): String? = null

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanImplTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/EmbraceSpanImplTest.kt
@@ -382,6 +382,25 @@ internal class EmbraceSpanImplTest {
     }
 
     @Test
+    fun `retained event and link data survives a stop once retention is requested`() {
+        with(embraceSpan) {
+            assertTrue(start())
+            retainDataAfterStop()
+            assertTrue(addEvent("an-event"))
+            assertTrue(addLink(FakeEmbraceSdkSpan.stopped()))
+        }
+        assertTrue(embraceSpan.stop())
+
+        val snapshot = checkNotNull(embraceSpan.snapshot())
+        assertEquals(1, snapshot.events?.size)
+        assertEquals(1, snapshot.links?.size)
+
+        embraceSpan.releaseRetainedData()
+        assertEquals(0, embraceSpan.events().size)
+        assertEquals(0, embraceSpan.links().size)
+    }
+
+    @Test
     fun `cannot stop twice irrespective of error code`() {
         with(embraceSpan) {
             assertTrue(start())

--- a/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanChangeNotificationTest.kt
+++ b/embrace-android-otel/src/test/kotlin/io/embrace/android/embracesdk/internal/otel/spans/SpanChangeNotificationTest.kt
@@ -76,6 +76,8 @@ internal class SpanChangeNotificationTest {
         "name",
         "events",
         "links",
+        "retainDataAfterStop",
+        "releaseRetainedData",
     )
 
     @Before

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/persistence/MultiFilePersistenceParityTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/persistence/MultiFilePersistenceParityTest.kt
@@ -104,7 +104,7 @@ internal class MultiFilePersistenceParityTest {
         )
     }
 
-    @Ignore("Fails on the session span's events, links, emb.process_identifier and attribute order")
+    @Ignore("The session span's attributes are persisted in an arbitrary order")
     @Test
     fun `multi-file session part span matches the golden file`() {
         testRule.runTest(
@@ -171,7 +171,6 @@ internal class MultiFilePersistenceParityTest {
         )
     }
 
-    @Ignore("The session span's events are not persisted")
     @Test
     fun `breadcrumbs recorded during the session are persisted identically`() {
         testRule.runTest(
@@ -384,7 +383,6 @@ internal class MultiFilePersistenceParityTest {
         )
     }
 
-    @Ignore("The session span's links are not persisted")
     @Test
     fun `the session span links are persisted identically`() {
         testRule.runTest(
@@ -558,14 +556,16 @@ internal class MultiFilePersistenceParityTest {
         return (sessionsDir.list() ?: emptyArray()).mapNotNull(SessionPartDirectory::fromDirName)
     }
 
-    private fun Span.normalised(): Span {
-        val span = copy(
-            events = events?.map { it.normalised() },
-            attributes = attributes?.sorted(),
-            links = links?.map { it.normalised() },
-        )
-        return if (span.name == SESSION_SPAN_NAME) span.copy(links = null) else span
-    }
+    /**
+     * Sorts the attributes of a span, its events and its links: the two payloads are built from
+     * separate reads of the same telemetry, so an attribute map that is unordered by nature can be
+     * iterated in a different order for each of them.
+     */
+    private fun Span.normalised(): Span = copy(
+        events = events?.map { it.normalised() },
+        attributes = attributes?.sorted(),
+        links = links?.map { it.normalised() },
+    )
 
     private fun SpanEvent.normalised(): SpanEvent = copy(attributes = attributes?.sorted())
 


### PR DESCRIPTION
## Goal

Resolves a couple of test failures in the persistence implementation by retaining data in the span object until all writes have completed. This is only enabled when this feature is, and in practice the objects should not be held for long.