### PR TITLE
Increase debounce time

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -58,9 +58,9 @@ class SessionPartWriterImpl(
         private const val MAX_CARRIED_OVER_SPANS: Int = 1000
         private const val CARRIED_OVER_SPAN_LIMIT_TYPE: String = "carried_over_span"
 
-        const val METADATA_WRITE_DELAY_MS: Long = 10
-        const val SESSION_SPAN_WRITE_DELAY_MS: Long = 100
-        const val SPAN_SNAPSHOT_WRITE_DELAY_MS: Long = 100
+        const val METADATA_WRITE_DELAY_MS: Long = 500
+        const val SESSION_SPAN_WRITE_DELAY_MS: Long = 1000
+        const val SPAN_SNAPSHOT_WRITE_DELAY_MS: Long = 1000
     }
 
     /**


### PR DESCRIPTION
## Goal

Increases the time for debouncing operations so that file writes happen less frequently by default. Note that the first write, session part end, and crashes all flush these writes immediately.
