### PR TITLE
Extract span limits

### DIFF
--- a/embrace-android-limits/src/main/kotlin/io/embrace/android/embracesdk/internal/limits/SpanLimits.kt
+++ b/embrace-android-limits/src/main/kotlin/io/embrace/android/embracesdk/internal/limits/SpanLimits.kt
@@ -1,0 +1,45 @@
+package io.embrace.android.embracesdk.internal.limits
+
+import io.embrace.android.embracesdk.internal.config.instrumented.OtelLimitsConfigImpl
+
+/**
+ * The limits that apply to a span, its events, its links and its attributes.
+ */
+sealed class SpanLimits(val internal: Boolean) {
+
+    abstract val maxNameLength: Int
+    abstract val maxEventCount: Int
+    abstract val maxLinkCount: Int
+    abstract val maxAttributeCount: Int
+    abstract val maxAttributeKeyLength: Int
+    abstract val maxAttributeValueLength: Int
+
+    /**
+     * Limits for telemetry the SDK records itself, which the app has no direct control over.
+     */
+    object Internal : SpanLimits(internal = true) {
+        override val maxNameLength: Int = OtelLimitsConfigImpl.getMaxInternalNameLength()
+        override val maxEventCount: Int = OtelLimitsConfigImpl.getMaxSystemEventCount()
+        override val maxLinkCount: Int = OtelLimitsConfigImpl.getMaxSystemLinkCount()
+        override val maxAttributeCount: Int = OtelLimitsConfigImpl.getMaxSystemAttributeCount()
+        override val maxAttributeKeyLength: Int = OtelLimitsConfigImpl.getMaxInternalAttributeKeyLength()
+        override val maxAttributeValueLength: Int = OtelLimitsConfigImpl.getMaxInternalAttributeValueLength()
+    }
+
+    /**
+     * Limits for telemetry recorded through the public API, where a misbehaving app could otherwise
+     * exhaust memory or produce payloads the backend will reject.
+     */
+    object Custom : SpanLimits(internal = false) {
+        override val maxNameLength: Int = OtelLimitsConfigImpl.getMaxNameLength()
+        override val maxEventCount: Int = OtelLimitsConfigImpl.getMaxCustomEventCount()
+        override val maxLinkCount: Int = OtelLimitsConfigImpl.getMaxCustomLinkCount()
+        override val maxAttributeCount: Int = OtelLimitsConfigImpl.getMaxCustomAttributeCount()
+        override val maxAttributeKeyLength: Int = OtelLimitsConfigImpl.getMaxCustomAttributeKeyLength()
+        override val maxAttributeValueLength: Int = OtelLimitsConfigImpl.getMaxCustomAttributeValueLength()
+    }
+
+    companion object {
+        fun of(internal: Boolean): SpanLimits = if (internal) Internal else Custom
+    }
+}

--- a/embrace-android-limits/src/main/kotlin/io/embrace/android/embracesdk/internal/limits/TelemetryLimitEnforcer.kt
+++ b/embrace-android-limits/src/main/kotlin/io/embrace/android/embracesdk/internal/limits/TelemetryLimitEnforcer.kt
@@ -1,0 +1,82 @@
+package io.embrace.android.embracesdk.internal.limits
+
+import io.embrace.android.embracesdk.internal.config.instrumented.OtelLimitsConfigImpl
+import io.embrace.android.embracesdk.internal.config.instrumented.schema.OtelLimitsConfig
+import io.embrace.android.embracesdk.internal.telemetry.AppliedLimitType
+import io.embrace.android.embracesdk.internal.telemetry.TelemetryService
+import io.embrace.android.embracesdk.internal.utils.PropertyUtils
+
+/**
+ * Applies the upper bounds of captured telemetry, reporting every limit that
+ * had to be applied via [TelemetryService.trackAppliedLimit].
+ */
+class TelemetryLimitEnforcer(
+    val otelLimits: OtelLimitsConfig = OtelLimitsConfigImpl,
+    private val telemetryService: TelemetryService,
+    private val exemptFromValueTruncation: (String) -> Boolean = { false },
+) {
+
+    fun truncateName(name: String, maxLength: Int): String {
+        val truncated = PropertyUtils.truncate(name, maxLength)
+        if (truncated != name) {
+            telemetryService.trackAppliedLimit(SPAN_NAME_TELEMETRY_TYPE, AppliedLimitType.TRUNCATE_STRING)
+        }
+        return truncated
+    }
+
+    fun truncateAttributes(
+        attributes: Map<String, String>,
+        maxCount: Int,
+        maxKeyLength: Int,
+        maxValueLength: Int,
+    ): Map<String, String> {
+        val truncatedEntries = attributes.entries.take(maxCount)
+        if (truncatedEntries.size < attributes.size) {
+            telemetryService.trackAppliedLimit(SPAN_ATTRIBUTE_TELEMETRY_TYPE, AppliedLimitType.TRUNCATE_ATTRIBUTES)
+        }
+        return truncatedEntries.associate {
+            truncateAttribute(
+                key = it.key,
+                value = it.value,
+                maxKeyLength = maxKeyLength,
+                maxValueLength = maxValueLength,
+            )
+        }
+    }
+
+    fun truncateAttribute(key: String, value: String, maxKeyLength: Int, maxValueLength: Int): Pair<String, String> {
+        val truncatedKey = PropertyUtils.truncate(key, maxKeyLength)
+        if (truncatedKey != key) {
+            telemetryService.trackAppliedLimit(SPAN_ATTRIBUTE_KEY_TELEMETRY_TYPE, AppliedLimitType.TRUNCATE_STRING)
+        }
+
+        val truncatedValue = if (exemptFromValueTruncation(key)) {
+            value
+        } else {
+            PropertyUtils.truncate(value, maxValueLength)
+        }
+        if (truncatedValue != value) {
+            telemetryService.trackAppliedLimit(SPAN_ATTRIBUTE_VALUE_TELEMETRY_TYPE, AppliedLimitType.TRUNCATE_STRING)
+        }
+
+        return Pair(truncatedKey, truncatedValue)
+    }
+
+    /**
+     * Drops everything past the first [max] items, reporting the drop against [telemetryType].
+     */
+    fun <T> capCount(items: List<T>, max: Int, telemetryType: String): List<T> {
+        val capped = items.take(max)
+        if (capped.size < items.size) {
+            telemetryService.trackAppliedLimit(telemetryType, AppliedLimitType.DROP)
+        }
+        return capped
+    }
+}
+
+const val SPAN_EVENT_TELEMETRY_TYPE = "span_event"
+
+private const val SPAN_NAME_TELEMETRY_TYPE = "span_name"
+private const val SPAN_ATTRIBUTE_TELEMETRY_TYPE = "span_attribute"
+private const val SPAN_ATTRIBUTE_KEY_TELEMETRY_TYPE = "span_attribute_key"
+private const val SPAN_ATTRIBUTE_VALUE_TELEMETRY_TYPE = "span_attribute_value"

--- a/embrace-android-limits/src/test/kotlin/io/embrace/android/embracesdk/internal/limits/SpanLimitsTest.kt
+++ b/embrace-android-limits/src/test/kotlin/io/embrace/android/embracesdk/internal/limits/SpanLimitsTest.kt
@@ -1,0 +1,55 @@
+package io.embrace.android.embracesdk.internal.limits
+
+import io.embrace.android.embracesdk.internal.config.instrumented.OtelLimitsConfigImpl
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+internal class SpanLimitsTest {
+
+    private val config = OtelLimitsConfigImpl
+
+    @Test
+    fun `internal limits are resolved from the system flavour of each limit`() {
+        with(SpanLimits.Internal) {
+            assertTrue(internal)
+            assertEquals(config.getMaxInternalNameLength(), maxNameLength)
+            assertEquals(config.getMaxSystemEventCount(), maxEventCount)
+            assertEquals(config.getMaxSystemLinkCount(), maxLinkCount)
+            assertEquals(config.getMaxSystemAttributeCount(), maxAttributeCount)
+            assertEquals(config.getMaxInternalAttributeKeyLength(), maxAttributeKeyLength)
+            assertEquals(config.getMaxInternalAttributeValueLength(), maxAttributeValueLength)
+        }
+    }
+
+    @Test
+    fun `custom limits are resolved from the custom flavour of each limit`() {
+        with(SpanLimits.Custom) {
+            assertFalse(internal)
+            assertEquals(config.getMaxNameLength(), maxNameLength)
+            assertEquals(config.getMaxCustomEventCount(), maxEventCount)
+            assertEquals(config.getMaxCustomLinkCount(), maxLinkCount)
+            assertEquals(config.getMaxCustomAttributeCount(), maxAttributeCount)
+            assertEquals(config.getMaxCustomAttributeKeyLength(), maxAttributeKeyLength)
+            assertEquals(config.getMaxCustomAttributeValueLength(), maxAttributeValueLength)
+        }
+    }
+
+    @Test
+    fun `internal telemetry is allowed more than custom telemetry`() {
+        assertTrue(SpanLimits.Internal.maxNameLength > SpanLimits.Custom.maxNameLength)
+        assertTrue(SpanLimits.Internal.maxEventCount > SpanLimits.Custom.maxEventCount)
+        assertTrue(SpanLimits.Internal.maxLinkCount > SpanLimits.Custom.maxLinkCount)
+        assertTrue(SpanLimits.Internal.maxAttributeCount > SpanLimits.Custom.maxAttributeCount)
+        assertTrue(SpanLimits.Internal.maxAttributeKeyLength > SpanLimits.Custom.maxAttributeKeyLength)
+        assertTrue(SpanLimits.Internal.maxAttributeValueLength > SpanLimits.Custom.maxAttributeValueLength)
+    }
+
+    @Test
+    fun `of selects the flavour matching the internal flag`() {
+        assertSame(SpanLimits.Internal, SpanLimits.of(internal = true))
+        assertSame(SpanLimits.Custom, SpanLimits.of(internal = false))
+    }
+}

--- a/embrace-android-limits/src/test/kotlin/io/embrace/android/embracesdk/internal/limits/TelemetryLimitEnforcerTest.kt
+++ b/embrace-android-limits/src/test/kotlin/io/embrace/android/embracesdk/internal/limits/TelemetryLimitEnforcerTest.kt
@@ -1,0 +1,103 @@
+package io.embrace.android.embracesdk.internal.limits
+
+import io.embrace.android.embracesdk.fakes.FakeTelemetryService
+import io.embrace.android.embracesdk.internal.config.instrumented.OtelLimitsConfigImpl
+import io.embrace.android.embracesdk.internal.telemetry.AppliedLimitType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+internal class TelemetryLimitEnforcerTest {
+
+    private val telemetryService = FakeTelemetryService()
+
+    private fun enforcer(exemptFromValueTruncation: (String) -> Boolean = { false }) =
+        TelemetryLimitEnforcer(
+            telemetryService = telemetryService,
+            exemptFromValueTruncation = exemptFromValueTruncation,
+        )
+
+    @Test
+    fun `name within the limit is untouched and nothing is reported`() {
+        assertEquals("span", enforcer().truncateName("span", maxLength = 10))
+        assertEquals(emptyList<Pair<String, AppliedLimitType>>(), telemetryService.appliedLimits)
+    }
+
+    @Test
+    fun `name over the limit is truncated and reported`() {
+        assertEquals("abcde...", enforcer().truncateName("abcdefghij", maxLength = 8))
+        assertEquals(listOf("span_name" to AppliedLimitType.TRUNCATE_STRING), telemetryService.appliedLimits)
+    }
+
+    @Test
+    fun `attributes within the limits are untouched and nothing is reported`() {
+        val attributes = mapOf("key" to "value")
+        assertEquals(
+            attributes,
+            enforcer().truncateAttributes(attributes, maxCount = 5, maxKeyLength = 10, maxValueLength = 10),
+        )
+        assertEquals(emptyList<Pair<String, AppliedLimitType>>(), telemetryService.appliedLimits)
+    }
+
+    @Test
+    fun `attributes over the count limit drop the trailing entries and are reported`() {
+        val attributes = mapOf("a" to "1", "b" to "2", "c" to "3")
+        assertEquals(
+            mapOf("a" to "1", "b" to "2"),
+            enforcer().truncateAttributes(attributes, maxCount = 2, maxKeyLength = 10, maxValueLength = 10),
+        )
+        assertEquals(listOf("span_attribute" to AppliedLimitType.TRUNCATE_ATTRIBUTES), telemetryService.appliedLimits)
+    }
+
+    @Test
+    fun `over-long attribute keys and values are truncated and reported separately`() {
+        assertEquals(
+            mapOf("abcde..." to "vwxyz..."),
+            enforcer().truncateAttributes(
+                attributes = mapOf("abcdefghij" to "vwxyz12345"),
+                maxCount = 5,
+                maxKeyLength = 8,
+                maxValueLength = 8,
+            ),
+        )
+        assertEquals(
+            listOf(
+                "span_attribute_key" to AppliedLimitType.TRUNCATE_STRING,
+                "span_attribute_value" to AppliedLimitType.TRUNCATE_STRING,
+            ),
+            telemetryService.appliedLimits,
+        )
+    }
+
+    @Test
+    fun `exempt attribute keys keep their full value`() {
+        val enforcer = enforcer(exemptFromValueTruncation = { it == "stacktrace" })
+        assertEquals(
+            "stacktrace" to "vwxyz12345",
+            enforcer.truncateAttribute("stacktrace", "vwxyz12345", maxKeyLength = 10, maxValueLength = 8),
+        )
+        assertEquals(
+            "other" to "vwxyz...",
+            enforcer.truncateAttribute("other", "vwxyz12345", maxKeyLength = 10, maxValueLength = 8),
+        )
+        assertEquals(listOf("span_attribute_value" to AppliedLimitType.TRUNCATE_STRING), telemetryService.appliedLimits)
+    }
+
+    @Test
+    fun `capCount leaves a list within the limit alone`() {
+        val items = listOf(1, 2, 3)
+        assertEquals(items, enforcer().capCount(items, max = 3, telemetryType = "span_event"))
+        assertEquals(emptyList<Pair<String, AppliedLimitType>>(), telemetryService.appliedLimits)
+    }
+
+    @Test
+    fun `capCount drops the excess and reports it against the given telemetry type`() {
+        assertEquals(listOf(1, 2), enforcer().capCount(listOf(1, 2, 3, 4), max = 2, telemetryType = "span_link"))
+        assertEquals(listOf("span_link" to AppliedLimitType.DROP), telemetryService.appliedLimits)
+    }
+
+    @Test
+    fun `otelLimits defaults to the instrumented config`() {
+        assertSame(OtelLimitsConfigImpl, enforcer().otelLimits)
+    }
+}

--- a/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/DataValidator.kt
+++ b/embrace-android-otel/src/main/kotlin/io/embrace/android/embracesdk/internal/otel/sdk/DataValidator.kt
@@ -2,9 +2,10 @@ package io.embrace.android.embracesdk.internal.otel.sdk
 
 import io.embrace.android.embracesdk.internal.config.instrumented.OtelLimitsConfigImpl
 import io.embrace.android.embracesdk.internal.config.instrumented.schema.OtelLimitsConfig
-import io.embrace.android.embracesdk.internal.telemetry.AppliedLimitType
+import io.embrace.android.embracesdk.internal.limits.SPAN_EVENT_TELEMETRY_TYPE
+import io.embrace.android.embracesdk.internal.limits.SpanLimits
+import io.embrace.android.embracesdk.internal.limits.TelemetryLimitEnforcer
 import io.embrace.android.embracesdk.internal.telemetry.TelemetryService
-import io.embrace.android.embracesdk.internal.utils.PropertyUtils
 import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 
 /**
@@ -13,90 +14,44 @@ import io.embrace.android.embracesdk.spans.EmbraceSpanEvent
 class DataValidator(
     val otelLimitsConfig: OtelLimitsConfig = OtelLimitsConfigImpl,
     private val bypassValidation: (() -> Boolean) = { false },
-    private val telemetryService: TelemetryService,
+    telemetryService: TelemetryService,
 ) {
-    fun truncateName(name: String, internal: Boolean): String {
-        val maxLength = if (internal) {
-            otelLimitsConfig.getMaxInternalNameLength()
-        } else {
-            otelLimitsConfig.getMaxNameLength()
-        }
-        val truncated = PropertyUtils.truncate(name, maxLength)
-        if (truncated != name) {
-            telemetryService.trackAppliedLimit("span_name", AppliedLimitType.TRUNCATE_STRING)
-        }
-        return truncated
-    }
+    private val enforcer = TelemetryLimitEnforcer(
+        otelLimits = otelLimitsConfig,
+        telemetryService = telemetryService,
+        exemptFromValueTruncation = String::isValidLongValueAttribute,
+    )
 
-    fun <T> truncateEvents(events: List<T>, internal: Boolean): List<T> {
-        val truncatedEvents = if (internal) {
-            events.take(otelLimitsConfig.getMaxSystemEventCount())
-        } else if (!bypassValidation()) {
-            events.take(otelLimitsConfig.getMaxCustomEventCount())
-        } else {
-            events
-        }
-        if (truncatedEvents.size < events.size) {
-            telemetryService.trackAppliedLimit("span_event", AppliedLimitType.DROP)
-        }
-        return truncatedEvents
+    fun truncateName(name: String, internal: Boolean): String =
+        enforcer.truncateName(name, SpanLimits.of(internal).maxNameLength)
+
+    fun <T> truncateEvents(events: List<T>, internal: Boolean): List<T> = if (internal || !bypassValidation()) {
+        enforcer.capCount(events, SpanLimits.of(internal).maxEventCount, SPAN_EVENT_TELEMETRY_TYPE)
+    } else {
+        events
     }
 
     fun truncateAttributes(attributes: Map<String, String>, internal: Boolean, countOverride: Int? = null): Map<String, String> {
-        val maxAttributeCount = countOverride ?: if (internal) {
-            otelLimitsConfig.getMaxSystemAttributeCount()
-        } else {
-            otelLimitsConfig.getMaxCustomAttributeCount()
+        if (!internal && bypassValidation()) {
+            return attributes
         }
-        val maxKeyLength = if (internal) {
-            otelLimitsConfig.getMaxInternalAttributeKeyLength()
-        } else {
-            otelLimitsConfig.getMaxCustomAttributeKeyLength()
-        }
-        val maxValueLength = if (internal) {
-            otelLimitsConfig.getMaxInternalAttributeValueLength()
-        } else {
-            otelLimitsConfig.getMaxCustomAttributeValueLength()
-        }
-
-        return if (internal || !bypassValidation()) {
-            attributes.truncate(
-                maxCount = maxAttributeCount,
-                maxKeyLength = maxKeyLength,
-                maxValueLength = maxValueLength,
-            )
-        } else {
-            attributes
-        }
+        val limits = SpanLimits.of(internal)
+        return enforcer.truncateAttributes(
+            attributes = attributes,
+            maxCount = countOverride ?: limits.maxAttributeCount,
+            maxKeyLength = limits.maxAttributeKeyLength,
+            maxValueLength = limits.maxAttributeValueLength,
+        )
     }
 
     fun truncateAttribute(key: String, value: String, internal: Boolean): Pair<String, String> {
-        val maxKeyLength = if (internal) {
-            otelLimitsConfig.getMaxInternalAttributeKeyLength()
-        } else {
-            otelLimitsConfig.getMaxCustomAttributeKeyLength()
-        }
-        val maxValueLength = if (internal) {
-            otelLimitsConfig.getMaxInternalAttributeValueLength()
-        } else {
-            otelLimitsConfig.getMaxCustomAttributeValueLength()
-        }
-
-        val truncatedKey = PropertyUtils.truncate(key, maxKeyLength)
-        if (truncatedKey != key) {
-            telemetryService.trackAppliedLimit("span_attribute_key", AppliedLimitType.TRUNCATE_STRING)
-        }
-
-        val truncatedValue = if (key.isValidLongValueAttribute()) {
-            value
-        } else {
-            PropertyUtils.truncate(value, maxValueLength)
-        }
-        if (truncatedValue != value) {
-            telemetryService.trackAppliedLimit("span_attribute_value", AppliedLimitType.TRUNCATE_STRING)
-        }
-
-        return Pair(truncatedKey, truncatedValue)
+        val limits = SpanLimits.of(internal)
+        return enforcer.truncateAttribute(
+            key = key,
+            value = value,
+            maxKeyLength = limits.maxAttributeKeyLength,
+            maxValueLength = limits.maxAttributeValueLength,
+        )
     }
 
     fun createTruncatedSpanEvent(
@@ -115,43 +70,4 @@ class DataValidator(
             ),
         )
     }
-
-    private fun Map<String, String>.truncate(
-        maxCount: Int,
-        maxKeyLength: Int,
-        maxValueLength: Int,
-    ): Map<String, String> {
-        val truncatedEntries = entries.take(maxCount)
-        if (truncatedEntries.size < entries.size) {
-            telemetryService.trackAppliedLimit("span_attribute", AppliedLimitType.TRUNCATE_ATTRIBUTES)
-        }
-
-        return truncatedEntries.associate {
-            val truncatedKey = PropertyUtils.truncate(
-                value = it.key,
-                maxLength = maxKeyLength,
-            )
-            if (truncatedKey != it.key) {
-                telemetryService.trackAppliedLimit("span_attribute_key", AppliedLimitType.TRUNCATE_STRING)
-            }
-
-            val truncatedValue = truncateAttributeValue(
-                key = it.key,
-                value = it.value,
-                maxLength = maxValueLength,
-            )
-            if (truncatedValue != it.value) {
-                telemetryService.trackAppliedLimit("span_attribute_value", AppliedLimitType.TRUNCATE_STRING)
-            }
-
-            truncatedKey to truncatedValue
-        }
-    }
-
-    private fun truncateAttributeValue(key: String, value: String, maxLength: Int): String =
-        if (key.isValidLongValueAttribute()) {
-            value
-        } else {
-            PropertyUtils.truncate(value, maxLength)
-        }
 }


### PR DESCRIPTION
## Goal

Extracts the limits for span data capture so that in future it can be enforced when reading spans too.
