### PR TITLE
Carry over spans in new persistence mechanism

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
@@ -111,6 +111,7 @@ class UserSessionOrchestrationModuleImpl(
                     .filterNot { it.hasEmbraceAttribute(EmbType.Ux.Session) }
                     .mapNotNull(EmbraceSdkSpan::snapshot)
             },
+            initModule.telemetryService,
             sessionPartDirectoryStore,
             sessionPartWriteTracker,
             onWritesComplete = { sessionPartReader?.readPersistedSessionParts() },

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -19,6 +19,8 @@ import io.embrace.android.embracesdk.internal.session.persistence.SessionPartWri
 import io.embrace.android.embracesdk.internal.session.persistence.SessionSpanWriter
 import io.embrace.android.embracesdk.internal.session.persistence.SpanSnapshotsWriter
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionPartSpan
+import io.embrace.android.embracesdk.internal.telemetry.AppliedLimitType
+import io.embrace.android.embracesdk.internal.telemetry.TelemetryService
 import io.embrace.android.embracesdk.internal.utils.UuidSource
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import java.io.File
@@ -39,6 +41,7 @@ class SessionPartWriterImpl(
     private val metadataSource: EnvelopeMetadataSource,
     private val currentSessionPartSpan: CurrentSessionPartSpan,
     private val spanSnapshotSource: () -> List<Span>,
+    private val telemetryService: TelemetryService,
     private val directoryStore: SessionPartDirectoryStore =
         SessionPartDirectoryStore(sessionsDir, worker, clock, logger),
     private val writeTracker: SessionPartWriteTracker = SessionPartWriteTracker(),
@@ -47,6 +50,8 @@ class SessionPartWriterImpl(
 
     private companion object {
         const val CRASH_DRAIN_TIMEOUT_MS: Long = 3000
+        const val MAX_CARRIED_OVER_SPANS: Int = 1000
+        const val CARRIED_OVER_SPAN_LIMIT_TYPE: String = "carried_over_span"
     }
 
     /**
@@ -62,6 +67,9 @@ class SessionPartWriterImpl(
     @Volatile
     private var resourceListenerRegistered = false
 
+    private val bufferLock = Any()
+    private val carriedOverSpans = ArrayDeque<Span>()
+
     override fun onSessionPartStarted(timestamp: Long, userSessionId: String, sessionPartId: String) {
         if (!acceptingWrites()) {
             return
@@ -75,14 +83,21 @@ class SessionPartWriterImpl(
             ),
         )
 
-        current = writers
         writeTracker.markWriting(sessionPartId)
 
         // the session span is snapshotted after it has stopped, so it must hold on to its events and
         // links until this part's writes have completed
         writers.span?.retainDataAfterStop()
-
         directoryStore.create(writers.directory)
+
+        synchronized(bufferLock) {
+            if (carriedOverSpans.isNotEmpty()) {
+                queueCompletedSpansWrite(writers, carriedOverSpans.toList())
+                carriedOverSpans.clear()
+            }
+            current = writers
+        }
+
         queueManifestWrite(writers)
         queueMetadataWrite(writers)
         queueSessionSpanWrite(writers)
@@ -108,6 +123,10 @@ class SessionPartWriterImpl(
             }
             writers.span?.releaseRetainedData()
         }
+
+        synchronized(bufferLock) {
+            current = null
+        }
     }
 
     override fun onMetadataChanged() {
@@ -121,7 +140,10 @@ class SessionPartWriterImpl(
         if (!acceptingWrites() || spans.isEmpty()) {
             return
         }
-        queueCompletedSpansWrite(current ?: return, spans)
+        val writers = current ?: synchronized(bufferLock) {
+            current ?: return carryOver(spans)
+        }
+        queueCompletedSpansWrite(writers, spans)
     }
 
     private fun onResourceChanged() {
@@ -216,6 +238,20 @@ class SessionPartWriterImpl(
     private fun queueCompletedSpansWrite(writers: PartWriters, spans: List<Span>) {
         execute(InternalErrorType.CompletedSpansWriteFail, { worker.submit(it) }) {
             writers.completedSpans.write(spans)
+        }
+    }
+
+    /**
+     * Holds [spans] until the next session part starts. Spans beyond [MAX_CARRIED_OVER_SPANS] are
+     * dropped.
+     */
+    private fun carryOver(spans: List<Span>) {
+        spans.forEach { span ->
+            if (carriedOverSpans.size >= MAX_CARRIED_OVER_SPANS) {
+                telemetryService.trackAppliedLimit(CARRIED_OVER_SPAN_LIMIT_TYPE, AppliedLimitType.DROP)
+            } else {
+                carriedOverSpans.add(span)
+            }
         }
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -19,6 +19,7 @@ import io.embrace.android.embracesdk.fakes.FakePayloadMessageCollator
 import io.embrace.android.embracesdk.fakes.FakePayloadStore
 import io.embrace.android.embracesdk.fakes.FakeProcessStateTracker
 import io.embrace.android.embracesdk.fakes.FakeTelemetryDestination
+import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.FakeUserSessionPropertiesService
 import io.embrace.android.embracesdk.fakes.TestUuidSource
 import io.embrace.android.embracesdk.fakes.behavior.FakeUserSessionBehavior
@@ -1241,6 +1242,7 @@ internal class SessionOrchestratorTest {
                 FakeEnvelopeMetadataSource(),
                 currentSessionPartSpan,
                 { emptyList() },
+                FakeTelemetryService(),
             ),
         ).apply {
             start()

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterBoundaryTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterBoundaryTest.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionPartSpan
 import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.FakeInternalLogger
+import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.TestUuidSource
 import io.embrace.android.embracesdk.fakes.createPersistenceBehavior
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
@@ -89,6 +90,7 @@ internal class SessionPartWriterBoundaryTest {
             { EnvelopeMetadata(userId = "user${writeCount++}") },
             currentSessionPartSpan,
             { emptyList() },
+            FakeTelemetryService(),
         )
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionPartSpan
 import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.FakeInternalLogger
+import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.TestUuidSource
 import io.embrace.android.embracesdk.fakes.createPersistenceBehavior
 import io.embrace.android.embracesdk.internal.clock.millisToNanos
@@ -21,6 +22,7 @@ import io.embrace.android.embracesdk.internal.session.persistence.SessionManifes
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectory
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartSpan
 import io.embrace.android.embracesdk.internal.session.persistence.SpanSnapshots
+import io.embrace.android.embracesdk.internal.telemetry.AppliedLimitType
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -56,6 +58,7 @@ internal class SessionPartWriterImplTest {
     private lateinit var clock: FakeClock
     private lateinit var executor: BlockingScheduledExecutorService
     private lateinit var logger: FakeInternalLogger
+    private lateinit var telemetryService: FakeTelemetryService
 
     private var writeCount = 0
     private var onMetadataRead: () -> Unit = {}
@@ -84,6 +87,7 @@ internal class SessionPartWriterImplTest {
         clock = FakeClock()
         executor = BlockingScheduledExecutorService(clock, true)
         logger = FakeInternalLogger(throwOnInternalError = false)
+        telemetryService = FakeTelemetryService()
         writeCount = 0
         resourceCount = 0
         onMetadataRead = {}
@@ -827,12 +831,66 @@ internal class SessionPartWriterImplTest {
     }
 
     @Test
-    fun `completed spans before any session part starts write nothing`() {
+    fun `completed spans before any session part starts are held and logged against the first part`() {
         val writer = createWriter()
         writer.onSpanCompleted(listOf(completedSpan("network-request")))
-
         assertEquals(emptyList<SessionPartDirectory>(), sessionPartDirs())
         assertEquals(0, executor.submitCount)
+
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        assertEquals(listOf("network-request"), completedSpanNamesIn(SESSION_PART_ID))
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `completed spans after a session part ended are logged against the next part`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        endPart()
+        writer.onSessionPartEnded(SESSION_PART_ID)
+        drain()
+
+        writer.onSpanCompleted(listOf(completedSpan("carried-over")))
+        drain()
+        assertEquals(emptyList<String?>(), completedSpanNamesOnDisk(SESSION_PART_ID))
+
+        clock.tick(10000)
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, OTHER_SESSION_PART_ID)
+
+        assertEquals(listOf("carried-over"), completedSpanNamesIn(OTHER_SESSION_PART_ID))
+        assertEquals(emptyList<String?>(), completedSpanNamesOnDisk(SESSION_PART_ID))
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `completed spans while a session part is open are logged against it rather than held`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+
+        writer.onSpanCompleted(listOf(completedSpan("network-request")))
+        drain()
+        assertEquals(listOf("network-request"), completedSpanNamesOnDisk(SESSION_PART_ID))
+
+        clock.tick(10000)
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, OTHER_SESSION_PART_ID)
+
+        assertEquals(emptyList<String?>(), completedSpanNamesIn(OTHER_SESSION_PART_ID))
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `spans held past the limit are dropped and counted as an applied limit`() {
+        val writer = createWriter()
+        writer.onSpanCompleted(List(1002) { completedSpan("held-$it") })
+
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+
+        assertEquals(1000, completedSpanNamesIn(SESSION_PART_ID).size)
+        assertEquals(
+            List(2) { "carried_over_span" to AppliedLimitType.DROP },
+            telemetryService.appliedLimits,
+        )
         assertNoInternalErrors()
     }
 
@@ -916,6 +974,7 @@ internal class SessionPartWriterImplTest {
         metadataSource,
         currentSessionPartSpan,
         { inFlightSpans },
+        telemetryService,
     )
 
     private fun configService(

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceChangeTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceChangeTest.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionPartSpan
 import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.FakeInternalLogger
+import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.TestUuidSource
 import io.embrace.android.embracesdk.fakes.createPersistenceBehavior
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
@@ -235,6 +236,7 @@ internal class SessionPartWriterResourceChangeTest {
         { EnvelopeMetadata(userId = "my-user-id") },
         currentSessionPartSpan,
         { emptyList() },
+        FakeTelemetryService(),
     )
 
     private fun startPart(writer: SessionPartWriter, sessionPartId: String) {

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceReadTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceReadTest.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.fakes.FakeCurrentSessionPartSpan
 import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.FakeEnvelopeResourceSource
 import io.embrace.android.embracesdk.fakes.FakeInternalLogger
+import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.TestUuidSource
 import io.embrace.android.embracesdk.fakes.createPersistenceBehavior
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
@@ -112,6 +113,7 @@ internal class SessionPartWriterResourceReadTest {
             EnvelopeMetadataSource { EnvelopeMetadata(userId = "my-user-id") },
             currentSessionPartSpan,
             { inFlightSpans },
+            FakeTelemetryService(),
         )
         service = SessionReconstructionService(lazy { sessionsDir }, logger)
     }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterTrackerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterTrackerTest.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeCurrentSessionPartSpan
 import io.embrace.android.embracesdk.fakes.FakeEmbraceSdkSpan
 import io.embrace.android.embracesdk.fakes.FakeInternalLogger
+import io.embrace.android.embracesdk.fakes.FakeTelemetryService
 import io.embrace.android.embracesdk.fakes.TestUuidSource
 import io.embrace.android.embracesdk.fakes.createPersistenceBehavior
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
@@ -68,6 +69,7 @@ internal class SessionPartWriterTrackerTest {
             { EnvelopeMetadata() },
             currentSessionPartSpan,
             { emptyList() },
+            FakeTelemetryService(),
             writeTracker = writeTracker,
         )
     }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/persistence/MultiFilePersistenceParityTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/persistence/MultiFilePersistenceParityTest.kt
@@ -31,15 +31,17 @@ import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.network.http.HttpMethod
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
+import io.embrace.android.embracesdk.spans.EmbraceSpan
 import io.embrace.android.embracesdk.testcases.features.createNativeSymbolsForCurrentArch
 import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule
 import io.embrace.android.embracesdk.testframework.actions.EmbracePayloadAssertionInterface
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.embrace.android.embracesdk.testframework.assertions.Placeholder
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -338,9 +340,8 @@ internal class MultiFilePersistenceParityTest {
         )
     }
 
-    @Ignore("Spans completed with no active session part are not persisted")
     @Test
-    fun `spans completed while no session part is active are persisted identically`() {
+    fun `spans completed before the first session part directory exists are persisted identically`() {
         testRule.runTest(
             persistedRemoteConfig = RemoteConfig(
                 pctMultiFilePersistenceEnabled = 100.0f,
@@ -348,18 +349,70 @@ internal class MultiFilePersistenceParityTest {
             ),
             testCaseAction = {
                 recordSession()
-                embrace.recordSpan("orphaned-span") {
-                    clock.tick(100)
+            },
+            assertAction = {
+                val names = assertParity().single().allSpanNames()
+                assertTrue("emb-sdk-init missing from: $names", "emb-sdk-init" in names)
+            },
+        )
+    }
+
+    @Test
+    fun `a span that stops after its session part ended is persisted identically`() {
+        lateinit var span: EmbraceSpan
+        testRule.runTest(
+            persistedRemoteConfig = RemoteConfig(
+                pctMultiFilePersistenceEnabled = 100.0f,
+                backgroundActivityConfig = BackgroundActivityRemoteConfig(0f),
+            ),
+            testCaseAction = {
+                recordSession {
+                    span = checkNotNull(embrace.startSpan("late-span"))
                 }
+                clock.tick(100)
+                span.stop()
                 clock.tick(20000)
                 recordSession()
             },
             assertAction = {
                 val parts = assertParity(expectedParts = 2)
                 assertTrue(
-                    "orphaned-span missing from every payload",
-                    parts.any { "orphaned-span" in it.allSpanNames() },
+                    "late-span missing from every payload",
+                    parts.any { "late-span" in it.allSpanNames() },
                 )
+            },
+        )
+    }
+
+    @Test
+    fun `no span is created while no session part is active`() {
+        var blockRan = false
+        lateinit var orphaned: EmbraceSpan
+        testRule.runTest(
+            persistedRemoteConfig = RemoteConfig(
+                pctMultiFilePersistenceEnabled = 100.0f,
+                backgroundActivityConfig = BackgroundActivityRemoteConfig(0f),
+            ),
+            testCaseAction = {
+                recordSession()
+                orphaned = embrace.startSpan("started-span")
+                embrace.recordSpan("recorded-span") {
+                    blockRan = true
+                    clock.tick(100)
+                }
+                clock.tick(20000)
+                recordSession()
+            },
+            assertAction = {
+                assertFalse("a span was started with no active session part", orphaned.isRecording)
+                assertNull("a span was started with no active session part", orphaned.spanId)
+                assertTrue("recordSpan did not run the block it was given", blockRan)
+
+                assertParity(expectedParts = 2).forEach { part ->
+                    val names = part.allSpanNames()
+                    assertFalse("started-span was persisted: $names", "started-span" in names)
+                    assertFalse("recorded-span was persisted: $names", "recorded-span" in names)
+                }
             },
         )
     }


### PR DESCRIPTION
## Goal

If a span finishes and a session part isn't available yet on startup, buffer the call as per the legacy mechanism. This allows traces such as emb-sdk-init to be included in the payload.