### PR TITLE
Gradle plugin enum config support

### DIFF
--- a/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/framework/smali/SmaliParser.kt
+++ b/embrace-gradle-plugin-integration-tests/src/test/kotlin/io/embrace/android/gradle/integration/framework/smali/SmaliParser.kt
@@ -11,6 +11,7 @@ class SmaliParser {
         private const val STRING_CONSTANT = "const-string"
         private const val LOW_INT_CONSTANT = "const/16"
         private const val BOOL_CONSTANT = "const/4"
+        private const val STATIC_FIELD_READ = "sget-object"
         private const val CONSTRUCTOR = "<init>()V"
         private const val CLASS_CONSTRUCTOR = "<clinit>()V"
         private const val RETURN_TYPE_STRING = "Ljava/lang/String;"
@@ -81,13 +82,12 @@ class SmaliParser {
         } else if (input.startsWith(LOW_INT_CONSTANT) && returnType == RETURN_TYPE_INT) {
             readHexValue(input)
         } else if (input.startsWith(BOOL_CONSTANT) && returnType == RETURN_TYPE_BOOL) {
-            when (readHexValue(input)) {
-                "1" -> "true"
-                "0" -> "false"
-                else -> error("Unexpected boolean value")
-            }
+            readBooleanValue(input)
         } else if (input.startsWith(STRING_CONSTANT) && (returnType == RETURN_TYPE_LIST || returnType == RETURN_TYPE_MAP)) {
             input.split(" ").last().replace("\"", "")
+        } else if (input.startsWith(STATIC_FIELD_READ) && isEnumReturnType(returnType)) {
+            // an enum constant is read from a static field, e.g. `sget-object v0, LFoo;->BAR:LFoo;`
+            input.substringAfterLast("->").substringBefore(":")
         } else {
             null
         }
@@ -109,9 +109,28 @@ class SmaliParser {
         }
     }
 
+    /**
+     * Any object return type other than the ones handled above is assumed to be an enum, as those
+     * are the only object-returning config methods.
+     */
+    private fun isEnumReturnType(returnType: String): Boolean {
+        return returnType.startsWith("L") &&
+            returnType != RETURN_TYPE_STRING &&
+            returnType != RETURN_TYPE_LIST &&
+            returnType != RETURN_TYPE_MAP
+    }
+
     private fun readHexValue(input: String): String {
         val token = input.split(" ").last()
         val value = token.replace("\"", "").replace("0x", "")
         return value.toInt(16).toString()
+    }
+
+    fun readBooleanValue(input: String): String {
+        return when (readHexValue(input)) {
+            "1" -> "true"
+            "0" -> "false"
+            else -> error("Unexpected boolean value")
+        }
     }
 }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/EnumReturnValueMethodVisitor.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/EnumReturnValueMethodVisitor.kt
@@ -1,0 +1,26 @@
+package io.embrace.android.gradle.plugin.instrumentation.config
+
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+
+/**
+ * Visits a method that returns an enum and replaces its return value with the [replacedValue]
+ * constant of the enum named by [enumInternalName].
+ *
+ * Enum constants are static fields on the enum class, so unlike the other return types this reads
+ * the value rather than loading a constant.
+ */
+class EnumReturnValueMethodVisitor(
+    val enumInternalName: String,
+    val replacedValue: String,
+    api: Int,
+    nextVisitor: MethodVisitor,
+) : MethodVisitor(api, nextVisitor) {
+
+    override fun visitInsn(opcode: Int) {
+        if (opcode == Opcodes.ARETURN) {
+            visitFieldInsn(Opcodes.GETSTATIC, enumInternalName, replacedValue, "L$enumInternalName;")
+        }
+        super.visitInsn(opcode)
+    }
+}

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/ConfigModelDsl.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/ConfigModelDsl.kt
@@ -48,3 +48,24 @@ fun InstrumentedConfigClass.stringListMethod(name: String, valueProvider: () -> 
 fun InstrumentedConfigClass.mapMethod(name: String, valueProvider: () -> Map<String, String>?) {
     addMethod(InstrumentedConfigMethod(name, ReturnType.MAP, valueProvider))
 }
+
+/**
+ * DSL to declare how an SDK config method that returns an enum should be instrumented.
+ *
+ * [enumClassName] is the fully qualified name of the SDK enum that the method returns, and the
+ * value provider supplies the name of the constant to return.
+ */
+fun InstrumentedConfigClass.enumMethod(
+    name: String,
+    enumClassName: String,
+    valueProvider: () -> String?,
+) {
+    addMethod(
+        InstrumentedConfigMethod(
+            functionName = name,
+            returnType = ReturnType.ENUM,
+            valueProvider = valueProvider,
+            enumInternalName = enumClassName.replace('.', '/'),
+        ),
+    )
+}

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/InstrumentedConfigMethod.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/InstrumentedConfigMethod.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.gradle.plugin.instrumentation.config.arch
 
 import io.embrace.android.gradle.plugin.instrumentation.config.BooleanReturnValueMethodVisitor
+import io.embrace.android.gradle.plugin.instrumentation.config.EnumReturnValueMethodVisitor
 import io.embrace.android.gradle.plugin.instrumentation.config.IntReturnValueMethodVisitor
 import io.embrace.android.gradle.plugin.instrumentation.config.LongReturnValueMethodVisitor
 import io.embrace.android.gradle.plugin.instrumentation.config.MapReturnValueMethodVisitor
@@ -15,10 +16,19 @@ class InstrumentedConfigMethod(
     private val functionName: String,
     private val returnType: ReturnType,
     private val valueProvider: () -> Any?,
+    /**
+     * Internal name of the returned enum. Required for [ReturnType.ENUM] and unused otherwise.
+     */
+    private val enumInternalName: String? = null,
 ) {
 
+    private val descriptor: String = when (returnType) {
+        ReturnType.ENUM -> "()L${checkNotNull(enumInternalName)};"
+        else -> returnType.descriptor
+    }
+
     fun isConfigInstrumentationTarget(name: String, descriptor: String): Boolean {
-        return functionName == name && descriptor == returnType.descriptor
+        return functionName == name && descriptor == this.descriptor
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -45,13 +55,19 @@ class InstrumentedConfigMethod(
                 api,
                 visitor,
             )
-            ReturnType.STRING_LIST -> io.embrace.android.gradle.plugin.instrumentation.config.StringListReturnValueMethodVisitor(
+            ReturnType.STRING_LIST -> StringListReturnValueMethodVisitor(
                 result as List<String>,
                 api,
                 visitor,
             )
             ReturnType.MAP -> MapReturnValueMethodVisitor(
                 result as Map<String, String>,
+                api,
+                visitor,
+            )
+            ReturnType.ENUM -> EnumReturnValueMethodVisitor(
+                checkNotNull(enumInternalName),
+                result as String,
                 api,
                 visitor,
             )

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/ReturnType.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/ReturnType.kt
@@ -10,4 +10,10 @@ enum class ReturnType(val descriptor: String) {
     STRING("()Ljava/lang/String;"),
     STRING_LIST("()Ljava/util/List;"),
     MAP("()Ljava/util/Map;"),
+
+    /**
+     * An enum constant. The descriptor depends on which enum the method returns, so it is supplied
+     * per method by [InstrumentedConfigMethod] rather than being fixed here.
+     */
+    ENUM(""),
 }

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/EnumReturnValueMethodVisitorTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/EnumReturnValueMethodVisitorTest.kt
@@ -1,0 +1,81 @@
+package io.embrace.android.gradle.plugin.instrumentation.config
+
+import io.embrace.android.gradle.plugin.instrumentation.ASM_API_VERSION
+import io.embrace.android.gradle.plugin.instrumentation.config.arch.ReturnType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.Type
+
+/**
+ * Generates a class whose method returns an enum, instruments it, then loads and invokes it. Unlike
+ * the other return types this emits a static field read rather than a constant load, so it is worth
+ * proving that the bytecode actually verifies.
+ */
+class EnumReturnValueMethodVisitorTest {
+
+    private companion object {
+        private const val SUBJECT_NAME = "EnumReturnValueSubject"
+        private val ENUM_INTERNAL_NAME: String = Type.getInternalName(ReturnType::class.java)
+        private val ENUM_DESCRIPTOR = "L$ENUM_INTERNAL_NAME;"
+    }
+
+    @Test
+    fun `the instrumented constant is returned`() {
+        assertEquals(ReturnType.MAP, invokeInstrumented(replacedValue = "MAP"))
+    }
+
+    @Test
+    fun `every constant can be returned`() {
+        ReturnType.entries.forEach { expected ->
+            assertEquals(expected, invokeInstrumented(replacedValue = expected.name))
+        }
+    }
+
+    private fun invokeInstrumented(replacedValue: String): Any? {
+        val bytecode = generateSubject(replacedValue)
+        val cls = SubjectClassLoader(bytecode).loadClass(SUBJECT_NAME)
+        val instance = cls.getDeclaredConstructor().newInstance()
+        return cls.getMethod("value").invoke(instance)
+    }
+
+    private fun generateSubject(replacedValue: String): ByteArray {
+        val writer = ClassWriter(ClassWriter.COMPUTE_FRAMES or ClassWriter.COMPUTE_MAXS)
+        writer.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, SUBJECT_NAME, null, "java/lang/Object", null)
+
+        writer.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null).apply {
+            visitCode()
+            visitVarInsn(Opcodes.ALOAD, 0)
+            visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false)
+            visitInsn(Opcodes.RETURN)
+            visitMaxs(0, 0)
+            visitEnd()
+        }
+
+        // the uninstrumented body returns BOOLEAN, standing in for the SDK's own default
+        val method = writer.visitMethod(Opcodes.ACC_PUBLIC, "value", "()$ENUM_DESCRIPTOR", null, null)
+        with(EnumReturnValueMethodVisitor(ENUM_INTERNAL_NAME, replacedValue, ASM_API_VERSION, method)) {
+            visitCode()
+            visitFieldInsn(Opcodes.GETSTATIC, ENUM_INTERNAL_NAME, ReturnType.BOOLEAN.name, ENUM_DESCRIPTOR)
+            visitInsn(Opcodes.ARETURN)
+            visitMaxs(0, 0)
+            visitEnd()
+        }
+
+        writer.visitEnd()
+        return writer.toByteArray()
+    }
+
+    private class SubjectClassLoader(
+        private val bytecode: ByteArray,
+    ) : ClassLoader(SubjectClassLoader::class.java.classLoader) {
+
+        override fun findClass(name: String): Class<*> {
+            return when (name) {
+                SUBJECT_NAME -> defineClass(name, bytecode, 0, bytecode.size)
+                else -> super.findClass(name)
+            }
+        }
+    }
+}

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/ConfigInstrumentationAssertions.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/ConfigInstrumentationAssertions.kt
@@ -2,6 +2,7 @@ package io.embrace.android.gradle.plugin.instrumentation.config.arch.sdk
 
 import io.embrace.android.gradle.plugin.instrumentation.ASM_API_VERSION
 import io.embrace.android.gradle.plugin.instrumentation.config.BooleanReturnValueMethodVisitor
+import io.embrace.android.gradle.plugin.instrumentation.config.EnumReturnValueMethodVisitor
 import io.embrace.android.gradle.plugin.instrumentation.config.IntReturnValueMethodVisitor
 import io.embrace.android.gradle.plugin.instrumentation.config.LongReturnValueMethodVisitor
 import io.embrace.android.gradle.plugin.instrumentation.config.MapReturnValueMethodVisitor
@@ -34,6 +35,7 @@ fun verifyConfigMethodVisitor(
             is StringReturnValueMethodVisitor -> visitor.replacedValue
             is StringListReturnValueMethodVisitor -> visitor.replacedValue
             is MapReturnValueMethodVisitor -> visitor.replacedValue
+            is EnumReturnValueMethodVisitor -> visitor.replacedValue
             else -> null
         },
     )


### PR DESCRIPTION
## Goal
Implement support for config functions that return `enum` constants to the Gradle plugin, alongside the existing support for `string`, `bool`, `int`, `map`, etc.

## Testing
Unit tests to cover the new bytecode modification.