### PR TITLE
Gradle Plugin support for WebViewFragmentCapture

### DIFF
--- a/embrace-config-schema.json
+++ b/embrace-config-schema.json
@@ -88,6 +88,11 @@
               "description": "Set to false to disable capturing of web views.",
               "default": true,
               "type": "boolean"
+            },
+            "fragment_capture": {
+              "description": "Controls how the URL fragment - the part after the '#' - is captured for web views. One of keep, redact or remove. 'keep' captures it unaltered. 'redact' removes the values from any key=value pairs and drops long unstructured segments, while preserving hash routes and short anchors; pick this to avoid capturing tokens without losing the route the user was on. 'remove' discards the fragment entirely. Independent of capture_query_params. If webview:enable is set to false, this setting has no effect since all capture of web view information is disabled.",
+              "default": "keep",
+              "type": "string"
             }
           },
           "minProperties": 1

--- a/embrace-gradle-plugin-integration-tests/fixtures/android-with-code/proguard-rules.pro
+++ b/embrace-gradle-plugin-integration-tests/fixtures/android-with-code/proguard-rules.pro
@@ -1,2 +1,2 @@
 -keep class com.example.app.Foo { *; }
--keep class io.embrace.android.embracesdk.internal.config.instrumented.* { *; }
+-keep class io.embrace.android.embracesdk.internal.config.instrumented.** { *; }

--- a/embrace-gradle-plugin-integration-tests/src/test/resources/config-overrides.json
+++ b/embrace-gradle-plugin-integration-tests/src/test/resources/config-overrides.json
@@ -63,7 +63,8 @@
     },
     "webview": {
       "enable": false,
-      "capture_query_params": false
+      "capture_query_params": false,
+      "fragment_capture": "redact"
     },
     "capture_fcm_pii_data": true
   }

--- a/embrace-gradle-plugin-integration-tests/src/test/resources/instrumented-config-default.json
+++ b/embrace-gradle-plugin-integration-tests/src/test/resources/instrumented-config-default.json
@@ -15,6 +15,9 @@
       "className": "EnabledFeatureConfigImpl",
       "methods": [
         {
+          "signature": "getWebViewBreadcrumbFragmentCapture()Lio/embrace/android/embracesdk/internal/config/instrumented/schema/WebViewFragmentCapture;"
+        },
+        {
           "signature": "is3rdPartySigHandlerDetectionEnabled()Z"
         },
         {

--- a/embrace-gradle-plugin-integration-tests/src/test/resources/instrumented-config-overrides.json
+++ b/embrace-gradle-plugin-integration-tests/src/test/resources/instrumented-config-overrides.json
@@ -17,6 +17,10 @@
       "className": "EnabledFeatureConfigImpl",
       "methods": [
         {
+          "signature": "getWebViewBreadcrumbFragmentCapture()Lio/embrace/android/embracesdk/internal/config/instrumented/schema/WebViewFragmentCapture;",
+          "returnValue": "REDACT"
+        },
+        {
           "signature": "is3rdPartySigHandlerDetectionEnabled()Z",
           "returnValue": "true"
         },

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/EnabledFeatureConfigInstrumentation.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/EnabledFeatureConfigInstrumentation.kt
@@ -1,8 +1,12 @@
 package io.embrace.android.gradle.plugin.instrumentation.config.arch.sdk
 
 import io.embrace.android.gradle.plugin.instrumentation.config.arch.boolMethod
+import io.embrace.android.gradle.plugin.instrumentation.config.arch.enumMethod
 import io.embrace.android.gradle.plugin.instrumentation.config.arch.modelSdkConfigClass
 import io.embrace.android.gradle.plugin.instrumentation.config.model.VariantConfig
+
+private const val WEB_VIEW_FRAGMENT_CAPTURE_CLASS =
+    "io.embrace.android.embracesdk.internal.config.instrumented.schema.WebViewFragmentCapture"
 
 fun createEnabledFeatureConfigInstrumentation(cfg: VariantConfig) = modelSdkConfigClass {
     boolMethod("isNativeCrashCaptureEnabled") { cfg.embraceConfig?.ndkEnabled }
@@ -22,6 +26,9 @@ fun createEnabledFeatureConfigInstrumentation(cfg: VariantConfig) = modelSdkConf
         boolMethod("isBackgroundActivityCaptureEnabled") { backgroundActivityConfig?.backgroundActivityCaptureEnabled }
         boolMethod("isWebViewBreadcrumbCaptureEnabled") { webViewConfig?.captureWebViews }
         boolMethod("isWebViewBreadcrumbQueryParamCaptureEnabled") { webViewConfig?.captureQueryParams }
+        enumMethod("getWebViewBreadcrumbFragmentCapture", WEB_VIEW_FRAGMENT_CAPTURE_CLASS) {
+            webViewConfig?.fragmentCapture?.name
+        }
         boolMethod("isFcmPiiDataCaptureEnabled") { captureFcmPiiData }
         boolMethod("isRequestContentLengthCaptureEnabled") { networking?.captureRequestContentLength }
         boolMethod("isOkHttpResponseBodySizeCaptureEnabled") { networking?.captureOkHttpResponseBodySize }

--- a/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/WebViewLocalConfig.kt
+++ b/embrace-gradle-plugin/src/main/java/io/embrace/android/gradle/plugin/instrumentation/config/model/WebViewLocalConfig.kt
@@ -11,10 +11,30 @@ data class WebViewLocalConfig(
 
     @Json(name = "capture_query_params")
     val captureQueryParams: Boolean? = null,
+
+    @Json(name = "fragment_capture")
+    val fragmentCapture: FragmentCapture? = null,
 ) : Serializable {
 
     private companion object {
         @Suppress("ConstPropertyName")
         private const val serialVersionUID = 1L
+    }
+
+    /**
+     * Mirrors the SDK's own WebViewFragmentCapture enum, which is instrumented by constant name.
+     * Declaring the states here rather than taking a String means an unsupported value fails the
+     * build instead of silently falling back to the default.
+     */
+    enum class FragmentCapture {
+
+        @Json(name = "keep")
+        KEEP,
+
+        @Json(name = "redact")
+        REDACT,
+
+        @Json(name = "remove")
+        REMOVE,
     }
 }

--- a/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/EnabledFeatureConfigInstrumentationKtTest.kt
+++ b/embrace-gradle-plugin/src/test/java/io/embrace/android/gradle/plugin/instrumentation/config/arch/sdk/EnabledFeatureConfigInstrumentationKtTest.kt
@@ -42,6 +42,11 @@ class EnabledFeatureConfigInstrumentationKtTest {
         ConfigMethod("isBackgroundActivityCaptureEnabled", "()Z", true),
         ConfigMethod("isWebViewBreadcrumbCaptureEnabled", "()Z", true),
         ConfigMethod("isWebViewBreadcrumbQueryParamCaptureEnabled", "()Z", true),
+        ConfigMethod(
+            "getWebViewBreadcrumbFragmentCapture",
+            "()Lio/embrace/android/embracesdk/internal/config/instrumented/schema/WebViewFragmentCapture;",
+            "REDACT",
+        ),
         ConfigMethod("isFcmPiiDataCaptureEnabled", "()Z", true),
         ConfigMethod("isRequestContentLengthCaptureEnabled", "()Z", true),
         ConfigMethod("isOkHttpResponseBodySizeCaptureEnabled", "()Z", true),
@@ -119,6 +124,7 @@ class EnabledFeatureConfigInstrumentationKtTest {
                         webViewConfig = WebViewLocalConfig(
                             captureWebViews = true,
                             captureQueryParams = true,
+                            fragmentCapture = WebViewLocalConfig.FragmentCapture.REDACT,
                         ),
                         viewConfig = ViewLocalConfig(
                             enableAutomaticActivityCapture = true,


### PR DESCRIPTION
## Goal
Introduce support for the `WebViewFragmentCapture` option to the Gradle Plugin using the new `enumMethod ` support. This PR also adds the `fragment_capture` option to the `embrace-config-schema.json`
