### PR TITLE
Avoid and forbide use of non-performant means of obtaining serializers

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -50,7 +50,10 @@ potential-bugs:
 style:
   ForbiddenImport:
     active: true
-    imports: [ 'android.util.Pair' ]
+    # kotlinx.serialization.serializer / serializerOrNull resolve a serializer at runtime. Forbid their use in production,
+    # but allow usage in tests. Instead, prod code should use the generated serializers (e.g. ListSerializer).
+    imports: [ 'android.util.Pair', 'kotlinx.serialization.serializer', 'kotlinx.serialization.serializerOrNull' ]
+    excludes: [ '**/test/**', '**/integrationTest/**', '**/androidTest/**', '**/testFixtures/**' ]
   ForbiddenComment:
     active: false
   MagicNumber:

--- a/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/store/RemoteConfigStoreImpl.kt
+++ b/embrace-android-config/src/main/kotlin/io/embrace/android/embracesdk/internal/config/store/RemoteConfigStoreImpl.kt
@@ -5,9 +5,7 @@ import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.config.source.ConfigHttpResponse
 import io.embrace.android.embracesdk.internal.serialization.EmbraceBinary
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
-import io.embrace.android.embracesdk.internal.serialization.decodeFromStream
-import io.embrace.android.embracesdk.internal.serialization.encodeToStream
-import io.embrace.android.embracesdk.internal.serialization.toJson
+import kotlinx.serialization.builtins.nullable
 import java.io.File
 
 internal class RemoteConfigStoreImpl(
@@ -28,7 +26,7 @@ internal class RemoteConfigStoreImpl(
     private fun loadFromCache(): StoredConfigResponse? {
         return try {
             val cached = cachedConfigFile.inputStream().buffered().use {
-                EmbraceBinary.decodeFromStream<CachedConfiguration>(it)
+                EmbraceBinary.decodeFromStream(CachedConfiguration.serializer(), it)
             }
             StoredConfigResponse(
                 cfg = cached.remoteConfig,
@@ -71,7 +69,7 @@ internal class RemoteConfigStoreImpl(
         try {
             storageDir.mkdirs()
             configFile.outputStream().buffered().use { stream ->
-                serializer.toJson<RemoteConfig?>(response.cfg, stream)
+                serializer.toJson(response.cfg, RemoteConfig.serializer().nullable, stream)
             }
             response.etag?.let(etagFile::writeText)
         } catch (exc: Exception) {
@@ -101,7 +99,7 @@ internal class RemoteConfigStoreImpl(
                 remoteConfig = cfg,
             )
             cachedConfigFile.outputStream().buffered().use { stream ->
-                EmbraceBinary.encodeToStream(cached, stream)
+                EmbraceBinary.encodeToStream(CachedConfiguration.serializer(), cached, stream)
             }
         } catch (exc: Exception) {
             // a partially-written or failed blob must not be read back: delete it and rely on the

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/NativeSymbolTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/NativeSymbolTest.kt
@@ -8,7 +8,6 @@ import io.embrace.android.embracesdk.fakes.config.FakeBase64SharedObjectFilesMap
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
 import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.payload.NativeSymbols
-import io.embrace.android.embracesdk.internal.serialization.toJson
 import okhttp3.OkHttpClient
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -67,7 +66,7 @@ class NativeSymbolTest {
         arch: String = "arm64-v8a",
     ): ConfigService {
         val cfg = if (symbolMap != null) {
-            val json = serializer.toJson(NativeSymbols(symbols = symbolMap))
+            val json = serializer.toJson(NativeSymbols(symbols = symbolMap), NativeSymbols.serializer())
             val encodedSymbols = Base64.encode(json.toByteArray())
             FakeInstrumentedConfig(symbols = FakeBase64SharedObjectFilesMap(encodedSymbols))
         } else {

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/OkHttpRemoteConfigSourceTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/OkHttpRemoteConfigSourceTest.kt
@@ -7,7 +7,6 @@ import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRe
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.config.source.ConfigEndpoint
 import io.embrace.android.embracesdk.internal.config.source.OkHttpRemoteConfigSource
-import io.embrace.android.embracesdk.internal.serialization.toJson
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import okhttp3.mockwebserver.MockResponse
@@ -45,7 +44,7 @@ class OkHttpRemoteConfigSourceTest {
         // serialize the config response
         configResponseBuffer = Buffer()
         val gzipSink = GzipSink(configResponseBuffer).buffer()
-        TestPlatformSerializer().toJson(remoteConfig, gzipSink.outputStream())
+        TestPlatformSerializer().toJson(remoteConfig, RemoteConfig.serializer(), gzipSink.outputStream())
         source = OkHttpRemoteConfigSource(
             lazyOf(client),
             TestPlatformSerializer(),

--- a/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/PersistedConfigTest.kt
+++ b/embrace-android-config/src/test/kotlin/io/embrace/android/embracesdk/internal/config/PersistedConfigTest.kt
@@ -10,7 +10,6 @@ import io.embrace.android.embracesdk.internal.config.remote.OtelKotlinSdkConfig
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.config.source.ConfigHttpResponse
 import io.embrace.android.embracesdk.internal.config.store.RemoteConfigStoreImpl
-import io.embrace.android.embracesdk.internal.serialization.toJson
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -170,7 +169,7 @@ internal class PersistedConfigTest {
         } else if (persisted != null) {
             val storageDir = File(filesDir, PersistedConfig.STORAGE_DIR_NAME).apply { mkdirs() }
             File(storageDir, "most_recent_response").outputStream().buffered().use {
-                serializer.toJson(persisted, it)
+                serializer.toJson(persisted, RemoteConfig.serializer(), it)
             }
         }
         return PersistedConfig(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/SharedPrefsStore.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/SharedPrefsStore.kt
@@ -9,6 +9,7 @@ import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.store.KeyValueStoreEditor
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 import java.util.concurrent.atomic.AtomicBoolean
@@ -67,7 +68,7 @@ internal class SharedPrefsStore(
     override fun getStringMap(key: String): Map<String, String>? {
         return pending(key) {
             val mapString = impl.getString(key, null) ?: return@pending null
-            serializer.fromJson(mapString, mapSerializer)
+            serializer.fromJson(mapString, stringMapSerializer)
         }
     }
 
@@ -170,8 +171,7 @@ internal class SharedPrefsStore(
         val value: Any?,
         val write: (KeyValueStoreEditor) -> Unit,
     )
-
-    private companion object {
-        val mapSerializer = MapSerializer(String.serializer(), String.serializer())
-    }
 }
+
+internal val stringMapSerializer: KSerializer<Map<String, String>> =
+    MapSerializer(String.serializer(), String.serializer())

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/SharedPrefsStoreEditor.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/prefs/SharedPrefsStoreEditor.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.internal.prefs
 
 import android.content.SharedPreferences
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
-import io.embrace.android.embracesdk.internal.serialization.toJson
 import io.embrace.android.embracesdk.internal.store.KeyValueStoreEditor
 
 internal class SharedPrefsStoreEditor(
@@ -35,7 +34,7 @@ internal class SharedPrefsStoreEditor(
         value: Map<String, String>?,
     ) {
         val mapString = when {
-            value != null -> serializer.toJson(value)
+            value != null -> serializer.toJson(value, stringMapSerializer)
             else -> null
         }
         editor.putString(key, mapString)

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/CachedLogEnvelopeStoreImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/CachedLogEnvelopeStoreImpl.kt
@@ -9,7 +9,6 @@ import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
-import io.embrace.android.embracesdk.internal.serialization.toJson
 import io.embrace.android.embracesdk.internal.worker.PriorityWorker
 import java.io.File
 
@@ -38,6 +37,7 @@ class CachedLogEnvelopeStoreImpl(
         fileStorageService.store(storedTelemetryMetadata) { stream ->
             serializer.toJson(
                 LogPayload().createLogEnvelope(resource, metadata),
+                Envelope.serializer(LogPayload.serializer()),
                 stream,
             )
         }

--- a/embrace-android-instrumentation-app-exit-info/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/AeiNdkCrashProtobufSendTest.kt
+++ b/embrace-android-instrumentation-app-exit-info/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/aei/AeiNdkCrashProtobufSendTest.kt
@@ -12,10 +12,10 @@ import io.embrace.android.embracesdk.fakes.FakeTelemetryDestination
 import io.embrace.android.embracesdk.fakes.behavior.FakeAutoDataCaptureBehavior
 import io.embrace.android.embracesdk.fakes.fakeBackgroundWorker
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.internal.serialization.fromJson
-import io.embrace.android.embracesdk.internal.serialization.toJson
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.io.InputStream
@@ -57,9 +57,10 @@ internal class AeiNdkCrashProtobufSendTest {
         val input = HashMap<String, String>()
         input["serialization_test"] = trace
         val serializer = EmbraceSerializer()
-        val json = serializer.toJson<Map<String, String>>(input)
+        val mapSerializer = MapSerializer(String.serializer(), String.serializer())
+        val json = serializer.toJson(input, mapSerializer)
 
-        val output: Map<String, String> = serializer.fromJson(json)
+        val output: Map<String, String> = serializer.fromJson(json, mapSerializer)
         val outputTrace = checkNotNull(output["serialization_test"])
         val byteStream = outputTrace.decodeBlob()
         assertProtobufIsReadable(byteStream)

--- a/embrace-android-instrumentation-crash-jvm/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/JvmCrashDataSourceImpl.kt
+++ b/embrace-android-instrumentation-crash-jvm/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/jvm/JvmCrashDataSourceImpl.kt
@@ -10,13 +10,15 @@ import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.arch.schema.TelemetryAttributes
 import io.embrace.android.embracesdk.internal.arch.stacktrace.truncateStacktrace
 import io.embrace.android.embracesdk.internal.payload.LegacyExceptionInfo
+import io.embrace.android.embracesdk.internal.payload.ThreadInfo
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
-import io.embrace.android.embracesdk.internal.serialization.toJson
+import io.embrace.android.embracesdk.internal.serialization.stringListSerializer
 import io.embrace.android.embracesdk.internal.store.Ordinal
 import io.embrace.android.embracesdk.internal.utils.encodeToUTF8String
 import io.embrace.android.embracesdk.semconv.EmbAndroidAttributes
 import io.opentelemetry.kotlin.semconv.ExceptionAttributes
 import io.opentelemetry.kotlin.semconv.LogAttributes
+import kotlinx.serialization.builtins.ListSerializer
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -69,7 +71,7 @@ class JvmCrashDataSourceImpl(
                     setAttribute(
                         ExceptionAttributes.EXCEPTION_STACKTRACE,
                         encodeToUTF8String(
-                            serializer.toJson(crashException.lines),
+                            serializer.toJson(crashException.lines, stringListSerializer),
                         ),
                     )
                     setAttribute(LogAttributes.LOG_RECORD_UID, crashId)
@@ -115,7 +117,7 @@ class JvmCrashDataSourceImpl(
             result.add(0, exceptionInfo)
             throwable = throwable.cause
         }
-        return serializer.toJson<List<LegacyExceptionInfo>>(result)
+        return serializer.toJson(result, ListSerializer(LegacyExceptionInfo.serializer()))
     }
 
     /**
@@ -123,7 +125,7 @@ class JvmCrashDataSourceImpl(
      */
     private fun getThreadsInfo(): String {
         val threadsList = Thread.getAllStackTraces().map { truncateStacktrace(it.key, it.value) }
-        return serializer.toJson(threadsList)
+        return serializer.toJson(threadsList, ListSerializer(ThreadInfo.serializer()))
     }
 
     /**

--- a/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashDataSourceImpl.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashDataSourceImpl.kt
@@ -8,10 +8,11 @@ import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.arch.schema.TelemetryAttributes
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
-import io.embrace.android.embracesdk.internal.serialization.toJson
 import io.embrace.android.embracesdk.internal.store.Ordinal
 import io.embrace.android.embracesdk.semconv.EmbAndroidAttributes
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
 
 internal class NativeCrashDataSourceImpl(
     private val nativeCrashProcessor: NativeCrashProcessor,
@@ -69,7 +70,7 @@ internal class NativeCrashDataSourceImpl(
                 if (!symbols.isNullOrEmpty()) {
                     setAttribute(
                         EmbType.System.NativeCrash.embNativeCrashSymbols,
-                        args.serializer.toJson(symbols),
+                        args.serializer.toJson(symbols, MapSerializer(String.serializer(), String.serializer())),
                         keepBlankishValues = false,
                     )
                 }

--- a/embrace-android-instrumentation-crash-ndk/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashDataSourceImplTest.kt
+++ b/embrace-android-instrumentation-crash-ndk/src/test/kotlin/io/embrace/android/embracesdk/internal/instrumentation/crash/ndk/NativeCrashDataSourceImplTest.kt
@@ -9,10 +9,12 @@ import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType.System.NativeCrash.embNativeCrashException
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType.System.NativeCrash.embNativeCrashSymbols
 import io.embrace.android.embracesdk.internal.payload.NativeCrashData
-import io.embrace.android.embracesdk.internal.serialization.toJson
 import io.embrace.android.embracesdk.internal.utils.toUTF8String
 import io.embrace.android.embracesdk.semconv.EmbAndroidAttributes
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.nullable
+import kotlinx.serialization.builtins.serializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -68,7 +70,10 @@ internal class NativeCrashDataSourceImplTest {
             )
             assertEquals("1", attributes[EmbAndroidAttributes.EMB_ANDROID_CRASH_NUMBER])
             assertEquals(testNativeCrashData.crash, attributes[embNativeCrashException])
-            val json = args.serializer.toJson(testNativeCrashData.symbols)
+            val json = args.serializer.toJson(
+                testNativeCrashData.symbols,
+                MapSerializer(String.serializer(), String.serializer()).nullable,
+            )
             assertEquals(
                 json.toByteArray().toUTF8String(),
                 attributes[embNativeCrashSymbols],

--- a/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkCaptureDataSourceImpl.kt
+++ b/embrace-android-instrumentation-network-common/src/main/kotlin/io/embrace/android/embracesdk/internal/instrumentation/network/NetworkCaptureDataSourceImpl.kt
@@ -8,7 +8,6 @@ import io.embrace.android.embracesdk.internal.arch.schema.SchemaType
 import io.embrace.android.embracesdk.internal.config.remote.NetworkCaptureRuleRemoteConfig
 import io.embrace.android.embracesdk.internal.payload.NetworkCapturedCall
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
-import io.embrace.android.embracesdk.internal.serialization.toJson
 import io.embrace.android.embracesdk.internal.store.KeyValueStore
 import io.embrace.android.embracesdk.internal.telemetry.AppliedLimitType
 import kotlin.math.max
@@ -198,7 +197,7 @@ class NetworkCaptureDataSourceImpl(
     private fun encryptNetworkCall(capturedNetworkCall: NetworkCapturedCall): String? {
         val capturePublicKey = configService.networkBehavior.getNetworkBodyCapturePublicKey() ?: return null
         return networkCaptureEncryptionManager.encrypt(
-            serializer.toJson(capturedNetworkCall),
+            serializer.toJson(capturedNetworkCall, NetworkCapturedCall.serializer()),
             capturePublicKey,
         )
     }

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/serialization/EmbraceBinary.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/serialization/EmbraceBinary.kt
@@ -14,7 +14,6 @@ import kotlinx.serialization.encoding.CompositeDecoder
 import kotlinx.serialization.encoding.CompositeEncoder
 import kotlinx.serialization.modules.EmptySerializersModule
 import kotlinx.serialization.modules.SerializersModule
-import kotlinx.serialization.serializer
 import java.io.ByteArrayOutputStream
 import java.io.DataInput
 import java.io.DataInputStream
@@ -85,12 +84,6 @@ sealed class EmbraceBinary(
 
 /** Shared instance, mirroring [embraceJson]. */
 internal val embraceBinary: EmbraceBinary = EmbraceBinary
-
-inline fun <reified T> EmbraceBinary.encodeToStream(value: T, outputStream: OutputStream): Unit =
-    encodeToStream(serializer<T>(), value, outputStream)
-
-inline fun <reified T> EmbraceBinary.decodeFromStream(inputStream: InputStream): T =
-    decodeFromStream(serializer<T>(), inputStream)
 
 private class DataOutputEncoder(
     private val output: DataOutput,

--- a/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/serialization/PlatformSerializer.kt
+++ b/embrace-android-payload/src/main/kotlin/io/embrace/android/embracesdk/internal/serialization/PlatformSerializer.kt
@@ -2,17 +2,17 @@ package io.embrace.android.embracesdk.internal.serialization
 
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerializationStrategy
-import kotlinx.serialization.serializer
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
 import java.io.InputStream
 import java.io.OutputStream
 
 /**
  * Interface for JSON serializer wrapper that can be wrapped for testing purposes.
  *
- * The core methods take an explicit [SerializationStrategy] / [DeserializationStrategy] so the
- * interface stays free of reified type parameters. For ergonomic call sites, use the reified
- * inline extensions ([toJson], [fromJson]) defined below — the kotlinx-serialization compiler
- * plugin resolves [serializer]`<T>()` at compile time, capturing the full parameterized type.
+ * Every method takes an explicit [SerializationStrategy] / [DeserializationStrategy]. Do not
+ * resolve serializers at runtime due to potential performance impact. Instead, use the
+ * generated ones(e.g. MapSerializer), which don't need to be resolved when used.
  */
 interface PlatformSerializer {
     fun <T> toJson(value: T, serializer: SerializationStrategy<T>): String
@@ -21,20 +21,10 @@ interface PlatformSerializer {
     fun <T> fromJson(inputStream: InputStream, deserializer: DeserializationStrategy<T>): T
 }
 
-inline fun <reified T> PlatformSerializer.toJson(value: T): String =
-    toJson(value, serializer())
-
-inline fun <reified T> PlatformSerializer.toJson(value: T, outputStream: OutputStream): Unit =
-    toJson(value, serializer(), outputStream)
-
-inline fun <reified T> PlatformSerializer.fromJson(json: String): T =
-    fromJson(json, serializer<T>())
-
-inline fun <reified T> PlatformSerializer.fromJson(inputStream: InputStream): T =
-    fromJson(inputStream, serializer<T>())
-
 /**
  * Return the first 200 elements of [elements] as a JSON-encoded string.
  */
 fun PlatformSerializer.truncatedStacktrace(elements: Array<StackTraceElement>): String =
-    toJson(elements.take(200).map(StackTraceElement::toString).toList())
+    toJson(elements.take(200).map(StackTraceElement::toString).toList(), stringListSerializer)
+
+val stringListSerializer: SerializationStrategy<List<String>> = ListSerializer(String.serializer())

--- a/embrace-android-payload/src/test/kotlin/io/embrace/android/embracesdk/internal/payload/EmbraceSerializerTest.kt
+++ b/embrace-android-payload/src/test/kotlin/io/embrace/android/embracesdk/internal/payload/EmbraceSerializerTest.kt
@@ -1,9 +1,8 @@
 package io.embrace.android.embracesdk.internal.payload
 
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.internal.serialization.fromJson
-import io.embrace.android.embracesdk.internal.serialization.toJson
 import io.embrace.android.embracesdk.internal.serialization.truncatedStacktrace
+import kotlinx.serialization.builtins.ListSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -18,22 +17,23 @@ internal class EmbraceSerializerTest {
     @Test
     fun testWriteToFile() {
         val stream = ByteArrayOutputStream()
-        serializer.toJson(payload, stream)
+        serializer.toJson(payload, Attribute.serializer(), stream)
         assertTrue(stream.toByteArray().isNotEmpty())
     }
 
     @Test
     fun testLoadObject() {
-        val stream = serializer.toJson(payload).byteInputStream()
-        val result: Attribute = serializer.fromJson(stream)
+        val stream = serializer.toJson(payload, Attribute.serializer()).byteInputStream()
+        val result: Attribute = serializer.fromJson(stream, Attribute.serializer())
         assertEquals(payload, result)
     }
 
     @Test
     fun testLoadListOfObjects() {
         val listOfObjects = listOf(payload, payload2)
-        val stream = serializer.toJson(listOfObjects).byteInputStream()
-        val result: List<Attribute> = serializer.fromJson(stream)
+        val listSerializer = ListSerializer(Attribute.serializer())
+        val stream = serializer.toJson(listOfObjects, listSerializer).byteInputStream()
+        val result: List<Attribute> = serializer.fromJson(stream, listSerializer)
         assertEquals(2, result.size)
         assertEquals(payload, result[0])
         assertEquals(payload2, result[1])

--- a/embrace-android-payload/src/test/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeResourceAdapterTest.kt
+++ b/embrace-android-payload/src/test/kotlin/io/embrace/android/embracesdk/internal/payload/EnvelopeResourceAdapterTest.kt
@@ -1,8 +1,6 @@
 package io.embrace.android.embracesdk.internal.payload
 
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.internal.serialization.fromJson
-import io.embrace.android.embracesdk.internal.serialization.toJson
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -51,13 +49,13 @@ internal class EnvelopeResourceAdapterTest {
 
     @Test
     fun testFullObject() {
-        val observed = serializer.toJson(fullResource)
+        val observed = serializer.toJson(fullResource, EnvelopeResource.serializer())
         val expected = loadGoldenFile("envelope_resource_full.json")
         assertObjectsMatch(expected, observed)
 
         // Null fields serialization
         val emptyResource = EnvelopeResource()
-        val emptyJson = serializer.toJson(emptyResource)
+        val emptyJson = serializer.toJson(emptyResource, EnvelopeResource.serializer())
         assertNotNull(emptyJson)
         assertTrue(emptyJson.startsWith("{"))
         assertTrue(emptyJson.endsWith("}"))
@@ -65,7 +63,7 @@ internal class EnvelopeResourceAdapterTest {
 
     @Test
     fun testNullObject() {
-        val observed = serializer.toJson(emptyResource)
+        val observed = serializer.toJson(emptyResource, EnvelopeResource.serializer())
         val expected = loadGoldenFile("envelope_resource_null.json")
         assertObjectsMatch(expected, observed)
     }
@@ -79,13 +77,13 @@ internal class EnvelopeResourceAdapterTest {
             4 to AppFramework.FLUTTER,
         ).forEach { (value, expected) ->
             val json = """{"app_framework": $value}"""
-            val resource: EnvelopeResource = serializer.fromJson(json)
+            val resource: EnvelopeResource = serializer.fromJson(json, EnvelopeResource.serializer())
             assertEquals(expected, resource.appFramework)
         }
 
         // unknown value handled
         val unknownJson = """{"app_framework": 999}"""
-        val unknownResource: EnvelopeResource = serializer.fromJson(unknownJson)
+        val unknownResource: EnvelopeResource = serializer.fromJson(unknownJson, EnvelopeResource.serializer())
         assertNull(unknownResource.appFramework)
     }
 
@@ -96,8 +94,8 @@ internal class EnvelopeResourceAdapterTest {
     }
 
     private fun assertObjectsMatch(input: String, actual: String) {
-        val expected: EnvelopeResource = serializer.fromJson(input)
-        val observed: EnvelopeResource = serializer.fromJson(actual)
+        val expected: EnvelopeResource = serializer.fromJson(input, EnvelopeResource.serializer())
+        val observed: EnvelopeResource = serializer.fromJson(actual, EnvelopeResource.serializer())
 
         assertEquals(expected.appVersion, observed.appVersion)
         assertEquals(expected.appFramework, observed.appFramework)

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/FakeNativeSymbols.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/FakeNativeSymbols.kt
@@ -5,14 +5,13 @@ import io.embrace.android.embracesdk.fakes.TestPlatformSerializer
 import io.embrace.android.embracesdk.fakes.config.FakeBase64SharedObjectFilesMap
 import io.embrace.android.embracesdk.internal.config.CpuAbi
 import io.embrace.android.embracesdk.internal.payload.NativeSymbols
-import io.embrace.android.embracesdk.internal.serialization.toJson
 
 fun createNativeSymbolsForCurrentArch(
     symbols: Map<String, String>,
     abi: CpuAbi = CpuAbi.ARMEABI_V7A,
 ): FakeBase64SharedObjectFilesMap {
     val symbols = NativeSymbols(mapOf(abi.archName to symbols))
-    val json = TestPlatformSerializer().toJson(symbols)
+    val json = TestPlatformSerializer().toJson(symbols, NativeSymbols.serializer())
 
     val encoded = Base64.encodeToString(
         json.toByteArray(),

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/features/JvmCrashFeatureTest.kt
@@ -26,7 +26,6 @@ import io.embrace.android.embracesdk.internal.payload.LegacyExceptionInfo
 import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
 import io.embrace.android.embracesdk.internal.serialization.EmbraceSerializer
-import io.embrace.android.embracesdk.internal.serialization.toJson
 import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
 import io.embrace.android.embracesdk.internal.utils.getSafeStackTrace
 import io.embrace.android.embracesdk.internal.worker.Worker
@@ -37,6 +36,7 @@ import io.embrace.android.embracesdk.testframework.SdkIntegrationTestRule.Compan
 import io.embrace.android.embracesdk.testframework.actions.EmbraceSetupInterface
 import io.opentelemetry.kotlin.logging.SeverityNumber
 import io.opentelemetry.kotlin.semconv.LogAttributes
+import kotlinx.serialization.builtins.ListSerializer
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -290,7 +290,10 @@ internal class JvmCrashFeatureTest {
                     expectedState = "foreground"
                 )
                 val exceptionInfo = LegacyExceptionInfo.ofThrowable(testException)
-                val expectedExceptionCause = serializer.toJson(listOf(exceptionInfo))
+                val expectedExceptionCause = serializer.toJson(
+                    listOf(exceptionInfo),
+                    ListSerializer(LegacyExceptionInfo.serializer())
+                )
                 val expectedJsException = "{\"n\":\"name\",\"m\":\"message\",\"t\":\"type\",\"st\":\"stacktrace\"}"
 
                 val message = payloadStorageService.getPersistedSession()
@@ -355,7 +358,10 @@ internal class JvmCrashFeatureTest {
         )
 
         val exceptionInfo = LegacyExceptionInfo.ofThrowable(testException)
-        val expectedExceptionCause = serializer.toJson(listOf(exceptionInfo))
+        val expectedExceptionCause = serializer.toJson(
+            listOf(exceptionInfo),
+            ListSerializer(LegacyExceptionInfo.serializer())
+        )
 
         attributes?.assertMatches(
             mapOf(

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/SdkIntegrationTestRule.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/SdkIntegrationTestRule.kt
@@ -23,7 +23,6 @@ import io.embrace.android.embracesdk.internal.injection.EssentialServiceModule
 import io.embrace.android.embracesdk.internal.injection.EssentialServiceModuleImpl
 import io.embrace.android.embracesdk.internal.injection.InitModule
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
-import io.embrace.android.embracesdk.internal.serialization.toJson
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.testframework.actions.EmbraceActionInterface
@@ -208,7 +207,7 @@ internal class SdkIntegrationTestRule(
         val responseFile = File(storageDir, "most_recent_response")
 
         responseFile.outputStream().buffered().use { stream ->
-            TestPlatformSerializer().toJson(persistedRemoteConfig, stream)
+            TestPlatformSerializer().toJson(persistedRemoteConfig, RemoteConfig.serializer(), stream)
         }
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePayloadAssertionInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbracePayloadAssertionInterface.kt
@@ -19,7 +19,6 @@ import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
 import io.embrace.android.embracesdk.internal.payload.Span
-import io.embrace.android.embracesdk.internal.serialization.toJson
 import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
 import io.embrace.android.embracesdk.semconv.EmbAndroidAttributes
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
@@ -27,6 +26,8 @@ import io.embrace.android.embracesdk.testframework.assertions.JsonComparator.com
 import io.embrace.android.embracesdk.testframework.assertions.Placeholder
 import io.embrace.android.embracesdk.testframework.server.FakeApiServer
 import io.embrace.android.embracesdk.testframework.server.FormPart
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -254,7 +255,7 @@ internal class EmbracePayloadAssertionInterface(
         assertEquals("ERROR", log.severityText)
         assertEquals("", log.body)
 
-        val symbols = serializer.toJson(symbolMap)
+        val symbols = serializer.toJson(symbolMap, MapSerializer(String.serializer(), String.serializer()))
         assertEquals(crashData.nativeCrash.timestamp, log.timeUnixNano?.nanosToMillis())
 
         val attrs = checkNotNull(log.attributes)
@@ -322,7 +323,7 @@ internal class EmbracePayloadAssertionInterface(
         placeholders: Map<Placeholder, String> = emptyMap(),
     ) {
         try {
-            val observedJson = serializer.toJson(payload)
+            val observedJson = serializer.toJson(payload, kotlinx.serialization.serializer<T>())
             val expectedJson = placeholders.entries.fold(
                 ResourceReader.readResourceAsText(goldenFileName)
             ) { json, (placeholder, value) ->

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/actions/EmbraceSetupInterface.kt
@@ -41,9 +41,9 @@ import io.embrace.android.embracesdk.internal.instrumentation.crash.ndk.sharedOb
 import io.embrace.android.embracesdk.internal.instrumentation.thread.blockage.createThreadBlockageService
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
+import io.embrace.android.embracesdk.internal.payload.NativeCrashData
 import io.embrace.android.embracesdk.internal.prefs.createKeyValueStore
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
-import io.embrace.android.embracesdk.internal.serialization.toJson
 import io.embrace.android.embracesdk.internal.session.lifecycle.AndroidxProcessLifecycleTracker
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionPartSpan
 import io.embrace.android.embracesdk.internal.store.KeyValueStore
@@ -234,7 +234,7 @@ internal class EmbraceSetupInterface(
     ) {
         crashData.getCrashFile().createNewFile()
         val key = crashData.getCrashFile().absolutePath
-        val json = serializer.toJson(crashData.nativeCrash)
+        val json = serializer.toJson(crashData.nativeCrash, NativeCrashData.serializer())
         fakeJniDelegate.addCrashRaw(key, json)
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/server/FakeApiServer.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testframework/server/FakeApiServer.kt
@@ -8,7 +8,6 @@ import io.embrace.android.embracesdk.internal.delivery.debug.DeliveryTracer
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.LogPayload
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
-import io.embrace.android.embracesdk.internal.serialization.toJson
 import io.embrace.android.embracesdk.internal.otel.sdk.findAttributeValue
 import io.embrace.android.embracesdk.internal.utils.threadLocal
 import io.embrace.android.embracesdk.assertions.getLastLog
@@ -135,7 +134,7 @@ internal class FakeApiServer(
         if (configResponseJson != null) {
             gzipSink.use { it.writeUtf8(configResponseJson) }
         } else {
-            serializer.toJson(remoteConfig, gzipSink.outputStream())
+            serializer.toJson(remoteConfig, RemoteConfig.serializer(), gzipSink.outputStream())
         }
         val response = MockResponse()
             .setBody(configResponseBuffer)

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ReactNativeInternalInterfaceImpl.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/api/delegate/ReactNativeInternalInterfaceImpl.kt
@@ -12,7 +12,6 @@ import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.instrumentation.crash.jvm.JvmCrashDataSource
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.JsException
-import io.embrace.android.embracesdk.internal.serialization.toJson
 import io.embrace.android.embracesdk.internal.utils.encodeToUTF8String
 
 internal class ReactNativeInternalInterfaceImpl(
@@ -39,7 +38,7 @@ internal class ReactNativeInternalInterfaceImpl(
                 attributes.setAttribute(
                     embAndroidReactNativeCrashJsException,
                     encodeToUTF8String(
-                        serializer.toJson(exception),
+                        serializer.toJson(exception, JsException.serializer()),
                     ),
                 )
                 SchemaType.ReactNativeCrash(attributes)

--- a/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
+++ b/embrace-android-sdk/src/test/kotlin/io/embrace/android/embracesdk/injection/ModuleInitBootstrapperTest.kt
@@ -22,7 +22,6 @@ import io.embrace.android.embracesdk.internal.injection.InitModuleImpl
 import io.embrace.android.embracesdk.internal.injection.ModuleInitBootstrapper
 import io.embrace.android.embracesdk.internal.injection.postInit
 import io.embrace.android.embracesdk.internal.injection.postLoadInstrumentation
-import io.embrace.android.embracesdk.internal.serialization.toJson
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import io.opentelemetry.kotlin.NoopOpenTelemetry
 import org.junit.Assert.assertEquals
@@ -184,7 +183,7 @@ internal class ModuleInitBootstrapperTest {
     private fun createBootstrapperWithPersistedConfig(cfg: RemoteConfig): ModuleInitBootstrapper {
         val storageDir = File(context.filesDir, PersistedConfig.STORAGE_DIR_NAME).apply { mkdirs() }
         File(storageDir, "most_recent_response").outputStream().buffered().use { stream ->
-            TestPlatformSerializer().toJson(cfg, stream)
+            TestPlatformSerializer().toJson(cfg, RemoteConfig.serializer(), stream)
         }
         return ModuleInitBootstrapper(
             initModule = FakeInitModule(clock = clock, logger = logger),


### PR DESCRIPTION
Reference Kotlin Serialization serializers directly instead of relying on helper methods that could trigger classloading in apps where those classe aren't preloaded by AOT. Band this via a detekt rule. Also share serializer instance if possible to avoid race conditions that might create contention in sensitive areas.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>