### PR TITLE
Add config to enable URL fragment redaction in the WebViews

### DIFF
--- a/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeBreadcrumbBehavior.kt
+++ b/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/behavior/FakeBreadcrumbBehavior.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.fakes.behavior
 
 import io.embrace.android.embracesdk.internal.config.behavior.BreadcrumbBehavior
+import io.embrace.android.embracesdk.internal.config.instrumented.schema.WebViewFragmentCapture
 
 class FakeBreadcrumbBehavior(
     var customBreadcrumbLimitImpl: Int = 100,
@@ -11,6 +12,7 @@ class FakeBreadcrumbBehavior(
     var automaticActivityCaptureEnabled: Boolean = true,
     var webViewBreadcrumbCaptureEnabled: Boolean = true,
     var queryParamCaptureEnabled: Boolean = true,
+    var fragmentCapture: WebViewFragmentCapture = WebViewFragmentCapture.KEEP,
     var captureFcmPiiDataEnabled: Boolean = false,
 ) : BreadcrumbBehavior {
 
@@ -22,5 +24,6 @@ class FakeBreadcrumbBehavior(
     override fun isActivityBreadcrumbCaptureEnabled(): Boolean = automaticActivityCaptureEnabled
     override fun isWebViewBreadcrumbCaptureEnabled(): Boolean = webViewBreadcrumbCaptureEnabled
     override fun isWebViewBreadcrumbQueryParamCaptureEnabled(): Boolean = queryParamCaptureEnabled
+    override fun getWebViewBreadcrumbFragmentCapture(): WebViewFragmentCapture = fragmentCapture
     override fun isFcmPiiDataCaptureEnabled(): Boolean = captureFcmPiiDataEnabled
 }

--- a/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeEnabledFeatureConfig.kt
+++ b/embrace-android-config-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/config/FakeEnabledFeatureConfig.kt
@@ -2,6 +2,7 @@ package io.embrace.android.embracesdk.fakes.config
 
 import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfigImpl
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.EnabledFeatureConfig
+import io.embrace.android.embracesdk.internal.config.instrumented.schema.WebViewFragmentCapture
 
 class FakeEnabledFeatureConfig(
     base: EnabledFeatureConfig = InstrumentedConfigImpl.enabledFeatures,
@@ -19,6 +20,7 @@ class FakeEnabledFeatureConfig(
     private val bgActivityCapture: Boolean = base.isBackgroundActivityCaptureEnabled(),
     private val webviewBreadcrumbCapture: Boolean = base.isWebViewBreadcrumbCaptureEnabled(),
     private val webviewQueryCapture: Boolean = base.isWebViewBreadcrumbQueryParamCaptureEnabled(),
+    private val webviewFragmentCapture: WebViewFragmentCapture = base.getWebViewBreadcrumbFragmentCapture(),
     private val fcmPiiCapture: Boolean = base.isFcmPiiDataCaptureEnabled(),
     private val requestContentLengthCapture: Boolean = base.isRequestContentLengthCaptureEnabled(),
     private val okHttpResponseBodySizeCapture: Boolean = base.isOkHttpResponseBodySizeCaptureEnabled(),
@@ -51,6 +53,7 @@ class FakeEnabledFeatureConfig(
     override fun isBackgroundActivityCaptureEnabled(): Boolean = bgActivityCapture
     override fun isWebViewBreadcrumbCaptureEnabled(): Boolean = webviewBreadcrumbCapture
     override fun isWebViewBreadcrumbQueryParamCaptureEnabled(): Boolean = webviewQueryCapture
+    override fun getWebViewBreadcrumbFragmentCapture(): WebViewFragmentCapture = webviewFragmentCapture
     override fun isFcmPiiDataCaptureEnabled(): Boolean = fcmPiiCapture
     override fun isRequestContentLengthCaptureEnabled(): Boolean = requestContentLengthCapture
     override fun isOkHttpResponseBodySizeCaptureEnabled(): Boolean = okHttpResponseBodySizeCapture

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BreadcrumbBehavior.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BreadcrumbBehavior.kt
@@ -1,5 +1,7 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
+import io.embrace.android.embracesdk.internal.config.instrumented.schema.WebViewFragmentCapture
+
 interface BreadcrumbBehavior {
 
     fun getCustomBreadcrumbLimit(): Int
@@ -26,6 +28,13 @@ interface BreadcrumbBehavior {
      * Control whether query params for webviews are captured.
      */
     fun isWebViewBreadcrumbQueryParamCaptureEnabled(): Boolean
+
+    /**
+     * Controls how the URL fragment for webviews is captured. A fragment carries OAuth
+     * implicit-grant 'access_token' and OpenID Connect 'id_token' values by specification, and it
+     * also carries the hash route the user was on, so both keeping and dropping it lose something.
+     */
+    fun getWebViewBreadcrumbFragmentCapture(): WebViewFragmentCapture
 
     fun isFcmPiiDataCaptureEnabled(): Boolean
 

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BreadcrumbBehaviorImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BreadcrumbBehaviorImpl.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.config.behavior
 import io.embrace.android.embracesdk.internal.config.behavior.BreadcrumbBehavior.Companion.DEFAULT_BREADCRUMB_LIMIT
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.EnabledFeatureConfig
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.InstrumentedConfig
+import io.embrace.android.embracesdk.internal.config.instrumented.schema.WebViewFragmentCapture
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 
 /**
@@ -37,6 +38,9 @@ class BreadcrumbBehaviorImpl(
 
     override fun isWebViewBreadcrumbQueryParamCaptureEnabled(): Boolean =
         local.isWebViewBreadcrumbQueryParamCaptureEnabled()
+
+    override fun getWebViewBreadcrumbFragmentCapture(): WebViewFragmentCapture =
+        local.getWebViewBreadcrumbFragmentCapture()
 
     override fun isFcmPiiDataCaptureEnabled(): Boolean = local.isFcmPiiDataCaptureEnabled()
 }

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BreadcrumbBehaviorImplTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/behavior/BreadcrumbBehaviorImplTest.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.config.behavior
 
 import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfigImpl
+import io.embrace.android.embracesdk.internal.config.instrumented.schema.WebViewFragmentCapture
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.config.remote.UiRemoteConfig
 import org.junit.Assert.assertEquals
@@ -35,6 +36,7 @@ internal class BreadcrumbBehaviorImplTest {
             assertTrue(isActivityBreadcrumbCaptureEnabled())
             assertTrue(isWebViewBreadcrumbCaptureEnabled())
             assertTrue(isWebViewBreadcrumbQueryParamCaptureEnabled())
+            assertEquals(WebViewFragmentCapture.KEEP, getWebViewBreadcrumbFragmentCapture())
             assertFalse(isFcmPiiDataCaptureEnabled())
         }
     }

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/EnabledFeatureConfig.kt
@@ -104,6 +104,13 @@ interface EnabledFeatureConfig {
     fun isWebViewBreadcrumbQueryParamCaptureEnabled(): Boolean = true
 
     /**
+     * How the URL fragment is captured in WebView breadcrumbs.
+     *
+     * sdk_config.webview.fragment_capture
+     */
+    fun getWebViewBreadcrumbFragmentCapture(): WebViewFragmentCapture = WebViewFragmentCapture.KEEP
+
+    /**
      * Gates whether the FCM feature should capture PII data
      *
      * sdk_config.capture_fcm_pii_data

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/WebViewFragmentCapture.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/WebViewFragmentCapture.kt
@@ -1,0 +1,18 @@
+package io.embrace.android.embracesdk.internal.config.instrumented.schema
+
+/**
+ * How the fragment of a webview URL (the part after the '#') should be treated when it is captured.
+ *
+ * The Gradle plugin selects a constant by name, so renaming one is a breaking change.
+ */
+enum class WebViewFragmentCapture {
+
+    /** Capture the fragment unaltered. */
+    KEEP,
+
+    /** Drop the values from any key/value pairs and any long unstructured segment. */
+    REDACT,
+
+    /** Do not capture the fragment at all. */
+    REMOVE,
+}

--- a/embrace-android-payload/src/test/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/WebViewFragmentCaptureTest.kt
+++ b/embrace-android-payload/src/test/kotlin/io/embrace/android/embracesdk/internal/config/instrumented/schema/WebViewFragmentCaptureTest.kt
@@ -1,0 +1,26 @@
+package io.embrace.android.embracesdk.internal.config.instrumented.schema
+
+import io.embrace.android.embracesdk.internal.config.instrumented.InstrumentedConfigImpl
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class WebViewFragmentCaptureTest {
+
+    @Test
+    fun `the default is keep`() {
+        assertEquals(
+            WebViewFragmentCapture.KEEP,
+            InstrumentedConfigImpl.enabledFeatures.getWebViewBreadcrumbFragmentCapture(),
+        )
+    }
+
+    @Test
+    fun `constant names are stable`() {
+        // the Gradle plugin selects a constant by name, so renaming one silently breaks
+        // instrumentation for anyone who has set the config value
+        assertEquals(
+            listOf("KEEP", "REDACT", "REMOVE"),
+            WebViewFragmentCapture.entries.map { it.name },
+        )
+    }
+}


### PR DESCRIPTION
## Goal
Introduce config (for `embrace-config.json`) to control the capturing / redaction of URL fragments captured by the `WebView` instrumentation.

## Testing
Added unit test to check the expected default value, and naming (which will become a contract with the Gradle plugin in a later PR).