### PR TITLE
Persist span snapshot on span changes

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
@@ -4,7 +4,6 @@ import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.delivery.storage.StorageLocation
 import io.embrace.android.embracesdk.internal.delivery.storage.asFile
-import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.otel.spans.hasEmbraceAttribute
 import io.embrace.android.embracesdk.internal.resurrection.SessionPartReader
 import io.embrace.android.embracesdk.internal.session.UserSessionMetadataStore
@@ -110,7 +109,6 @@ class UserSessionOrchestrationModuleImpl(
                 // don't include the session part span
                 openTelemetryModule.spanRepository.getActiveEmbraceSpans()
                     .filterNot { it.hasEmbraceAttribute(EmbType.Ux.Session) }
-                    .mapNotNull(EmbraceSdkSpan::snapshot)
             },
             initModule.telemetryService,
             sessionPartDirectoryStore,
@@ -121,6 +119,11 @@ class UserSessionOrchestrationModuleImpl(
         openTelemetryModule.spanRepository.addCompletedOtelSpansListener { spans ->
             // don't include the session part span
             sessionPartWriter.onSpanCompleted(spans.filterNot { it.hasEmbraceAttribute(EmbType.Ux.Session) })
+        }
+        openTelemetryModule.spanRepository.addSpanChangeListener { span ->
+            if (!span.hasEmbraceAttribute(EmbType.Ux.Session)) {
+                sessionPartWriter.onSpanSnapshotChanged()
+            }
         }
 
         SessionOrchestratorImpl(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriter.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriter.kt
@@ -29,6 +29,11 @@ interface SessionPartWriter {
     fun onSpanCompleted(spans: List<Span>)
 
     /**
+     * An in-flight span has changed, so the span snapshots on disk are stale.
+     */
+    fun onSpanSnapshotChanged()
+
+    /**
      * The periodic cache interval has elapsed. Rewrites the session span so disk reflects reality.
      */
     fun onPeriodicWrite()

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -40,7 +40,7 @@ class SessionPartWriterImpl(
     private val resourceSource: EnvelopeResourceSource,
     private val metadataSource: EnvelopeMetadataSource,
     private val currentSessionPartSpan: CurrentSessionPartSpan,
-    private val spanSnapshotSource: () -> List<Span>,
+    private val inFlightSpanSource: () -> List<EmbraceSdkSpan>,
     private val telemetryService: TelemetryService,
     private val directoryStore: SessionPartDirectoryStore =
         SessionPartDirectoryStore(sessionsDir, worker, clock, logger),
@@ -153,6 +153,13 @@ class SessionPartWriterImpl(
         queueCompletedSpansWrite(writers, spans)
     }
 
+    override fun onSpanSnapshotChanged() {
+        if (!acceptingWrites()) {
+            return
+        }
+        queueSpanSnapshotsRefresh(current ?: return)
+    }
+
     private fun onResourceChanged() {
         if (!acceptingWrites()) {
             return
@@ -231,17 +238,22 @@ class SessionPartWriterImpl(
      * Writes in-flight spans to a snapshot file.
      */
     private fun queueSpanSnapshotsWrite(writers: PartWriters) {
-        // TODO: future: don't call this every time the listener is invoked as it's expensive to
-        // obtain _all_ the spans for every change. Currently this write only happens at session
-        // start/end
         val spans = try {
-            spanSnapshotSource()
+            inFlightSpanSource()
         } catch (exc: Throwable) {
             logger.trackInternalError(InternalErrorType.SpanSnapshotsWriteFail, exc)
             return
         }
         execute(InternalErrorType.SpanSnapshotsWriteFail, writers.spanSnapshotWrites::submit) {
-            writers.spanSnapshots.write(spans)
+            writers.spanSnapshots.write(spans.mapNotNull(EmbraceSdkSpan::snapshot))
+        }
+    }
+
+    private fun queueSpanSnapshotsRefresh(writers: PartWriters) {
+        execute(InternalErrorType.SpanSnapshotsWriteFail, writers.spanSnapshotWrites::submit) {
+            if (current === writers) {
+                writers.spanSnapshots.write(inFlightSpanSource().mapNotNull(EmbraceSdkSpan::snapshot))
+            }
         }
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
@@ -13,6 +13,7 @@ import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadataSource
 import io.embrace.android.embracesdk.internal.envelope.resource.EnvelopeResourceSource
+import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
 import io.embrace.android.embracesdk.internal.payload.Span
@@ -48,7 +49,6 @@ internal class SessionPartWriterImplTest {
         private const val SESSION_SPAN_FILE_NAME = "session_span.pb"
         private const val SPAN_SNAPSHOTS_FILE_NAME = "span_snapshots.pb"
         private const val COMPLETED_SPANS_FILE_NAME = "completed_spans.pb"
-        private val IN_FLIGHT_SPAN = Span(spanId = "aaaaaaaaaaaaaaa1", name = "network-request")
         private const val ENVELOPE_VERSION = "0.1.0"
         private const val ENVELOPE_TYPE = "spans"
         private val SYMBOLS = mapOf("armeabi-v7a" to "my-symbols")
@@ -72,7 +72,7 @@ internal class SessionPartWriterImplTest {
 
     private lateinit var sessionSpan: FakeEmbraceSdkSpan
     private lateinit var currentSessionPartSpan: FakeCurrentSessionPartSpan
-    private var inFlightSpans: List<Span> = emptyList()
+    private var inFlightSpans: List<EmbraceSdkSpan> = emptyList()
     private var onSpanSnapshotsRead: () -> Unit = {}
 
     private var resourceCount = 0
@@ -804,7 +804,7 @@ internal class SessionPartWriterImplTest {
     @Test
     fun `the in-flight spans are written as soon as a session part starts`() {
         val writer = createWriter()
-        inFlightSpans = listOf(IN_FLIGHT_SPAN)
+        inFlightSpans = listOf(inFlightSpan("network-request"))
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
         assertEquals(listOf("network-request"), spanSnapshotNamesIn(SESSION_PART_ID))
         assertNoInternalErrors()
@@ -813,12 +813,12 @@ internal class SessionPartWriterImplTest {
     @Test
     fun `the in-flight spans are rewritten when the session part ends`() {
         val writer = createWriter()
-        inFlightSpans = listOf(IN_FLIGHT_SPAN)
+        inFlightSpans = listOf(inFlightSpan("network-request"))
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
         drain()
 
         clock.tick(1000)
-        inFlightSpans = listOf(IN_FLIGHT_SPAN.copy(name = "view-load"))
+        inFlightSpans = listOf(inFlightSpan("view-load"))
         endPart()
         writer.onSessionPartEnded(SESSION_PART_ID)
 
@@ -837,14 +837,186 @@ internal class SessionPartWriterImplTest {
     @Test
     fun `a periodic write leaves the span snapshots untouched`() {
         val writer = createWriter()
-        inFlightSpans = listOf(IN_FLIGHT_SPAN)
+        inFlightSpans = listOf(inFlightSpan("network-request"))
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
         drain()
 
-        inFlightSpans = listOf(IN_FLIGHT_SPAN.copy(name = "view-load"))
+        inFlightSpans = listOf(inFlightSpan("view-load"))
         writer.onPeriodicWrite()
 
         assertEquals(listOf("network-request"), spanSnapshotNamesIn(SESSION_PART_ID))
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a span snapshot change rewrites the in-flight spans`() {
+        val writer = createWriter()
+        inFlightSpans = listOf(inFlightSpan("network-request"))
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+
+        inFlightSpans = listOf(inFlightSpan("view-load"))
+        writer.onSpanSnapshotChanged()
+
+        assertEquals(listOf("view-load"), spanSnapshotNamesIn(SESSION_PART_ID))
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `the in-flight spans are gathered when the write runs rather than when it is queued`() {
+        var reads = 0
+        onSpanSnapshotsRead = { reads++ }
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+        assertEquals(1, reads)
+
+        inFlightSpans = listOf(inFlightSpan("network-request"))
+        writer.onSpanSnapshotChanged()
+        assertEquals(1, reads)
+        assertEquals(emptyList<String>(), spanSnapshotNamesOnDisk(SESSION_PART_ID))
+
+        drain()
+        assertEquals(2, reads)
+        assertEquals(listOf("network-request"), spanSnapshotNamesOnDisk(SESSION_PART_ID))
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a burst of span snapshot changes is coalesced into one write of the latest spans`() {
+        var reads = 0
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+
+        onSpanSnapshotsRead = { reads++ }
+        repeat(4) { index ->
+            clock.tick(1000)
+            inFlightSpans = listOf(inFlightSpan("view-load-$index"))
+            writer.onSpanSnapshotChanged()
+        }
+        drain()
+
+        assertEquals(1, reads)
+        assertEquals(listOf("view-load-3"), spanSnapshotNamesIn(SESSION_PART_ID))
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `the in-flight spans persisted for a session part are the ones it ended with`() {
+        val writer = createWriter()
+        inFlightSpans = listOf(inFlightSpan("network-request"))
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+
+        clock.tick(1000)
+        endPart()
+        writer.onSessionPartEnded(SESSION_PART_ID)
+        inFlightSpans = listOf(inFlightSpan("next-part-span"))
+        drain()
+
+        assertEquals(listOf("network-request"), spanSnapshotNamesOnDisk(SESSION_PART_ID))
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `the in-flight spans persisted for a session part are the ones it started with`() {
+        val writer = createWriter()
+        inFlightSpans = listOf(inFlightSpan("network-request"))
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+
+        clock.tick(1000)
+        inFlightSpans = listOf(inFlightSpan("later-span"))
+        drain()
+
+        assertEquals(listOf("network-request"), spanSnapshotNamesOnDisk(SESSION_PART_ID))
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a span snapshot change is dropped once another session part has started`() {
+        val writer = createWriter()
+        inFlightSpans = listOf(inFlightSpan("network-request"))
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+        writer.onSpanSnapshotChanged()
+
+        clock.tick(10000)
+        inFlightSpans = listOf(inFlightSpan("next-part-span"))
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, OTHER_SESSION_PART_ID)
+        drain()
+
+        assertEquals(listOf("network-request"), spanSnapshotNamesOnDisk(SESSION_PART_ID))
+        assertEquals(listOf("next-part-span"), spanSnapshotNamesOnDisk(OTHER_SESSION_PART_ID))
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `an in-flight span is snapshotted when its write runs rather than when it is queued`() {
+        val writer = createWriter()
+        val span = inFlightSpan("network-request")
+        inFlightSpans = listOf(span)
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        span.name = "view-load"
+        drain()
+
+        assertEquals(listOf("view-load"), spanSnapshotNamesOnDisk(SESSION_PART_ID))
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a span snapshot change before any session part starts writes nothing`() {
+        val writer = createWriter()
+        writer.onSpanSnapshotChanged()
+
+        assertEquals(emptyList<SessionPartDirectory>(), sessionPartDirs())
+        assertEquals(0, executor.submitCount)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a span snapshot change after a session part ended is not written to it`() {
+        val writer = createWriter()
+        inFlightSpans = listOf(inFlightSpan("network-request"))
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+
+        clock.tick(1000)
+        endPart()
+        writer.onSessionPartEnded(SESSION_PART_ID)
+        drain()
+
+        inFlightSpans = listOf(inFlightSpan("view-load"))
+        writer.onSpanSnapshotChanged()
+
+        assertEquals(listOf("network-request"), spanSnapshotNamesIn(SESSION_PART_ID))
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a span snapshot change is ignored when multi file persistence is disabled`() {
+        val writer = createWriter(enabled = false)
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        writer.onSpanSnapshotChanged()
+
+        assertEquals(emptyList<SessionPartDirectory>(), sessionPartDirs())
+        assertEquals(0, executor.submitCount)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `no span snapshots are written once a crash has been handled`() {
+        val writer = createWriter()
+        inFlightSpans = listOf(inFlightSpan("network-request"))
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        writer.onCrash()
+        val submitCount = executor.submitCount
+
+        inFlightSpans = listOf(inFlightSpan("view-load"))
+        writer.onSpanSnapshotChanged()
+
+        assertEquals(submitCount, executor.submitCount)
+        assertEquals(listOf("network-request"), spanSnapshotNamesOnDisk(SESSION_PART_ID))
         assertNoInternalErrors()
     }
 
@@ -1116,6 +1288,9 @@ internal class SessionPartWriterImplTest {
         }
     }
 
+    private fun inFlightSpan(name: String) =
+        FakeEmbraceSdkSpan(name = name).apply { start(clock.now()) }
+
     private fun completedSpan(name: String) = Span(
         traceId = "6c9b1f2ec1d34f3c9a7d0b8e5f2a4c11",
         spanId = "aaaaaaaaaaaaaaa2",
@@ -1209,12 +1384,15 @@ internal class SessionPartWriterImplTest {
 
     private fun spanSnapshotNamesIn(sessionPartId: String): List<String?>? {
         drain()
-        return partFile(sessionPartId, SPAN_SNAPSHOTS_FILE_NAME)
+        return spanSnapshotNamesOnDisk(sessionPartId)
+    }
+
+    private fun spanSnapshotNamesOnDisk(sessionPartId: String): List<String?>? =
+        partFile(sessionPartId, SPAN_SNAPSHOTS_FILE_NAME)
             ?.inputStream()
             ?.use(SpanSnapshots.ADAPTER::decode)
             ?.spans
             ?.map { it.name }
-    }
 
     private fun completedSpanNamesIn(sessionPartId: String): List<String?> {
         drain()

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceReadTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceReadTest.kt
@@ -12,9 +12,9 @@ import io.embrace.android.embracesdk.fakes.TestUuidSource
 import io.embrace.android.embracesdk.fakes.createPersistenceBehavior
 import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadataSource
+import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
-import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.session.persistence.CompletedSpans
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectory
 import io.embrace.android.embracesdk.internal.session.persistence.SessionReconstructionService
@@ -60,17 +60,6 @@ internal class SessionPartWriterResourceReadTest {
             span_id = "aaaaaaaaaaaaaaa2",
             name = "emb-startup-moment",
         )
-
-        private val inFlightSpan = Span(
-            traceId = spanTemplate.trace_id,
-            spanId = "aaaaaaaaaaaaaaa3",
-            name = "emb-network-request",
-            startTimeNanos = spanTemplate.start_time_unix_nano,
-            status = Span.Status.UNSET,
-            events = emptyList(),
-            attributes = emptyList(),
-            links = emptyList(),
-        )
     }
 
     @get:Rule
@@ -85,7 +74,8 @@ internal class SessionPartWriterResourceReadTest {
     private lateinit var currentSessionPartSpan: FakeCurrentSessionPartSpan
     private lateinit var service: SessionReconstructionService
     private lateinit var resourceSource: FakeEnvelopeResourceSource
-    private var inFlightSpans: List<Span> = emptyList()
+    private lateinit var inFlightSpan: FakeEmbraceSdkSpan
+    private var inFlightSpans: List<EmbraceSdkSpan> = emptyList()
 
     @Before
     fun setUp() {
@@ -93,6 +83,7 @@ internal class SessionPartWriterResourceReadTest {
         clock = FakeClock()
         executor = BlockingScheduledExecutorService(clock, true)
         logger = FakeInternalLogger(throwOnInternalError = false)
+        inFlightSpan = FakeEmbraceSdkSpan(name = "emb-network-request").apply { start(clock.now()) }
         inFlightSpans = listOf(inFlightSpan)
         sessionSpan = FakeEmbraceSdkSpan(name = "emb-session").apply { start(clock.now()) }
         currentSessionPartSpan = FakeCurrentSessionPartSpan(clock).apply { sessionPartSpan = sessionSpan }
@@ -154,7 +145,7 @@ internal class SessionPartWriterResourceReadTest {
     @Test
     fun `the in-flight spans are reconstructed as snapshots`() {
         val envelope = checkNotNull(writeSessionPart())
-        assertEquals(inFlightSpan, envelope.data.spanSnapshots?.first())
+        assertEquals(checkNotNull(inFlightSpan.snapshot()), envelope.data.spanSnapshots?.first())
         assertEquals(emptyList<FakeInternalLogger.LogMessage>(), logger.internalErrorMessages)
     }
 


### PR DESCRIPTION
## Goal

Persists span snapshot on span changes rather than just at the session part start/end.

## Testing

Added unit tests