### PR TITLE
Read session part on IO thread

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
@@ -65,6 +65,7 @@ class UserSessionOrchestrationModuleImpl(
             processIdProvider = { openTelemetryModule.otelSdkConfig.processIdentifier },
             configService = configService,
             logger = initModule.logger,
+            worker = workerThreadModule.backgroundWorker(Worker.Background.IoRegWorker),
         )
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/SessionPartReader.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/SessionPartReader.kt
@@ -15,6 +15,7 @@ import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDir
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectoryStore
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartWriteTracker
 import io.embrace.android.embracesdk.internal.session.persistence.SessionReconstructionService
+import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 
 /**
@@ -30,26 +31,29 @@ class SessionPartReader(
     private val processIdProvider: () -> String,
     private val configService: ConfigService,
     private val logger: InternalLogger,
+    private val worker: BackgroundWorker,
 ) {
 
     /**
-     * Reads every completed session part on disk and hands it to the intake service.
+     * Queues a read of every completed session part on disk. The work runs on [worker] so that it
+     * does not hold up telemetry queued on the session persistence worker.
      */
     fun readPersistedSessionParts() {
         if (!configService.persistenceBehavior.isMultiFilePersistenceEnabled()) {
             return
         }
-
-        directoryStore.storedDirectories()
-            .filterNot { writeTracker.isWriting(it.sessionPartId) }
-            .sortedWith(SessionPartDirectory.comparator)
-            .forEach { directory ->
-                runCatching {
-                    deliver(directory)
-                }.onFailure {
-                    logger.trackInternalError(InternalErrorType.SessionPartReadFail, it)
+        worker.submit {
+            directoryStore.storedDirectories()
+                .filterNot { writeTracker.isWriting(it.sessionPartId) }
+                .sortedWith(SessionPartDirectory.comparator)
+                .forEach { directory ->
+                    runCatching {
+                        deliver(directory)
+                    }.onFailure {
+                        logger.trackInternalError(InternalErrorType.SessionPartReadFail, it)
+                    }
                 }
-            }
+        }
     }
 
     /**

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/SessionPartReaderTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/SessionPartReaderTest.kt
@@ -81,6 +81,7 @@ internal class SessionPartReaderTest {
     private lateinit var directoryStore: SessionPartDirectoryStore
     private lateinit var intakeService: FakeIntakeService
     private lateinit var writeTracker: SessionPartWriteTracker
+    private lateinit var readExecutor: BlockingScheduledExecutorService
 
     @Before
     fun setUp() {
@@ -91,6 +92,7 @@ internal class SessionPartReaderTest {
         directoryStore = SessionPartDirectoryStore(lazy { sessionsDir }, BackgroundWorker(executor), clock, logger)
         intakeService = FakeIntakeService()
         writeTracker = SessionPartWriteTracker()
+        readExecutor = BlockingScheduledExecutorService(clock, false)
     }
 
     @Test
@@ -180,6 +182,18 @@ internal class SessionPartReaderTest {
         assertNothingDelivered(retained = listOf(partDirectory))
     }
 
+    @Test
+    fun `reading is queued on the worker rather than run on the calling thread`() {
+        persist(partDirectory)
+        readExecutor.blockingMode = true
+        createReader().readPersistedSessionParts()
+        assertNothingDelivered(retained = listOf(partDirectory))
+
+        readExecutor.runCurrentlyBlocked()
+        assertEquals(partDirectory.sessionPartId, intakeService.intakeList.single().metadata.sessionPartId)
+        assertDeleted(partDirectory)
+    }
+
     private fun createReader(enabled: Boolean = true) = SessionPartReader(
         directoryStore = directoryStore,
         reconstructionService = SessionReconstructionService(lazy { sessionsDir }, logger),
@@ -192,6 +206,7 @@ internal class SessionPartReaderTest {
             ),
         ),
         logger = logger,
+        worker = BackgroundWorker(readExecutor),
     )
 
     private fun persist(directory: SessionPartDirectory, span: Span = sessionSpan()) {

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/SdkInitActions.kt
@@ -194,9 +194,8 @@ internal fun ModuleGraph.triggerPayloadSend() {
             deliveryModule?.schedulingService?.onResurrectionComplete()
         }
     }
-    worker.submit { // deliver any session parts persisted by the multi-file persistence layer
-        userSessionOrchestrationModule.sessionPartReader?.readPersistedSessionParts()
-    }
+    // deliver any session parts persisted by the multi-file persistence layer
+    userSessionOrchestrationModule.sessionPartReader?.readPersistedSessionParts()
     worker.submit { // potentially trigger first delivery attempt by firing network status callback
         deliveryModule?.schedulingService?.let(
             essentialServiceModule.networkConnectivityService::addNetworkConnectivityListener,


### PR DESCRIPTION
## Goal

Refactors code to make it more explicit that session parts should be read on the IO thread rather than the session-persistence thread.
