### PR TITLE
Alter write debounce delay

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/CoalescingWriteQueue.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/CoalescingWriteQueue.kt
@@ -15,10 +15,12 @@ import java.util.concurrent.atomic.AtomicReference
  * A write is held as a [FutureTask] armed with a scheduled trigger that runs it
  * [delayMs] later. Cancelling that trigger does not cancel the [FutureTask] it wraps. This
  * lets [flush] force the task to run early rather than queueing the work twice.
+ *
+ * The first write submitted to a queue is not debounced.
  */
 internal class CoalescingWriteQueue(
     private val worker: BackgroundWorker,
-    private val delayMs: Long = DEFAULT_DELAY_MS,
+    private val delayMs: Long,
 ) {
     private val pending = AtomicReference<PendingWrite?>(null)
 
@@ -29,14 +31,14 @@ internal class CoalescingWriteQueue(
     private val sequence = AtomicLong()
 
     /**
-     * Arms [runnable] to run [delayMs] from now, disarming whatever was armed before it.
-     * In-progress writes are left to finish.
+     * Arms [runnable] to run once the delay from [delayFor] has elapsed, disarming whatever was
+     * armed before it. In-progress writes are left to finish.
      */
     fun submit(runnable: Runnable) {
         val seq = sequence.incrementAndGet()
         val task = FutureTask(runnable, Unit)
         val trigger = runCatching {
-            worker.schedule<Unit>(task, delayMs, TimeUnit.MILLISECONDS)
+            worker.schedule<Unit>(task, delayFor(seq), TimeUnit.MILLISECONDS)
         }.getOrNull()
         val write = PendingWrite(seq, task, trigger)
 
@@ -64,13 +66,20 @@ internal class CoalescingWriteQueue(
         runCatching { worker.submit(write.task) }
     }
 
+    /**
+     * How long the write numbered [seq] waits before it runs. The very first write for a session
+     * part is not debounced. All other writes wait for [delayMs].
+     */
+    private fun delayFor(seq: Long): Long = if (seq == FIRST_WRITE_SEQ) NO_DELAY_MS else delayMs
+
     private class PendingWrite(
         val seq: Long,
         val task: FutureTask<Unit>,
         val trigger: Future<*>?,
     )
 
-    companion object {
-        const val DEFAULT_DELAY_MS = 0L
+    private companion object {
+        const val FIRST_WRITE_SEQ: Long = 1
+        const val NO_DELAY_MS: Long = 0
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -46,13 +46,16 @@ class SessionPartWriterImpl(
         SessionPartDirectoryStore(sessionsDir, worker, clock, logger),
     private val writeTracker: SessionPartWriteTracker = SessionPartWriteTracker(),
     private val onWritesComplete: () -> Unit = {},
-    private val writeDelayMs: Long = CoalescingWriteQueue.DEFAULT_DELAY_MS,
 ) : SessionPartWriter {
 
-    private companion object {
-        const val CRASH_DRAIN_TIMEOUT_MS: Long = 3000
-        const val MAX_CARRIED_OVER_SPANS: Int = 1000
-        const val CARRIED_OVER_SPAN_LIMIT_TYPE: String = "carried_over_span"
+    internal companion object {
+        private const val CRASH_DRAIN_TIMEOUT_MS: Long = 3000
+        private const val MAX_CARRIED_OVER_SPANS: Int = 1000
+        private const val CARRIED_OVER_SPAN_LIMIT_TYPE: String = "carried_over_span"
+
+        const val METADATA_WRITE_DELAY_MS: Long = 10
+        const val SESSION_SPAN_WRITE_DELAY_MS: Long = 10
+        const val SPAN_SNAPSHOT_WRITE_DELAY_MS: Long = 100
     }
 
     /**
@@ -337,9 +340,9 @@ class SessionPartWriterImpl(
             logger = logger,
         )
 
-        val metadataWrites = CoalescingWriteQueue(worker, writeDelayMs)
-        val sessionSpanWrites = CoalescingWriteQueue(worker, writeDelayMs)
-        val spanSnapshotWrites = CoalescingWriteQueue(worker, writeDelayMs)
+        val metadataWrites = CoalescingWriteQueue(worker, METADATA_WRITE_DELAY_MS)
+        val sessionSpanWrites = CoalescingWriteQueue(worker, SESSION_SPAN_WRITE_DELAY_MS)
+        val spanSnapshotWrites = CoalescingWriteQueue(worker, SPAN_SNAPSHOT_WRITE_DELAY_MS)
 
         private val writeQueues = listOf(metadataWrites, sessionSpanWrites, spanSnapshotWrites)
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/CoalescingWriteQueueTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/CoalescingWriteQueueTest.kt
@@ -23,6 +23,15 @@ internal class CoalescingWriteQueueTest {
 
     private fun write(name: String) = Runnable { writes.add(name) }
 
+    /**
+     * Burns the queue's first write, which is never debounced, so that a test can exercise the
+     * delayed path.
+     */
+    private fun primeQueue(target: CoalescingWriteQueue = queue) {
+        target.submit(write("prime"))
+        writes.clear()
+    }
+
     @Before
     fun setUp() {
         executor = BlockingScheduledExecutorService(FakeClock(), blockingMode = false)
@@ -31,7 +40,53 @@ internal class CoalescingWriteQueueTest {
     }
 
     @Test
+    fun `the first write runs without waiting for the delay`() {
+        queue.submit(write("first"))
+        assertEquals(listOf("first"), writes)
+        assertEquals(0, executor.scheduledTasksCount())
+    }
+
+    @Test
+    fun `only the first write skips the delay`() {
+        queue.submit(write("first"))
+        queue.submit(write("second"))
+        assertEquals(listOf("first"), writes)
+        assertEquals(1, executor.scheduledTasksCount())
+
+        executor.moveForwardAndRunBlocked(DELAY_MS)
+        assertEquals(listOf("first", "second"), writes)
+    }
+
+    @Test
+    fun `the first write is queued on the worker rather than run inline`() {
+        val blockedExecutor = BlockingScheduledExecutorService(FakeClock(), blockingMode = true)
+        val blockedQueue = CoalescingWriteQueue(BackgroundWorker(blockedExecutor), DELAY_MS)
+
+        blockedQueue.submit(write("first"))
+        assertEquals(emptyList<String>(), writes)
+        assertEquals(0, blockedExecutor.scheduledTasksCount())
+
+        blockedExecutor.runCurrentlyBlocked()
+        assertEquals(listOf("first"), writes)
+    }
+
+    @Test
+    fun `a flushed write does not re-enable the immediate path`() {
+        primeQueue()
+        queue.submit(write("first"))
+        queue.flush()
+        assertEquals(listOf("first"), writes)
+
+        queue.submit(write("second"))
+        assertEquals(listOf("first"), writes)
+
+        executor.moveForwardAndRunBlocked(DELAY_MS)
+        assertEquals(listOf("first", "second"), writes)
+    }
+
+    @Test
     fun `a write waits out its delay`() {
+        primeQueue()
         queue.submit(write("first"))
 
         assertEquals(1, executor.scheduledTasksCount())
@@ -43,6 +98,7 @@ internal class CoalescingWriteQueueTest {
 
     @Test
     fun `writes submitted within the delay collapse to the last one`() {
+        primeQueue()
         queue.submit(write("first"))
         executor.moveForwardAndRunBlocked(DELAY_MS - 1)
         queue.submit(write("second"))
@@ -54,6 +110,7 @@ internal class CoalescingWriteQueueTest {
 
     @Test
     fun `writes submitted after the delay all run`() {
+        primeQueue()
         queue.submit(write("first"))
         executor.moveForwardAndRunBlocked(DELAY_MS)
         queue.submit(write("second"))
@@ -64,6 +121,7 @@ internal class CoalescingWriteQueueTest {
 
     @Test
     fun `flush runs the pending write immediately`() {
+        primeQueue()
         queue.submit(write("first"))
         queue.flush()
         assertEquals(listOf("first"), writes)
@@ -71,6 +129,7 @@ internal class CoalescingWriteQueueTest {
 
     @Test
     fun `a write forced by flush does not run again when its delay elapses`() {
+        primeQueue()
         queue.submit(write("first"))
         queue.flush()
 
@@ -87,6 +146,7 @@ internal class CoalescingWriteQueueTest {
 
     @Test
     fun `flush twice runs the pending write once`() {
+        primeQueue()
         queue.submit(write("first"))
         queue.flush()
         queue.flush()
@@ -95,6 +155,7 @@ internal class CoalescingWriteQueueTest {
 
     @Test
     fun `a write submitted after flush is armed as normal`() {
+        primeQueue()
         queue.submit(write("first"))
         queue.flush()
 
@@ -106,6 +167,7 @@ internal class CoalescingWriteQueueTest {
 
     @Test
     fun `a write that throws does not fail flush`() {
+        primeQueue()
         queue.submit { error("write failed") }
         queue.flush()
         assertEquals(emptyList<String>(), writes)
@@ -124,6 +186,10 @@ internal class CoalescingWriteQueueTest {
         val blockedExecutor = BlockingScheduledExecutorService(FakeClock(), blockingMode = true)
         val blockedQueue = CoalescingWriteQueue(BackgroundWorker(blockedExecutor), DELAY_MS)
 
+        primeQueue(blockedQueue)
+        blockedExecutor.runCurrentlyBlocked()
+        writes.clear()
+
         blockedQueue.submit(write("first"))
         blockedQueue.flush()
         assertEquals(emptyList<String>(), writes)
@@ -140,6 +206,8 @@ internal class CoalescingWriteQueueTest {
         }
         val reentrantQueue = CoalescingWriteQueue(BackgroundWorker(hookedExecutor), DELAY_MS)
         queueRef = reentrantQueue
+
+        primeQueue(reentrantQueue)
 
         reentrantQueue.submit(write("first"))
         executor.moveForwardAndRunBlocked(DELAY_MS)
@@ -160,7 +228,7 @@ internal class CoalescingWriteQueueTest {
 
         override fun schedule(command: Runnable?, delay: Long, unit: TimeUnit?): ScheduledFuture<*> {
             val future = delegate.schedule(command, delay, unit)
-            if (!hooked) {
+            if (!hooked && delay > 0) {
                 hooked = true
                 onFirstSchedule()
             }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -2072,11 +2072,7 @@ internal class SessionOrchestratorTest {
         return sessionSpanOnDisk(sessionPartId)
     }
 
-    private fun drainPersistence() {
-        do {
-            sessionPersistenceExecutor.moveForwardAndRunBlocked(CoalescingWriteQueue.DEFAULT_DELAY_MS)
-        } while (sessionPersistenceExecutor.scheduledTasksCount() > 0)
-    }
+    private fun drainPersistence() = sessionPersistenceExecutor.drainWrites()
 
     private fun sessionSpanOnDisk(sessionPartId: String): SessionPartSpan? {
         val directory = partDirs().single { it.sessionPartId == sessionPartId }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriteDrain.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriteDrain.kt
@@ -1,0 +1,29 @@
+package io.embrace.android.embracesdk.internal.session.orchestrator
+
+import io.embrace.android.embracesdk.concurrency.BlockingScheduledExecutorService
+
+/**
+ * Exceeds the longest delay that any [CoalescingWriteQueue] in [SessionPartWriterImpl] is armed
+ * with, so that advancing time by this much always makes a debounced write due.
+ */
+internal val WRITE_DRAIN_TICK_MS: Long = maxOf(
+    SessionPartWriterImpl.METADATA_WRITE_DELAY_MS,
+    SessionPartWriterImpl.SESSION_SPAN_WRITE_DELAY_MS,
+    SessionPartWriterImpl.SPAN_SNAPSHOT_WRITE_DELAY_MS,
+)
+
+private const val MAX_DRAIN_ITERATIONS = 100
+
+/**
+ * Runs every queued session part write, including the debounced ones, by advancing time until
+ * nothing is left scheduled.
+ */
+internal fun BlockingScheduledExecutorService.drainWrites(tickMs: Long = WRITE_DRAIN_TICK_MS) {
+    repeat(MAX_DRAIN_ITERATIONS) {
+        moveForwardAndRunBlocked(tickMs)
+        if (scheduledTasksCount() == 0) {
+            return
+        }
+    }
+    error("session part writes never settled")
+}

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterBoundaryTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterBoundaryTest.kt
@@ -106,9 +106,10 @@ internal class SessionPartWriterBoundaryTest {
         startPart(SECOND_PART_ID)
         drain()
 
-        // the queued write went to the first part
-        assertEquals("user1", metadataIn(FIRST_PART_ID)?.user_id)
-        assertEquals("user2", metadataIn(SECOND_PART_ID)?.user_id)
+        // the queued write went to the first part. it ran after the second part's own writes, as
+        // those are not debounced, hence the higher user id
+        assertEquals("user2", metadataIn(FIRST_PART_ID)?.user_id)
+        assertEquals("user1", metadataIn(SECOND_PART_ID)?.user_id)
         assertEquals(3, writeCount)
         assertNoInternalErrors()
     }
@@ -122,6 +123,24 @@ internal class SessionPartWriterBoundaryTest {
         drain()
 
         // the first of the queued writes was superseded, and the one that ran went to the first part
+        assertEquals("user2", metadataIn(FIRST_PART_ID)?.user_id)
+        assertEquals("user1", metadataIn(SECOND_PART_ID)?.user_id)
+        assertEquals(3, writeCount)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a metadata write queued before a part ends is flushed ahead of the newer part`() {
+        startPart(FIRST_PART_ID)
+        drain()
+        writer.onMetadataChanged()
+
+        // the orchestrator always ends a part before the next one starts, and ending it flushes
+        // the debounced write rather than leaving it armed
+        endPart(FIRST_PART_ID)
+        startPart(SECOND_PART_ID)
+        drain()
+
         assertEquals("user1", metadataIn(FIRST_PART_ID)?.user_id)
         assertEquals("user2", metadataIn(SECOND_PART_ID)?.user_id)
         assertEquals(3, writeCount)
@@ -278,11 +297,7 @@ internal class SessionPartWriterBoundaryTest {
         sessionSpan = checkNotNull(currentSessionPartSpan.sessionPartSpan)
     }
 
-    private fun drain() {
-        do {
-            executor.moveForwardAndRunBlocked(CoalescingWriteQueue.DEFAULT_DELAY_MS)
-        } while (executor.scheduledTasksCount() > 0)
-    }
+    private fun drain() = executor.drainWrites()
 
     private fun sessionPartDirs(): List<SessionPartDirectory> =
         (sessionsDir.list() ?: emptyArray())

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
@@ -34,6 +34,8 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
 import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
 
 internal class SessionPartWriterImplTest {
 
@@ -41,7 +43,6 @@ internal class SessionPartWriterImplTest {
         private const val USER_SESSION_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         private const val SESSION_PART_ID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         private const val OTHER_SESSION_PART_ID = "cccccccccccccccccccccccccccccccc"
-        private const val WRITE_DELAY_MS = 5000L
         private const val METADATA_FILE_NAME = "metadata.pb"
         private const val MANIFEST_FILE_NAME = "manifest.pb"
         private const val SESSION_SPAN_FILE_NAME = "session_span.pb"
@@ -619,16 +620,17 @@ internal class SessionPartWriterImplTest {
         executor.blockingMode = false
         onMetadataRead = { events.add("metadata-write") }
 
-        val writer = createWriter(
-            worker = BackgroundWorker(recordingExecutor),
-            writeDelayMs = WRITE_DELAY_MS,
-        )
+        val writer = createWriter(worker = BackgroundWorker(recordingExecutor))
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        assertEquals(listOf("metadata-write"), events)
+        events.clear()
+
+        writer.onMetadataChanged()
         assertEquals(emptyList<String>(), events)
 
         writer.onCrash()
         assertEquals(listOf("metadata-write", "shutdown"), events)
-        assertEquals("user0", metadataOnDisk(SESSION_PART_ID)?.user_id)
+        assertEquals("user1", metadataOnDisk(SESSION_PART_ID)?.user_id)
         assertNoInternalErrors()
     }
 
@@ -636,21 +638,73 @@ internal class SessionPartWriterImplTest {
     fun `a debounced write runs before the part's writes are announced as complete`() {
         var endTimeAtCompletion: Long? = null
         val writer = createWriter(
-            writeDelayMs = WRITE_DELAY_MS,
             onWritesComplete = {
                 endTimeAtCompletion = sessionSpanOnDisk(SESSION_PART_ID)?.span?.end_time_unix_nano
             },
         )
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
-        drain(WRITE_DELAY_MS)
+        drain()
 
         clock.tick(10000)
         endPart()
         val expectedEndTimeNanos = clock.now().millisToNanos()
         writer.onSessionPartEnded(SESSION_PART_ID)
-        drain(WRITE_DELAY_MS)
+        drain()
 
         assertEquals(expectedEndTimeNanos, endTimeAtCompletion)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `the first write of a session part is not debounced`() {
+        executor.blockingMode = false
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+
+        assertEquals("user0", metadataOnDisk(SESSION_PART_ID)?.user_id)
+        assertEquals("span0", sessionSpanOnDisk(SESSION_PART_ID)?.span?.name)
+        assertEquals(0, executor.scheduledTasksCount())
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a write after the first one waits out its delay`() {
+        executor.blockingMode = false
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        writer.onMetadataChanged()
+        assertEquals("user0", metadataOnDisk(SESSION_PART_ID)?.user_id)
+
+        executor.moveForwardAndRunBlocked(SessionPartWriterImpl.METADATA_WRITE_DELAY_MS)
+        assertEquals("user1", metadataOnDisk(SESSION_PART_ID)?.user_id)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `each write queue is armed with its own delay`() {
+        val delays = mutableListOf<Long>()
+        val writer = createWriter(worker = BackgroundWorker(DelayRecordingExecutor(executor, delays)))
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+
+        // every write queued when the part starts is the first one for its file
+        assertEquals(listOf(0L, 0L, 0L), delays)
+        delays.clear()
+
+        writer.onMetadataChanged()
+        assertEquals(listOf(SessionPartWriterImpl.METADATA_WRITE_DELAY_MS), delays)
+        delays.clear()
+
+        endPart()
+        writer.onSessionPartEnded(SESSION_PART_ID)
+        assertEquals(
+            listOf(
+                SessionPartWriterImpl.SESSION_SPAN_WRITE_DELAY_MS,
+                SessionPartWriterImpl.SPAN_SNAPSHOT_WRITE_DELAY_MS,
+            ),
+            delays,
+        )
+        drain()
         assertNoInternalErrors()
     }
 
@@ -1037,6 +1091,20 @@ internal class SessionPartWriterImplTest {
         assertNoInternalErrors()
     }
 
+    /**
+     * Records the delay that each write is armed with.
+     */
+    private class DelayRecordingExecutor(
+        private val delegate: ScheduledExecutorService,
+        private val delays: MutableList<Long>,
+    ) : ScheduledExecutorService by delegate {
+
+        override fun schedule(command: Runnable?, delay: Long, unit: TimeUnit?): ScheduledFuture<*> {
+            delays.add(delay)
+            return delegate.schedule(command, delay, unit)
+        }
+    }
+
     private class ShutdownRecordingExecutor(
         private val delegate: ScheduledExecutorService,
         private val onShutdown: () -> Unit,
@@ -1065,7 +1133,6 @@ internal class SessionPartWriterImplTest {
         configService: FakeConfigService = configService(enabled),
         sessionsDir: File = this.sessionsDir,
         worker: BackgroundWorker = BackgroundWorker(executor),
-        writeDelayMs: Long = CoalescingWriteQueue.DEFAULT_DELAY_MS,
         onWritesComplete: () -> Unit = {},
     ) = SessionPartWriterImpl(
         lazy { sessionsDir },
@@ -1083,7 +1150,6 @@ internal class SessionPartWriterImplTest {
         },
         telemetryService,
         onWritesComplete = onWritesComplete,
-        writeDelayMs = writeDelayMs,
     )
 
     private fun configService(
@@ -1097,14 +1163,10 @@ internal class SessionPartWriterImplTest {
         },
     )
 
-    private fun drain(delayMs: Long = CoalescingWriteQueue.DEFAULT_DELAY_MS) {
-        do {
-            executor.moveForwardAndRunBlocked(delayMs)
-        } while (executor.scheduledTasksCount() > 0)
-    }
+    private fun drain() = executor.drainWrites()
 
     private fun drainOnce() {
-        executor.moveForwardAndRunBlocked(CoalescingWriteQueue.DEFAULT_DELAY_MS)
+        executor.moveForwardAndRunBlocked(WRITE_DRAIN_TICK_MS)
     }
 
     /**

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceChangeTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceChangeTest.kt
@@ -166,12 +166,12 @@ internal class SessionPartWriterResourceChangeTest {
         val writer = createWriter()
         startPart(writer, FIRST_PART_ID)
         drain()
-        assertEquals(3, resourceReads)
+        assertEquals(4, resourceReads)
 
         repeat(3) { changeResource("bundle-2.$it") }
         drain()
 
-        assertEquals(4, resourceReads)
+        assertEquals(5, resourceReads)
         assertEquals("bundle-2.2", bundleIdOnDisk(FIRST_PART_ID))
         assertNoInternalErrors()
     }
@@ -254,11 +254,7 @@ internal class SessionPartWriterResourceChangeTest {
         resourceListeners.forEach { listener -> listener(resource) }
     }
 
-    private fun drain() {
-        do {
-            executor.moveForwardAndRunBlocked(CoalescingWriteQueue.DEFAULT_DELAY_MS)
-        } while (executor.scheduledTasksCount() > 0)
-    }
+    private fun drain() = executor.drainWrites()
 
     private fun partDirs(): List<SessionPartDirectory> =
         (sessionsDir.list() ?: emptyArray())

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceReadTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceReadTest.kt
@@ -217,9 +217,5 @@ internal class SessionPartWriterResourceReadTest {
     private fun directory(): SessionPartDirectory =
         (sessionsDir.list() ?: emptyArray()).mapNotNull(SessionPartDirectory::fromDirName).single()
 
-    private fun drain() {
-        do {
-            executor.moveForwardAndRunBlocked(CoalescingWriteQueue.DEFAULT_DELAY_MS)
-        } while (executor.scheduledTasksCount() > 0)
-    }
+    private fun drain() = executor.drainWrites()
 }


### PR DESCRIPTION
## Goal

Alters the delays used for debouncing writes so that they are more likely to avoid bursts of writes, without overly increasing the time for data to get persisted. Additionally altered queueing so that the first write is always written. 

## Testing

Added unit tests.
