### PR TITLE
Enforce limit on large persisted span

### DIFF
--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansReader.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansReader.kt
@@ -16,7 +16,11 @@ private const val SPANS_TAG = 1
  * not reported: every record written in full before it is returned. A record that is all
  * present but does not decode is corruption and throws.
  */
-internal fun readCompletedSpans(source: BufferedSource, maxBytes: Long = MAX_PART_FILE_BYTES): DecodedSpans {
+internal fun readCompletedSpans(
+    source: BufferedSource,
+    maxBytes: Long = MAX_PART_FILE_BYTES,
+    maxRecordBytes: Long = MAX_RECORD_BYTES,
+): DecodedSpans {
     val spans = mutableListOf<SpanProto>()
     var corruption: Throwable? = null
     val reader = ProtoReader(source)
@@ -27,7 +31,12 @@ internal fun readCompletedSpans(source: BufferedSource, maxBytes: Long = MAX_PAR
         val record = try {
             when (reader.nextTag()) {
                 -1 -> return DecodedSpans(spans, corruption)
-                SPANS_TAG -> reader.readBytes()
+                SPANS_TAG -> {
+                    if (reader.nextFieldMinLengthInBytes() > maxRecordBytes) {
+                        return DecodedSpans(spans, corruption)
+                    }
+                    reader.readBytes()
+                }
                 else -> {
                     reader.skip()
                     continue

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionPartLimits.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionPartLimits.kt
@@ -6,4 +6,9 @@ package io.embrace.android.embracesdk.internal.session.persistence
  */
 internal const val MAX_PART_FILE_BYTES: Long = 3L * 1024 * 1024
 
+/**
+ * Upper bound on the size of a single record in the completed spans file.
+ */
+internal const val MAX_RECORD_BYTES: Long = 512L * 1024
+
 internal const val OVERSIZED_PART_FILE_MSG = "Session part file exceeds the maximum size"

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansReaderTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansReaderTest.kt
@@ -32,6 +32,12 @@ internal class CompletedSpansReaderTest {
         private fun read(bytes: ByteArray, maxBytes: Long): List<SpanProto> =
             Buffer().write(bytes).use { readCompletedSpans(it, maxBytes) }.spans
 
+        private fun readBoundedRecords(bytes: ByteArray, maxRecordBytes: Long): List<SpanProto> =
+            Buffer().write(bytes).use { readCompletedSpans(it, MAX_PART_FILE_BYTES, maxRecordBytes) }.spans
+
+        /** The length a record declares, which is the encoded span the frame wraps. */
+        private fun declaredLengthOf(span: SpanProto): Long = SpanProto.ADAPTER.encode(span).size.toLong()
+
         /** The budget a record consumes, which is the record itself and not the framing round it. */
         private fun budgetOf(vararg spans: SpanProto): Long =
             spans.sumOf { SpanProto.ADAPTER.encode(it).size }.toLong()
@@ -88,6 +94,38 @@ internal class CompletedSpansReaderTest {
     fun `an oversized length prefix does not read past the end of the log`() {
         val log = completedSpansLog(listOf(first)) + OVERSIZED_LENGTH_PREFIX
         assertEquals(listOf(first), read(log))
+    }
+
+    @Test
+    fun `a record declaring more than the record bound is dropped along with the rest of the log`() {
+        val small = paddedSpanProto(paddedSpanId(1), padding = 8)
+        val large = paddedSpanProto(paddedSpanId(2), padding = 4096)
+        val log = completedSpansLog(listOf(small, large, small))
+        assertEquals(listOf(small), readBoundedRecords(log, declaredLengthOf(large) - 1))
+    }
+
+    @Test
+    fun `a record exactly at the record bound reads back`() {
+        val log = completedSpansLog(listOf(first, second))
+        assertEquals(listOf(first, second), readBoundedRecords(log, declaredLengthOf(first)))
+    }
+
+    @Test
+    fun `a first record declaring more than the record bound reads back no spans`() {
+        val log = completedSpansLog(listOf(first, second))
+        assertEquals(emptyList<SpanProto>(), readBoundedRecords(log, declaredLengthOf(first) - 1))
+    }
+
+    @Test
+    fun `a length prefix beyond the record bound is rejected before the body is read`() {
+        val log = completedSpansLog(listOf(first)) + OVERSIZED_LENGTH_PREFIX + completedSpansLog(listOf(second))
+        assertEquals(listOf(first), readBoundedRecords(log, MAX_RECORD_BYTES))
+    }
+
+    @Test
+    fun `a large but legitimate record reads back under the production bound`() {
+        val padded = paddedSpanProto(paddedSpanId(1), padding = 64 * 1024)
+        assertEquals(listOf(padded), readBoundedRecords(completedSpansLog(listOf(padded)), MAX_RECORD_BYTES))
     }
 
     @Test


### PR DESCRIPTION
## Goal

Enforces a reasonable upper limit when reading spans so that we don't have an unbounded allocation if a single span is very large.
