### PR TITLE
Thread through crash shutdown path

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/CoalescingWriteQueue.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/CoalescingWriteQueue.kt
@@ -4,7 +4,6 @@ import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import java.util.concurrent.Future
 import java.util.concurrent.FutureTask
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 
@@ -15,7 +14,7 @@ import java.util.concurrent.atomic.AtomicReference
  *
  * A write is held as a [FutureTask] armed with a scheduled trigger that runs it
  * [delayMs] later. Cancelling that trigger does not cancel the [FutureTask] it wraps. This
- * lets [shutdown] force the task to run early rather than queueing the work twice.
+ * lets [flush] force the task to run early rather than queueing the work twice.
  */
 internal class CoalescingWriteQueue(
     private val worker: BackgroundWorker,
@@ -56,20 +55,13 @@ internal class CoalescingWriteQueue(
     }
 
     /**
-     * Runs the pending write and blocks for up to [timeoutMs] so the newest data is on disk
-     * before the caller moves on. This is typically because the process is about to die.
+     * Forces the pending write onto the worker now, disarming its scheduled trigger so that the
+     * write does not run twice. This call does not block.
      */
-    fun shutdown(timeoutMs: Long) {
+    fun flush() {
         val write = pending.getAndSet(null) ?: return
         write.trigger?.cancel(false)
-
-        if (runCatching { worker.submit(write.task) }.isFailure) {
-            write.task.run()
-        }
-        when (runCatching { write.task.get(timeoutMs, TimeUnit.MILLISECONDS) }.exceptionOrNull()) {
-            is TimeoutException -> write.task.run()
-            is InterruptedException -> Thread.currentThread().interrupt()
-        }
+        runCatching { worker.submit(write.task) }
     }
 
     private class PendingWrite(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -46,6 +46,7 @@ class SessionPartWriterImpl(
         SessionPartDirectoryStore(sessionsDir, worker, clock, logger),
     private val writeTracker: SessionPartWriteTracker = SessionPartWriteTracker(),
     private val onWritesComplete: () -> Unit = {},
+    private val writeDelayMs: Long = CoalescingWriteQueue.DEFAULT_DELAY_MS,
 ) : SessionPartWriter {
 
     private companion object {
@@ -109,12 +110,19 @@ class SessionPartWriterImpl(
         if (!acceptingWrites()) {
             return
         }
-        val writers = current ?: return
-        if (writers.directory.sessionPartId != sessionPartId) {
-            return
+
+        val writers = synchronized(bufferLock) {
+            val ref = current ?: return
+            if (ref.directory.sessionPartId != sessionPartId) {
+                return
+            }
+            current = null
+            ref
         }
         queueSessionSpanWrite(writers)
         queueSpanSnapshotsWrite(writers)
+        writers.flushPendingWrites()
+
         worker.submit {
             writeTracker.markComplete(sessionPartId)
 
@@ -122,10 +130,6 @@ class SessionPartWriterImpl(
                 notifyWritesComplete()
             }
             writers.span?.releaseRetainedData()
-        }
-
-        synchronized(bufferLock) {
-            current = null
         }
     }
 
@@ -165,6 +169,9 @@ class SessionPartWriterImpl(
             return
         }
         writesSealed = true
+
+        // flush then wait for pending writes
+        current?.flushPendingWrites()
         worker.shutdownAndWait(CRASH_DRAIN_TIMEOUT_MS)
     }
 
@@ -330,8 +337,12 @@ class SessionPartWriterImpl(
             logger = logger,
         )
 
-        val metadataWrites = CoalescingWriteQueue(worker)
-        val sessionSpanWrites = CoalescingWriteQueue(worker)
-        val spanSnapshotWrites = CoalescingWriteQueue(worker)
+        val metadataWrites = CoalescingWriteQueue(worker, writeDelayMs)
+        val sessionSpanWrites = CoalescingWriteQueue(worker, writeDelayMs)
+        val spanSnapshotWrites = CoalescingWriteQueue(worker, writeDelayMs)
+
+        private val writeQueues = listOf(metadataWrites, sessionSpanWrites, spanSnapshotWrites)
+
+        fun flushPendingWrites() = writeQueues.forEach(CoalescingWriteQueue::flush)
     }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/CoalescingWriteQueueTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/CoalescingWriteQueueTest.kt
@@ -14,7 +14,6 @@ internal class CoalescingWriteQueueTest {
 
     private companion object {
         private const val DELAY_MS = 5000L
-        private const val TIMEOUT_MS = 1000L
     }
 
     private lateinit var executor: BlockingScheduledExecutorService
@@ -64,16 +63,16 @@ internal class CoalescingWriteQueueTest {
     }
 
     @Test
-    fun `shutdown runs the pending write immediately`() {
+    fun `flush runs the pending write immediately`() {
         queue.submit(write("first"))
-        queue.shutdown(TIMEOUT_MS)
+        queue.flush()
         assertEquals(listOf("first"), writes)
     }
 
     @Test
-    fun `a write forced by shutdown does not run again when its delay elapses`() {
+    fun `a write forced by flush does not run again when its delay elapses`() {
         queue.submit(write("first"))
-        queue.shutdown(TIMEOUT_MS)
+        queue.flush()
 
         executor.moveForwardAndRunBlocked(DELAY_MS)
         assertEquals(listOf("first"), writes)
@@ -81,23 +80,23 @@ internal class CoalescingWriteQueueTest {
     }
 
     @Test
-    fun `shutdown with nothing pending does nothing`() {
-        queue.shutdown(TIMEOUT_MS)
+    fun `flush with nothing pending does nothing`() {
+        queue.flush()
         assertEquals(emptyList<String>(), writes)
     }
 
     @Test
-    fun `shutdown twice runs the pending write once`() {
+    fun `flush twice runs the pending write once`() {
         queue.submit(write("first"))
-        queue.shutdown(TIMEOUT_MS)
-        queue.shutdown(TIMEOUT_MS)
+        queue.flush()
+        queue.flush()
         assertEquals(listOf("first"), writes)
     }
 
     @Test
-    fun `a write submitted after shutdown is armed as normal`() {
+    fun `a write submitted after flush is armed as normal`() {
         queue.submit(write("first"))
-        queue.shutdown(TIMEOUT_MS)
+        queue.flush()
 
         queue.submit(write("second"))
         executor.moveForwardAndRunBlocked(DELAY_MS)
@@ -106,20 +105,30 @@ internal class CoalescingWriteQueueTest {
     }
 
     @Test
-    fun `a write that throws does not fail shutdown`() {
+    fun `a write that throws does not fail flush`() {
         queue.submit { error("write failed") }
-        queue.shutdown(TIMEOUT_MS)
+        queue.flush()
         assertEquals(emptyList<String>(), writes)
     }
 
     @Test
-    fun `a write submitted to a shut down worker is flushed by shutdown`() {
+    fun `flush drops a write that the worker will not take`() {
         executor.shutdown()
         queue.submit(write("first"))
+        queue.flush()
+        assertEquals(emptyList<String>(), writes)
+    }
 
+    @Test
+    fun `flush does not wait for the write to run`() {
+        val blockedExecutor = BlockingScheduledExecutorService(FakeClock(), blockingMode = true)
+        val blockedQueue = CoalescingWriteQueue(BackgroundWorker(blockedExecutor), DELAY_MS)
+
+        blockedQueue.submit(write("first"))
+        blockedQueue.flush()
         assertEquals(emptyList<String>(), writes)
 
-        queue.shutdown(TIMEOUT_MS)
+        blockedExecutor.runCurrentlyBlocked()
         assertEquals(listOf("first"), writes)
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
@@ -33,6 +33,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
+import java.util.concurrent.ScheduledExecutorService
 
 internal class SessionPartWriterImplTest {
 
@@ -40,6 +41,7 @@ internal class SessionPartWriterImplTest {
         private const val USER_SESSION_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         private const val SESSION_PART_ID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         private const val OTHER_SESSION_PART_ID = "cccccccccccccccccccccccccccccccc"
+        private const val WRITE_DELAY_MS = 5000L
         private const val METADATA_FILE_NAME = "metadata.pb"
         private const val MANIFEST_FILE_NAME = "manifest.pb"
         private const val SESSION_SPAN_FILE_NAME = "session_span.pb"
@@ -70,6 +72,7 @@ internal class SessionPartWriterImplTest {
     private lateinit var sessionSpan: FakeEmbraceSdkSpan
     private lateinit var currentSessionPartSpan: FakeCurrentSessionPartSpan
     private var inFlightSpans: List<Span> = emptyList()
+    private var onSpanSnapshotsRead: () -> Unit = {}
 
     private var resourceCount = 0
     private val resourceSource = object : EnvelopeResourceSource {
@@ -92,6 +95,7 @@ internal class SessionPartWriterImplTest {
         resourceCount = 0
         onMetadataRead = {}
         inFlightSpans = emptyList()
+        onSpanSnapshotsRead = {}
         sessionSpan = FakeEmbraceSdkSpan(name = "span0").apply { start(clock.now()) }
         currentSessionPartSpan = FakeCurrentSessionPartSpan(clock).apply { sessionPartSpan = sessionSpan }
     }
@@ -609,6 +613,92 @@ internal class SessionPartWriterImplTest {
     }
 
     @Test
+    fun `a crash flushes the debounced writes before the worker is shut down`() {
+        val events = mutableListOf<String>()
+        val recordingExecutor = ShutdownRecordingExecutor(executor) { events.add("shutdown") }
+        executor.blockingMode = false
+        onMetadataRead = { events.add("metadata-write") }
+
+        val writer = createWriter(
+            worker = BackgroundWorker(recordingExecutor),
+            writeDelayMs = WRITE_DELAY_MS,
+        )
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        assertEquals(emptyList<String>(), events)
+
+        writer.onCrash()
+        assertEquals(listOf("metadata-write", "shutdown"), events)
+        assertEquals("user0", metadataOnDisk(SESSION_PART_ID)?.user_id)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a debounced write runs before the part's writes are announced as complete`() {
+        var endTimeAtCompletion: Long? = null
+        val writer = createWriter(
+            writeDelayMs = WRITE_DELAY_MS,
+            onWritesComplete = {
+                endTimeAtCompletion = sessionSpanOnDisk(SESSION_PART_ID)?.span?.end_time_unix_nano
+            },
+        )
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain(WRITE_DELAY_MS)
+
+        clock.tick(10000)
+        endPart()
+        val expectedEndTimeNanos = clock.now().millisToNanos()
+        writer.onSessionPartEnded(SESSION_PART_ID)
+        drain(WRITE_DELAY_MS)
+
+        assertEquals(expectedEndTimeNanos, endTimeAtCompletion)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a write racing with the end of a session part is not queued for it`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+        assertEquals(1, writeCount)
+
+        // simulate another thread reporting a change while the session part is finalised
+        onSpanSnapshotsRead = {
+            onSpanSnapshotsRead = {}
+            writer.onMetadataChanged()
+        }
+        endPart()
+        writer.onSessionPartEnded(SESSION_PART_ID)
+        drain()
+
+        // the part is no longer current, so the write does not land
+        assertEquals(1, writeCount)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a completed span racing with the end of a session part is carried over`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+
+        onSpanSnapshotsRead = {
+            onSpanSnapshotsRead = {}
+            writer.onSpanCompleted(listOf(completedSpan("network-request")))
+        }
+        endPart()
+        writer.onSessionPartEnded(SESSION_PART_ID)
+        drain()
+
+        assertEquals(emptyList<String>(), completedSpanNamesIn(SESSION_PART_ID))
+
+        clock.tick(1000)
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, OTHER_SESSION_PART_ID)
+
+        assertEquals(listOf("network-request"), completedSpanNamesIn(OTHER_SESSION_PART_ID))
+        assertNoInternalErrors()
+    }
+
+    @Test
     fun `a write that has already started is not cancelled`() {
         val writer = createWriter()
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
@@ -947,6 +1037,17 @@ internal class SessionPartWriterImplTest {
         assertNoInternalErrors()
     }
 
+    private class ShutdownRecordingExecutor(
+        private val delegate: ScheduledExecutorService,
+        private val onShutdown: () -> Unit,
+    ) : ScheduledExecutorService by delegate {
+
+        override fun shutdown() {
+            onShutdown()
+            delegate.shutdown()
+        }
+    }
+
     private fun completedSpan(name: String) = Span(
         traceId = "6c9b1f2ec1d34f3c9a7d0b8e5f2a4c11",
         spanId = "aaaaaaaaaaaaaaa2",
@@ -963,9 +1064,12 @@ internal class SessionPartWriterImplTest {
         enabled: Boolean = true,
         configService: FakeConfigService = configService(enabled),
         sessionsDir: File = this.sessionsDir,
+        worker: BackgroundWorker = BackgroundWorker(executor),
+        writeDelayMs: Long = CoalescingWriteQueue.DEFAULT_DELAY_MS,
+        onWritesComplete: () -> Unit = {},
     ) = SessionPartWriterImpl(
         lazy { sessionsDir },
-        BackgroundWorker(executor),
+        worker,
         configService,
         TestUuidSource(),
         clock,
@@ -973,8 +1077,13 @@ internal class SessionPartWriterImplTest {
         resourceSource,
         metadataSource,
         currentSessionPartSpan,
-        { inFlightSpans },
+        {
+            onSpanSnapshotsRead()
+            inFlightSpans
+        },
         telemetryService,
+        onWritesComplete = onWritesComplete,
+        writeDelayMs = writeDelayMs,
     )
 
     private fun configService(
@@ -988,9 +1097,9 @@ internal class SessionPartWriterImplTest {
         },
     )
 
-    private fun drain() {
+    private fun drain(delayMs: Long = CoalescingWriteQueue.DEFAULT_DELAY_MS) {
         do {
-            executor.moveForwardAndRunBlocked(CoalescingWriteQueue.DEFAULT_DELAY_MS)
+            executor.moveForwardAndRunBlocked(delayMs)
         } while (executor.scheduledTasksCount() > 0)
     }
 


### PR DESCRIPTION
## Goal

Threads through the necessary behavior for handling the crash shutdown path. The `CoalescingWriteQueue` now simply submits the task to the worker immediately and the caller is responsible for waiting with a timeout.

Additionally I spotted a race where writes could happen to a session part that was ending so I tightened the logic to prevent that.
