### PR TITLE
Add initial emb-trace names

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/caching/PayloadCachingServiceImpl.kt
@@ -57,7 +57,7 @@ internal class PayloadCachingServiceImpl(
     ): Envelope<SessionPartPayload>? {
         deliveryTracer?.onSessionCache()
 
-        EmbTrace.trace("on-session-cache") {
+        EmbTrace.trace("periodic-cache-supply") {
             if (initial.sessionPartId != sessionIdsProvider.getCurrentSessionPartId()) {
                 return null
             }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
@@ -28,6 +28,7 @@ import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
 import io.embrace.android.embracesdk.internal.session.UserSessionRestoreDecision
 import io.embrace.android.embracesdk.internal.session.getSessionPartSpan
 import io.embrace.android.embracesdk.internal.session.getUserSessionProperties
+import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import java.io.InputStream
@@ -57,10 +58,12 @@ internal class PayloadResurrectionServiceImpl(
         nativeCrashServiceProvider: Provider<NativeCrashService?>,
         userSessionRestoreDecisionProvider: Provider<UserSessionRestoreDecision?>,
     ) {
-        runCatching {
-            processTombstones(nativeCrashServiceProvider, userSessionRestoreDecisionProvider())
-        }.onFailure {
-            logger.trackInternalError(InternalErrorType.PayloadResurrectionFail, it)
+        EmbTrace.trace("resurrect-payloads") {
+            runCatching {
+                processTombstones(nativeCrashServiceProvider, userSessionRestoreDecisionProvider())
+            }.onFailure {
+                logger.trackInternalError(InternalErrorType.PayloadResurrectionFail, it)
+            }
         }
         completionListeners.forEach { listener ->
             runCatching {
@@ -312,7 +315,9 @@ internal class PayloadResurrectionServiceImpl(
         userSessionTerminationReason: String?,
         isBackgroundOnly: Boolean,
     ): Envelope<SessionPartPayload> {
-        val deadPart = serializer.fromJson(payloadStream, Envelope.serializer(SessionPartPayload.serializer()))
+        val deadPart = EmbTrace.trace("payload-json-deserialize") {
+            serializer.fromJson(payloadStream, Envelope.serializer(SessionPartPayload.serializer()))
+        }
         val deadSessionPartSpan = deadPart.getSessionPartSpan()
         val sessionPartId = deadSessionPartSpan?.resolveSessionPartIdForCrashMatch()
         val appState = deadSessionPartSpan?.attributes?.findAttributeValue(EmbSessionAttributes.EMB_STATE)

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/SessionPartReader.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/SessionPartReader.kt
@@ -15,6 +15,7 @@ import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDir
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectoryStore
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartWriteTracker
 import io.embrace.android.embracesdk.internal.session.persistence.SessionReconstructionService
+import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 
@@ -43,16 +44,18 @@ class SessionPartReader(
             return
         }
         worker.submit {
-            directoryStore.storedDirectories()
-                .filterNot { writeTracker.isWriting(it.sessionPartId) }
-                .sortedWith(SessionPartDirectory.comparator)
-                .forEach { directory ->
-                    runCatching {
-                        deliver(directory)
-                    }.onFailure {
-                        logger.trackInternalError(InternalErrorType.SessionPartReadFail, it)
+            EmbTrace.trace("mf-read-session-parts") {
+                directoryStore.storedDirectories()
+                    .filterNot { writeTracker.isWriting(it.sessionPartId) }
+                    .sortedWith(SessionPartDirectory.comparator)
+                    .forEach { directory ->
+                        runCatching {
+                            deliver(directory)
+                        }.onFailure {
+                            logger.trackInternalError(InternalErrorType.SessionPartReadFail, it)
+                        }
                     }
-                }
+            }
         }
     }
 

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/caching/PeriodicSessionPartCacher.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/caching/PeriodicSessionPartCacher.kt
@@ -38,7 +38,7 @@ class PeriodicSessionPartCacher(
         if (stopped) {
             return@Runnable
         }
-        EmbTrace.trace("snapshot-session") {
+        EmbTrace.trace("periodic-cache-tick") {
             try {
                 provider()
             } catch (ex: Exception) {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImpl.kt
@@ -10,6 +10,7 @@ import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
 import io.embrace.android.embracesdk.internal.session.LifeEventType
 import io.embrace.android.embracesdk.internal.session.SessionPartToken
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionPartSnapshotType
+import io.embrace.android.embracesdk.internal.utils.EmbTrace
 
 internal class PayloadFactoryImpl(
     private val payloadMessageCollator: PayloadMessageCollator,
@@ -55,9 +56,11 @@ internal class PayloadFactoryImpl(
         timestamp: Long,
         initial: SessionPartToken,
     ): Envelope<SessionPartPayload>? =
-        when (state) {
-            ProcessState.FOREGROUND -> snapshotSession(initial)
-            ProcessState.BACKGROUND -> snapshotBackgroundActivity(initial)
+        EmbTrace.trace("sf-payload-snapshot-build") {
+            when (state) {
+                ProcessState.FOREGROUND -> snapshotSession(initial)
+                ProcessState.BACKGROUND -> snapshotBackgroundActivity(initial)
+            }
         }
 
     override fun startSessionWithManual(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -282,7 +282,7 @@ internal class SessionOrchestratorImpl(
             crashId = crashId,
         )
 
-        EmbTrace.trace("flush-session-part-writes") {
+        EmbTrace.trace("mf-flush-writes") {
             sessionPartWriter?.onCrash()
         }
     }
@@ -386,7 +386,7 @@ internal class SessionOrchestratorImpl(
                             }
 
                             // persist the stopped session part span
-                            EmbTrace.trace("write-session-part-span") {
+                            EmbTrace.trace("mf-part-ended") {
                                 sessionPartWriter?.onSessionPartEnded(sessionPartId)
                             }
                         },
@@ -427,7 +427,7 @@ internal class SessionOrchestratorImpl(
                         sessionPartSpanAttrPopulator.populateSessionPartSpanStartAttrs(newSessionPart, userSession)
                         if (transitionType != TransitionType.CRASH) {
                             // create the directory that holds this session part's telemetry
-                            EmbTrace.trace("create-session-part-dir") {
+                            EmbTrace.trace("mf-part-started") {
                                 sessionPartWriter?.onSessionPartStarted(
                                     timestamp = timestamp,
                                     userSessionId = userSession?.userSessionId ?: "",

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -23,6 +23,7 @@ import io.embrace.android.embracesdk.internal.session.persistence.SpanSnapshotsW
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionPartSpan
 import io.embrace.android.embracesdk.internal.telemetry.AppliedLimitType
 import io.embrace.android.embracesdk.internal.telemetry.TelemetryService
+import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.android.embracesdk.internal.utils.UuidSource
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
@@ -157,11 +158,11 @@ class SessionPartWriterImpl(
         queueCompletedSpansWrite(writers, spans)
     }
 
-    override fun onSpanSnapshotChanged() {
+    override fun onSpanSnapshotChanged() = EmbTrace.trace("mf-span-snapshot-changed") {
         if (!acceptingWrites()) {
-            return
+            return@trace
         }
-        queueSpanSnapshotsRefresh(current ?: return)
+        queueSpanSnapshotsRefresh(current ?: return@trace)
     }
 
     private fun onResourceChanged() {
@@ -207,7 +208,7 @@ class SessionPartWriterImpl(
         }
     }
 
-    private fun queueManifestWrite(writers: PartWriters) {
+    private fun queueManifestWrite(writers: PartWriters) = EmbTrace.trace("mf-queue-manifest") {
         execute(writers, InternalErrorType.SessionManifestWriteFail, { worker.submit(it) }) {
             writers.manifest.write(
                 directory = writers.directory,
@@ -219,7 +220,7 @@ class SessionPartWriterImpl(
         }
     }
 
-    private fun queueMetadataWrite(writers: PartWriters) {
+    private fun queueMetadataWrite(writers: PartWriters) = EmbTrace.trace("mf-queue-metadata") {
         execute(writers, InternalErrorType.SessionMetadataWriteFail, writers.metadataWrites::submit) {
             writers.metadata.write()
         }
@@ -228,18 +229,19 @@ class SessionPartWriterImpl(
     /**
      * Writes the session span as it stands right now.
      */
-    private fun queueSessionSpanWrite(writers: PartWriters, onlyIfCurrent: Boolean = false) {
-        val span = writers.span ?: return
-        execute(writers, InternalErrorType.SessionSpanWriteFail, writers.sessionSpanWrites::submit) {
-            if (onlyIfCurrent && current !== writers) {
-                return@execute
-            }
-            val snapshot = span.snapshot()
-            if (snapshot != null) {
-                writers.sessionSpan.write(snapshot.withHeartbeat())
+    private fun queueSessionSpanWrite(writers: PartWriters, onlyIfCurrent: Boolean = false) =
+        EmbTrace.trace("mf-queue-session-span") {
+            val span = writers.span ?: return@trace
+            execute(writers, InternalErrorType.SessionSpanWriteFail, writers.sessionSpanWrites::submit) {
+                if (onlyIfCurrent && current !== writers) {
+                    return@execute
+                }
+                val snapshot = span.snapshot()
+                if (snapshot != null) {
+                    writers.sessionSpan.write(snapshot.withHeartbeat())
+                }
             }
         }
-    }
 
     /**
      * Stamps emb.heartbeat_unix_time_nanos on the span.
@@ -256,19 +258,19 @@ class SessionPartWriterImpl(
     /**
      * Writes in-flight spans to a snapshot file.
      */
-    private fun queueSpanSnapshotsWrite(writers: PartWriters) {
+    private fun queueSpanSnapshotsWrite(writers: PartWriters) = EmbTrace.trace("mf-queue-span-snapshots") {
         val spans = try {
             inFlightSpanSource()
         } catch (exc: Throwable) {
             logger.trackInternalError(InternalErrorType.SpanSnapshotsWriteFail, exc)
-            return
+            return@trace
         }
         execute(writers, InternalErrorType.SpanSnapshotsWriteFail, writers.spanSnapshotWrites::submit) {
             writers.spanSnapshots.write(spans.mapNotNull(EmbraceSdkSpan::snapshot))
         }
     }
 
-    private fun queueSpanSnapshotsRefresh(writers: PartWriters) {
+    private fun queueSpanSnapshotsRefresh(writers: PartWriters) = EmbTrace.trace("mf-queue-span-snapshots-refresh") {
         execute(writers, InternalErrorType.SpanSnapshotsWriteFail, writers.spanSnapshotWrites::submit) {
             if (current === writers) {
                 writers.spanSnapshots.write(inFlightSpanSource().mapNotNull(EmbraceSdkSpan::snapshot))
@@ -276,16 +278,17 @@ class SessionPartWriterImpl(
         }
     }
 
-    private fun queueCompletedSpansWrite(writers: PartWriters, spans: List<Span>) {
-        execute(null, InternalErrorType.CompletedSpansWriteFail, { worker.submit(it) }) {
-            if (writers.sealed) {
-                // the part sealed while this write was queued. Hold the spans for the next one
-                synchronized(bufferLock) { carryOver(spans) }
-            } else {
-                writers.completedSpans.write(spans)
+    private fun queueCompletedSpansWrite(writers: PartWriters, spans: List<Span>) =
+        EmbTrace.trace("mf-queue-completed-spans") {
+            execute(null, InternalErrorType.CompletedSpansWriteFail, { worker.submit(it) }) {
+                if (writers.sealed) {
+                    // the part sealed while this write was queued. Hold the spans for the next one
+                    synchronized(bufferLock) { carryOver(spans) }
+                } else {
+                    writers.completedSpans.write(spans)
+                }
             }
         }
-    }
 
     /**
      * Holds [spans] until the next session part starts. Spans beyond [MAX_CARRIED_OVER_SPANS] are

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImpl.kt
@@ -13,6 +13,7 @@ import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.serialization.PlatformSerializer
+import io.embrace.android.embracesdk.internal.utils.SystemTrace
 import io.embrace.android.embracesdk.internal.worker.PriorityWorker
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Future
@@ -117,13 +118,17 @@ class IntakeServiceImpl(
                 metadata.complete -> payloadStorageService
                 else -> cacheStorageService
             }
-            service.store(metadata) { stream ->
-                val envelopeSerializer = metadata.envelopeType.envelopeSerializer
-                if (envelopeSerializer != null) {
-                    serializer.toJson(intake, envelopeSerializer, stream)
-                } else { // payload doesn't require serialization
-                    val pair = intake.data as Pair<String, ByteArray>
-                    storeAttachment(stream, pair.second, pair.first)
+            SystemTrace.trace("intake-process") {
+                service.store(metadata) { stream ->
+                    val envelopeSerializer = metadata.envelopeType.envelopeSerializer
+                    if (envelopeSerializer != null) {
+                        SystemTrace.trace("payload-json-serialize") {
+                            serializer.toJson(intake, envelopeSerializer, stream)
+                        }
+                    } else { // payload doesn't require serialization
+                        val pair = intake.data as Pair<String, ByteArray>
+                        storeAttachment(stream, pair.second, pair.first)
+                    }
                 }
             }
 

--- a/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/SystemTrace.kt
+++ b/embrace-android-infra/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/SystemTrace.kt
@@ -1,0 +1,63 @@
+package io.embrace.android.embracesdk.internal.utils
+
+/**
+ * Maximum length `android.os.Trace` accepts for a section name.
+ */
+const val MAX_TRACE_NAME_LENGTH: Int = 127
+
+/**
+ * Prefixes [name] with "emb-" and truncates the result to [MAX_TRACE_NAME_LENGTH], which is the
+ * longest name `android.os.Trace` accepts.
+ *
+ * Only pays for the extra substring allocation when the name actually exceeds that limit.
+ */
+fun prefixedTraceName(name: String): String {
+    val prefixed = "emb-$name"
+    return when {
+        prefixed.length > MAX_TRACE_NAME_LENGTH -> prefixed.substring(0, MAX_TRACE_NAME_LENGTH)
+        else -> prefixed
+    }
+}
+
+/**
+ * Records sections into whatever tracing mechanism the platform provides.
+ */
+interface SectionRecorder {
+
+    /**
+     * Opens a section named [sectionName].
+     *
+     * @return true if a section was actually opened, and so must be closed with [endSection].
+     */
+    fun beginSection(sectionName: String): Boolean
+
+    /**
+     * Closes the section most recently opened by [beginSection] on this thread.
+     */
+    fun endSection()
+}
+
+/**
+ * Adds sections to system traces from modules that cannot depend on the Android SDK.
+ */
+object SystemTrace {
+
+    @Volatile
+    var recorder: SectionRecorder? = null
+
+    /**
+     * Create a trace section around [code] and return its result. The name of the section will be
+     * [sectionName] prefixed by "emb-" and truncated to [MAX_TRACE_NAME_LENGTH].
+     */
+    inline fun <T> trace(sectionName: String, code: Provider<T>): T {
+        val recorder = recorder ?: return code()
+        val opened = recorder.beginSection(sectionName)
+        try {
+            return code()
+        } finally {
+            if (opened) {
+                recorder.endSection()
+            }
+        }
+    }
+}

--- a/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
+++ b/embrace-android-sdk/src/main/kotlin/io/embrace/android/embracesdk/internal/injection/ModuleInitBootstrapper.kt
@@ -13,8 +13,10 @@ import io.embrace.android.embracesdk.internal.instrumentation.thread.blockage.Th
 import io.embrace.android.embracesdk.internal.instrumentation.thread.blockage.ThreadBlockageServiceSupplier
 import io.embrace.android.embracesdk.internal.prefs.createKeyValueStore
 import io.embrace.android.embracesdk.internal.storage.StorageService
+import io.embrace.android.embracesdk.internal.utils.AndroidSectionRecorder
 import io.embrace.android.embracesdk.internal.utils.BuildVersionChecker
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
+import io.embrace.android.embracesdk.internal.utils.SystemTrace
 import io.embrace.android.embracesdk.internal.utils.VersionChecker
 import io.embrace.android.embracesdk.internal.worker.Worker
 
@@ -75,6 +77,7 @@ internal class ModuleInitBootstrapper(
             if (isInitialized()) {
                 return@trace false
             }
+            SystemTrace.recorder = AndroidSectionRecorder
             // stamped before anything else so that the SDK init span covers all the work below,
             // and the perf samples cover the same interval as the span
             val startTimeMs = initModule.clock.now()

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansWriter.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansWriter.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.session.persistence
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.Span
+import io.embrace.android.embracesdk.internal.utils.SystemTrace
 import java.io.File
 import java.io.IOException
 
@@ -33,12 +34,14 @@ class CompletedSpansWriter(
      * place. A session part in which nothing completed has no log at all, which reconstruction
      * reads back as no completed spans.
      */
-    fun write(spans: List<Span>): Boolean = synchronized(lock) {
-        try {
-            writeImpl(spans)
-        } catch (exc: Throwable) {
-            trackFailure(exc)
-            false
+    fun write(spans: List<Span>): Boolean = SystemTrace.trace("mf-write-completed-spans") {
+        synchronized(lock) {
+            try {
+                writeImpl(spans)
+            } catch (exc: Throwable) {
+                trackFailure(exc)
+                false
+            }
         }
     }
 

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionManifestWriter.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionManifestWriter.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.session.persistence
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
+import io.embrace.android.embracesdk.internal.utils.SystemTrace
 import java.io.File
 import java.io.IOException
 
@@ -29,8 +30,8 @@ class SessionManifestWriter(
         envelopeVersion: String,
         envelopeType: String,
         sharedLibSymbolMapping: Map<String, String>? = null,
-    ): Boolean {
-        return try {
+    ): Boolean = SystemTrace.trace("mf-write-manifest") {
+        try {
             writeImpl(directory, resource, envelopeVersion, envelopeType, sharedLibSymbolMapping)
         } catch (exc: Throwable) {
             trackFailure(exc)

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionMetadataWriter.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionMetadataWriter.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
+import io.embrace.android.embracesdk.internal.utils.SystemTrace
 import java.io.File
 import java.io.IOException
 
@@ -26,12 +27,14 @@ class SessionMetadataWriter(
     /**
      * Writes the metadata for the active session part, replacing any metadata already on disk.
      */
-    fun write(): Boolean = synchronized(lock) {
-        try {
-            writeImpl()
-        } catch (exc: Throwable) {
-            trackFailure(exc)
-            false
+    fun write(): Boolean = SystemTrace.trace("mf-write-metadata") {
+        synchronized(lock) {
+            try {
+                writeImpl()
+            } catch (exc: Throwable) {
+                trackFailure(exc)
+                false
+            }
         }
     }
 

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionPartFiles.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionPartFiles.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.session.persistence
 
+import io.embrace.android.embracesdk.internal.utils.SystemTrace
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -33,14 +34,16 @@ internal const val SPAN_SNAPSHOTS_FILE_NAME = "span_snapshots.pb"
  * as an internal error of the appropriate type.
  */
 internal fun writeAtomically(partDir: File, fileName: String, maxBytes: Long, encode: (OutputStream) -> Unit) {
-    val tmpFile = File.createTempFile(fileName, ".tmp", partDir)
-    try {
-        LimitedOutputStream(tmpFile.outputStream().buffered(), maxBytes).use(encode)
-        if (!tmpFile.renameTo(File(partDir, fileName))) {
-            throw IOException("Failed to rename $fileName")
+    SystemTrace.trace("mf-file-write-atomic") {
+        val tmpFile = File.createTempFile(fileName, ".tmp", partDir)
+        try {
+            LimitedOutputStream(tmpFile.outputStream().buffered(), maxBytes).use(encode)
+            if (!tmpFile.renameTo(File(partDir, fileName))) {
+                throw IOException("Failed to rename $fileName")
+            }
+        } finally {
+            tmpFile.delete()
         }
-    } finally {
-        tmpFile.delete()
     }
 }
 
@@ -48,8 +51,10 @@ internal fun writeAtomically(partDir: File, fileName: String, maxBytes: Long, en
  * Appends [bytes] to [fileName] in [partDir], creating the file if it is not there yet.
  */
 internal fun appendTo(partDir: File, fileName: String, bytes: ByteArray) {
-    FileOutputStream(File(partDir, fileName), true).use { stream ->
-        stream.write(bytes)
+    SystemTrace.trace("mf-file-append") {
+        FileOutputStream(File(partDir, fileName), true).use { stream ->
+            stream.write(bytes)
+        }
     }
 }
 

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionService.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionService.kt
@@ -121,7 +121,7 @@ class SessionReconstructionService(
      */
     private fun dedupeSpanIds(spans: List<Span>, spanSnapshots: List<Span>): DedupedSpans =
         SystemTrace.trace("mf-dedupe-span-ids") {
-            val completedIds = spans.mapNotNull(Span::spanId).toSet()
+            val completedIds = spans.mapNotNullTo(HashSet(), Span::spanId)
             val remainingSnapshots = spanSnapshots.filter { snapshot ->
                 val id = snapshot.spanId
                 id == null || id !in completedIds

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionService.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionService.kt
@@ -6,6 +6,7 @@ import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.SessionPartPayload
 import io.embrace.android.embracesdk.internal.payload.Span
+import io.embrace.android.embracesdk.internal.utils.SystemTrace
 import okio.buffer
 import okio.source
 import java.io.File
@@ -23,14 +24,15 @@ class SessionReconstructionService(
     /**
      * Reconstructs the envelope for the given session part, or null if it cannot be read.
      */
-    fun reconstruct(directory: SessionPartDirectory): Envelope<SessionPartPayload>? {
-        return try {
-            reconstructImpl(directory)
-        } catch (exc: Throwable) {
-            trackFailure(exc)
-            null
+    fun reconstruct(directory: SessionPartDirectory): Envelope<SessionPartPayload>? =
+        SystemTrace.trace("mf-session-reconstruct") {
+            try {
+                reconstructImpl(directory)
+            } catch (exc: Throwable) {
+                trackFailure(exc)
+                null
+            }
         }
-    }
 
     private fun reconstructImpl(directory: SessionPartDirectory): Envelope<SessionPartPayload>? {
         val partDir = File(sessionsDir.value, directory.dirName)
@@ -117,24 +119,25 @@ class SessionReconstructionService(
      * The completed span always supersedes snapshots, and otherwise the span with the latest end time
      * is chosen.
      */
-    private fun dedupeSpanIds(spans: List<Span>, spanSnapshots: List<Span>): DedupedSpans {
-        val completedIds = spans.mapNotNull(Span::spanId).toSet()
-        val remainingSnapshots = spanSnapshots.filter { snapshot ->
-            val id = snapshot.spanId
-            id == null || id !in completedIds
-        }
-        val dedupedSpans = keepLatestPerSpanId(spans)
-        val dedupedSnapshots = keepLatestPerSpanId(remainingSnapshots)
+    private fun dedupeSpanIds(spans: List<Span>, spanSnapshots: List<Span>): DedupedSpans =
+        SystemTrace.trace("mf-dedupe-span-ids") {
+            val completedIds = spans.mapNotNull(Span::spanId).toSet()
+            val remainingSnapshots = spanSnapshots.filter { snapshot ->
+                val id = snapshot.spanId
+                id == null || id !in completedIds
+            }
+            val dedupedSpans = keepLatestPerSpanId(spans)
+            val dedupedSnapshots = keepLatestPerSpanId(remainingSnapshots)
 
-        val duplicates = (spans.size - dedupedSpans.size) + (spanSnapshots.size - dedupedSnapshots.size)
-        if (duplicates > 0) {
-            logger.trackInternalError(
-                InternalErrorType.DuplicateSpanIds,
-                IllegalStateException("Removed duplicate spans from session part payload"),
-            )
+            val duplicates = (spans.size - dedupedSpans.size) + (spanSnapshots.size - dedupedSnapshots.size)
+            if (duplicates > 0) {
+                logger.trackInternalError(
+                    InternalErrorType.DuplicateSpanIds,
+                    IllegalStateException("Removed duplicate spans from session part payload"),
+                )
+            }
+            DedupedSpans(dedupedSpans, dedupedSnapshots)
         }
-        return DedupedSpans(dedupedSpans, dedupedSnapshots)
-    }
 
     private fun keepLatestPerSpanId(spans: List<Span>): List<Span> {
         val winners = mutableMapOf<String, Int>()
@@ -157,16 +160,17 @@ class SessionReconstructionService(
      *
      * An oversized log is truncated rather than rejected.
      */
-    private fun readCompletedSpansFile(partDir: File): List<Span>? {
+    private fun readCompletedSpansFile(partDir: File): List<Span>? = SystemTrace.trace("mf-read-completed-spans") {
         val src = File(partDir, COMPLETED_SPANS_FILE_NAME)
         if (!src.exists()) {
-            return emptyList()
+            return@trace emptyList()
         }
         if (src.length() > MAX_PART_FILE_BYTES) {
             trackFailure(IOException(OVERSIZED_PART_FILE_MSG))
         }
-        return try {
-            src.source().buffer().use(::readCompletedSpans).map(SpanProto::toPayload)
+        try {
+            val decoded = src.source().buffer().use(::readCompletedSpans)
+            SystemTrace.trace("mf-spans-proto-to-payload") { decoded.map(SpanProto::toPayload) }
         } catch (exc: Throwable) {
             trackFailure(exc)
             null
@@ -187,7 +191,7 @@ class SessionReconstructionService(
             SpanSnapshots.ADAPTER,
             SpanSnapshots::format_version,
         ) ?: return null
-        return snapshots.spans.map(SpanProto::toPayload)
+        return SystemTrace.trace("mf-spans-proto-to-payload") { snapshots.spans.map(SpanProto::toPayload) }
     }
 
     /**
@@ -203,9 +207,9 @@ class SessionReconstructionService(
         fileName: String,
         adapter: ProtoAdapter<T>,
         formatVersion: (T) -> Int,
-    ): T? {
+    ): T? = SystemTrace.trace(partFileReadSectionName(fileName)) {
         val src = File(partDir, fileName)
-        return try {
+        try {
             val message = decodePartFile(src, adapter)
 
             val version = formatVersion(message)
@@ -237,4 +241,12 @@ class SessionReconstructionService(
     }
 
     private class DedupedSpans(val spans: List<Span>, val spanSnapshots: List<Span>)
+}
+
+private fun partFileReadSectionName(fileName: String): String = when (fileName) {
+    MANIFEST_FILE_NAME -> "mf-read-manifest"
+    METADATA_FILE_NAME -> "mf-read-metadata"
+    SESSION_SPAN_FILE_NAME -> "mf-read-session-span"
+    SPAN_SNAPSHOTS_FILE_NAME -> "mf-read-span-snapshots"
+    else -> "mf-read-file-other"
 }

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionSpanWriter.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionSpanWriter.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.session.persistence
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.Span
+import io.embrace.android.embracesdk.internal.utils.SystemTrace
 import java.io.File
 import java.io.IOException
 
@@ -17,12 +18,14 @@ class SessionSpanWriter(
 
     private val lock = Any()
 
-    fun write(span: Span): Boolean = synchronized(lock) {
-        try {
-            writeImpl(span)
-        } catch (exc: Throwable) {
-            trackFailure(exc)
-            false
+    fun write(span: Span): Boolean = SystemTrace.trace("mf-write-session-span") {
+        synchronized(lock) {
+            try {
+                writeImpl(span)
+            } catch (exc: Throwable) {
+                trackFailure(exc)
+                false
+            }
         }
     }
 

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SpanSnapshotsWriter.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SpanSnapshotsWriter.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.session.persistence
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.Span
+import io.embrace.android.embracesdk.internal.utils.SystemTrace
 import java.io.File
 import java.io.IOException
 
@@ -24,12 +25,14 @@ class SpanSnapshotsWriter(
     /**
      * Writes the in-flight spans for the active session part, replacing any already on disk.
      */
-    fun write(spans: List<Span>): Boolean = synchronized(lock) {
-        try {
-            writeImpl(spans)
-        } catch (exc: Throwable) {
-            trackFailure(exc)
-            false
+    fun write(spans: List<Span>): Boolean = SystemTrace.trace("mf-write-span-snapshots") {
+        synchronized(lock) {
+            try {
+                writeImpl(spans)
+            } catch (exc: Throwable) {
+                trackFailure(exc)
+                false
+            }
         }
     }
 

--- a/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImpl.kt
+++ b/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImpl.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.delivery.StoredTelemetryMetadata
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
+import io.embrace.android.embracesdk.internal.utils.SystemTrace
 import io.embrace.android.embracesdk.internal.worker.PriorityWorker
 import java.io.File
 import java.io.FileNotFoundException
@@ -44,9 +45,9 @@ class FileStorageServiceImpl(
     private fun storeImpl(
         metadata: StoredTelemetryMetadata,
         action: SerializationAction,
-    ) {
+    ) = SystemTrace.trace("payload-file-write") {
         if (index.prune(newEntry = metadata)) {
-            return
+            return@trace
         }
 
         // write to a temporary file then rename it, to avoid sending incomplete files

--- a/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/StoredEntryIndex.kt
+++ b/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/StoredEntryIndex.kt
@@ -3,6 +3,7 @@ package io.embrace.android.embracesdk.internal.delivery.storage
 import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
+import io.embrace.android.embracesdk.internal.utils.SystemTrace
 import io.embrace.android.embracesdk.internal.utils.threadSafeToList
 import java.io.File
 import java.io.FileNotFoundException
@@ -82,24 +83,24 @@ class StoredEntryIndex<T>(
      * count-based limit is then enforced, and the return value indicates whether [newEntry] itself
      * was pruned and so should not be written to disk.
      */
-    fun prune(newEntry: T? = null): Boolean {
+    fun prune(newEntry: T? = null): Boolean = SystemTrace.trace("storage-index-prune") {
         // remove entries created before the cutoff
         val cutoffMs = clock.now() - maxAgeMs
         if (cutoffMs > 0L) {
             entries.filter { layout.timestampOf(it) < cutoffMs }.forEach(::delete)
         }
 
-        newEntry ?: return false
+        newEntry ?: return@trace false
 
         // remove entries by count
         val count = entries.size
         if (count < storageLimit) {
-            return false
+            return@trace false
         }
         val input = (entries + newEntry).toMutableList()
         val removalCount = input.size - storageLimit
         if (removalCount < 0) {
-            return false
+            return@trace false
         }
         val removals = if (removalCount == 1) {
             // exceeding the limit by one is the common case, so avoid sorting the whole index
@@ -111,6 +112,6 @@ class StoredEntryIndex<T>(
         removals.forEach(::delete)
 
         // notify the caller whether the new entry should be dropped
-        return removals.contains(newEntry)
+        removals.contains(newEntry)
     }
 }

--- a/embrace-android-utils/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/AndroidSectionRecorder.kt
+++ b/embrace-android-utils/src/main/kotlin/io/embrace/android/embracesdk/internal/utils/AndroidSectionRecorder.kt
@@ -1,0 +1,28 @@
+package io.embrace.android.embracesdk.internal.utils
+
+import android.annotation.SuppressLint
+import android.os.Build
+import android.os.Build.VERSION_CODES
+import android.os.Trace
+
+/**
+ * Records sections into system traces via `android.os.Trace`, for the JVM-only modules
+ * that reach tracing through [SystemTrace] because they cannot reference that class at compile time.
+ */
+object AndroidSectionRecorder : SectionRecorder {
+
+    @SuppressLint("UnclosedTrace")
+    override fun beginSection(sectionName: String): Boolean {
+        if (Build.VERSION.SDK_INT < VERSION_CODES.Q || !Trace.isEnabled()) {
+            return false
+        }
+        Trace.beginSection(prefixedTraceName(sectionName))
+        return true
+    }
+
+    override fun endSection() {
+        if (Build.VERSION.SDK_INT >= VERSION_CODES.Q) {
+            Trace.endSection()
+        }
+    }
+}

--- a/embrace-test-common/build.gradle.kts
+++ b/embrace-test-common/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     implementation(project(":embrace-android-payload"))
-    implementation(project(":embrace-android-infra"))
+    api(project(":embrace-android-infra"))
     implementation(platform(libs.okhttp.bom))
     implementation(libs.mockwebserver)
     implementation(libs.robolectric)


### PR DESCRIPTION
## Goal

Adds some initial tracing using `EmbTrace` to the single-file (sf) and multi-file (mf) persistence layers. This will be used to compare performance between the two solutions.