### PR TITLE
Implement URL fragment redaction for WebViews

### DIFF
--- a/embrace-android-instrumentation-webview/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/webview/UrlFragmentRedactor.kt
+++ b/embrace-android-instrumentation-webview/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/webview/UrlFragmentRedactor.kt
@@ -1,0 +1,88 @@
+package io.embrace.android.embracesdk.internal.instrumentation.webview
+
+/**
+ * Drops the values from any `key=value` pairs in a URL fragment, and drops any long unstructured
+ * segment, while leaving hash routes and short anchors intact.
+ *
+ * Must produce byte-identical output to the iOS implementation, so treat a change here as a change
+ * to both platforms. Operates on the raw percent-encoded string so that an encoded `%26` is not
+ * mistaken for a separator, and emits each separator as it was found so that `;` is not rewritten
+ * to `&`. Lengths are measured in UTF-16 code units.
+ */
+internal object UrlFragmentRedactor {
+
+    private const val MAX_KEY_LENGTH = 64
+    private const val OPAQUE_SEGMENT_THRESHOLD = 64
+    private const val MAX_RECURSION_DEPTH = 4
+    private const val PAIR_SEPARATORS = "&;"
+
+    // a denylist rather than an allowlist, as real parameter names include `mids[]` and `filter:name`
+    private val DISALLOWED_KEY_CHARS = charArrayOf('/', '?', '#', '&', '=')
+    private const val SPACE_CODE = 0x20
+    private val WHITESPACE_CONTROL_CODES = 0x09..0x0D
+
+    /**
+     * Redacts [fragment], which is the part of a URL after the '#' with the '#' itself removed.
+     */
+    fun redact(fragment: String): String = redactPairs(fragment, depth = 0)
+
+    private fun redactPairs(text: String, depth: Int): String {
+        val result = StringBuilder(text.length)
+        var segmentStart = 0
+
+        text.forEachIndexed { index, char ->
+            if (PAIR_SEPARATORS.contains(char)) {
+                result.append(redactSegment(text.substring(segmentStart, index), depth))
+                result.append(char)
+                segmentStart = index + 1
+            }
+        }
+        result.append(redactSegment(text.substring(segmentStart), depth))
+        return result.toString()
+    }
+
+    /**
+     * Applies the segment rules in order, first match wins.
+     */
+    private fun redactSegment(segment: String, depth: Int): String {
+        // a key/value pair: keep the name and the '=', drop the value
+        val equalsOffset = segment.indexOf('=')
+        if (equalsOffset > 0 && isPlausibleKey(segment, equalsOffset)) {
+            return segment.substring(0, equalsOffset + 1)
+        }
+
+        // a route: keep the path and recurse past an embedded '?'. Exceeding the recursion bound
+        // falls through to the length rule below.
+        val firstChar = segment.firstOrNull()
+        if ((firstChar == '/' || firstChar == '!') && depth < MAX_RECURSION_DEPTH) {
+            val queryOffset = segment.indexOf('?')
+            if (queryOffset < 0) {
+                return segment
+            }
+            val route = segment.substring(0, queryOffset + 1)
+            return route + redactPairs(segment.substring(queryOffset + 1), depth + 1)
+        }
+
+        // no recognisable structure, so judge on length alone
+        return when {
+            segment.length <= OPAQUE_SEGMENT_THRESHOLD -> segment
+            else -> ""
+        }
+    }
+
+    private fun isPlausibleKey(segment: String, equalsOffset: Int): Boolean {
+        if (equalsOffset > MAX_KEY_LENGTH) {
+            return false
+        }
+        for (i in 0 until equalsOffset) {
+            if (isDisallowedInKey(segment[i])) {
+                return false
+            }
+        }
+        return true
+    }
+
+    private fun isDisallowedInKey(char: Char): Boolean = char in DISALLOWED_KEY_CHARS ||
+        char.code == SPACE_CODE ||
+        char.code in WHITESPACE_CONTROL_CODES
+}

--- a/embrace-android-instrumentation-webview/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/webview/WebViewUrlDataSource.kt
+++ b/embrace-android-instrumentation-webview/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/webview/WebViewUrlDataSource.kt
@@ -5,9 +5,10 @@ import io.embrace.android.embracesdk.internal.arch.datasource.DataSourceImpl
 import io.embrace.android.embracesdk.internal.arch.limits.UpToLimitStrategy
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.config.behavior.BreadcrumbBehavior
+import io.embrace.android.embracesdk.internal.config.instrumented.schema.WebViewFragmentCapture
 
 /**
- * Captures custom breadcrumbs.
+ * Captures the URLs of pages loaded in a webview.
  */
 class WebViewUrlDataSource(
     args: InstrumentationArgs,
@@ -19,21 +20,34 @@ class WebViewUrlDataSource(
 
     private val breadcrumbBehavior: BreadcrumbBehavior = args.configService.breadcrumbBehavior
 
-    private companion object {
-        private const val QUERY_PARAMETER_DELIMITER = "?"
-    }
-
     fun logWebView(url: String?) {
         captureTelemetry(inputValidation = { url != null }) {
-            // Check if web view query params should be captured.
-            var parsedUrl: String = url ?: ""
-            if (!breadcrumbBehavior.isWebViewBreadcrumbQueryParamCaptureEnabled()) {
-                val queryOffset = url?.indexOf(QUERY_PARAMETER_DELIMITER) ?: 0
-                if (queryOffset > 0) {
-                    parsedUrl = url?.substring(0, queryOffset) ?: ""
-                }
-            }
-            addSessionPartEvent(SchemaType.WebViewUrl(parsedUrl), clock.now())
+            addSessionPartEvent(SchemaType.WebViewUrl(sanitizeUrl(url ?: "")), clock.now())
+        }
+    }
+
+    /**
+     * Applies the query and fragment settings to a captured URL. The URL is split once at the first
+     * '#' so that each setting applies to its own component and neither depends on the other.
+     */
+    private fun sanitizeUrl(url: String): String {
+        val fragmentOffset = url.indexOf('#')
+        val hasFragment = fragmentOffset >= 0
+        val base = if (hasFragment) url.substring(0, fragmentOffset) else url
+        val fragment = if (hasFragment) url.substring(fragmentOffset + 1) else ""
+
+        val capturedBase = when {
+            breadcrumbBehavior.isWebViewBreadcrumbQueryParamCaptureEnabled() -> base
+            else -> base.substringBefore('?')
+        }
+
+        if (!hasFragment) {
+            return capturedBase
+        }
+        return when (breadcrumbBehavior.getWebViewBreadcrumbFragmentCapture()) {
+            WebViewFragmentCapture.KEEP -> "$capturedBase#$fragment"
+            WebViewFragmentCapture.REDACT -> capturedBase + "#" + UrlFragmentRedactor.redact(fragment)
+            WebViewFragmentCapture.REMOVE -> capturedBase
         }
     }
 }

--- a/embrace-android-instrumentation-webview/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/webview/UrlFragmentRedactorTest.kt
+++ b/embrace-android-instrumentation-webview/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/webview/UrlFragmentRedactorTest.kt
@@ -1,0 +1,203 @@
+package io.embrace.android.embracesdk.internal.instrumentation.webview
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The vectors here are shared with the iOS SDK and both platforms must produce identical output for
+ * each one, so a change to this list is a change to both repos.
+ */
+internal class UrlFragmentRedactorTest {
+
+    private fun assertRedacted(expected: String, input: String) {
+        assertEquals("redacting '$input'", expected, UrlFragmentRedactor.redact(input))
+    }
+
+    // rule 1 - key=value: keep the key and the '=', drop the value
+
+    @Test
+    fun `key value pairs lose their values`() {
+        assertRedacted("access_token=", "access_token=eyJ0eXAiOiJKV1Qi")
+        assertRedacted(
+            "access_token=&token_type=&expires_in=",
+            "access_token=eyJ0eXAiOiJKV1Qi&token_type=Bearer&expires_in=3600",
+        )
+        assertRedacted("id_token=&state=", "id_token=eyJ0eXAiOiJKV1Qi&state=abc")
+    }
+
+    @Test
+    fun `punctuation in a key name is allowed`() {
+        assertRedacted("mids[]=&layout=", "mids[]=6&layout=webview")
+        assertRedacted("filter:name=", "filter:name=bob")
+    }
+
+    @Test
+    fun `a segment with no value is kept alongside pairs`() {
+        assertRedacted("flag&other=", "flag&other=1")
+    }
+
+    @Test
+    fun `an empty key does not qualify as a pair`() {
+        assertRedacted("=value", "=value")
+    }
+
+    @Test
+    fun `a key over the length limit does not qualify as a pair`() {
+        val key = "a".repeat(65)
+        assertRedacted("", "$key=x")
+    }
+
+    @Test
+    fun `a key at the length limit still qualifies as a pair`() {
+        val key = "a".repeat(64)
+        assertRedacted("$key=", "$key=x")
+    }
+
+    // rule 2 - routes: keep the path, recurse past an embedded '?'
+
+    @Test
+    fun `routes are kept whole`() {
+        assertRedacted("/orders/123", "/orders/123")
+        assertRedacted("!/checkout/step-2", "!/checkout/step-2")
+        assertRedacted("/2/", "/2/")
+    }
+
+    @Test
+    fun `a route recurses past an embedded question mark`() {
+        assertRedacted("/search?q=", "/search?q=shoes")
+    }
+
+    @Test
+    fun `a leading slash beats the length test`() {
+        val route = "/a/very/long/route/" + "segment/".repeat(10)
+        assertRedacted(route, route)
+    }
+
+    @Test
+    fun `a route followed by pairs redacts only the pairs`() {
+        assertRedacted(
+            "/survey-form/abc&state=&session_state=&iss=",
+            "/survey-form/abc&state=6f1a&session_state=90b2&iss=x",
+        )
+    }
+
+    // rule 3 - short and unstructured: keep verbatim
+
+    @Test
+    fun `short unstructured segments are kept verbatim`() {
+        assertRedacted("terms-and-conditions", "terms-and-conditions")
+        assertRedacted("accordion-a5c7d862a4-item-7712f03666", "accordion-a5c7d862a4-item-7712f03666")
+    }
+
+    @Test
+    fun `a bare identifier survives`() {
+        // an accepted gap: no threshold separates a keyless identifier from a legitimate anchor
+        assertRedacted("550c8890cc23ed42", "550c8890cc23ed42")
+    }
+
+    @Test
+    fun `a segment at the opaque threshold is kept`() {
+        val segment = "a".repeat(64)
+        assertRedacted(segment, segment)
+    }
+
+    // rule 4 - long and unstructured: drop
+
+    @Test
+    fun `long unstructured segments are dropped`() {
+        assertRedacted("", "eyJhbGciOiJIUzI1NiJ9." + "a".repeat(70))
+    }
+
+    @Test
+    fun `a segment one over the opaque threshold is dropped`() {
+        assertRedacted("", "a".repeat(65))
+    }
+
+    // trap 1 - base64 '=' padding is not a key separator
+
+    @Test
+    fun `base64 padding is not treated as a key separator`() {
+        val padded = "eyJsYXlvdXQiOns" + "A".repeat(1605) + "fX0="
+        assertEquals(1624, padded.length)
+        assertRedacted("", padded)
+    }
+
+    @Test
+    fun `an unpadded base64 blob matches the padded case`() {
+        // a length that emits no padding must be handled identically to one that does
+        assertRedacted("", "eyJsYXlvdXQiOns" + "A".repeat(1608))
+    }
+
+    // trap 2 - parse the encoded form; an encoded separator is not a separator
+
+    @Test
+    fun `an encoded separator is not a separator`() {
+        assertRedacted("a=", "a=x%26evil=y")
+    }
+
+    @Test
+    fun `multiple encoding layers are left encoded`() {
+        assertRedacted("eid=&format=", "eid=1%25252C2&format=320x50_as")
+    }
+
+    // separators
+
+    @Test
+    fun `a semicolon separator is preserved rather than normalised`() {
+        assertRedacted("a=;b=", "a=1;b=2")
+    }
+
+    @Test
+    fun `mixed separators are each preserved in place`() {
+        assertRedacted("a=;b=&c=", "a=1;b=2&c=3")
+    }
+
+    @Test
+    fun `a bare separator is preserved`() {
+        assertRedacted(";", ";")
+        assertRedacted("&", "&")
+    }
+
+    @Test
+    fun `a matrix parameter in a route splits on the semicolon`() {
+        assertRedacted("/orders;id=", "/orders;id=123/detail")
+    }
+
+    @Test
+    fun `empty segments and their separators are preserved`() {
+        assertRedacted("a=&&b=", "a=1&&b=2")
+    }
+
+    @Test
+    fun `an empty fragment redacts to an empty fragment`() {
+        assertRedacted("", "")
+    }
+
+    // '?' past the '#' is an ordinary character, not a query
+
+    @Test
+    fun `a question mark after a valid key drops the rest of the segment`() {
+        assertRedacted("a=", "a=1?b=2")
+        assertRedacted("user_id=&utm_medium=", "user_id=6f1a?utm_source=foo&utm_medium=push")
+    }
+
+    @Test
+    fun `a question mark before any equals disqualifies the key`() {
+        // 'frag?x' is not a plausible key and this is not a route, so the length rule keeps it
+        // verbatim, value included
+        assertRedacted("frag?x=1", "frag?x=1")
+    }
+
+    // recursion bound
+
+    @Test
+    fun `deep nesting terminates`() {
+        // four route hops are followed, then the remainder busts the length rule and is dropped
+        assertRedacted("/?/?/?/?", "/?".repeat(50_000))
+    }
+
+    @Test
+    fun `a short segment past the recursion bound falls through to the length rule`() {
+        assertRedacted("/a?/b?/c?/d?/e?f", "/a?/b?/c?/d?/e?f")
+    }
+}

--- a/embrace-android-instrumentation-webview/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/webview/WebViewUrlDataSourceTest.kt
+++ b/embrace-android-instrumentation-webview/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/webview/WebViewUrlDataSourceTest.kt
@@ -2,13 +2,14 @@ package io.embrace.android.embracesdk.internal.instrumentation.webview
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.embrace.android.embracesdk.fakes.FakeClock
 import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeInstrumentationArgs
 import io.embrace.android.embracesdk.fakes.behavior.FakeBreadcrumbBehavior
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
+import io.embrace.android.embracesdk.internal.config.instrumented.schema.WebViewFragmentCapture
 import io.opentelemetry.kotlin.semconv.UrlAttributes
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -16,7 +17,6 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 internal class WebViewUrlDataSourceTest {
 
-    private lateinit var source: WebViewUrlDataSource
     private lateinit var args: FakeInstrumentationArgs
 
     @Before
@@ -24,67 +24,189 @@ internal class WebViewUrlDataSourceTest {
         args = FakeInstrumentationArgs(ApplicationProvider.getApplicationContext())
     }
 
-    @Test
-    fun `add breadcrumb`() {
-        source = WebViewUrlDataSource(args)
-        source.logWebView("http://www.google.com?query=123")
+    private fun createSource(
+        queryParamCaptureEnabled: Boolean = false,
+        fragmentCapture: WebViewFragmentCapture = WebViewFragmentCapture.KEEP,
+    ): WebViewUrlDataSource {
+        args = FakeInstrumentationArgs(
+            ApplicationProvider.getApplicationContext(),
+            configService = FakeConfigService(
+                breadcrumbBehavior = FakeBreadcrumbBehavior(
+                    queryParamCaptureEnabled = queryParamCaptureEnabled,
+                    fragmentCapture = fragmentCapture,
+                    webViewBreadcrumbCaptureEnabled = true,
+                ),
+            ),
+        )
+        return WebViewUrlDataSource(args)
+    }
+
+    private fun assertCaptured(
+        expected: String,
+        url: String?,
+        queryParamCaptureEnabled: Boolean = false,
+        fragmentCapture: WebViewFragmentCapture = WebViewFragmentCapture.KEEP,
+    ) {
+        val source = createSource(queryParamCaptureEnabled, fragmentCapture)
+        source.logWebView(url)
         with(args.destination.addedEvents.single()) {
             assertEquals(EmbType.Ux.WebView, schemaType.telemetryType)
             assertEquals(args.clock.now(), startTimeMs)
-            assertEquals(
-                mapOf(
-                    UrlAttributes.URL_FULL to "http://www.google.com?query=123",
-                ),
-                schemaType.attributes(),
-            )
+            assertEquals(mapOf(UrlAttributes.URL_FULL to expected), schemaType.attributes())
         }
+    }
+
+    @Test
+    fun `add breadcrumb`() {
+        assertCaptured(
+            expected = "http://www.google.com?query=123",
+            url = "http://www.google.com?query=123",
+            queryParamCaptureEnabled = true,
+        )
     }
 
     @Test
     fun `query param capture disabled`() {
-        args = FakeInstrumentationArgs(
-            ApplicationProvider.getApplicationContext(),
-            configService = FakeConfigService(
-                breadcrumbBehavior = FakeBreadcrumbBehavior(
-                    queryParamCaptureEnabled = false,
-                    webViewBreadcrumbCaptureEnabled = true,
-                ),
-            ),
+        assertCaptured(
+            expected = "http://www.google.com",
+            url = "http://www.google.com?query=123",
         )
-
-        val clock = FakeClock()
-        source = WebViewUrlDataSource(args)
-        source.logWebView("http://www.google.com?query=123")
-        with(args.destination.addedEvents.single()) {
-            assertEquals(EmbType.Ux.WebView, schemaType.telemetryType)
-            assertEquals(clock.now(), startTimeMs)
-            assertEquals(
-                mapOf(
-                    UrlAttributes.URL_FULL to "http://www.google.com",
-                ),
-                schemaType.attributes(),
-            )
-        }
     }
 
     @Test
     fun `limit not exceeded`() {
-        args = FakeInstrumentationArgs(
-            ApplicationProvider.getApplicationContext(),
-            configService = FakeConfigService(
-                breadcrumbBehavior = FakeBreadcrumbBehavior(
-                    queryParamCaptureEnabled = false,
-                    webViewBreadcrumbCaptureEnabled = true,
-                ),
-            ),
-        )
-
-        source = WebViewUrlDataSource(args)
+        val source = createSource()
         repeat(150) { k ->
-            source.logWebView(
-                "http://www.google.com?query=$k",
-            )
+            source.logWebView("http://www.google.com?query=$k")
         }
         assertEquals(100, args.destination.addedEvents.size)
+    }
+
+    @Test
+    fun `null url captures nothing`() {
+        val source = createSource()
+        source.logWebView(null)
+        assertTrue(args.destination.addedEvents.isEmpty())
+    }
+
+    // the fragment setting, with the query stripped
+
+    @Test
+    fun `fragment retained by default`() {
+        assertCaptured(
+            expected = "http://g.com#tok=x",
+            url = "http://g.com?q=1#tok=x",
+            fragmentCapture = WebViewFragmentCapture.KEEP,
+        )
+    }
+
+    @Test
+    fun `fragment redacted`() {
+        assertCaptured(
+            expected = "http://g.com#tok=",
+            url = "http://g.com?q=1#tok=x",
+            fragmentCapture = WebViewFragmentCapture.REDACT,
+        )
+    }
+
+    @Test
+    fun `fragment removed`() {
+        assertCaptured(
+            expected = "http://g.com",
+            url = "http://g.com?q=1#tok=x",
+            fragmentCapture = WebViewFragmentCapture.REMOVE,
+        )
+    }
+
+    @Test
+    fun `hash route survives query strip`() {
+        assertCaptured(
+            expected = "http://g.com#/orders/123",
+            url = "http://g.com?q=1#/orders/123",
+            fragmentCapture = WebViewFragmentCapture.REDACT,
+        )
+    }
+
+    @Test
+    fun `oauth implicit redirect`() {
+        assertCaptured(
+            expected = "https://permissions.customer.eu/#access_token=",
+            url = "https://permissions.customer.eu/#access_token=eyJ0eXAiOiJKV1Qi",
+            fragmentCapture = WebViewFragmentCapture.REDACT,
+        )
+    }
+
+    @Test
+    fun `question mark inside fragment is not a query`() {
+        // the '?' falls after the '#', so the query strip must not reach it
+        assertCaptured(
+            expected = "http://g.com#frag?x=1",
+            url = "http://g.com#frag?x=1",
+            fragmentCapture = WebViewFragmentCapture.KEEP,
+        )
+    }
+
+    @Test
+    fun `no query or fragment unchanged`() {
+        assertCaptured(
+            expected = "http://g.com",
+            url = "http://g.com",
+            fragmentCapture = WebViewFragmentCapture.REDACT,
+        )
+    }
+
+    @Test
+    fun `empty fragment survives as a trailing hash`() {
+        assertCaptured(
+            expected = "http://g.com#",
+            url = "http://g.com#",
+            fragmentCapture = WebViewFragmentCapture.REDACT,
+        )
+    }
+
+    @Test
+    fun `empty fragment is dropped by remove`() {
+        assertCaptured(
+            expected = "http://g.com",
+            url = "http://g.com#",
+            fragmentCapture = WebViewFragmentCapture.REMOVE,
+        )
+    }
+
+    @Test
+    fun `query only url`() {
+        assertCaptured(expected = "", url = "?a=1")
+    }
+
+    // the two settings are independent
+
+    @Test
+    fun `capture enabled retains all`() {
+        assertCaptured(
+            expected = "http://g.com?q=1#tok=x",
+            url = "http://g.com?q=1#tok=x",
+            queryParamCaptureEnabled = true,
+            fragmentCapture = WebViewFragmentCapture.KEEP,
+        )
+    }
+
+    @Test
+    fun `capture enabled still redacts the fragment`() {
+        assertCaptured(
+            expected = "http://g.com?q=1#tok=",
+            url = "http://g.com?q=1#tok=x",
+            queryParamCaptureEnabled = true,
+            fragmentCapture = WebViewFragmentCapture.REDACT,
+        )
+    }
+
+    @Test
+    fun `capture enabled with remove keeps the query only`() {
+        assertCaptured(
+            expected = "http://g.com?q=1",
+            url = "http://g.com?q=1#tok=x",
+            queryParamCaptureEnabled = true,
+            fragmentCapture = WebViewFragmentCapture.REMOVE,
+        )
     }
 }


### PR DESCRIPTION
## Goal
Implement URL fragment redaction ( controlled by the new `WebViewFragmentCapture` config) to the `WebView` instrumentation module.

## Testing
Unit tests to cover all the redaction patterns we now support.