### PR TITLE
Don't notify on crash

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionOrchestratorImpl.kt
@@ -387,7 +387,10 @@ internal class SessionOrchestratorImpl(
 
                             // persist the stopped session part span
                             EmbTrace.trace("mf-part-ended") {
-                                sessionPartWriter?.onSessionPartEnded(sessionPartId)
+                                sessionPartWriter?.onSessionPartEnded(
+                                    sessionPartId = sessionPartId,
+                                    crashing = transitionType == TransitionType.CRASH,
+                                )
                             }
                         },
                         startSessionPartCallback = {

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriter.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriter.kt
@@ -15,7 +15,7 @@ interface SessionPartWriter {
     /**
      * A session part has ended. Persists any necessary information.
      */
-    fun onSessionPartEnded(sessionPartId: String)
+    fun onSessionPartEnded(sessionPartId: String, crashing: Boolean = false)
 
     /**
      * User information has changed and should be persisted.

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -114,7 +114,7 @@ class SessionPartWriterImpl(
         registerResourceChangeListener()
     }
 
-    override fun onSessionPartEnded(sessionPartId: String) {
+    override fun onSessionPartEnded(sessionPartId: String, crashing: Boolean) {
         if (!acceptingWrites()) {
             return
         }
@@ -135,7 +135,7 @@ class SessionPartWriterImpl(
             writers.sealed = true
             writeTracker.markComplete(sessionPartId)
 
-            if (!processTerminating) {
+            if (!crashing && !processTerminating) {
                 notifyWritesComplete()
             }
             writers.span?.releaseRetainedData()

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
@@ -687,11 +687,30 @@ internal class SessionPartWriterImplTest {
         writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
         clock.tick(10000)
         endPart()
-        writer.onSessionPartEnded(SESSION_PART_ID)
+        writer.onSessionPartEnded(SESSION_PART_ID, crashing = true)
         writer.onCrash()
 
         assertEquals(clock.now().millisToNanos(), sessionSpanOnDisk(SESSION_PART_ID)?.span?.end_time_unix_nano)
         assertTrue(executor.isShutdown)
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `a crash never announces its writes as complete even if the seal runs before the crash flush`() {
+        val events = mutableListOf<String>()
+        val writer = createWriter(onWritesComplete = { events.add("writes-complete") })
+        writer.onSessionPartStarted(clock.now(), USER_SESSION_ID, SESSION_PART_ID)
+        drain()
+
+        clock.tick(10000)
+        endPart()
+        val expectedEndTimeNanos = clock.now().millisToNanos()
+        writer.onSessionPartEnded(SESSION_PART_ID, crashing = true)
+        drain()
+        writer.onCrash()
+
+        assertEquals(emptyList<String>(), events)
+        assertEquals(expectedEndTimeNanos, sessionSpanOnDisk(SESSION_PART_ID)?.span?.end_time_unix_nano)
         assertNoInternalErrors()
     }
 

--- a/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/persistence/MultiFilePersistenceParityTest.kt
+++ b/embrace-android-sdk/src/integrationTest/kotlin/io/embrace/android/embracesdk/testcases/persistence/MultiFilePersistenceParityTest.kt
@@ -432,7 +432,7 @@ internal class MultiFilePersistenceParityTest(
     }
 
     @Test
-    fun `a crashed session part is handed to the intake service rather than delivered`() {
+    fun `a crashed session part is left on disk for the next process launch`() {
         testRule.runTest(
             persistedRemoteConfig = remoteConfig(),
             testCaseAction = {
@@ -442,10 +442,29 @@ internal class MultiFilePersistenceParityTest(
             },
             assertAction = {
                 assertEquals(0, getSessionEnvelopes(0).size)
-                assertTrue(
-                    "the crashed session part was left behind on disk",
-                    storedSessionPartDirectories().isEmpty(),
-                )
+
+                when (persistenceMode) {
+                    // the legacy layer keeps no session part directories
+                    PersistenceMode.LEGACY -> assertEquals(
+                        emptyList<SessionPartDirectory>(),
+                        storedSessionPartDirectories(),
+                    )
+
+                    // reading a part back is very unlikely to complete while the process is
+                    // crashing, so the part is sealed and left for the next launch to deliver
+                    // rather than being handed to the intake service here
+                    PersistenceMode.MULTI_FILE -> {
+                        assertEquals(
+                            "the crashed session part was not left on disk",
+                            1,
+                            storedSessionPartDirectories().size,
+                        )
+                        assertNotNull(
+                            "the crashed session part was left unsealed on disk",
+                            sessionSpanOnDisk()?.span?.end_time_unix_nano,
+                        )
+                    }
+                }
             },
         )
     }


### PR DESCRIPTION
## Goal

Don't attempt to read a completed session part when a crash has happened. Leave it for the next process launch as it's very unlikely to complete.