### PR TITLE
Avoid redundant session envelope creation

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPartEnvelopeSource.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPartEnvelopeSource.kt
@@ -10,4 +10,13 @@ interface SessionPartEnvelopeSource {
         startNewSession: Boolean,
         crashId: String? = null,
     ): Envelope<SessionPartPayload>
+
+    /**
+     * Applies the same side effects as [getEnvelope] without assembling an envelope.
+     */
+    fun endSessionPart(
+        endType: SessionPartSnapshotType,
+        startNewSession: Boolean,
+        crashId: String? = null,
+    )
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPartEnvelopeSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPartEnvelopeSourceImpl.kt
@@ -35,4 +35,12 @@ internal class SessionPartEnvelopeSourceImpl(
             payloadSource.getSessionPartPayload(endType, startNewSession, crashId),
         )
     }
+
+    override fun endSessionPart(
+        endType: SessionPartSnapshotType,
+        startNewSession: Boolean,
+        crashId: String?,
+    ) {
+        payloadSource.endSessionPart(endType, startNewSession, crashId)
+    }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPartPayloadSource.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPartPayloadSource.kt
@@ -12,4 +12,14 @@ interface SessionPartPayloadSource {
         startNewSession: Boolean,
         crashId: String? = null,
     ): SessionPartPayload
+
+    /**
+     * Applies the same side effects as [getSessionPartPayload] without mapping in-flight spans
+     * into snapshots.
+     */
+    fun endSessionPart(
+        endType: SessionPartSnapshotType,
+        startNewSession: Boolean,
+        crashId: String? = null,
+    )
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPartPayloadSourceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPartPayloadSourceImpl.kt
@@ -27,6 +27,24 @@ internal class SessionPartPayloadSourceImpl(
         endType: SessionPartSnapshotType,
         startNewSession: Boolean,
         crashId: String?,
+    ): SessionPartPayload = collectSessionPart(endType, startNewSession, crashId, buildSnapshots = true)
+
+    override fun endSessionPart(
+        endType: SessionPartSnapshotType,
+        startNewSession: Boolean,
+        crashId: String?,
+    ) {
+        collectSessionPart(endType, startNewSession, crashId, buildSnapshots = false)
+    }
+
+    /**
+     * Ends the session part, collecting its telemetry into a [SessionPartPayload].
+     */
+    private fun collectSessionPart(
+        endType: SessionPartSnapshotType,
+        startNewSession: Boolean,
+        crashId: String?,
+        buildSnapshots: Boolean,
     ): SessionPartPayload {
         val isCacheAttempt = endType == SessionPartSnapshotType.PERIODIC_CACHE
         val includeSnapshots = endType != SessionPartSnapshotType.JVM_CRASH
@@ -43,13 +61,15 @@ internal class SessionPartPayloadSourceImpl(
         }
 
         // Snapshots should only be included if the process is expected to last beyond the current user session
-        val snapshots: List<Span>? = if (includeSnapshots) {
-            retrieveSpanSnapshots(isCacheAttempt)
-        } else {
-            emptyList()
+        val snapshots: List<Span>? = when {
+            !buildSnapshots -> null
+            includeSnapshots -> retrieveSpanSnapshots(isCacheAttempt)
+            else -> emptyList()
         }
 
-        // Ensure the span retrieving is last as that potentially ends the session part span, which effectively ends the user session
+        // Ensure the span retrieving is last as that potentially ends the session part span, which effectively ends the user session.
+        // Its result goes unused when no payload is wanted, but its side effects - recording pending telemetry, stopping the session
+        // part span and draining the completed spans - are required either way.
         val spans: List<Span>? = retrieveSpanData(isCacheAttempt, startNewSession, crashId)
 
         return SessionPartPayload(

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactory.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactory.kt
@@ -59,7 +59,7 @@ interface PayloadFactory {
     /**
      * Ends a session manually.
      */
-    fun endSessionWithManual(timestamp: Long, initial: SessionPartToken): Envelope<SessionPartPayload>
+    fun endSessionWithManual(timestamp: Long, initial: SessionPartToken): Envelope<SessionPartPayload>?
 
     /**
      * Create and return and empty [Envelope] for a [LogPayload] based on the current state of the SDK

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImpl.kt
@@ -88,8 +88,8 @@ internal class PayloadFactoryImpl(
         )
     }
 
-    override fun endSessionWithManual(timestamp: Long, initial: SessionPartToken): Envelope<SessionPartPayload> {
-        return payloadMessageCollator.buildFinalEnvelope(
+    override fun endSessionWithManual(timestamp: Long, initial: SessionPartToken): Envelope<SessionPartPayload>? {
+        return endSessionPart(
             FinalEnvelopeParams(
                 initial = initial,
                 endType = SessionPartSnapshotType.NORMAL_END,
@@ -149,8 +149,8 @@ internal class PayloadFactoryImpl(
         )
     }
 
-    private fun endSessionWithState(initial: SessionPartToken): Envelope<SessionPartPayload> {
-        return payloadMessageCollator.buildFinalEnvelope(
+    private fun endSessionWithState(initial: SessionPartToken): Envelope<SessionPartPayload>? {
+        return endSessionPart(
             FinalEnvelopeParams(
                 initial = initial,
                 endType = SessionPartSnapshotType.NORMAL_END,
@@ -167,7 +167,7 @@ internal class PayloadFactoryImpl(
 
         // kept for backwards compat. the backend expects the start time to be 1 ms greater
         // than the adjacent session, and manually adjusts.
-        return payloadMessageCollator.buildFinalEnvelope(
+        return endSessionPart(
             FinalEnvelopeParams(
                 initial = initial,
                 endType = SessionPartSnapshotType.NORMAL_END,
@@ -180,8 +180,8 @@ internal class PayloadFactoryImpl(
     private fun endSessionWithCrash(
         initial: SessionPartToken,
         crashId: String,
-    ): Envelope<SessionPartPayload> {
-        return payloadMessageCollator.buildFinalEnvelope(
+    ): Envelope<SessionPartPayload>? {
+        return endSessionPart(
             FinalEnvelopeParams(
                 initial = initial,
                 endType = SessionPartSnapshotType.JVM_CRASH,
@@ -199,7 +199,7 @@ internal class PayloadFactoryImpl(
         if (!isBackgroundActivityEnabled()) {
             return null
         }
-        return payloadMessageCollator.buildFinalEnvelope(
+        return endSessionPart(
             FinalEnvelopeParams(
                 initial = initial,
                 endType = SessionPartSnapshotType.JVM_CRASH,
@@ -237,6 +237,20 @@ internal class PayloadFactoryImpl(
             ),
         )
     }
+
+    /**
+     * Ends the session part described by [params], returning its envelope if one is needed.
+     */
+    private fun endSessionPart(params: FinalEnvelopeParams): Envelope<SessionPartPayload>? =
+        when {
+            envelopeRequired() -> payloadMessageCollator.buildFinalEnvelope(params)
+            else -> {
+                payloadMessageCollator.endSessionPart(params)
+                null
+            }
+        }
+
+    private fun envelopeRequired(): Boolean = !configService.persistenceBehavior.isMultiFilePersistenceEnabled()
 
     private fun isBackgroundActivityEnabled(): Boolean = configService.backgroundActivityBehavior.isBackgroundActivityCaptureEnabled()
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollator.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollator.kt
@@ -16,4 +16,10 @@ interface PayloadMessageCollator {
      * Builds a fully populated payload.
      */
     fun buildFinalEnvelope(params: FinalEnvelopeParams): Envelope<SessionPartPayload>
+
+    /**
+     * Ends the session part, applying the same side effects as [buildFinalEnvelope] but without
+     * assembling an envelope.
+     */
+    fun endSessionPart(params: FinalEnvelopeParams)
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImpl.kt
@@ -30,18 +30,18 @@ internal class PayloadMessageCollatorImpl(
         )
     }
 
-    override fun buildFinalEnvelope(params: FinalEnvelopeParams): Envelope<SessionPartPayload> {
-        val envelope = sessionPartEnvelopeSource.getEnvelope(
+    override fun buildFinalEnvelope(params: FinalEnvelopeParams): Envelope<SessionPartPayload> =
+        sessionPartEnvelopeSource.getEnvelope(
             endType = params.endType,
             startNewSession = params.startNewSession,
             crashId = params.crashId,
         )
-        return Envelope(
-            resource = envelope.resource,
-            metadata = envelope.metadata,
-            data = envelope.data,
-            version = envelope.version,
-            type = envelope.type,
+
+    override fun endSessionPart(params: FinalEnvelopeParams) {
+        sessionPartEnvelopeSource.endSessionPart(
+            endType = params.endType,
+            startNewSession = params.startNewSession,
+            crashId = params.crashId,
         )
     }
 }

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -590,9 +590,6 @@ internal class SessionOrchestratorImpl(
     }
 
     private fun processEndMessage(envelope: Envelope<SessionPartPayload>?, transitionType: TransitionType) {
-        if (multiFilePersistenceEnabled()) {
-            return
-        }
         envelope?.let {
             payloadStore?.storeSessionPartPayload(envelope, transitionType)
         }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeOtelPayloadMapper.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakeOtelPayloadMapper.kt
@@ -4,6 +4,12 @@ import io.embrace.android.embracesdk.internal.envelope.session.OtelPayloadMapper
 import io.embrace.android.embracesdk.internal.payload.Span
 
 class FakeOtelPayloadMapper : OtelPayloadMapper {
+
+    var recordCalled: Boolean = false
+
     override fun snapshotSpans(): List<Span> = emptyList()
-    override fun record() { }
+
+    override fun record() {
+        recordCalled = true
+    }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadMessageCollator.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadMessageCollator.kt
@@ -17,6 +17,8 @@ class FakePayloadMessageCollator(
 
     val sessionCount: AtomicInteger = AtomicInteger(0)
     val baCount: AtomicInteger = AtomicInteger(0)
+    var finalEnvelopeCount: Int = 0
+    var endedWithoutEnvelopeCount: Int = 0
 
     override fun buildInitialPart(params: InitialEnvelopeParams): SessionPartToken = with(params) {
         when (processState) {
@@ -42,9 +44,19 @@ class FakePayloadMessageCollator(
     override fun buildFinalEnvelope(
         params: FinalEnvelopeParams,
     ): Envelope<SessionPartPayload> {
+        finalEnvelopeCount++
+        endSessionPartSpan(params)
+        return Envelope(data = SessionPartPayload())
+    }
+
+    override fun endSessionPart(params: FinalEnvelopeParams) {
+        endedWithoutEnvelopeCount++
+        endSessionPartSpan(params)
+    }
+
+    private fun endSessionPartSpan(params: FinalEnvelopeParams) {
         if (params.endType != SessionPartSnapshotType.PERIODIC_CACHE) {
             currentSessionPartSpan.endSession(startNewSession = params.startNewSession)
         }
-        return Envelope(data = SessionPartPayload())
     }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPartEnvelopeSourceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPartEnvelopeSourceImplTest.kt
@@ -9,21 +9,32 @@ import org.junit.Test
 
 internal class SessionPartEnvelopeSourceImplTest {
 
+    private val metadataSource = FakeEnvelopeMetadataSource()
+    private val resourceSource = FakeEnvelopeResourceSource()
+    private val partPayloadSource = FakeSessionPartPayloadSource()
+    private val source = SessionPartEnvelopeSourceImpl(
+        metadataSource,
+        resourceSource,
+        partPayloadSource,
+    )
+
     @Test
     fun getEnvelope() {
-        val metadataSource = FakeEnvelopeMetadataSource()
-        val resourceSource = FakeEnvelopeResourceSource()
-        val partPayloadSource = FakeSessionPartPayloadSource()
-        val source = SessionPartEnvelopeSourceImpl(
-            metadataSource,
-            resourceSource,
-            partPayloadSource,
-        )
         val payload = source.getEnvelope(SessionPartSnapshotType.NORMAL_END, true)
         assertEquals(metadataSource.metadata, payload.metadata)
         assertEquals(resourceSource.resource, payload.resource)
         assertEquals(partPayloadSource.sessionPayload, payload.data)
         assertEquals("spans", payload.type)
         assertEquals("0.1.0", payload.version)
+        assertEquals(1, partPayloadSource.payloadBuiltCount)
+    }
+
+    @Test
+    fun `ending a session part builds neither a resource nor metadata`() {
+        source.endSessionPart(SessionPartSnapshotType.NORMAL_END, true)
+        assertEquals(1, partPayloadSource.endedWithoutPayloadCount)
+        assertEquals(0, partPayloadSource.payloadBuiltCount)
+        assertEquals(0, resourceSource.readCount)
+        assertEquals(0, metadataSource.readCount)
     }
 }

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPartPayloadSourceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/envelope/session/SessionPartPayloadSourceImplTest.kt
@@ -7,6 +7,7 @@ import io.embrace.android.embracesdk.fakes.FakeOtelPayloadMapper
 import io.embrace.android.embracesdk.fakes.FakeProcessStateTracker
 import io.embrace.android.embracesdk.internal.arch.schema.EmbType
 import io.embrace.android.embracesdk.internal.arch.schema.ErrorCodeAttribute
+import io.embrace.android.embracesdk.internal.arch.state.ProcessState
 import io.embrace.android.embracesdk.internal.logging.InternalLoggerImpl
 import io.embrace.android.embracesdk.internal.otel.spans.SpanRepository
 import io.embrace.android.embracesdk.internal.otel.spans.SpanTerminationMode
@@ -16,8 +17,10 @@ import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.session.orchestrator.SessionPartSnapshotType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -98,6 +101,100 @@ internal class SessionPartPayloadSourceImplTest {
 
         assertFalse(timedOutSpan.isRecording)
         assertEquals(ErrorCodeAttribute.Failure, timedOutSpan.errorCode)
+    }
+
+    @Test
+    fun `ending a session part without a payload applies the same side effects`() {
+        val endingSpan = checkNotNull(currentSessionPartSpan.sessionPartSpan)
+        impl.endSessionPart(SessionPartSnapshotType.NORMAL_END, true)
+        assertFalse(endingSpan.isRecording)
+        assertNotEquals(endingSpan, currentSessionPartSpan.sessionPartSpan)
+    }
+
+    @Test
+    fun `ending a session part without a payload does not snapshot in flight spans`() {
+        impl.endSessionPart(SessionPartSnapshotType.NORMAL_END, true)
+        assertEquals(0, activeSpan.snapshotCount)
+    }
+
+    @Test
+    fun `building a session part payload does snapshot in flight spans`() {
+        impl.getSessionPartPayload(SessionPartSnapshotType.NORMAL_END, true)
+        assertEquals(1, activeSpan.snapshotCount)
+    }
+
+    @Test
+    fun `timed out spans are failed when the session part ends without a payload`() {
+        val clock = FakeClock()
+        val timedOutSpan = FakeEmbraceSdkSpan(terminationMode = SpanTerminationMode.Timeout(1000L)).apply {
+            start(clock.now())
+        }
+        val repository = SpanRepository().apply {
+            trackStartedEmbraceSpan(checkNotNull(currentSessionPartSpan.sessionPartSpan))
+            trackStartedEmbraceSpan(timedOutSpan)
+        }
+        val source = SessionPartPayloadSourceImpl(
+            null,
+            currentSessionPartSpan,
+            repository,
+            FakeOtelPayloadMapper(),
+            FakeProcessStateTracker(),
+            clock,
+            InternalLoggerImpl(),
+        )
+
+        clock.tick(2000L)
+        source.endSessionPart(SessionPartSnapshotType.NORMAL_END, true)
+
+        assertFalse(timedOutSpan.isRecording)
+        assertEquals(ErrorCodeAttribute.Failure, timedOutSpan.errorCode)
+    }
+
+    @Test
+    fun `spans are auto terminated when a session part ends in the background without a payload`() {
+        val terminatedSpan = FakeEmbraceSdkSpan(terminationMode = SpanTerminationMode.OnBackground).apply {
+            start(0L)
+        }
+        val repository = SpanRepository().apply {
+            trackStartedEmbraceSpan(checkNotNull(currentSessionPartSpan.sessionPartSpan))
+            trackStartedEmbraceSpan(terminatedSpan)
+        }
+        val source = SessionPartPayloadSourceImpl(
+            null,
+            currentSessionPartSpan,
+            repository,
+            FakeOtelPayloadMapper(),
+            FakeProcessStateTracker(ProcessState.BACKGROUND),
+            FakeClock(),
+            InternalLoggerImpl(),
+        )
+        source.endSessionPart(SessionPartSnapshotType.NORMAL_END, true)
+        assertFalse(terminatedSpan.isRecording)
+    }
+
+    @Test
+    fun `a crash that ends without a payload still ends the session part`() {
+        val endingSpan = checkNotNull(currentSessionPartSpan.sessionPartSpan)
+        impl.endSessionPart(SessionPartSnapshotType.JVM_CRASH, false, crashId = "crash-id")
+        assertNull(currentSessionPartSpan.sessionPartSpan)
+        assertFalse(endingSpan.isRecording)
+        assertEquals(ErrorCodeAttribute.Failure, endingSpan.errorCode)
+    }
+
+    @Test
+    fun `pending telemetry is recorded when a session part ends without a payload`() {
+        val otelPayloadMapper = FakeOtelPayloadMapper()
+        val source = SessionPartPayloadSourceImpl(
+            null,
+            currentSessionPartSpan,
+            spanRepository,
+            otelPayloadMapper,
+            FakeProcessStateTracker(),
+            FakeClock(),
+            InternalLoggerImpl(),
+        )
+        source.endSessionPart(SessionPartSnapshotType.NORMAL_END, true)
+        assertTrue(otelPayloadMapper.recordCalled)
     }
 
     private fun assertPayloadPopulated(

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionHandlerTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/UserSessionHandlerTest.kt
@@ -12,12 +12,14 @@ import io.embrace.android.embracesdk.fakes.FakeSessionIdsProvider
 import io.embrace.android.embracesdk.fakes.FakeSessionPartTracker
 import io.embrace.android.embracesdk.fakes.FakeUserService
 import io.embrace.android.embracesdk.fakes.FakeUserSessionPropertiesService
+import io.embrace.android.embracesdk.fakes.createPersistenceBehavior
 import io.embrace.android.embracesdk.fakes.createSessionBehavior
 import io.embrace.android.embracesdk.fakes.fakeSessionPartToken
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakePayloadSourceModule
 import io.embrace.android.embracesdk.internal.arch.state.ProcessState
 import io.embrace.android.embracesdk.internal.capture.session.UserSessionPropertiesService
+import io.embrace.android.embracesdk.internal.config.remote.RemoteConfig
 import io.embrace.android.embracesdk.internal.envelope.session.SessionPartEnvelopeSourceImpl
 import io.embrace.android.embracesdk.internal.envelope.session.SessionPartPayloadSourceImpl
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
@@ -33,7 +35,11 @@ import io.embrace.android.embracesdk.internal.session.message.PayloadMessageColl
 import io.embrace.android.embracesdk.internal.spans.CurrentSessionPartSpan
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -170,6 +176,63 @@ internal class UserSessionHandlerTest {
 
         payloadFactory.endPayloadWithCrash(ProcessState.FOREGROUND, clock.now(), initial, "crashId")
         assertEquals(0, spanRepository.completedOtelSpans().size)
+    }
+
+    @Test
+    fun `backgrounding still flushes completed spans when no envelope is built`() {
+        enableMultiFilePersistence()
+        startFakeSession()
+        initializeServices()
+        spanService.recordSpan("test-span") {}
+        assertEquals(1, spanRepository.completedOtelSpans().size)
+
+        clock.tick(15000L)
+        assertNull(payloadFactory.endPayloadWithState(ProcessState.FOREGROUND, clock.now(), initial))
+        assertEquals(0, spanRepository.completedOtelSpans().size)
+    }
+
+    @Test
+    fun `crash ending still flushes completed spans when no envelope is built`() {
+        enableMultiFilePersistence()
+        startFakeSession()
+        initializeServices()
+        spanService.recordSpan("test-span") {}
+        assertEquals(1, spanRepository.completedOtelSpans().size)
+
+        assertNull(payloadFactory.endPayloadWithCrash(ProcessState.FOREGROUND, clock.now(), initial, "crashId"))
+        assertEquals(0, spanRepository.completedOtelSpans().size)
+    }
+
+    @Test
+    fun `the session part span is stopped when no envelope is built`() {
+        enableMultiFilePersistence()
+        startFakeSession()
+        initializeServices()
+        val endingSpan = checkNotNull(currentSessionPartSpan.current())
+
+        clock.tick(15000L)
+        assertNull(payloadFactory.endPayloadWithState(ProcessState.FOREGROUND, clock.now(), initial))
+
+        assertFalse(endingSpan.isRecording)
+        assertNotEquals(endingSpan, currentSessionPartSpan.current())
+    }
+
+    @Test
+    fun `in flight spans are not snapshotted when no envelope is built`() {
+        enableMultiFilePersistence()
+        startFakeSession()
+        initializeServices()
+        val inFlight = checkNotNull(spanService.startSpan("in-flight-span"))
+
+        clock.tick(15000L)
+        assertNull(payloadFactory.endPayloadWithState(ProcessState.FOREGROUND, clock.now(), initial))
+        assertTrue(inFlight.isRecording)
+    }
+
+    private fun enableMultiFilePersistence() {
+        configService.persistenceBehavior = createPersistenceBehavior(
+            remoteCfg = RemoteConfig(pctMultiFilePersistenceEnabled = 100.0f),
+        )
     }
 
     private fun startFakeSession(): SessionPartToken {

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadFactoryImplTest.kt
@@ -4,6 +4,7 @@ import io.embrace.android.embracesdk.fakes.FakeConfigService
 import io.embrace.android.embracesdk.fakes.FakeSessionIdsProvider
 import io.embrace.android.embracesdk.fakes.FakeSessionPartPayloadSource
 import io.embrace.android.embracesdk.fakes.createBackgroundActivityBehavior
+import io.embrace.android.embracesdk.fakes.createPersistenceBehavior
 import io.embrace.android.embracesdk.fakes.injection.FakeInitModule
 import io.embrace.android.embracesdk.fakes.injection.FakePayloadSourceModule
 import io.embrace.android.embracesdk.internal.arch.state.ProcessState
@@ -70,6 +71,38 @@ internal class PayloadFactoryImplTest {
         verifyPayloadWithState(state = BACKGROUND, zygoteCreated = false, startNewSession = false)
         verifyPayloadWithManual()
     }
+
+    @Test
+    fun `no envelope is built when multi file persistence is enabled`() {
+        configService.persistenceBehavior = createPersistenceBehavior(
+            remoteCfg = RemoteConfig(pctMultiFilePersistenceEnabled = 100.0f),
+        )
+        assertNull(factory.endPayloadWithState(FOREGROUND, 0, newSessionPart()))
+        assertNull(factory.endPayloadWithCrash(FOREGROUND, 0, newSessionPart(), "crashId"))
+        assertNull(factory.endSessionWithManual(0, newSessionPart()))
+        assertEquals(0, partPayloadSource.payloadBuiltCount)
+        assertEquals(3, partPayloadSource.endedWithoutPayloadCount)
+    }
+
+    @Test
+    fun `an envelope is built when multi file persistence is disabled`() {
+        assertNotNull(factory.endPayloadWithState(FOREGROUND, 0, newSessionPart()))
+        assertNotNull(factory.endPayloadWithCrash(FOREGROUND, 0, newSessionPart(), "crashId"))
+        assertNotNull(factory.endSessionWithManual(0, newSessionPart()))
+        assertEquals(3, partPayloadSource.payloadBuiltCount)
+        assertEquals(0, partPayloadSource.endedWithoutPayloadCount)
+    }
+
+    @Test
+    fun `a periodic cache snapshot still builds an envelope when multi file persistence is enabled`() {
+        configService.persistenceBehavior = createPersistenceBehavior(
+            remoteCfg = RemoteConfig(pctMultiFilePersistenceEnabled = 100.0f),
+        )
+        assertNotNull(factory.snapshotPayload(FOREGROUND, 0, newSessionPart()))
+        assertEquals(1, partPayloadSource.payloadBuiltCount)
+    }
+
+    private fun newSessionPart() = checkNotNull(factory.startPayloadWithState(FOREGROUND, 0, false, { 1 }, { 1 }))
 
     private fun verifyPayloadWithState(state: ProcessState, zygoteCreated: Boolean, startNewSession: Boolean) {
         val zygote = factory.startPayloadWithState(state, 0, false, { 1 }, { 1 })

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/message/PayloadMessageCollatorImplTest.kt
@@ -31,15 +31,17 @@ internal class PayloadMessageCollatorImplTest {
     private lateinit var coreModule: CoreModule
     private lateinit var currentSessionPartSpan: CurrentSessionPartSpan
     private lateinit var collator: PayloadMessageCollatorImpl
+    private lateinit var partPayloadSource: FakeSessionPartPayloadSource
 
     @Before
     fun setUp() {
         initModule = FakeInitModule()
         coreModule = CoreModuleImpl(RuntimeEnvironment.getApplication(), initModule)
+        partPayloadSource = FakeSessionPartPayloadSource()
         val sessionPartEnvelopeSource = SessionPartEnvelopeSourceImpl(
             metadataSource = FakeEnvelopeMetadataSource(),
             resourceSource = FakeEnvelopeResourceSource(),
-            payloadSource = FakeSessionPartPayloadSource(),
+            payloadSource = partPayloadSource,
         )
         currentSessionPartSpan = initModule.openTelemetryModule.currentSessionPartSpan
         collator = PayloadMessageCollatorImpl(
@@ -133,6 +135,32 @@ internal class PayloadMessageCollatorImplTest {
             ),
         )
         payload.verifyFinalFieldsPopulated()
+    }
+
+    @Test
+    fun `end a session part without building an envelope`() {
+        val startMsg = collator.buildInitialPart(
+            InitialEnvelopeParams(
+                false,
+                LifeEventType.STATE,
+                5,
+                ProcessState.FOREGROUND,
+                1,
+                1,
+            ),
+        )
+        collator.endSessionPart(
+            FinalEnvelopeParams(
+                initial = startMsg,
+                endType = SessionPartSnapshotType.NORMAL_END,
+                logger = initModule.logger,
+                continueMonitoring = true,
+                crashId = "crashId",
+            ),
+        )
+        assertEquals(1, partPayloadSource.endedWithoutPayloadCount)
+        assertEquals(0, partPayloadSource.payloadBuiltCount)
+        assertEquals(true, partPayloadSource.lastStartNewSession)
     }
 
     @Test

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorTest.kt
@@ -1129,6 +1129,31 @@ internal class SessionOrchestratorTest {
     }
 
     @Test
+    fun `no session part envelope is assembled when multi file persistence is enabled`() {
+        createOrchestrator(ProcessState.FOREGROUND, multiFilePersistenceConfigService())
+        val sessionPartId = checkNotNull(sessionTracker.getActiveSessionPartId())
+        clock.tick(10000)
+        orchestrator.onBackground()
+
+        assertEquals(0, payloadCollator.finalEnvelopeCount)
+        assertEquals(1, payloadCollator.endedWithoutEnvelopeCount)
+        assertEquals(clock.now().millisToNanos(), sessionSpanIn(sessionPartId)?.span?.end_time_unix_nano)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a session part envelope is assembled when multi file persistence is disabled`() {
+        createOrchestrator(ProcessState.FOREGROUND)
+        clock.tick(10000)
+        orchestrator.onBackground()
+
+        assertEquals(1, payloadCollator.finalEnvelopeCount)
+        assertEquals(0, payloadCollator.endedWithoutEnvelopeCount)
+        assertEquals(1, store.storedSessionPartPayloads.size)
+        assertNoInternalErrors()
+    }
+
+    @Test
     fun `no periodic caching is started when multi file persistence is enabled`() {
         createOrchestrator(ProcessState.FOREGROUND, multiFilePersistenceConfigService())
         assertEquals(0, sessionCacheExecutor.scheduledTasksCount())

--- a/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
+++ b/embrace-android-otel-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEmbraceSdkSpan.kt
@@ -176,6 +176,7 @@ class FakeEmbraceSdkSpan(
     override fun asW3cTraceParent(): String? = sdkSpan?.spanContext?.run { "00-${traceId}-${spanId}-01" }
 
     override fun snapshot(): io.embrace.android.embracesdk.internal.payload.Span? {
+        snapshotCount++
         return if (spanId == null) {
             null
         } else {
@@ -197,6 +198,8 @@ class FakeEmbraceSdkSpan(
     override fun retainDataAfterStop() {
         dataRetainedAfterStop = true
     }
+
+    var snapshotCount: Int = 0
 
     override fun releaseRetainedData() {
         retainedDataReleased = true

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEnvelopeMetadataSource.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEnvelopeMetadataSource.kt
@@ -7,5 +7,10 @@ class FakeEnvelopeMetadataSource : EnvelopeMetadataSource {
 
     var metadata: EnvelopeMetadata = EnvelopeMetadata()
 
-    override fun getEnvelopeMetadata(): EnvelopeMetadata = metadata
+    var readCount: Int = 0
+
+    override fun getEnvelopeMetadata(): EnvelopeMetadata {
+        readCount++
+        return metadata
+    }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEnvelopeResourceSource.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeEnvelopeResourceSource.kt
@@ -9,7 +9,12 @@ class FakeEnvelopeResourceSource : EnvelopeResourceSource {
     var customValues = mutableMapOf<String, String>()
     val listeners = mutableListOf<(EnvelopeResource) -> Unit>()
 
-    override fun getEnvelopeResource(): EnvelopeResource = resource
+    var readCount: Int = 0
+
+    override fun getEnvelopeResource(): EnvelopeResource {
+        readCount++
+        return resource
+    }
 
     override fun add(key: String, value: String) {
         customValues[key] = value

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionPartPayloadSource.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeSessionPartPayloadSource.kt
@@ -8,13 +8,25 @@ class FakeSessionPartPayloadSource : SessionPartPayloadSource {
 
     var sessionPayload: SessionPartPayload = SessionPartPayload()
     var lastStartNewSession: Boolean? = null
+    var payloadBuiltCount: Int = 0
+    var endedWithoutPayloadCount: Int = 0
 
     override fun getSessionPartPayload(
         endType: SessionPartSnapshotType,
         startNewSession: Boolean,
         crashId: String?,
     ): SessionPartPayload {
+        payloadBuiltCount++
         lastStartNewSession = startNewSession
         return SessionPartPayload()
+    }
+
+    override fun endSessionPart(
+        endType: SessionPartSnapshotType,
+        startNewSession: Boolean,
+        crashId: String?,
+    ) {
+        endedWithoutPayloadCount++
+        lastStartNewSession = startNewSession
     }
 }

--- a/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakePayloadSourceModule.kt
+++ b/embrace-test-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/injection/FakePayloadSourceModule.kt
@@ -86,4 +86,12 @@ private class FakeSessionPartEnvelopeSource(
             partPayloadSource.getSessionPartPayload(endType, startNewSession, crashId)
         )
     }
+
+    override fun endSessionPart(
+        endType: SessionPartSnapshotType,
+        startNewSession: Boolean,
+        crashId: String?,
+    ) {
+        partPayloadSource.endSessionPart(endType, startNewSession, crashId)
+    }
 }


### PR DESCRIPTION
## Goal

Avoids creating a redundant session envelope when multi-file persistence is enabled. This was previously done because the envelope construction has side effects, but this changeset extracts out those side effects to avoid the expensive cost of constructing an entire payload.

## Testing

Added unit tests.
