### PR TITLE
Loosen persistence test assertion

### DIFF
--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/persistence/MultiFilePersistenceParityTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/persistence/MultiFilePersistenceParityTest.kt
@@ -104,7 +104,6 @@ internal class MultiFilePersistenceParityTest {
         )
     }
 
-    @Ignore("The session span's attributes are persisted in an arbitrary order")
     @Test
     fun `multi-file session part span matches the golden file`() {
         testRule.runTest(
@@ -471,8 +470,9 @@ internal class MultiFilePersistenceParityTest {
     private fun EmbracePayloadAssertionInterface.assertMatchesGoldenFile(
         envelope: Envelope<SessionPartPayload>,
     ) {
+        val sessionSpan = envelope.findSessionPartSpan()
         validatePayloadAgainstGoldenFile(
-            payload = envelope.findSessionPartSpan(),
+            payload = sessionSpan.copy(attributes = sessionSpan.attributes?.sorted()),
             goldenFileName = GOLDEN_FILE,
             placeholders = mapOf(
                 Placeholder.USER_SESSION_ID to envelope.getUserSessionId(),


### PR DESCRIPTION
## Goal

Loosens an assertion in the persistence test that assumed attributes in the session span should be persisted in the same order for both persistence mechanisms.
