### PR TITLE
Only log internal error once

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -17,6 +17,7 @@ import io.embrace.android.embracesdk.internal.session.persistence.SessionManifes
 import io.embrace.android.embracesdk.internal.session.persistence.SessionMetadataWriter
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectory
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectoryStore
+import io.embrace.android.embracesdk.internal.session.persistence.SessionPartWriteTarget
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartWriteTracker
 import io.embrace.android.embracesdk.internal.session.persistence.SessionSpanWriter
 import io.embrace.android.embracesdk.internal.session.persistence.SpanSnapshotsWriter
@@ -211,7 +212,6 @@ class SessionPartWriterImpl(
     private fun queueManifestWrite(writers: PartWriters) = EmbTrace.trace("mf-queue-manifest") {
         execute(writers, InternalErrorType.SessionManifestWriteFail, { worker.submit(it) }) {
             writers.manifest.write(
-                directory = writers.directory,
                 resource = resourceSource.getEnvelopeResource(),
                 envelopeVersion = SESSION_ENVELOPE_VERSION,
                 envelopeType = SESSION_ENVELOPE_TYPE,
@@ -315,7 +315,7 @@ class SessionPartWriterImpl(
         action: () -> Unit,
     ) {
         val task = Runnable {
-            if (writers?.sealed == true) {
+            if (writers?.abandoned == true) {
                 return@Runnable
             }
             try {
@@ -355,34 +355,28 @@ class SessionPartWriterImpl(
         @Volatile
         var sealed: Boolean = false
 
+        private val target = SessionPartWriteTarget(sessionsDir) { directory }
+
+        /**
+         * Whether nothing more should be written for this part: it has either been fully written,
+         * or the directory is not on disk.
+         */
+        val abandoned: Boolean
+            get() = sealed || target.failed
+
         val span: EmbraceSdkSpan? = currentSessionPartSpan.current()
-        val manifest = SessionManifestWriter(sessionsDir, logger)
+        val manifest = SessionManifestWriter(target, logger)
 
         val metadata = SessionMetadataWriter(
-            sessionsDir = sessionsDir,
-            sessionPartDirectorySource = { directory },
+            target = target,
             metadataSource = metadataSource::getEnvelopeMetadata,
             resourceSource = resourceSource::getEnvelopeResource,
             logger = logger,
         )
 
-        val sessionSpan = SessionSpanWriter(
-            sessionsDir = sessionsDir,
-            sessionPartDirectorySource = { directory },
-            logger = logger,
-        )
-
-        val completedSpans = CompletedSpansWriter(
-            sessionsDir = sessionsDir,
-            sessionPartDirectorySource = { directory },
-            logger = logger,
-        )
-
-        val spanSnapshots = SpanSnapshotsWriter(
-            sessionsDir = sessionsDir,
-            sessionPartDirectorySource = { directory },
-            logger = logger,
-        )
+        val sessionSpan = SessionSpanWriter(target, logger)
+        val completedSpans = CompletedSpansWriter(target, logger)
+        val spanSnapshots = SpanSnapshotsWriter(target, logger)
 
         val metadataWrites = CoalescingWriteQueue(worker, METADATA_WRITE_DELAY_MS)
         val sessionSpanWrites = CoalescingWriteQueue(worker, SESSION_SPAN_WRITE_DELAY_MS)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/SessionPartReaderTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/SessionPartReaderTest.kt
@@ -21,6 +21,7 @@ import io.embrace.android.embracesdk.internal.session.persistence.SessionManifes
 import io.embrace.android.embracesdk.internal.session.persistence.SessionMetadataWriter
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectory
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartDirectoryStore
+import io.embrace.android.embracesdk.internal.session.persistence.SessionPartWriteTarget
 import io.embrace.android.embracesdk.internal.session.persistence.SessionPartWriteTracker
 import io.embrace.android.embracesdk.internal.session.persistence.SessionReconstructionService
 import io.embrace.android.embracesdk.internal.session.persistence.SessionSpanWriter
@@ -212,20 +213,19 @@ internal class SessionPartReaderTest {
     private fun persist(directory: SessionPartDirectory, span: Span = sessionSpan()) {
         create(directory)
 
-        SessionManifestWriter(lazy { sessionsDir }, logger).write(
-            directory = directory,
+        val target = SessionPartWriteTarget(lazy { sessionsDir }) { directory }
+        SessionManifestWriter(target, logger).write(
             resource = EnvelopeResource(appVersion = "1.0.0"),
             envelopeVersion = SESSION_ENVELOPE_VERSION,
             envelopeType = SESSION_ENVELOPE_TYPE,
         )
         SessionMetadataWriter(
-            sessionsDir = lazy { sessionsDir },
-            sessionPartDirectorySource = { directory },
+            target = target,
             metadataSource = { EnvelopeMetadata(username = "fake-user") },
             resourceSource = { EnvelopeResource(appVersion = "1.0.0") },
             logger = logger,
         ).write()
-        SessionSpanWriter(lazy { sessionsDir }, { directory }, logger).write(span)
+        SessionSpanWriter(target, logger).write(span)
     }
 
     /**

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterBoundaryTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterBoundaryTest.kt
@@ -252,10 +252,7 @@ internal class SessionPartWriterBoundaryTest {
         startPart(SECOND_PART_ID)
         drain()
 
-        assertEquals(
-            listOf("SessionSpanWriteFail", "SpanSnapshotsWriteFail"),
-            logger.internalErrorMessages.map { it.msg },
-        )
+        assertEquals(listOf("SessionSpanWriteFail"), logger.internalErrorMessages.map { it.msg })
         assertEquals("span1", sessionSpanIn(SECOND_PART_ID)?.span?.name)
     }
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
@@ -28,6 +28,7 @@ import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -233,45 +234,20 @@ internal class SessionPartWriterImplTest {
     }
 
     @Test
-    fun `a session part directory that cannot be created is reported and nothing is written`() {
+    fun `a session part directory that cannot be created is reported once and nothing is written`() {
         val writer = createWriter(sessionsDir = tempFolder.newFile("not_a_dir"))
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
         drain()
 
-        assertInternalErrors(
-            "SessionPartDirectoryStoreFail",
-            "SessionManifestWriteFail",
-            "SessionMetadataWriteFail",
-            "SessionSpanWriteFail",
-            "SpanSnapshotsWriteFail",
-        )
+        assertInternalErrors("SessionPartDirectoryStoreFail", "SessionManifestWriteFail")
 
         writer.onMetadataChanged()
         drain()
-
-        assertInternalErrors(
-            "SessionPartDirectoryStoreFail",
-            "SessionManifestWriteFail",
-            "SessionMetadataWriteFail",
-            "SessionSpanWriteFail",
-            "SpanSnapshotsWriteFail",
-            "SessionMetadataWriteFail",
-        )
-
         endPart()
         writer.onSessionPartEnded(SESSION_PART_ID)
         drain()
 
-        assertInternalErrors(
-            "SessionPartDirectoryStoreFail",
-            "SessionManifestWriteFail",
-            "SessionMetadataWriteFail",
-            "SessionSpanWriteFail",
-            "SpanSnapshotsWriteFail",
-            "SessionMetadataWriteFail",
-            "SessionSpanWriteFail",
-            "SpanSnapshotsWriteFail",
-        )
+        assertInternalErrors("SessionPartDirectoryStoreFail", "SessionManifestWriteFail")
         assertEquals(0, writeCount)
     }
 
@@ -643,6 +619,49 @@ internal class SessionPartWriterImplTest {
         drain()
 
         assertEquals(listOf("SessionSpanWriteFail"), logger.internalErrorMessages.map { it.msg })
+    }
+
+    @Test
+    fun `a session part whose directory is gone is given up on after the first failed write`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+        assertNoInternalErrors()
+        File(sessionsDir, partDirs().single().dirName).deleteRecursively()
+
+        repeat(10) { index ->
+            clock.tick(2000)
+            sessionSpan.name = "span${index + 1}"
+            writer.onSessionSpanChanged()
+            writer.onMetadataChanged()
+            writer.onSpanSnapshotChanged()
+            writer.onSpanCompleted(listOf(completedSpan("completed$index")))
+            drain()
+        }
+        assertEquals(1, logger.internalErrorMessages.size)
+    }
+
+    @Test
+    fun `the next session part is written after the previous one was given up on`() {
+        val writer = createWriter()
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+        File(sessionsDir, partDirs().single().dirName).deleteRecursively()
+
+        clock.tick(2000)
+        writer.onSessionSpanChanged()
+        drain()
+        assertEquals(1, logger.internalErrorMessages.size)
+
+        endPart()
+        writer.onSessionPartEnded(SESSION_PART_ID)
+        clock.tick(2000)
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, OTHER_SESSION_PART_ID)
+        drain()
+
+        assertNotNull(sessionSpanIn(OTHER_SESSION_PART_ID))
+        assertNotNull(manifestIn(OTHER_SESSION_PART_ID))
+        assertEquals(1, logger.internalErrorMessages.size)
     }
 
     @Test

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansWriter.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansWriter.kt
@@ -18,8 +18,7 @@ import java.io.IOException
  * for filtering it out.
  */
 class CompletedSpansWriter(
-    private val sessionsDir: Lazy<File>,
-    private val sessionPartDirectorySource: () -> SessionPartDirectory?,
+    private val target: SessionPartWriteTarget,
     private val logger: InternalLogger,
     private val maxBytes: Long = MAX_PART_FILE_BYTES,
 ) {
@@ -46,13 +45,9 @@ class CompletedSpansWriter(
     }
 
     private fun writeImpl(spans: List<Span>): Boolean {
-        val directory = sessionPartDirectorySource() ?: return false
+        val directory = target.directory ?: return false
+        val partDir = target.partDir(directory, ::trackFailure) ?: return false
 
-        val partDir = File(sessionsDir.value, directory.dirName)
-        if (!partDir.isDirectory) {
-            trackFailure(IOException("Not a session part directory"))
-            return false
-        }
         val records = CompletedSpans(spans = spans.map(Span::toProto))
         val bytes = CompletedSpans.ADAPTER.encode(records)
 

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionManifestWriter.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionManifestWriter.kt
@@ -4,8 +4,6 @@ import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
 import io.embrace.android.embracesdk.internal.utils.SystemTrace
-import java.io.File
-import java.io.IOException
 
 /**
  * Writes the immutable parts of the envelope resource and the identity of a session part to its
@@ -15,24 +13,23 @@ import java.io.IOException
  * lifetime of the process, so the file is never revisited.
  */
 class SessionManifestWriter(
-    private val sessionsDir: Lazy<File>,
+    private val target: SessionPartWriteTarget,
     private val logger: InternalLogger,
 ) {
 
     /**
-     * Writes the manifest for the given session part.
+     * Writes the manifest for the active session part.
      *
      * Returns true if a manifest is on disk for this session part
      */
     fun write(
-        directory: SessionPartDirectory,
         resource: EnvelopeResource,
         envelopeVersion: String,
         envelopeType: String,
         sharedLibSymbolMapping: Map<String, String>? = null,
     ): Boolean = SystemTrace.trace("mf-write-manifest") {
         try {
-            writeImpl(directory, resource, envelopeVersion, envelopeType, sharedLibSymbolMapping)
+            writeImpl(resource, envelopeVersion, envelopeType, sharedLibSymbolMapping)
         } catch (exc: Throwable) {
             trackFailure(exc)
             false
@@ -40,17 +37,13 @@ class SessionManifestWriter(
     }
 
     private fun writeImpl(
-        directory: SessionPartDirectory,
         resource: EnvelopeResource,
         envelopeVersion: String,
         envelopeType: String,
         sharedLibSymbolMapping: Map<String, String>?,
     ): Boolean {
-        val partDir = File(sessionsDir.value, directory.dirName)
-        if (!partDir.isDirectory) {
-            trackFailure(IOException("Not a session part directory"))
-            return false
-        }
+        val directory = target.directory ?: return false
+        val partDir = target.partDir(directory, ::trackFailure) ?: return false
 
         // build the message before touching the filesystem
         val manifest = SessionManifest(

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionMetadataWriter.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionMetadataWriter.kt
@@ -5,8 +5,6 @@ import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.EnvelopeMetadata
 import io.embrace.android.embracesdk.internal.payload.EnvelopeResource
 import io.embrace.android.embracesdk.internal.utils.SystemTrace
-import java.io.File
-import java.io.IOException
 
 /**
  * Writes the data that can change over the lifetime of a session part to its directory.
@@ -15,8 +13,7 @@ import java.io.IOException
  * starts, whenever the user info or envelope resource changes.
  */
 class SessionMetadataWriter(
-    private val sessionsDir: Lazy<File>,
-    private val sessionPartDirectorySource: () -> SessionPartDirectory?,
+    private val target: SessionPartWriteTarget,
     private val metadataSource: () -> EnvelopeMetadata,
     private val resourceSource: () -> EnvelopeResource,
     private val logger: InternalLogger,
@@ -39,13 +36,8 @@ class SessionMetadataWriter(
     }
 
     private fun writeImpl(): Boolean {
-        val directory = sessionPartDirectorySource() ?: return false
-
-        val partDir = File(sessionsDir.value, directory.dirName)
-        if (!partDir.isDirectory) {
-            trackFailure(IOException("Not a session part directory"))
-            return false
-        }
+        val directory = target.directory ?: return false
+        val partDir = target.partDir(directory, ::trackFailure) ?: return false
 
         val metadata = metadataSource().toProto(resourceSource().toMutableProto())
         writeAtomically(partDir, METADATA_FILE_NAME, Long.MAX_VALUE) { stream ->

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionPartWriteTarget.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionPartWriteTarget.kt
@@ -1,0 +1,44 @@
+package io.embrace.android.embracesdk.internal.session.persistence
+
+import java.io.File
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal const val MISSING_PART_DIR_MSG = "Not a session part directory"
+
+/**
+ * Where the telemetry for one session part is written.
+ */
+class SessionPartWriteTarget(
+    private val sessionsDir: Lazy<File>,
+    private val sessionPartDirectorySource: () -> SessionPartDirectory?,
+) {
+
+    private val givenUp = AtomicBoolean(false)
+
+    val failed: Boolean
+        get() = givenUp.get()
+
+    /**
+     * The session part to write telemetry for, or null if there is nothing to write for.
+     */
+    val directory: SessionPartDirectory?
+        get() = when {
+            failed -> null
+            else -> sessionPartDirectorySource()
+        }
+
+    /**
+     * The directory holding [directory]'s telemetry, or null if it is not on disk.
+     */
+    fun partDir(directory: SessionPartDirectory, onMissing: (Throwable) -> Unit): File? {
+        val partDir = File(sessionsDir.value, directory.dirName)
+        if (!partDir.isDirectory) {
+            if (givenUp.compareAndSet(false, true)) {
+                onMissing(IOException(MISSING_PART_DIR_MSG))
+            }
+            return null
+        }
+        return partDir
+    }
+}

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionService.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionService.kt
@@ -37,7 +37,7 @@ class SessionReconstructionService(
     private fun reconstructImpl(directory: SessionPartDirectory): Envelope<SessionPartPayload>? {
         val partDir = File(sessionsDir.value, directory.dirName)
         if (!partDir.isDirectory) {
-            trackFailure(IOException("Not a session part directory"))
+            trackFailure(IOException(MISSING_PART_DIR_MSG))
             return null
         }
 

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionSpanWriter.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionSpanWriter.kt
@@ -4,15 +4,12 @@ import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.utils.SystemTrace
-import java.io.File
-import java.io.IOException
 
 /**
  * Writes the session span for a session part to its directory.
  */
 class SessionSpanWriter(
-    private val sessionsDir: Lazy<File>,
-    private val sessionPartDirectorySource: () -> SessionPartDirectory?,
+    private val target: SessionPartWriteTarget,
     private val logger: InternalLogger,
 ) {
 
@@ -30,13 +27,9 @@ class SessionSpanWriter(
     }
 
     private fun writeImpl(span: Span): Boolean {
-        val directory = sessionPartDirectorySource() ?: return false
+        val directory = target.directory ?: return false
+        val partDir = target.partDir(directory, ::trackFailure) ?: return false
 
-        val partDir = File(sessionsDir.value, directory.dirName)
-        if (!partDir.isDirectory) {
-            trackFailure(IOException("Not a session part directory"))
-            return false
-        }
         val sessionSpan = SessionPartSpan(
             format_version = FORMAT_VERSION,
             span = span.toProto(),

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SpanSnapshotsWriter.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SpanSnapshotsWriter.kt
@@ -4,8 +4,6 @@ import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.utils.SystemTrace
-import java.io.File
-import java.io.IOException
 
 /**
  * Writes the in-flight spans for a session part to its directory.
@@ -15,8 +13,7 @@ import java.io.IOException
  * responsible for filtering it out.
  */
 class SpanSnapshotsWriter(
-    private val sessionsDir: Lazy<File>,
-    private val sessionPartDirectorySource: () -> SessionPartDirectory?,
+    private val target: SessionPartWriteTarget,
     private val logger: InternalLogger,
 ) {
 
@@ -37,13 +34,9 @@ class SpanSnapshotsWriter(
     }
 
     private fun writeImpl(spans: List<Span>): Boolean {
-        val directory = sessionPartDirectorySource() ?: return false
+        val directory = target.directory ?: return false
+        val partDir = target.partDir(directory, ::trackFailure) ?: return false
 
-        val partDir = File(sessionsDir.value, directory.dirName)
-        if (!partDir.isDirectory) {
-            trackFailure(IOException("Not a session part directory"))
-            return false
-        }
         val snapshots = SpanSnapshots(
             format_version = FORMAT_VERSION,
             spans = spans.map(Span::toProto),

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansWriterTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansWriterTest.kt
@@ -56,7 +56,7 @@ internal class CompletedSpansWriterTest {
         sessionsDir = tempFolder.newFolder("embrace_sessions")
         logger = FakeInternalLogger(throwOnInternalError = false)
         activePart = partDirectory
-        writer = CompletedSpansWriter(lazy { sessionsDir }, { activePart }, logger)
+        writer = CompletedSpansWriter(target { activePart }, logger)
         createPartDir(partDirectory)
     }
 
@@ -171,6 +171,15 @@ internal class CompletedSpansWriterTest {
     }
 
     @Test
+    fun `a session part with no directory is given up on and reported once`() {
+        val absent = SessionPartDirectory(timestamp = TIMESTAMP + 2, uuid = UUID)
+        repeat(20) {
+            assertFalse(write(absent))
+        }
+        assertWriteFailureTracked()
+    }
+
+    @Test
     fun `a file occupying the session part path is reported and left untouched`() {
         val occupied = SessionPartDirectory(timestamp = TIMESTAMP + 3, uuid = UUID)
         val occupyingFile = partDir(occupied).apply { writeText("not a directory") }
@@ -181,7 +190,7 @@ internal class CompletedSpansWriterTest {
 
     @Test
     fun `a failing session part source is reported and does not throw`() {
-        writer = CompletedSpansWriter(lazy { sessionsDir }, { error("boom") }, logger)
+        writer = CompletedSpansWriter(target { error("boom") }, logger)
         assertFalse(writer.write(completed))
         assertEquals(emptyList<String>(), partDir().list()?.toList())
         assertWriteFailureTracked()
@@ -280,7 +289,10 @@ internal class CompletedSpansWriterTest {
     }
 
     private fun boundedWriter(): CompletedSpansWriter =
-        CompletedSpansWriter(lazy { sessionsDir }, { activePart }, logger, twoSpanBudget)
+        CompletedSpansWriter(target { activePart }, logger, twoSpanBudget)
+
+    private fun target(source: () -> SessionPartDirectory?): SessionPartWriteTarget =
+        SessionPartWriteTarget(lazy { sessionsDir }, source)
 
     private fun createPartDir(directory: SessionPartDirectory): File =
         File(sessionsDir, directory.dirName).apply { mkdirs() }

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionManifestWriterTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionManifestWriterTest.kt
@@ -39,11 +39,15 @@ internal class SessionManifestWriterTest {
     private lateinit var logger: FakeInternalLogger
     private lateinit var writer: SessionManifestWriter
 
+    @Volatile
+    private var activePart: SessionPartDirectory? = partDirectory
+
     @Before
     fun setUp() {
         sessionsDir = tempFolder.newFolder("embrace_sessions")
         logger = FakeInternalLogger(throwOnInternalError = false)
-        writer = SessionManifestWriter(lazy { sessionsDir }, logger)
+        activePart = partDirectory
+        writer = SessionManifestWriter(SessionPartWriteTarget(lazy { sessionsDir }) { activePart }, logger)
         createPartDir(partDirectory)
     }
 
@@ -60,12 +64,15 @@ internal class SessionManifestWriterTest {
         manifestFile(directory).inputStream().use(SessionManifest.ADAPTER::decode)
 
     private fun write(
-        directory: SessionPartDirectory = partDirectory,
+        directory: SessionPartDirectory? = partDirectory,
         resource: EnvelopeResource = fullyPopulatedResource,
         envelopeVersion: String = ENVELOPE_VERSION,
         envelopeType: String = ENVELOPE_TYPE,
         sharedLibSymbolMapping: Map<String, String>? = null,
-    ): Boolean = writer.write(directory, resource, envelopeVersion, envelopeType, sharedLibSymbolMapping)
+    ): Boolean {
+        activePart = directory
+        return writer.write(resource, envelopeVersion, envelopeType, sharedLibSymbolMapping)
+    }
 
     private fun assertNoInternalErrors() {
         assertEquals(emptyList<FakeInternalLogger.LogMessage>(), logger.internalErrorMessages)

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionMetadataWriterTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionMetadataWriterTest.kt
@@ -55,8 +55,7 @@ internal class SessionMetadataWriterTest {
         resourceProvider = { fullyPopulatedResource }
         activePart = partDirectory
         writer = SessionMetadataWriter(
-            lazy { sessionsDir },
-            { activePart },
+            target { activePart },
             { metadataProvider() },
             { resourceProvider() },
             logger,
@@ -237,6 +236,15 @@ internal class SessionMetadataWriterTest {
     }
 
     @Test
+    fun `a session part with no directory is given up on and reported once`() {
+        val absent = SessionPartDirectory(timestamp = TIMESTAMP + 2, uuid = UUID)
+        repeat(20) {
+            assertFalse(write(absent))
+        }
+        assertWriteFailureTracked()
+    }
+
+    @Test
     fun `a file occupying the session part path is reported and left untouched`() {
         val occupied = SessionPartDirectory(timestamp = TIMESTAMP + 3, uuid = UUID)
         val occupyingFile = partDir(occupied).apply { writeText("not a directory") }
@@ -269,8 +277,7 @@ internal class SessionMetadataWriterTest {
     @Test
     fun `a failing session part source is reported and does not throw`() {
         writer = SessionMetadataWriter(
-            lazy { sessionsDir },
-            { error("boom") },
+            target { error("boom") },
             { metadataProvider() },
             { resourceProvider() },
             logger,
@@ -317,6 +324,9 @@ internal class SessionMetadataWriterTest {
         assertEquals(listOf(METADATA_FILE_NAME), partDir().list()?.toList())
         assertNoInternalErrors()
     }
+
+    private fun target(source: () -> SessionPartDirectory?): SessionPartWriteTarget =
+        SessionPartWriteTarget(lazy { sessionsDir }, source)
 
     private fun createPartDir(directory: SessionPartDirectory): File =
         File(sessionsDir, directory.dirName).apply { mkdirs() }

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionPartWriteTargetTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionPartWriteTargetTest.kt
@@ -1,0 +1,120 @@
+package io.embrace.android.embracesdk.internal.session.persistence
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+internal class SessionPartWriteTargetTest {
+
+    private companion object {
+        private const val TIMESTAMP = 1726739283136L
+        private const val UUID = "c2610cd1-389f-422a-bfbc-25312c7a599a"
+
+        private val partDirectory = SessionPartDirectory(
+            timestamp = TIMESTAMP,
+            uuid = UUID,
+            userSessionId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            sessionPartId = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        )
+    }
+
+    @get:Rule
+    val tempFolder: TemporaryFolder = TemporaryFolder()
+
+    private lateinit var sessionsDir: File
+    private lateinit var target: SessionPartWriteTarget
+
+    private var activePart: SessionPartDirectory? = partDirectory
+    private val reported = mutableListOf<Throwable>()
+
+    @Before
+    fun setUp() {
+        sessionsDir = tempFolder.newFolder("embrace_sessions")
+        activePart = partDirectory
+        reported.clear()
+        target = SessionPartWriteTarget(lazy { sessionsDir }) { activePart }
+    }
+
+    @Test
+    fun `a directory on disk is resolved without reporting anything`() {
+        val expected = createPartDir(partDirectory)
+        assertEquals(partDirectory, target.directory)
+        assertEquals(expected, partDir())
+        assertFalse(target.failed)
+        assertEquals(emptyList<Throwable>(), reported)
+    }
+
+    @Test
+    fun `nothing is resolved when no session part is active`() {
+        activePart = null
+        assertNull(target.directory)
+        assertFalse(target.failed)
+        assertEquals(emptyList<Throwable>(), reported)
+    }
+
+    @Test
+    fun `a missing directory fails the part and is reported`() {
+        assertNull(partDir())
+        assertTrue(target.failed)
+        assertEquals(MISSING_PART_DIR_MSG, reported.single().message)
+    }
+
+    @Test
+    fun `a file occupying the directory path fails the part`() {
+        File(sessionsDir, partDirectory.dirName).writeText("not a directory")
+        assertNull(partDir())
+        assertTrue(target.failed)
+        assertEquals(MISSING_PART_DIR_MSG, reported.single().message)
+    }
+
+    @Test
+    fun `a failed part is only reported once however many writes follow`() {
+        assertNull(partDir())
+        repeat(20) {
+            assertNull(target.directory)
+        }
+        assertEquals(1, reported.size)
+    }
+
+    @Test
+    fun `a failed part is not resurrected by the directory appearing later`() {
+        assertNull(partDir())
+        createPartDir(partDirectory)
+
+        assertNull(target.directory)
+        assertTrue(target.failed)
+        assertEquals(1, reported.size)
+    }
+
+    @Test
+    fun `failing one part does not fail the next one`() {
+        assertNull(partDir())
+
+        val other = SessionPartDirectory(timestamp = TIMESTAMP + 1, uuid = UUID)
+        createPartDir(other)
+        activePart = other
+        val next = SessionPartWriteTarget(lazy { sessionsDir }) { activePart }
+
+        assertEquals(other, next.directory)
+        assertEquals(File(sessionsDir, other.dirName), next.partDir(other, reported::add))
+        assertFalse(next.failed)
+        assertEquals(1, reported.size)
+    }
+
+    private fun createPartDir(directory: SessionPartDirectory): File =
+        File(sessionsDir, directory.dirName).apply { mkdirs() }
+
+    /**
+     * Resolves the active part's directory, recording anything reported along the way.
+     */
+    private fun partDir(): File? {
+        val directory = target.directory ?: return null
+        return target.partDir(directory, reported::add)
+    }
+}

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceCompletedSpansTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceCompletedSpansTest.kt
@@ -72,15 +72,14 @@ internal class SessionReconstructionServiceCompletedSpansTest {
         logger = FakeInternalLogger(throwOnInternalError = false)
         sessionSpan = fullyPopulatedSpan
         activePart = partDirectory
-        manifestWriter = SessionManifestWriter(lazy { sessionsDir }, logger)
+        manifestWriter = SessionManifestWriter(target(), logger)
         metadataWriter = SessionMetadataWriter(
-            lazy { sessionsDir },
-            { activePart },
+            target(),
             { fullyPopulatedMetadata },
             { fullyPopulatedResource },
             logger,
         )
-        sessionSpanWriter = SessionSpanWriter(lazy { sessionsDir }, { activePart }, logger)
+        sessionSpanWriter = SessionSpanWriter(target(), logger)
         service = SessionReconstructionService(lazy { sessionsDir }, logger)
         createPartDir(partDirectory)
     }
@@ -236,6 +235,9 @@ internal class SessionReconstructionServiceCompletedSpansTest {
         assertReconstructionFailureTracked()
     }
 
+    private fun target(): SessionPartWriteTarget =
+        SessionPartWriteTarget(lazy { sessionsDir }) { activePart }
+
     private fun createPartDir(directory: SessionPartDirectory): File =
         File(sessionsDir, directory.dirName).apply { mkdirs() }
 
@@ -262,7 +264,8 @@ internal class SessionReconstructionServiceCompletedSpansTest {
     }
 
     private fun writeManifest(directory: SessionPartDirectory = partDirectory) {
-        assertTrue(manifestWriter.write(directory, fullyPopulatedResource, ENVELOPE_VERSION, ENVELOPE_TYPE))
+        activePart = directory
+        assertTrue(manifestWriter.write(fullyPopulatedResource, ENVELOPE_VERSION, ENVELOPE_TYPE))
     }
 
     private fun writeMetadata(directory: SessionPartDirectory = partDirectory) {

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceDedupeTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceDedupeTest.kt
@@ -72,16 +72,15 @@ internal class SessionReconstructionServiceDedupeTest {
         logger = FakeInternalLogger(throwOnInternalError = false)
         sessionSpan = fullyPopulatedSpan
         activePart = partDirectory
-        manifestWriter = SessionManifestWriter(lazy { sessionsDir }, logger)
+        manifestWriter = SessionManifestWriter(target(), logger)
         metadataWriter = SessionMetadataWriter(
-            lazy { sessionsDir },
-            { activePart },
+            target(),
             { fullyPopulatedMetadata },
             { fullyPopulatedResource },
             logger,
         )
-        sessionSpanWriter = SessionSpanWriter(lazy { sessionsDir }, { activePart }, logger)
-        snapshotsWriter = SpanSnapshotsWriter(lazy { sessionsDir }, { activePart }, logger)
+        sessionSpanWriter = SessionSpanWriter(target(), logger)
+        snapshotsWriter = SpanSnapshotsWriter(target(), logger)
         service = SessionReconstructionService(lazy { sessionsDir }, logger)
         createPartDir(partDirectory)
     }
@@ -167,11 +166,14 @@ internal class SessionReconstructionServiceDedupeTest {
         assertNoInternalErrors()
     }
 
+    private fun target(): SessionPartWriteTarget =
+        SessionPartWriteTarget(lazy { sessionsDir }) { activePart }
+
     private fun createPartDir(directory: SessionPartDirectory): File =
         File(sessionsDir, directory.dirName).apply { mkdirs() }
 
     private fun write(spans: List<SpanProto> = emptyList(), snapshots: List<Span> = emptyList()) {
-        assertTrue(manifestWriter.write(partDirectory, fullyPopulatedResource, ENVELOPE_VERSION, ENVELOPE_TYPE))
+        assertTrue(manifestWriter.write(fullyPopulatedResource, ENVELOPE_VERSION, ENVELOPE_TYPE))
         assertTrue(metadataWriter.write())
         assertTrue(sessionSpanWriter.write(sessionSpan))
         File(File(sessionsDir, partDirectory.dirName), COMPLETED_SPANS_FILE_NAME)

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceFileSizeTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceFileSizeTest.kt
@@ -61,16 +61,15 @@ internal class SessionReconstructionServiceFileSizeTest {
         sessionsDir = tempFolder.newFolder("embrace_sessions")
         logger = FakeInternalLogger(throwOnInternalError = false)
         activePart = partDirectory
-        manifestWriter = SessionManifestWriter(lazy { sessionsDir }, logger)
+        manifestWriter = SessionManifestWriter(target(), logger)
         metadataWriter = SessionMetadataWriter(
-            lazy { sessionsDir },
-            { activePart },
+            target(),
             { fullyPopulatedMetadata },
             { fullyPopulatedResource },
             logger,
         )
-        sessionSpanWriter = SessionSpanWriter(lazy { sessionsDir }, { activePart }, logger)
-        snapshotsWriter = SpanSnapshotsWriter(lazy { sessionsDir }, { activePart }, logger)
+        sessionSpanWriter = SessionSpanWriter(target(), logger)
+        snapshotsWriter = SpanSnapshotsWriter(target(), logger)
         service = SessionReconstructionService(lazy { sessionsDir }, logger)
         File(sessionsDir, partDirectory.dirName).mkdirs()
         write()
@@ -169,10 +168,13 @@ internal class SessionReconstructionServiceFileSizeTest {
         assertEquals(size, file.length())
     }
 
+    private fun target(): SessionPartWriteTarget =
+        SessionPartWriteTarget(lazy { sessionsDir }) { activePart }
+
     private fun partFile(fileName: String): File = File(File(sessionsDir, partDirectory.dirName), fileName)
 
     private fun write() {
-        assertTrue(manifestWriter.write(partDirectory, fullyPopulatedResource, ENVELOPE_VERSION, ENVELOPE_TYPE))
+        assertTrue(manifestWriter.write(fullyPopulatedResource, ENVELOPE_VERSION, ENVELOPE_TYPE))
         assertTrue(metadataWriter.write())
         assertTrue(sessionSpanWriter.write(fullyPopulatedSpan))
         assertTrue(snapshotsWriter.write(listOf(inFlightSpan)))

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceManifestTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceManifestTest.kt
@@ -53,18 +53,20 @@ internal class SessionReconstructionServiceManifestTest {
         logger = FakeInternalLogger(throwOnInternalError = false)
         activePart = partDirectory
         writtenResource = fullyPopulatedResource
-        writer = SessionManifestWriter(lazy { sessionsDir }, logger)
+        writer = SessionManifestWriter(target(), logger)
         metadataWriter = SessionMetadataWriter(
-            lazy { sessionsDir },
-            { activePart },
+            target(),
             { fullyPopulatedMetadata },
             { writtenResource },
             logger,
         )
-        sessionSpanWriter = SessionSpanWriter(lazy { sessionsDir }, { activePart }, logger)
+        sessionSpanWriter = SessionSpanWriter(target(), logger)
         service = SessionReconstructionService(lazy { sessionsDir }, logger)
         createPartDir(partDirectory)
     }
+
+    private fun target(): SessionPartWriteTarget =
+        SessionPartWriteTarget(lazy { sessionsDir }) { activePart }
 
     private fun createPartDir(directory: SessionPartDirectory): File =
         File(sessionsDir, directory.dirName).apply { mkdirs() }
@@ -82,8 +84,8 @@ internal class SessionReconstructionServiceManifestTest {
         envelopeType: String = ENVELOPE_TYPE,
         sharedLibSymbolMapping: Map<String, String>? = null,
     ) {
-        assertTrue(writer.write(directory, resource, envelopeVersion, envelopeType, sharedLibSymbolMapping))
         activePart = directory
+        assertTrue(writer.write(resource, envelopeVersion, envelopeType, sharedLibSymbolMapping))
         writtenResource = resource
         assertTrue(metadataWriter.write())
         assertTrue(sessionSpanWriter.write(fullyPopulatedSpan))

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceMetadataTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceMetadataTest.kt
@@ -57,15 +57,14 @@ internal class SessionReconstructionServiceMetadataTest {
         metadataProvider = { fullyPopulatedMetadata }
         resourceProvider = { fullyPopulatedResource }
         activePart = partDirectory
-        manifestWriter = SessionManifestWriter(lazy { sessionsDir }, logger)
+        manifestWriter = SessionManifestWriter(target(), logger)
         metadataWriter = SessionMetadataWriter(
-            lazy { sessionsDir },
-            { activePart },
+            target(),
             { metadataProvider() },
             { resourceProvider() },
             logger,
         )
-        sessionSpanWriter = SessionSpanWriter(lazy { sessionsDir }, { activePart }, logger)
+        sessionSpanWriter = SessionSpanWriter(target(), logger)
         service = SessionReconstructionService(lazy { sessionsDir }, logger)
         createPartDir(partDirectory)
     }
@@ -200,6 +199,9 @@ internal class SessionReconstructionServiceMetadataTest {
         assertReconstructionFailureTracked()
     }
 
+    private fun target(): SessionPartWriteTarget =
+        SessionPartWriteTarget(lazy { sessionsDir }) { activePart }
+
     private fun createPartDir(directory: SessionPartDirectory): File =
         File(sessionsDir, directory.dirName).apply { mkdirs() }
 
@@ -228,7 +230,8 @@ internal class SessionReconstructionServiceMetadataTest {
     }
 
     private fun writeManifest(directory: SessionPartDirectory = partDirectory) {
-        assertTrue(manifestWriter.write(directory, fullyPopulatedResource, ENVELOPE_VERSION, ENVELOPE_TYPE))
+        activePart = directory
+        assertTrue(manifestWriter.write(fullyPopulatedResource, ENVELOPE_VERSION, ENVELOPE_TYPE))
     }
 
     private fun writeMetadata(directory: SessionPartDirectory = partDirectory) {

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceSessionSpanTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceSessionSpanTest.kt
@@ -53,15 +53,14 @@ internal class SessionReconstructionServiceSessionSpanTest {
         logger = FakeInternalLogger(throwOnInternalError = false)
         spanProvider = { fullyPopulatedSpan }
         activePart = partDirectory
-        manifestWriter = SessionManifestWriter(lazy { sessionsDir }, logger)
+        manifestWriter = SessionManifestWriter(target(), logger)
         metadataWriter = SessionMetadataWriter(
-            lazy { sessionsDir },
-            { activePart },
+            target(),
             { fullyPopulatedMetadata },
             { fullyPopulatedResource },
             logger,
         )
-        sessionSpanWriter = SessionSpanWriter(lazy { sessionsDir }, { activePart }, logger)
+        sessionSpanWriter = SessionSpanWriter(target(), logger)
         service = SessionReconstructionService(lazy { sessionsDir }, logger)
         createPartDir(partDirectory)
     }
@@ -221,6 +220,9 @@ internal class SessionReconstructionServiceSessionSpanTest {
         assertReconstructionFailureTracked()
     }
 
+    private fun target(): SessionPartWriteTarget =
+        SessionPartWriteTarget(lazy { sessionsDir }) { activePart }
+
     private fun createPartDir(directory: SessionPartDirectory): File =
         File(sessionsDir, directory.dirName).apply { mkdirs() }
 
@@ -249,7 +251,8 @@ internal class SessionReconstructionServiceSessionSpanTest {
     }
 
     private fun writeManifest(directory: SessionPartDirectory = partDirectory) {
-        assertTrue(manifestWriter.write(directory, fullyPopulatedResource, ENVELOPE_VERSION, ENVELOPE_TYPE))
+        activePart = directory
+        assertTrue(manifestWriter.write(fullyPopulatedResource, ENVELOPE_VERSION, ENVELOPE_TYPE))
     }
 
     private fun writeMetadata(directory: SessionPartDirectory = partDirectory) {

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceSpanSnapshotsTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceSpanSnapshotsTest.kt
@@ -61,16 +61,15 @@ internal class SessionReconstructionServiceSpanSnapshotsTest {
         logger = FakeInternalLogger(throwOnInternalError = false)
         sessionSpan = fullyPopulatedSpan
         activePart = partDirectory
-        manifestWriter = SessionManifestWriter(lazy { sessionsDir }, logger)
+        manifestWriter = SessionManifestWriter(target(), logger)
         metadataWriter = SessionMetadataWriter(
-            lazy { sessionsDir },
-            { activePart },
+            target(),
             { fullyPopulatedMetadata },
             { fullyPopulatedResource },
             logger,
         )
-        sessionSpanWriter = SessionSpanWriter(lazy { sessionsDir }, { activePart }, logger)
-        snapshotsWriter = SpanSnapshotsWriter(lazy { sessionsDir }, { activePart }, logger)
+        sessionSpanWriter = SessionSpanWriter(target(), logger)
+        snapshotsWriter = SpanSnapshotsWriter(target(), logger)
         service = SessionReconstructionService(lazy { sessionsDir }, logger)
         createPartDir(partDirectory)
     }
@@ -248,6 +247,9 @@ internal class SessionReconstructionServiceSpanSnapshotsTest {
         assertReconstructionFailureTracked()
     }
 
+    private fun target(): SessionPartWriteTarget =
+        SessionPartWriteTarget(lazy { sessionsDir }) { activePart }
+
     private fun createPartDir(directory: SessionPartDirectory): File =
         File(sessionsDir, directory.dirName).apply { mkdirs() }
 
@@ -269,7 +271,8 @@ internal class SessionReconstructionServiceSpanSnapshotsTest {
     }
 
     private fun writeManifest(directory: SessionPartDirectory = partDirectory) {
-        assertTrue(manifestWriter.write(directory, fullyPopulatedResource, ENVELOPE_VERSION, ENVELOPE_TYPE))
+        activePart = directory
+        assertTrue(manifestWriter.write(fullyPopulatedResource, ENVELOPE_VERSION, ENVELOPE_TYPE))
     }
 
     private fun writeMetadata(directory: SessionPartDirectory = partDirectory) {

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionSpanWriterTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionSpanWriterTest.kt
@@ -45,7 +45,7 @@ internal class SessionSpanWriterTest {
         sessionsDir = tempFolder.newFolder("embrace_sessions")
         logger = FakeInternalLogger(throwOnInternalError = false)
         activePart = partDirectory
-        writer = SessionSpanWriter(lazy { sessionsDir }, { activePart }, logger)
+        writer = SessionSpanWriter(target { activePart }, logger)
         createPartDir(partDirectory)
     }
 
@@ -150,6 +150,15 @@ internal class SessionSpanWriterTest {
     }
 
     @Test
+    fun `a session part with no directory is given up on and reported once`() {
+        val absent = SessionPartDirectory(timestamp = TIMESTAMP + 2, uuid = UUID)
+        repeat(20) {
+            assertFalse(write(absent))
+        }
+        assertWriteFailureTracked()
+    }
+
+    @Test
     fun `a file occupying the session part path is reported and left untouched`() {
         val occupied = SessionPartDirectory(timestamp = TIMESTAMP + 3, uuid = UUID)
         val occupyingFile = partDir(occupied).apply { writeText("not a directory") }
@@ -160,7 +169,7 @@ internal class SessionSpanWriterTest {
 
     @Test
     fun `a failing session part source is reported and does not throw`() {
-        writer = SessionSpanWriter(lazy { sessionsDir }, { error("boom") }, logger)
+        writer = SessionSpanWriter(target { error("boom") }, logger)
         assertFalse(writer.write(fullyPopulatedSpan))
         assertEquals(emptyList<String>(), partDir().list()?.toList())
         assertWriteFailureTracked()
@@ -222,6 +231,9 @@ internal class SessionSpanWriterTest {
         assertEquals(listOf(SESSION_SPAN_FILE_NAME), partDir().list()?.toList())
         assertNoInternalErrors()
     }
+
+    private fun target(source: () -> SessionPartDirectory?): SessionPartWriteTarget =
+        SessionPartWriteTarget(lazy { sessionsDir }, source)
 
     private fun createPartDir(directory: SessionPartDirectory): File =
         File(sessionsDir, directory.dirName).apply { mkdirs() }

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SpanSnapshotsWriterTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SpanSnapshotsWriterTest.kt
@@ -48,7 +48,7 @@ internal class SpanSnapshotsWriterTest {
         sessionsDir = tempFolder.newFolder("embrace_sessions")
         logger = FakeInternalLogger(throwOnInternalError = false)
         activePart = partDirectory
-        writer = SpanSnapshotsWriter(lazy { sessionsDir }, { activePart }, logger)
+        writer = SpanSnapshotsWriter(target { activePart }, logger)
         createPartDir(partDirectory)
     }
 
@@ -188,6 +188,15 @@ internal class SpanSnapshotsWriterTest {
     }
 
     @Test
+    fun `a session part with no directory is given up on and reported once`() {
+        val absent = SessionPartDirectory(timestamp = TIMESTAMP + 2, uuid = UUID)
+        repeat(20) {
+            assertFalse(write(absent))
+        }
+        assertWriteFailureTracked()
+    }
+
+    @Test
     fun `a file occupying the session part path is reported and left untouched`() {
         val occupied = SessionPartDirectory(timestamp = TIMESTAMP + 3, uuid = UUID)
         val occupyingFile = partDir(occupied).apply { writeText("not a directory") }
@@ -198,7 +207,7 @@ internal class SpanSnapshotsWriterTest {
 
     @Test
     fun `a failing session part source is reported and does not throw`() {
-        writer = SpanSnapshotsWriter(lazy { sessionsDir }, { error("boom") }, logger)
+        writer = SpanSnapshotsWriter(target { error("boom") }, logger)
         assertFalse(writer.write(snapshots))
         assertEquals(emptyList<String>(), partDir().list()?.toList())
         assertWriteFailureTracked()
@@ -260,6 +269,9 @@ internal class SpanSnapshotsWriterTest {
         assertEquals(listOf(SPAN_SNAPSHOTS_FILE_NAME), partDir().list()?.toList())
         assertNoInternalErrors()
     }
+
+    private fun target(source: () -> SessionPartDirectory?): SessionPartWriteTarget =
+        SessionPartWriteTarget(lazy { sessionsDir }, source)
 
     private fun createPartDir(directory: SessionPartDirectory): File =
         File(sessionsDir, directory.dirName).apply { mkdirs() }


### PR DESCRIPTION
## Goal

If a session part directory does not exist the SDK should only log an error once, rather than propagate multiple different types of error message. We likely don't want to attempt recovery from this situation as it indicates I/O problems (e.g. no disk space) or that the telemetry got pruned.

## Testing

Updated existing test coverage.
