### PR TITLE
Enforce overall span count limit when reading data

### DIFF
--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansReader.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansReader.kt
@@ -20,6 +20,7 @@ internal fun readCompletedSpans(
     source: BufferedSource,
     maxBytes: Long = MAX_PART_FILE_BYTES,
     maxRecordBytes: Long = MAX_RECORD_BYTES,
+    maxSpans: Int = MAX_PERSISTED_SPANS,
 ): DecodedSpans {
     val spans = mutableListOf<SpanProto>()
     var corruption: Throwable? = null
@@ -32,6 +33,9 @@ internal fun readCompletedSpans(
             when (reader.nextTag()) {
                 -1 -> return DecodedSpans(spans, corruption)
                 SPANS_TAG -> {
+                    if (spans.size >= maxSpans) {
+                        return DecodedSpans(spans, corruption, spanLimitReached = true)
+                    }
                     if (reader.nextFieldMinLengthInBytes() > maxRecordBytes) {
                         return DecodedSpans(spans, corruption)
                     }

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/DecodedSpans.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/DecodedSpans.kt
@@ -6,4 +6,5 @@ package io.embrace.android.embracesdk.internal.session.persistence
 internal class DecodedSpans(
     val spans: List<SpanProto>,
     val corruption: Throwable?,
+    val spanLimitReached: Boolean = false,
 )

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionPartLimits.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionPartLimits.kt
@@ -11,4 +11,14 @@ internal const val MAX_PART_FILE_BYTES: Long = 3L * 1024 * 1024
  */
 internal const val MAX_RECORD_BYTES: Long = 512L * 1024
 
+/**
+ * Upper bound on the number of spans materialised from one session part, counting completed spans
+ * and span snapshots together but not the session span itself, which is always delivered.
+ *
+ * This is the sum of the per-session-part span limits the SDK enforces when capturing telemetry.
+ */
+internal const val MAX_PERSISTED_SPANS: Int = 4000
+
 internal const val OVERSIZED_PART_FILE_MSG = "Session part file exceeds the maximum size"
+
+internal const val TOO_MANY_PERSISTED_SPANS_MSG = "Session part holds more spans than can be delivered"

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionService.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionService.kt
@@ -68,21 +68,14 @@ class SessionReconstructionService(
         }
         val metadata = metadataProto.toPayload()
 
-        val sessionSpan = readPartFile(
-            partDir,
-            SESSION_SPAN_FILE_NAME,
-            SessionPartSpan.ADAPTER,
-            SessionPartSpan::format_version,
-        ) ?: return null
+        val span = readSessionSpan(partDir) ?: return null
 
-        val span = sessionSpan.span
-        if (span == null) {
-            trackFailure(IOException("Session span file has no span"))
-            return null
+        val budget = SpanBudget()
+        val completedSpans = readCompletedSpansFile(partDir, budget) ?: return null
+        val persistedSnapshots = readSpanSnapshotsFile(partDir, budget) ?: return null
+        if (budget.exceeded) {
+            trackFailure(IllegalStateException(TOO_MANY_PERSISTED_SPANS_MSG))
         }
-
-        val completedSpans = readCompletedSpansFile(partDir) ?: return null
-        val persistedSnapshots = readSpanSnapshotsFile(partDir) ?: return null
 
         // A session span with no end time never finished, so it is delivered as a snapshot rather
         // than as a completed span. The snapshots file never holds the session span itself.
@@ -112,6 +105,21 @@ class SessionReconstructionService(
         )
     }
 
+    private fun readSessionSpan(partDir: File): SpanProto? {
+        val sessionSpan = readPartFile(
+            partDir,
+            SESSION_SPAN_FILE_NAME,
+            SessionPartSpan.ADAPTER,
+            SessionPartSpan::format_version,
+        ) ?: return null
+
+        val span = sessionSpan.span
+        if (span == null) {
+            trackFailure(IOException("Session span file has no span"))
+        }
+        return span
+    }
+
     /**
      * Removes spans that share a span ID with another span in the payload.
      *
@@ -119,7 +127,7 @@ class SessionReconstructionService(
      * The completed span always supersedes snapshots, and otherwise the span with the latest end time
      * is chosen.
      */
-    private fun dedupeSpanIds(spans: List<Span>, spanSnapshots: List<Span>): DedupedSpans =
+    private fun dedupeSpanIds(spans: List<Span>, spanSnapshots: List<Span>): PartSpans =
         SystemTrace.trace("mf-dedupe-span-ids") {
             val completedIds = spans.mapNotNullTo(HashSet(), Span::spanId)
             val remainingSnapshots = spanSnapshots.filter { snapshot ->
@@ -136,7 +144,7 @@ class SessionReconstructionService(
                     IllegalStateException("Removed duplicate spans from session part payload"),
                 )
             }
-            DedupedSpans(dedupedSpans, dedupedSnapshots)
+            PartSpans(dedupedSpans, dedupedSnapshots)
         }
 
     private fun keepLatestPerSpanId(spans: List<Span>): List<Span> {
@@ -160,29 +168,33 @@ class SessionReconstructionService(
      *
      * An oversized log is truncated rather than rejected.
      */
-    private fun readCompletedSpansFile(partDir: File): List<Span>? = SystemTrace.trace("mf-read-completed-spans") {
-        val src = File(partDir, COMPLETED_SPANS_FILE_NAME)
-        if (!src.exists()) {
-            return@trace emptyList()
+    private fun readCompletedSpansFile(partDir: File, budget: SpanBudget): List<Span>? =
+        SystemTrace.trace("mf-read-completed-spans") {
+            val src = File(partDir, COMPLETED_SPANS_FILE_NAME)
+            if (!src.exists()) {
+                return@trace emptyList()
+            }
+            if (src.length() > MAX_PART_FILE_BYTES) {
+                trackFailure(IOException(OVERSIZED_PART_FILE_MSG))
+            }
+            try {
+                val decoded = src.source().buffer().use { source ->
+                    readCompletedSpans(source, maxSpans = budget.remaining)
+                }
+                decoded.corruption?.let(::trackFailure)
+                budget.spend(decoded.spans.size, truncated = decoded.spanLimitReached)
+                SystemTrace.trace("mf-spans-proto-to-payload") { decoded.spans.map(SpanProto::toPayload) }
+            } catch (exc: Throwable) {
+                trackFailure(exc)
+                null
+            }
         }
-        if (src.length() > MAX_PART_FILE_BYTES) {
-            trackFailure(IOException(OVERSIZED_PART_FILE_MSG))
-        }
-        try {
-            val decoded = src.source().buffer().use(::readCompletedSpans)
-            decoded.corruption?.let(::trackFailure)
-            SystemTrace.trace("mf-spans-proto-to-payload") { decoded.spans.map(SpanProto::toPayload) }
-        } catch (exc: Throwable) {
-            trackFailure(exc)
-            null
-        }
-    }
 
     /**
      * Decodes the span snapshots persisted in a session part directory, or null if the file cannot
      * be read.
      */
-    private fun readSpanSnapshotsFile(partDir: File): List<Span>? {
+    private fun readSpanSnapshotsFile(partDir: File, budget: SpanBudget): List<Span>? {
         if (!File(partDir, SPAN_SNAPSHOTS_FILE_NAME).exists()) {
             return emptyList()
         }
@@ -192,7 +204,9 @@ class SessionReconstructionService(
             SpanSnapshots.ADAPTER,
             SpanSnapshots::format_version,
         ) ?: return null
-        return SystemTrace.trace("mf-spans-proto-to-payload") { snapshots.spans.map(SpanProto::toPayload) }
+        val afforded = snapshots.spans.take(budget.remaining)
+        budget.spend(afforded.size, truncated = afforded.size < snapshots.spans.size)
+        return SystemTrace.trace("mf-spans-proto-to-payload") { afforded.map(SpanProto::toPayload) }
     }
 
     /**
@@ -241,7 +255,21 @@ class SessionReconstructionService(
         logger.trackInternalError(InternalErrorType.SessionReconstructionFail, exc)
     }
 
-    private class DedupedSpans(val spans: List<Span>, val spanSnapshots: List<Span>)
+    private class PartSpans(val spans: List<Span>, val spanSnapshots: List<Span>)
+
+    private class SpanBudget {
+
+        var remaining: Int = MAX_PERSISTED_SPANS
+            private set
+
+        var exceeded: Boolean = false
+            private set
+
+        fun spend(spans: Int, truncated: Boolean) {
+            remaining -= spans
+            exceeded = exceeded || truncated
+        }
+    }
 }
 
 private fun partFileReadSectionName(fileName: String): String = when (fileName) {

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansReaderTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansReaderTest.kt
@@ -2,8 +2,10 @@ package io.embrace.android.embracesdk.internal.session.persistence
 
 import okio.Buffer
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
 import java.io.IOException
@@ -34,6 +36,11 @@ internal class CompletedSpansReaderTest {
 
         private fun readBoundedRecords(bytes: ByteArray, maxRecordBytes: Long): List<SpanProto> =
             Buffer().write(bytes).use { readCompletedSpans(it, MAX_PART_FILE_BYTES, maxRecordBytes) }.spans
+
+        private fun readBoundedSpans(bytes: ByteArray, maxSpans: Int): DecodedSpans =
+            Buffer().write(bytes).use {
+                readCompletedSpans(it, MAX_PART_FILE_BYTES, MAX_RECORD_BYTES, maxSpans)
+            }
 
         /** The length a record declares, which is the encoded span the frame wraps. */
         private fun declaredLengthOf(span: SpanProto): Long = SpanProto.ADAPTER.encode(span).size.toLong()
@@ -126,6 +133,41 @@ internal class CompletedSpansReaderTest {
     fun `a large but legitimate record reads back under the production bound`() {
         val padded = paddedSpanProto(paddedSpanId(1), padding = 64 * 1024)
         assertEquals(listOf(padded), readBoundedRecords(completedSpansLog(listOf(padded)), MAX_RECORD_BYTES))
+    }
+
+    @Test
+    fun `records past the span limit are dropped`() {
+        val log = completedSpansLog(listOf(first, second, third))
+        assertEquals(listOf(first, second), readBoundedSpans(log, maxSpans = 2).spans)
+    }
+
+    @Test
+    fun `a log at the span limit reads back in full and reports nothing`() {
+        val decoded = readBoundedSpans(completedSpansLog(listOf(first, second)), maxSpans = 2)
+        assertEquals(listOf(first, second), decoded.spans)
+        assertFalse(decoded.spanLimitReached)
+    }
+
+    @Test
+    fun `dropping records past the span limit is reported`() {
+        val log = completedSpansLog(listOf(first, second, third))
+        assertTrue(readBoundedSpans(log, maxSpans = 2).spanLimitReached)
+    }
+
+    @Test
+    fun `a span limit of zero reads back no spans`() {
+        val decoded = readBoundedSpans(completedSpansLog(listOf(first)), maxSpans = 0)
+        assertEquals(emptyList<SpanProto>(), decoded.spans)
+        assertTrue(decoded.spanLimitReached)
+    }
+
+    @Test
+    fun `a record past the span limit is not decoded at all`() {
+        val log = completedSpansLog(listOf(first, second)) + UNDECODABLE_RECORD
+        val decoded = readBoundedSpans(log, maxSpans = 2)
+        assertEquals(listOf(first, second), decoded.spans)
+        assertNull(decoded.corruption)
+        assertTrue(decoded.spanLimitReached)
     }
 
     @Test

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceFileSizeTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceFileSizeTest.kt
@@ -32,6 +32,7 @@ internal class SessionReconstructionServiceFileSizeTest {
         private const val SESSION_PART_ID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         private const val PADDING_FIELD_NUMBER = 1000
         private const val PADDING_FIELD_OVERHEAD = 6
+        private const val EMPTY_PADDING_FIELD_BYTES = 3
         private const val PADDED_SPAN_BYTES = 64 * 1024
 
         private val partDirectory = SessionPartDirectory(
@@ -144,6 +145,33 @@ internal class SessionReconstructionServiceFileSizeTest {
         assertEquals(logged.take(fitting).map(SpanProto::span_id), ids?.dropLast(1))
     }
 
+    @Test
+    fun `spans past the persisted span limit are dropped`() {
+        val logged = List(MAX_PERSISTED_SPANS + 5) { paddedSpanProto(paddedSpanId(it), padding = 1) }
+        partFile(COMPLETED_SPANS_FILE_NAME).writeBytes(completedSpansLog(logged))
+        val envelope = checkNotNull(service.reconstruct(partDirectory))
+        val spans = checkNotNull(envelope.data.spans)
+
+        assertEquals(MAX_PERSISTED_SPANS + 1, spans.size)
+        assertEquals(fullyPopulatedSpan, spans.last())
+        assertEquals(logged.take(MAX_PERSISTED_SPANS).map(SpanProto::span_id), spans.dropLast(1).map(Span::spanId))
+
+        assertEquals(emptyList<Span>(), envelope.data.spanSnapshots)
+        assertEquals(1, logger.internalErrorMessages.size)
+        assertEquals("SessionReconstructionFail", logger.internalErrorMessages.single().msg)
+    }
+
+    @Test
+    fun `a part at exactly the persisted span limit keeps every span`() {
+        val logged = List(MAX_PERSISTED_SPANS - 1) { paddedSpanProto(paddedSpanId(it), padding = 1) }
+        partFile(COMPLETED_SPANS_FILE_NAME).writeBytes(completedSpansLog(logged))
+
+        val envelope = checkNotNull(service.reconstruct(partDirectory))
+        assertEquals(MAX_PERSISTED_SPANS, envelope.data.spans?.size)
+        assertEquals(listOf(inFlightSpan), envelope.data.spanSnapshots)
+        assertNoInternalErrors()
+    }
+
     private fun assertOversizedFileRejected(fileName: String) {
         padToSize(fileName, MAX_PART_FILE_BYTES + 1)
         assertNull(service.reconstruct(partDirectory))
@@ -157,15 +185,46 @@ internal class SessionReconstructionServiceFileSizeTest {
      */
     private fun padToSize(fileName: String, size: Long) {
         val file = partFile(fileName)
-        val payloadSize = size - file.length() - PADDING_FIELD_OVERHEAD
+        file.appendBytes(paddingBytes(size - file.length()))
+        assertEquals(size, file.length())
+    }
+
+    /**
+     * Encodes padding fields occupying exactly [delta] bytes in total.
+     */
+    private fun paddingBytes(delta: Long): ByteArray {
+        val out = Buffer()
+        var remaining = delta
+        while (true) {
+            val field = paddingField(remaining)
+            if (field != null) {
+                out.write(field)
+                break
+            }
+            out.write(encodePadding(0))
+            remaining -= EMPTY_PADDING_FIELD_BYTES
+        }
+        assertEquals(delta, out.size)
+        return out.readByteArray()
+    }
+
+    /**
+     * A single padding field occupying exactly [delta] bytes, or null if no payload size reaches it.
+     */
+    private fun paddingField(delta: Long): ByteArray? =
+        (EMPTY_PADDING_FIELD_BYTES..PADDING_FIELD_OVERHEAD)
+            .asSequence()
+            .map { overhead -> encodePadding((delta - overhead).toInt()) }
+            .firstOrNull { it.size.toLong() == delta }
+
+    private fun encodePadding(payloadSize: Int): ByteArray {
         val padding = Buffer()
         ProtoAdapter.BYTES.encodeWithTag(
             ProtoWriter(padding),
             PADDING_FIELD_NUMBER,
-            ByteArray(payloadSize.toInt()).toByteString(),
+            ByteArray(payloadSize).toByteString(),
         )
-        file.appendBytes(padding.readByteArray())
-        assertEquals(size, file.length())
+        return padding.readByteArray()
     }
 
     private fun target(): SessionPartWriteTarget =


### PR DESCRIPTION
## Goal

Enforces an overall limit on the number of spans when deserializing persisted data.

## Testing

Added unit tests.
