### PR TITLE
Avoid creating periodic-cache worker

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/UserSessionOrchestrationModuleImpl.kt
@@ -121,7 +121,9 @@ class UserSessionOrchestrationModuleImpl(
             sessionPartWriter.onSpanCompleted(spans.filterNot { it.hasEmbraceAttribute(EmbType.Ux.Session) })
         }
         openTelemetryModule.spanRepository.addSpanChangeListener { span ->
-            if (!span.hasEmbraceAttribute(EmbType.Ux.Session)) {
+            if (span.hasEmbraceAttribute(EmbType.Ux.Session)) {
+                sessionPartWriter.onSessionSpanChanged()
+            } else {
                 sessionPartWriter.onSpanSnapshotChanged()
             }
         }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -83,6 +83,7 @@ internal class SessionOrchestratorImpl(
     private var inactivityTimerState: SessionTimerState? = null
     private var maxDurationTimerState: SessionTimerState? = null
     private var backgroundStartupWindowTimerState: SessionTimerState? = null
+    private var lastActivityTimerState: SessionTimerState? = null
 
     @Volatile
     override var userSessionRestoreDecision: UserSessionRestoreDecision? = null
@@ -363,6 +364,7 @@ internal class SessionOrchestratorImpl(
                 EmbTrace.trace("transition-state-start") {
                     // first, disable any previous periodic caching so the job doesn't overwrite the to-be saved session
                     payloadCachingService?.stopCaching()
+                    lastActivityTimerState?.cancel()
 
                     val endingSession = sessionTracker.getActiveSessionPart()
                     if (endingSession != null) {
@@ -433,24 +435,17 @@ internal class SessionOrchestratorImpl(
                                 )
                             }
 
-                            // initiate periodic caching of the payload if a new session has started
-                            EmbTrace.trace("initiate-periodic-caching") {
-                                updatePeriodicCacheAttrs()
-                                val updateIntervalMs = lastActivityUpdateIntervalMs(userSession)
-                                payloadCachingService?.startCaching(newSessionPart, endAppState) { state, timestamp, zygote ->
-                                    synchronized(lock) {
-                                        if (state == ProcessState.FOREGROUND) {
-                                            updateUserSessionActivityIfStale(
-                                                timestamp = timestamp,
-                                                updateIntervalMs = updateIntervalMs,
-                                            )
-                                        }
-                                        updatePeriodicCacheAttrs()
-                                        sessionPartWriter?.onPeriodicWrite()
+                            scheduleLastActivityUpdate(userSession, endAppState)
 
-                                        when {
-                                            multiFilePersistenceEnabled() -> null
-                                            else -> payloadFactory.snapshotPayload(state, timestamp, zygote)
+                            // initiate periodic caching of the payload if a new session has started.
+                            // the multi file layer writes as telemetry changes, so it needs no tick.
+                            if (!multiFilePersistenceEnabled()) {
+                                EmbTrace.trace("initiate-periodic-caching") {
+                                    updatePeriodicCacheAttrs()
+                                    payloadCachingService?.startCaching(newSessionPart, endAppState) { state, timestamp, zygote ->
+                                        synchronized(lock) {
+                                            updatePeriodicCacheAttrs()
+                                            payloadFactory.snapshotPayload(state, timestamp, zygote)
                                         }
                                     }
                                 }
@@ -477,6 +472,26 @@ internal class SessionOrchestratorImpl(
                 ),
             )
         }
+    }
+
+    /**
+     * Keeps the persisted last activity time of the user session fresh while the app is in the
+     * foreground, so a process that dies mid-session can tell on relaunch whether the user session
+     * was still active. Nothing else updates it between session part transitions, which can be
+     * hours apart.
+     */
+    private fun scheduleLastActivityUpdate(metadata: UserSessionMetadata?, endProcessState: ProcessState) {
+        if (endProcessState != ProcessState.FOREGROUND) {
+            return
+        }
+        val intervalMs = lastActivityUpdateIntervalMs(metadata)
+        val future = backgroundWorker.scheduleWithFixedDelay(
+            { synchronized(lock) { updateUserSessionActivityIfStale(clock.now(), intervalMs) } },
+            intervalMs,
+            intervalMs,
+            TimeUnit.MILLISECONDS,
+        ) ?: return
+        lastActivityTimerState = SessionTimerState(future)
     }
 
     private fun scheduleMaxDurationTimeout(metadata: UserSessionMetadata?) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriter.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriter.kt
@@ -34,9 +34,9 @@ interface SessionPartWriter {
     fun onSpanSnapshotChanged()
 
     /**
-     * The periodic cache interval has elapsed. Rewrites the session span so disk reflects reality.
+     * The session part span has changed.
      */
-    fun onPeriodicWrite()
+    fun onSessionSpanChanged()
 
     /**
      * The process is terminating due to a JVM crash. Blocks until the necessary session part info

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -1,6 +1,7 @@
 package io.embrace.android.embracesdk.internal.session.orchestrator
 
 import io.embrace.android.embracesdk.internal.clock.Clock
+import io.embrace.android.embracesdk.internal.clock.millisToNanos
 import io.embrace.android.embracesdk.internal.config.ConfigService
 import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadataSource
 import io.embrace.android.embracesdk.internal.envelope.resource.EnvelopeResourceSource
@@ -9,6 +10,7 @@ import io.embrace.android.embracesdk.internal.envelope.session.SESSION_ENVELOPE_
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSdkSpan
+import io.embrace.android.embracesdk.internal.payload.Attribute
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.session.persistence.CompletedSpansWriter
 import io.embrace.android.embracesdk.internal.session.persistence.SessionManifestWriter
@@ -23,6 +25,7 @@ import io.embrace.android.embracesdk.internal.telemetry.AppliedLimitType
 import io.embrace.android.embracesdk.internal.telemetry.TelemetryService
 import io.embrace.android.embracesdk.internal.utils.UuidSource
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import java.io.File
 
 /**
@@ -35,7 +38,7 @@ class SessionPartWriterImpl(
     private val worker: BackgroundWorker,
     private val configService: ConfigService,
     private val uuidSource: UuidSource,
-    clock: Clock,
+    private val clock: Clock,
     private val logger: InternalLogger,
     private val resourceSource: EnvelopeResourceSource,
     private val metadataSource: EnvelopeMetadataSource,
@@ -54,7 +57,7 @@ class SessionPartWriterImpl(
         private const val CARRIED_OVER_SPAN_LIMIT_TYPE: String = "carried_over_span"
 
         const val METADATA_WRITE_DELAY_MS: Long = 10
-        const val SESSION_SPAN_WRITE_DELAY_MS: Long = 10
+        const val SESSION_SPAN_WRITE_DELAY_MS: Long = 100
         const val SPAN_SNAPSHOT_WRITE_DELAY_MS: Long = 100
     }
 
@@ -167,11 +170,11 @@ class SessionPartWriterImpl(
         queueMetadataWrite(current ?: return)
     }
 
-    override fun onPeriodicWrite() {
+    override fun onSessionSpanChanged() {
         if (!acceptingWrites()) {
             return
         }
-        queueSessionSpanWrite(current ?: return)
+        queueSessionSpanWrite(current ?: return, onlyIfCurrent = true)
     }
 
     override fun onCrash() {
@@ -224,14 +227,29 @@ class SessionPartWriterImpl(
     /**
      * Writes the session span as it stands right now.
      */
-    private fun queueSessionSpanWrite(writers: PartWriters) {
+    private fun queueSessionSpanWrite(writers: PartWriters, onlyIfCurrent: Boolean = false) {
         val span = writers.span ?: return
         execute(InternalErrorType.SessionSpanWriteFail, writers.sessionSpanWrites::submit) {
+            if (onlyIfCurrent && current !== writers) {
+                return@execute
+            }
             val snapshot = span.snapshot()
             if (snapshot != null) {
-                writers.sessionSpan.write(snapshot)
+                writers.sessionSpan.write(snapshot.withHeartbeat())
             }
         }
+    }
+
+    /**
+     * Stamps emb.heartbeat_unix_time_nanos on the span.
+     */
+    private fun Span.withHeartbeat(): Span {
+        val heartbeat = Attribute(
+            EmbSessionAttributes.EMB_HEARTBEAT_TIME_UNIX_NANO,
+            (endTimeNanos ?: clock.now().millisToNanos()).toString(),
+        )
+        val existing = attributes.orEmpty().filterNot { it.key == heartbeat.key }
+        return copy(attributes = existing + heartbeat)
     }
 
     /**

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -504,11 +504,11 @@ internal class SessionOrchestratorTest {
         val initial = activeUserSession().lastActivityMs
 
         clock.tick(59_000)
-        sessionCacheExecutor.runCurrentlyBlocked()
+        inactivityWorkerExecutor.runCurrentlyBlocked()
         assertEquals(initial, activeUserSession().lastActivityMs)
 
         clock.tick(2_000)
-        sessionCacheExecutor.runCurrentlyBlocked()
+        inactivityWorkerExecutor.runCurrentlyBlocked()
         assertEquals(clock.now(), activeUserSession().lastActivityMs)
     }
 
@@ -521,11 +521,11 @@ internal class SessionOrchestratorTest {
         val initial = activeUserSession().lastActivityMs
 
         clock.tick(19_000L)
-        sessionCacheExecutor.runCurrentlyBlocked()
+        inactivityWorkerExecutor.runCurrentlyBlocked()
         assertEquals(initial, activeUserSession().lastActivityMs)
 
         clock.tick(2_000L)
-        sessionCacheExecutor.runCurrentlyBlocked()
+        inactivityWorkerExecutor.runCurrentlyBlocked()
         assertEquals(clock.now(), activeUserSession().lastActivityMs)
     }
 
@@ -541,7 +541,7 @@ internal class SessionOrchestratorTest {
         val backgroundedAt = activeUserSession().lastActivityMs
         clock.tick(2 * 60_000L)
         orchestrator.onSessionDataUpdate()
-        sessionCacheExecutor.runCurrentlyBlocked()
+        inactivityWorkerExecutor.runCurrentlyBlocked()
         assertEquals(backgroundedAt, activeUserSession().lastActivityMs)
     }
 
@@ -1066,38 +1066,6 @@ internal class SessionOrchestratorTest {
     }
 
     @Test
-    fun `the periodic cache tick rewrites the session span on disk`() {
-        createOrchestrator(ProcessState.FOREGROUND, multiFilePersistenceConfigService())
-        val partId = checkNotNull(sessionTracker.getActiveSessionPartId())
-        assertEquals("emb-session", sessionSpanIn(partId)?.span?.name)
-        clock.tick(2000)
-        checkNotNull(currentSessionPartSpan.sessionPartSpan).name = "refreshed-span"
-        sessionCacheExecutor.runCurrentlyBlocked()
-
-        assertEquals("refreshed-span", sessionSpanIn(partId)?.span?.name)
-        assertNoInternalErrors()
-    }
-
-    @Test
-    fun `the periodic cache tick only rewrites the session span in the background when session data changed`() {
-        createOrchestrator(ProcessState.BACKGROUND, multiFilePersistenceConfigService())
-        val partId = checkNotNull(sessionTracker.getActiveSessionPartId())
-        sessionCacheExecutor.runCurrentlyBlocked()
-        assertEquals("emb-session", sessionSpanIn(partId)?.span?.name)
-
-        clock.tick(2000)
-        checkNotNull(currentSessionPartSpan.sessionPartSpan).name = "refreshed-span"
-        sessionCacheExecutor.runCurrentlyBlocked()
-        assertEquals("emb-session", sessionSpanIn(partId)?.span?.name)
-
-        clock.tick(2000)
-        orchestrator.onSessionDataUpdate()
-        sessionCacheExecutor.runCurrentlyBlocked()
-        assertEquals("refreshed-span", sessionSpanIn(partId)?.span?.name)
-        assertNoInternalErrors()
-    }
-
-    @Test
     fun `crash does not create a session part directory`() {
         createOrchestrator(ProcessState.FOREGROUND, multiFilePersistenceConfigService())
         val initial = sessionPartDirs().single()
@@ -1161,16 +1129,17 @@ internal class SessionOrchestratorTest {
     }
 
     @Test
-    fun `the periodic cache builds no payload when multi file persistence is enabled`() {
+    fun `no periodic caching is started when multi file persistence is enabled`() {
         createOrchestrator(ProcessState.FOREGROUND, multiFilePersistenceConfigService())
-        val partId = checkNotNull(sessionTracker.getActiveSessionPartId())
+        assertEquals(0, sessionCacheExecutor.scheduledTasksCount())
+
         clock.tick(2000)
-        checkNotNull(currentSessionPartSpan.sessionPartSpan).name = "refreshed-span"
         sessionCacheExecutor.runCurrentlyBlocked()
 
-        // nothing was cached by the legacy layer
         assertEquals(emptyList<Any>(), store.cachedSessionPartPayloads)
-        assertEquals("refreshed-span", sessionSpanIn(partId)?.span?.name)
+
+        // the writer stamps its own heartbeat as it writes, so the legacy attrs are not needed
+        assertNull(destination.attributes[EmbSessionAttributes.EMB_HEARTBEAT_TIME_UNIX_NANO])
         assertNoInternalErrors()
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterBoundaryTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterBoundaryTest.kt
@@ -226,7 +226,7 @@ internal class SessionPartWriterBoundaryTest {
     }
 
     @Test
-    fun `a periodic write after a boundary only updates the newer session part`() {
+    fun `a session span change after a boundary only updates the newer session part`() {
         startPart(FIRST_PART_ID)
         drain()
         startPart(SECOND_PART_ID)
@@ -234,7 +234,7 @@ internal class SessionPartWriterBoundaryTest {
 
         clock.tick(2000)
         sessionSpan.name = "span-refreshed"
-        writer.onPeriodicWrite()
+        writer.onSessionSpanChanged()
         drain()
 
         assertEquals("span0", sessionSpanIn(FIRST_PART_ID)?.span?.name)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
@@ -25,6 +25,7 @@ import io.embrace.android.embracesdk.internal.session.persistence.SessionPartSpa
 import io.embrace.android.embracesdk.internal.session.persistence.SpanSnapshots
 import io.embrace.android.embracesdk.internal.telemetry.AppliedLimitType
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -429,7 +430,7 @@ internal class SessionPartWriterImplTest {
     }
 
     @Test
-    fun `a periodic write refreshes the session span for the current part`() {
+    fun `a session span change refreshes the session span for the current part`() {
         val writer = createWriter()
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
         drain()
@@ -437,10 +438,71 @@ internal class SessionPartWriterImplTest {
 
         clock.tick(2000)
         sessionSpan.name = "span1"
-        writer.onPeriodicWrite()
+        writer.onSessionSpanChanged()
         drain()
 
         assertEquals("span1", sessionSpanIn(SESSION_PART_ID)?.span?.name)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a session span write stamps the time of the write as the heartbeat`() {
+        executor.blockingMode = false
+        val writer = createWriter()
+        val startedAt = clock.now()
+        writer.onSessionPartStarted(startedAt, USER_SESSION_ID, SESSION_PART_ID)
+        assertEquals(listOf(startedAt.millisToNanos().toString()), heartbeatsOnDisk(SESSION_PART_ID))
+
+        clock.tick(2000)
+        writer.onSessionSpanChanged()
+        executor.moveForwardAndRunBlocked(SessionPartWriterImpl.SESSION_SPAN_WRITE_DELAY_MS)
+        assertEquals(listOf(clock.now().millisToNanos().toString()), heartbeatsOnDisk(SESSION_PART_ID))
+        assertNull(sessionSpan.attributes[EmbSessionAttributes.EMB_HEARTBEAT_TIME_UNIX_NANO])
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a heartbeat already on the session span is replaced rather than duplicated`() {
+        sessionSpan.addSystemAttribute(EmbSessionAttributes.EMB_HEARTBEAT_TIME_UNIX_NANO, "1")
+        executor.blockingMode = false
+        val writer = createWriter()
+        val startedAt = clock.now()
+        writer.onSessionPartStarted(startedAt, USER_SESSION_ID, SESSION_PART_ID)
+
+        assertEquals(listOf(startedAt.millisToNanos().toString()), heartbeatsOnDisk(SESSION_PART_ID))
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `an ended session span is written with its end time as the heartbeat`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+
+        clock.tick(10000)
+        val endedAt = clock.now()
+        endPart()
+        writer.onSessionPartEnded(SESSION_PART_ID)
+        drain()
+
+        assertEquals(endedAt.millisToNanos(), sessionSpanIn(SESSION_PART_ID)?.span?.end_time_unix_nano)
+        assertEquals(listOf(endedAt.millisToNanos().toString()), heartbeatsOnDisk(SESSION_PART_ID))
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a session span change that arrives after its session part ended is dropped`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+        clock.tick(10000)
+        endPart()
+        writer.onSessionPartEnded(SESSION_PART_ID)
+        drain()
+
+        File(sessionsDir, partDirs().single().dirName).deleteRecursively()
+        writer.onSessionSpanChanged()
+        drain()
         assertNoInternalErrors()
     }
 
@@ -508,14 +570,14 @@ internal class SessionPartWriterImplTest {
     }
 
     @Test
-    fun `repeated periodic writes keep the latest session span`() {
+    fun `repeated session span changes keep the latest session span`() {
         val writer = createWriter()
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
         drain()
         repeat(4) { index ->
             clock.tick(2000)
             sessionSpan.name = "span${index + 1}"
-            writer.onPeriodicWrite()
+            writer.onSessionSpanChanged()
             drain()
         }
 
@@ -524,9 +586,9 @@ internal class SessionPartWriterImplTest {
     }
 
     @Test
-    fun `a periodic write before any session part starts is a no-op`() {
+    fun `a session span change before any session part starts is a no-op`() {
         val writer = createWriter()
-        writer.onPeriodicWrite()
+        writer.onSessionSpanChanged()
         drain()
 
         assertEquals(emptyList<SessionPartDirectory>(), sessionPartDirs())
@@ -535,12 +597,12 @@ internal class SessionPartWriterImplTest {
     }
 
     @Test
-    fun `a periodic write writes nothing when the part started without a session span`() {
+    fun `a session span change writes nothing when the part started without a session span`() {
         currentSessionPartSpan.sessionPartSpan = null
         val writer = createWriter()
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
         drain()
-        writer.onPeriodicWrite()
+        writer.onSessionSpanChanged()
         drain()
 
         assertNull(sessionSpanIn(SESSION_PART_ID))
@@ -548,7 +610,7 @@ internal class SessionPartWriterImplTest {
     }
 
     @Test
-    fun `a periodic write is not made once multi file persistence is disabled`() {
+    fun `a session span change is not written once multi file persistence is disabled`() {
         val configService = configService(enabled = true)
         val writer = createWriter(configService = configService)
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
@@ -558,7 +620,7 @@ internal class SessionPartWriterImplTest {
         configService.persistenceBehavior = createPersistenceBehavior()
         clock.tick(2000)
         sessionSpan.name = "span1"
-        writer.onPeriodicWrite()
+        writer.onSessionSpanChanged()
         drain()
 
         assertEquals(submitCount, executor.submitCount)
@@ -575,7 +637,7 @@ internal class SessionPartWriterImplTest {
         File(sessionsDir, partDirs().single().dirName).deleteRecursively()
         repeat(4) {
             clock.tick(2000)
-            writer.onPeriodicWrite()
+            writer.onSessionSpanChanged()
         }
         drain()
 
@@ -591,7 +653,7 @@ internal class SessionPartWriterImplTest {
         repeat(4) { index ->
             clock.tick(2000)
             sessionSpan.name = "span${index + 1}"
-            writer.onPeriodicWrite()
+            writer.onSessionSpanChanged()
         }
         drain()
 
@@ -835,14 +897,14 @@ internal class SessionPartWriterImplTest {
     }
 
     @Test
-    fun `a periodic write leaves the span snapshots untouched`() {
+    fun `a session span change leaves the span snapshots untouched`() {
         val writer = createWriter()
         inFlightSpans = listOf(inFlightSpan("network-request"))
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
         drain()
 
         inFlightSpans = listOf(inFlightSpan("view-load"))
-        writer.onPeriodicWrite()
+        writer.onSessionSpanChanged()
 
         assertEquals(listOf("network-request"), spanSnapshotNamesIn(SESSION_PART_ID))
         assertNoInternalErrors()
@@ -1029,7 +1091,7 @@ internal class SessionPartWriterImplTest {
 
         clock.tick(2000)
         sessionSpan.name = "span1"
-        writer.onPeriodicWrite()
+        writer.onSessionSpanChanged()
         writer.onMetadataChanged()
         endPart()
         writer.onSessionPartEnded(SESSION_PART_ID)
@@ -1381,6 +1443,11 @@ internal class SessionPartWriterImplTest {
 
     private fun sessionSpanOnDisk(sessionPartId: String): SessionPartSpan? =
         partFile(sessionPartId, SESSION_SPAN_FILE_NAME)?.inputStream()?.use(SessionPartSpan.ADAPTER::decode)
+
+    private fun heartbeatsOnDisk(sessionPartId: String): List<String>? =
+        sessionSpanOnDisk(sessionPartId)?.span?.attributes
+            ?.filter { it.key == EmbSessionAttributes.EMB_HEARTBEAT_TIME_UNIX_NANO }
+            ?.map { it.value_ }
 
     private fun spanSnapshotNamesIn(sessionPartId: String): List<String?>? {
         drain()

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceReadTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterResourceReadTest.kt
@@ -15,11 +15,13 @@ import io.embrace.android.embracesdk.internal.envelope.metadata.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.otel.spans.EmbraceSdkSpan
 import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
+import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.session.persistence.CompletedSpans
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectory
 import io.embrace.android.embracesdk.internal.session.persistence.SessionReconstructionService
 import io.embrace.android.embracesdk.internal.session.persistence.SpanProto
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import okio.Buffer
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
@@ -124,7 +126,7 @@ internal class SessionPartWriterResourceReadTest {
     fun `the session span written at the start of the part is reconstructed as a snapshot`() {
         val envelope = checkNotNull(writeSessionPart())
         val expected = checkNotNull(sessionSpan.snapshot())
-        assertEquals(expected, envelope.data.spanSnapshots?.last())
+        assertEquals(expected, envelope.data.spanSnapshots?.last()?.withoutHeartbeat())
         assertNull(envelope.data.spans?.find { it.spanId == sessionSpan.spanId })
         assertEquals(emptyList<FakeInternalLogger.LogMessage>(), logger.internalErrorMessages)
     }
@@ -137,7 +139,7 @@ internal class SessionPartWriterResourceReadTest {
 
         val envelope = checkNotNull(service.reconstruct(directory()))
         val expected = checkNotNull(sessionSpan.snapshot())
-        assertEquals(expected, envelope.data.spans?.last())
+        assertEquals(expected, envelope.data.spans?.last()?.withoutHeartbeat())
         assertNull(envelope.data.spanSnapshots?.find { it.spanId == sessionSpan.spanId })
         assertEquals(emptyList<FakeInternalLogger.LogMessage>(), logger.internalErrorMessages)
     }
@@ -209,4 +211,8 @@ internal class SessionPartWriterResourceReadTest {
         (sessionsDir.list() ?: emptyArray()).mapNotNull(SessionPartDirectory::fromDirName).single()
 
     private fun drain() = executor.drainWrites()
+
+    private fun Span.withoutHeartbeat(): Span = copy(
+        attributes = attributes?.filterNot { it.key == EmbSessionAttributes.EMB_HEARTBEAT_TIME_UNIX_NANO },
+    )
 }

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/persistence/MultiFilePersistenceParityTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/persistence/MultiFilePersistenceParityTest.kt
@@ -11,6 +11,7 @@ import io.embrace.android.embracesdk.assertions.getSessionPartId
 import io.embrace.android.embracesdk.assertions.getUserSessionId
 import io.embrace.android.embracesdk.fakes.FakeInternalLogger
 import io.embrace.android.embracesdk.fakes.config.FakeInstrumentedConfig
+import io.embrace.android.embracesdk.internal.arch.attrs.toEmbraceAttributeName
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.state.ProcessState
 import io.embrace.android.embracesdk.internal.config.remote.BackgroundActivityRemoteConfig
@@ -25,6 +26,7 @@ import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.payload.SpanEvent
 import io.embrace.android.embracesdk.internal.session.getSessionProperty
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectory
+import io.embrace.android.embracesdk.internal.session.persistence.SessionPartSpan
 import io.embrace.android.embracesdk.internal.worker.Worker
 import io.embrace.android.embracesdk.network.EmbraceNetworkRequest
 import io.embrace.android.embracesdk.network.http.HttpMethod
@@ -304,7 +306,7 @@ internal class MultiFilePersistenceParityTest(
     }
 
     @Test
-    fun `a periodic write before the session ends does not change what is persisted`() {
+    fun `a periodic cache tick before the session ends does not change what is persisted`() {
         testRule.runTest(
             persistedRemoteConfig = remoteConfig(),
             testCaseAction = {
@@ -480,6 +482,18 @@ internal class MultiFilePersistenceParityTest(
                 Placeholder.SESSION_PART_ID to envelope.getSessionPartId(),
             ),
         )
+        assertHeartbeat(sessionSpan)
+    }
+
+    private fun assertHeartbeat(sessionSpan: Span) {
+        val expected = when (persistenceMode) {
+            PersistenceMode.LEGACY -> sessionSpan.startTimeNanos
+            PersistenceMode.MULTI_FILE -> sessionSpan.endTimeNanos
+        }
+        assertEquals(
+            expected?.toString(),
+            sessionSpan.attributes?.findAttributeValue(EmbSessionAttributes.EMB_HEARTBEAT_TIME_UNIX_NANO),
+        )
     }
 
     /**
@@ -499,14 +513,24 @@ internal class MultiFilePersistenceParityTest(
     private fun Envelope<SessionPartPayload>.allSpanNames(): List<String> =
         (data.spans.orEmpty() + data.spanSnapshots.orEmpty()).mapNotNull(Span::name)
 
-    private fun storedSessionPartDirectories(): List<SessionPartDirectory> {
+    private fun sessionSpanOnDisk(): SessionPartSpan? {
+        val directory = storedSessionPartDirectories().maxWithOrNull(SessionPartDirectory.comparator) ?: return null
+        return File(File(sessionsDir(), directory.dirName), SESSION_SPAN_FILE_NAME)
+            .takeIf(File::isFile)
+            ?.inputStream()
+            ?.use(SessionPartSpan.ADAPTER::decode)
+    }
+
+    private fun storedSessionPartDirectories(): List<SessionPartDirectory> =
+        (sessionsDir().list() ?: emptyArray()).mapNotNull(SessionPartDirectory::fromDirName)
+
+    private fun sessionsDir(): File {
         val ctx = ApplicationProvider.getApplicationContext<Context>()
-        val sessionsDir: File = StorageLocation.SESSION_SPLIT.asFile(
+        return StorageLocation.SESSION_SPLIT.asFile(
             logger = FakeInternalLogger(),
             rootDirSupplier = { ctx.filesDir },
             fallbackDirSupplier = { ctx.cacheDir },
         ).value
-        return (sessionsDir.list() ?: emptyArray()).mapNotNull(SessionPartDirectory::fromDirName)
     }
 
     /**
@@ -517,6 +541,9 @@ internal class MultiFilePersistenceParityTest(
 
     internal companion object {
         private const val SESSION_SPAN_NAME = "emb-session"
+        private const val SESSION_SPAN_FILE_NAME = "session_span.pb"
+        private const val EVENT_DRIVEN_PROPERTY = "event-driven"
+        private const val WRITE_DEBOUNCE_WAIT_MS = 1000L
         private const val GOLDEN_FILE = "multi_file_parity_session_part_span.json"
 
         @JvmStatic

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionLastActivityUpdateTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/session/UserSessionLastActivityUpdateTest.kt
@@ -20,16 +20,16 @@ internal class UserSessionLastActivityUpdateTest {
     @JvmField
     val testRule: SdkIntegrationTestRule = SdkIntegrationTestRule {
         EmbraceSetupInterface(
-            workersToFake = listOf(Worker.Background.PeriodicCacheWorker),
+            workersToFake = listOf(Worker.Background.NonIoRegWorker),
         ).apply {
-            getFakedWorkerExecutor(Worker.Background.PeriodicCacheWorker).blockingMode = false
+            getFakedWorkerExecutor(Worker.Background.NonIoRegWorker).blockingMode = false
         }
     }
 
     @Test
-    fun `foreground periodic cache task updates user session last activity time`() {
+    fun `foreground task updates user session last activity time`() {
         lateinit var store: KeyValueStore
-        lateinit var cacheWorker: BlockingScheduledExecutorService
+        lateinit var worker: BlockingScheduledExecutorService
         val inactivityTimeoutSeconds = 60
         testRule.runTest(
             persistedRemoteConfig = RemoteConfig(
@@ -37,13 +37,13 @@ internal class UserSessionLastActivityUpdateTest {
             ),
             setupAction = {
                 store = getStore()
-                cacheWorker = getFakedWorkerExecutor(Worker.Background.PeriodicCacheWorker)
+                worker = getFakedWorkerExecutor(Worker.Background.NonIoRegWorker)
             },
             testCaseAction = {
                 recordSession {
                     val initialLastActivityMs = store.currentUserSessionLastActivityTimestamp()
-                    clock.tick(90_000)
-                    cacheWorker.runCurrentlyBlocked()
+                    clock.tick(30_000)
+                    worker.runCurrentlyBlocked()
                     assertTrue(store.currentUserSessionLastActivityTimestamp() > initialLastActivityMs)
                 }
             },

--- a/embrace-android-sdk/src/integrationTest/resources/multi_file_parity_session_part_span.json
+++ b/embrace-android-sdk/src/integrationTest/resources/multi_file_parity_session_part_span.json
@@ -38,7 +38,7 @@
     },
     {
       "key": "emb.heartbeat_time_unix_nano",
-      "value": "169220160010000000"
+      "value": "__EMBRACE_TEST_IGNORE__"
     },
     {
       "key": "emb.is_emulator",


### PR DESCRIPTION
## Goal

Avoids creating a periodic-cache worker when multi-file persistence is enabled, which saves the instantiation of one unnecessary thread.

## Testing

Updated unit tests.
