### PR TITLE
Gracefully handle corrupt span records

### DIFF
--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansReader.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansReader.kt
@@ -16,8 +16,9 @@ private const val SPANS_TAG = 1
  * not reported: every record written in full before it is returned. A record that is all
  * present but does not decode is corruption and throws.
  */
-internal fun readCompletedSpans(source: BufferedSource, maxBytes: Long = MAX_PART_FILE_BYTES): List<SpanProto> {
+internal fun readCompletedSpans(source: BufferedSource, maxBytes: Long = MAX_PART_FILE_BYTES): DecodedSpans {
     val spans = mutableListOf<SpanProto>()
+    var corruption: Throwable? = null
     val reader = ProtoReader(source)
     reader.beginMessage()
     var remaining = maxBytes
@@ -25,7 +26,7 @@ internal fun readCompletedSpans(source: BufferedSource, maxBytes: Long = MAX_PAR
     while (true) {
         val record = try {
             when (reader.nextTag()) {
-                -1 -> return spans
+                -1 -> return DecodedSpans(spans, corruption)
                 SPANS_TAG -> reader.readBytes()
                 else -> {
                     reader.skip()
@@ -33,12 +34,17 @@ internal fun readCompletedSpans(source: BufferedSource, maxBytes: Long = MAX_PAR
                 }
             }
         } catch (exc: EOFException) {
-            return spans
+            return DecodedSpans(spans, corruption)
         }
         remaining -= record.size
         if (remaining < 0) {
-            return spans
+            return DecodedSpans(spans, corruption)
         }
-        spans.add(SpanProto.ADAPTER.decode(record))
+        try {
+            spans.add(SpanProto.ADAPTER.decode(record))
+        } catch (exc: Exception) {
+            // keep exc associated with first bad record, then continue
+            corruption = corruption ?: exc
+        }
     }
 }

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/DecodedSpans.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/DecodedSpans.kt
@@ -1,0 +1,9 @@
+package io.embrace.android.embracesdk.internal.session.persistence
+
+/**
+ * The spans read back from a completed spans file, including the first exception (if any) found when decoding
+ */
+internal class DecodedSpans(
+    val spans: List<SpanProto>,
+    val corruption: Throwable?,
+)

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionService.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionService.kt
@@ -170,7 +170,8 @@ class SessionReconstructionService(
         }
         try {
             val decoded = src.source().buffer().use(::readCompletedSpans)
-            SystemTrace.trace("mf-spans-proto-to-payload") { decoded.map(SpanProto::toPayload) }
+            decoded.corruption?.let(::trackFailure)
+            SystemTrace.trace("mf-spans-proto-to-payload") { decoded.spans.map(SpanProto::toPayload) }
         } catch (exc: Throwable) {
             trackFailure(exc)
             null

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansReaderTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansReaderTest.kt
@@ -2,6 +2,8 @@ package io.embrace.android.embracesdk.internal.session.persistence
 
 import okio.Buffer
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.fail
 import org.junit.Test
 import java.io.IOException
@@ -18,12 +20,17 @@ internal class CompletedSpansReaderTest {
         /** Field 1, length delimited, claiming more bytes than any log could hold. */
         private val OVERSIZED_LENGTH_PREFIX = byteArrayOf(0x0A, -1, -1, -1, -1, 0x07)
 
+        /** An intact frame round a record body holding an invalid field encoding. */
+        private val UNDECODABLE_RECORD = byteArrayOf(0x0A, 0x01, 0x0E)
+
         private fun span(id: String) = fullyPopulatedSpanProto.copy(span_id = id)
 
-        private fun read(bytes: ByteArray): List<SpanProto> = Buffer().write(bytes).use(::readCompletedSpans)
+        private fun decode(bytes: ByteArray): DecodedSpans = Buffer().write(bytes).use(::readCompletedSpans)
+
+        private fun read(bytes: ByteArray): List<SpanProto> = decode(bytes).spans
 
         private fun read(bytes: ByteArray, maxBytes: Long): List<SpanProto> =
-            Buffer().write(bytes).use { readCompletedSpans(it, maxBytes) }
+            Buffer().write(bytes).use { readCompletedSpans(it, maxBytes) }.spans
 
         /** The budget a record consumes, which is the record itself and not the framing round it. */
         private fun budgetOf(vararg spans: SpanProto): Long =
@@ -109,6 +116,36 @@ internal class CompletedSpansReaderTest {
         } catch (expected: IOException) {
             // the records before it are still lost, but reporting beats delivering a partial log
         }
+    }
+
+    @Test
+    fun `an undecodable record is dropped and the records either side of it are kept`() {
+        val log = completedSpansLog(listOf(first)) + UNDECODABLE_RECORD + completedSpansLog(listOf(second))
+        assertEquals(listOf(first, second), read(log))
+    }
+
+    @Test
+    fun `an undecodable record is reported so the caller can track it`() {
+        val log = completedSpansLog(listOf(first)) + UNDECODABLE_RECORD
+        assertNotNull(decode(log).corruption)
+    }
+
+    @Test
+    fun `a log every record of which is undecodable reads back no spans`() {
+        val decoded = decode(UNDECODABLE_RECORD + UNDECODABLE_RECORD)
+        assertEquals(emptyList<SpanProto>(), decoded.spans)
+        assertNotNull(decoded.corruption)
+    }
+
+    @Test
+    fun `a log with no undecodable records reports no corruption`() {
+        assertNull(decode(completedSpansLog(listOf(first, second))).corruption)
+    }
+
+    @Test
+    fun `an undecodable record counts against the budget`() {
+        val log = completedSpansLog(listOf(first)) + UNDECODABLE_RECORD + completedSpansLog(listOf(second))
+        assertEquals(listOf(first), read(log, budgetOf(first, second)))
     }
 
     @Test

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansWriterTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansWriterTest.kt
@@ -304,7 +304,7 @@ internal class CompletedSpansWriterTest {
         File(partDir(directory), COMPLETED_SPANS_FILE_NAME)
 
     private fun readLog(directory: SessionPartDirectory = partDirectory): List<SpanProto> =
-        logFile(directory).source().buffer().use(::readCompletedSpans)
+        logFile(directory).source().buffer().use(::readCompletedSpans).spans
 
     private fun write(
         directory: SessionPartDirectory? = partDirectory,

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceCompletedSpansTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceCompletedSpansTest.kt
@@ -48,6 +48,9 @@ internal class SessionReconstructionServiceCompletedSpansTest {
 
         /** Field 1 tagged with wire type 6, which is not a field encoding protobuf defines. */
         private val INVALID_FIELD_ENCODING = byteArrayOf(0x0E)
+
+        /** An intact frame round a record body holding an invalid field encoding. */
+        private val UNDECODABLE_RECORD = byteArrayOf(0x0A, 0x01, 0x0E)
     }
 
     @get:Rule
@@ -189,7 +192,28 @@ internal class SessionReconstructionServiceCompletedSpansTest {
     }
 
     @Test
-    fun `a completed spans log holding undecodable bytes is reported and does not throw`() {
+    fun `an undecodable record is reported but does not lose the rest of the log`() {
+        write(spans = listOf(endedSpanProto))
+        completedSpansFile().appendBytes(UNDECODABLE_RECORD)
+        completedSpansFile().appendBytes(completedSpansLog(listOf(secondEndedSpanProto)))
+
+        val spans = checkNotNull(service.reconstruct(partDirectory)?.data?.spans)
+        assertEquals(listOf(endedSpan, secondEndedSpan, fullyPopulatedSpan), spans)
+        assertReconstructionFailureTracked()
+    }
+
+    @Test
+    fun `several undecodable records are reported once`() {
+        write(spans = listOf(endedSpanProto))
+        completedSpansFile().appendBytes(UNDECODABLE_RECORD + UNDECODABLE_RECORD)
+
+        val spans = checkNotNull(service.reconstruct(partDirectory)?.data?.spans)
+        assertEquals(listOf(endedSpan, fullyPopulatedSpan), spans)
+        assertReconstructionFailureTracked()
+    }
+
+    @Test
+    fun `a completed spans log holding nothing but a malformed frame is reported and does not throw`() {
         write()
         completedSpansFile().writeBytes(INVALID_FIELD_ENCODING)
         assertNull(service.reconstruct(partDirectory))


### PR DESCRIPTION
## Goal

Gracefully handle corrupt span records by attempting to continue if one is invalid, rather than dropping _all_ spans.