### PR TITLE
Resolve build failure caused by ApplicationStartInfo use

### DIFF
--- a/embrace-android-instrumentation-startup-trace/build.gradle.kts
+++ b/embrace-android-instrumentation-startup-trace/build.gradle.kts
@@ -6,6 +6,7 @@ description = "Embrace Android SDK: Startup Trace Instrumentation"
 
 android {
     namespace = "io.embrace.android.embracesdk.instrumentation.startup"
+    defaultConfig.consumerProguardFiles("embrace-proguard.cfg")
 }
 
 dependencies {

--- a/embrace-android-instrumentation-startup-trace/embrace-proguard.cfg
+++ b/embrace-android-instrumentation-startup-trace/embrace-proguard.cfg
@@ -1,0 +1,1 @@
+-dontwarn android.app.ApplicationStartInfo


### PR DESCRIPTION
## Goal
Resolve the integration tests failing when attempting to resolve `ApplicationStartInfo` by adding a `nowarn` option to the `startup-trace`.

## Testing
Relied on the integration tests passing