### PR TITLE
Enforce overall limit on json files

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImpl.kt
@@ -31,6 +31,7 @@ import io.embrace.android.embracesdk.internal.session.getUserSessionProperties
 import io.embrace.android.embracesdk.internal.utils.EmbTrace
 import io.embrace.android.embracesdk.internal.utils.Provider
 import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
+import java.io.IOException
 import java.io.InputStream
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeUnit
@@ -46,6 +47,7 @@ internal class PayloadResurrectionServiceImpl(
     private val cachedLogEnvelopeStore: CachedLogEnvelopeStore,
     private val logger: InternalLogger,
     private val serializer: PlatformSerializer,
+    private val maxPayloadBytes: Long = MAX_CACHED_PAYLOAD_BYTES,
 ) : PayloadResurrectionService {
 
     private val completionListeners = CopyOnWriteArrayList<() -> Unit>()
@@ -152,10 +154,11 @@ internal class PayloadResurrectionServiceImpl(
         if (sessionlessNativeCrashes.isNotEmpty()) {
             val cachedCrashEnvelopeMetadata = undeliveredPayloads.firstOrNull { it.isCrashEnvelope() }
             val cachedCrashEnvelope = cachedCrashEnvelopeMetadata
-                ?.loadDecompressedPayload()
-                ?.let { payloadStream ->
+                ?.let { metadata ->
                     runCatching {
-                        serializer.fromJson(payloadStream, Envelope.serializer(LogPayload.serializer()))
+                        metadata.loadDecompressedPayload()?.let { payloadStream ->
+                            serializer.fromJson(payloadStream, Envelope.serializer(LogPayload.serializer()))
+                        }
                     }.getOrNull()
                 }
                 ?.also { runCatching { cacheStorageService.delete(cachedCrashEnvelopeMetadata) } }
@@ -451,14 +454,22 @@ internal class PayloadResurrectionServiceImpl(
     private fun Span.resolveSessionPartIdForCrashMatch(): String? =
         attributes?.findAttributeValue(EmbSessionAttributes.EMB_SESSION_PART_ID)
 
-    private fun StoredTelemetryMetadata.loadDecompressedPayload(): InputStream? =
-        cacheStorageService.loadPayloadAsStream(this)?.let {
+    /**
+     * Opens the cached payload for reading, or returns null if it is not on disk or does not hold
+     * gzipped data. Throws [IOException] if the file is larger than [maxPayloadBytes].
+     */
+    private fun StoredTelemetryMetadata.loadDecompressedPayload(): InputStream? {
+        if (cacheStorageService.payloadSizeBytes(this) > maxPayloadBytes) {
+            throw IOException(OVERSIZED_PAYLOAD_MSG)
+        }
+        return cacheStorageService.loadPayloadAsStream(this)?.let {
             try {
                 GZIPInputStream(it)
             } catch (_: ZipException) {
                 null
             }
         }
+    }
 
     /**
      * To approximate the time of any snapshot to be converted into a failed span, we look to the session part span of the payload and take

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/ResurrectionLimits.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/ResurrectionLimits.kt
@@ -1,0 +1,9 @@
+package io.embrace.android.embracesdk.internal.resurrection
+
+/**
+ * Upper bound on the size of a cached payload file read back during resurrection. This is
+ * meant as an upper bound to prevent memory exhaustion.
+ */
+internal const val MAX_CACHED_PAYLOAD_BYTES: Long = 3L * 1024 * 1024
+
+internal const val OVERSIZED_PAYLOAD_MSG = "Cached payload file exceeds the maximum size"

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
@@ -514,6 +514,65 @@ class PayloadResurrectionServiceImplTest {
     }
 
     @Test
+    fun `a session payload larger than the maximum file size is not resurrected`() {
+        cacheStorageService.addPayload(metadata = sessionMetadata, data = deadSessionEnvelope)
+        val service = serviceWithMaxPayloadBytes(cachedSizeOf(sessionMetadata) - 1)
+        service.resurrectOldPayloads(nativeCrashServiceProvider = { nativeCrashService })
+        assertResurrectionFailure()
+    }
+
+    @Test
+    fun `a session payload exactly at the maximum file size is resurrected`() {
+        cacheStorageService.addPayload(metadata = sessionMetadata, data = deadSessionEnvelope)
+        val service = serviceWithMaxPayloadBytes(cachedSizeOf(sessionMetadata))
+        service.resurrectOldPayloads(nativeCrashServiceProvider = { nativeCrashService })
+
+        assertEquals(1, payloadStorageService.storedPayloadCount())
+        assertEquals(0, cacheStorageService.storedPayloadCount())
+        assertTrue(logger.internalErrorMessages.isEmpty())
+    }
+
+    @Test
+    fun `a session payload is resurrected under the production file size limit`() {
+        cacheStorageService.addPayload(metadata = sessionMetadata, data = deadSessionEnvelope)
+        assertTrue(cachedSizeOf(sessionMetadata) < MAX_CACHED_PAYLOAD_BYTES)
+        resurrectInBackground()
+
+        assertEquals(1, payloadStorageService.storedPayloadCount())
+        assertEquals(0, cacheStorageService.storedPayloadCount())
+        assertTrue(logger.internalErrorMessages.isEmpty())
+    }
+
+    @Test
+    fun `a cached crash envelope larger than the maximum file size does not abort resurrection`() {
+        val deadSessionCrashData = createNativeCrashData(
+            nativeCrashId = "native-crash-1",
+            sessionPartId = "no-session-id",
+        )
+        cacheStorageService.addPayload(
+            metadata = fakeCachedCrashEnvelopeMetadata,
+            data = fakeEmptyLogEnvelope(),
+        )
+        nativeCrashService.addNativeCrashData(deadSessionCrashData)
+
+        val service = serviceWithMaxPayloadBytes(cachedSizeOf(fakeCachedCrashEnvelopeMetadata) - 1)
+        service.resurrectOldPayloads(nativeCrashServiceProvider = { nativeCrashService })
+
+        assertEquals(0, payloadStorageService.storedPayloadCount())
+        assertEquals(0, cacheStorageService.storedPayloadCount())
+        assertTrue(cachedLogEnvelopeStore.createdEnvelopes.isEmpty())
+
+        assertEquals(1, nativeCrashService.nativeCrashesSent.size)
+        assertEquals(deadSessionCrashData, nativeCrashService.nativeCrashesSent.single().first)
+
+        assertEquals(1, logger.internalErrorMessages.size)
+        assertEquals(
+            InternalErrorType.NativeCrashResurrectionError.toString(),
+            logger.internalErrorMessages.single().msg,
+        )
+    }
+
+    @Test
     fun `sessionless native crash sent without envelope data when crash envelope stream returns null`() {
         val deadSessionCrashData = createNativeCrashData(
             nativeCrashId = "native-crash-1",
@@ -802,6 +861,28 @@ class PayloadResurrectionServiceImplTest {
                 Envelope.sessionEnvelopeSerializer,
             )
         }
+    }
+
+    private fun cachedSizeOf(metadata: StoredTelemetryMetadata): Long =
+        cacheStorageService.payloadSizeBytes(metadata)
+
+    private fun serviceWithMaxPayloadBytes(maxPayloadBytes: Long): PayloadResurrectionServiceImpl {
+        return PayloadResurrectionServiceImpl(
+            intakeService = IntakeServiceImpl(
+                schedulingService,
+                payloadStorageService,
+                cacheStorageService,
+                logger,
+                serializer,
+                PriorityWorker(intakeExecutor),
+            ),
+            payloadStorageService = payloadStorageService,
+            cacheStorageService = cacheStorageService,
+            cachedLogEnvelopeStore = cachedLogEnvelopeStore,
+            logger = logger,
+            serializer = serializer,
+            maxPayloadBytes = maxPayloadBytes,
+        )
     }
 
     private fun serviceWithPayloadStream(payloadStream: InputStream?): PayloadResurrectionServiceImpl {

--- a/embrace-android-delivery-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadStorageService.kt
+++ b/embrace-android-delivery-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakePayloadStorageService.kt
@@ -75,6 +75,9 @@ class FakePayloadStorageService(
         }
     }
 
+    override fun payloadSizeBytes(metadata: StoredTelemetryMetadata): Long =
+        cachedPayloads[metadata]?.size?.toLong() ?: 0L
+
     override fun delete(metadata: StoredTelemetryMetadata, callback: () -> Unit) {
         if (worker == null) {
             deleteSynchronous(metadata, callback)

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/ExecutionResult.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/execution/ExecutionResult.kt
@@ -45,6 +45,12 @@ sealed class ExecutionResult(
     data class Incomplete(val exception: Throwable, val retry: Boolean) : ExecutionResult(retry)
 
     /**
+     * An execution attempt was not made because the payload is larger than the SDK will upload. Retrying
+     * would not make it deliverable, so the payload is discarded.
+     */
+    data class PayloadTooLarge(val sizeBytes: Long) : ExecutionResult(false)
+
+    /**
      * Execution was not attempted because the network isn't ready. It should be sent at the next possible time.
      */
     object NetworkNotReady : ExecutionResult(true)

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/DeliveryLimits.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/DeliveryLimits.kt
@@ -1,0 +1,8 @@
+package io.embrace.android.embracesdk.internal.delivery.scheduling
+
+/**
+ * Upper bound on the size of a payload the SDK will attempt to upload.
+ */
+internal const val MAX_UPLOAD_PAYLOAD_BYTES: Long = 3L * 1024 * 1024
+
+internal const val OVERSIZED_UPLOAD_MSG = "Payload exceeds the maximum size for upload"

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImpl.kt
@@ -13,6 +13,7 @@ import io.embrace.android.embracesdk.internal.delivery.storedTelemetryComparator
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
+import java.io.IOException
 import java.io.InputStream
 import java.net.ConnectException
 import java.net.NoRouteToHostException
@@ -34,6 +35,7 @@ class SchedulingServiceImpl(
     private val clock: Clock,
     private val logger: InternalLogger,
     private val deliveryTracer: DeliveryTracer? = null,
+    private val maxPayloadBytes: Long = MAX_UPLOAD_PAYLOAD_BYTES,
 ) : SchedulingService {
 
     private val blockedEndpoints: MutableMap<Endpoint, Long> = ConcurrentHashMap()
@@ -175,23 +177,7 @@ class SchedulingServiceImpl(
         deliveryTracer?.onExecuteDelivery(payload)
         activeSends.add(payload)
         deliveryWorker.submit {
-            // Do not execute if the network isn't ready
-            val result: ExecutionResult = if (!connectionStatus.ready()) {
-                ExecutionResult.NetworkNotReady
-            } else {
-                try {
-                    payload.toStream()?.use { stream ->
-                        executionService.attemptHttpRequest(
-                            payloadStream = { stream },
-                            envelopeType = payload.envelopeType,
-                            payloadType = payload.payloadTypesHeader,
-                        )
-                    } ?: ExecutionResult.NotAttempted
-                } catch (t: Throwable) {
-                    logger.trackInternalError(InternalErrorType.DeliverySchedulingFail, t)
-                    ExecutionResult.Incomplete(exception = t, retry = false)
-                }
-            }
+            val result: ExecutionResult = attemptDelivery(payload)
 
             // Block the connection right away to prevent future delivery if the request just run dictates that
             if (result.failedToConnect()) {
@@ -203,6 +189,42 @@ class SchedulingServiceImpl(
                 deliveryTracer?.onProcessingDeliveryResult(payload, result)
                 result.processDeliveryResult(payload)
             }
+        }
+    }
+
+    /**
+     * Runs the delivery attempt for [payload] on the delivery worker, returning the result the
+     * scheduling thread should then process.
+     *
+     * The payload is not sent if the network isn't ready, or if it is larger than the SDK will
+     * upload. The size is checked before the request is prepared because the stored bytes are sent
+     * as the request body verbatim, so an oversized file is an oversized request.
+     */
+    private fun attemptDelivery(payload: StoredTelemetryMetadata): ExecutionResult {
+        if (!connectionStatus.ready()) {
+            return ExecutionResult.NetworkNotReady
+        }
+
+        val sizeBytes = storageService.payloadSizeBytes(payload)
+        if (sizeBytes > maxPayloadBytes) {
+            logger.trackInternalError(
+                type = InternalErrorType.PayloadDeliveryFail,
+                throwable = IOException("$OVERSIZED_UPLOAD_MSG: $sizeBytes bytes"),
+            )
+            return ExecutionResult.PayloadTooLarge(sizeBytes)
+        }
+
+        return try {
+            payload.toStream()?.use { stream ->
+                executionService.attemptHttpRequest(
+                    payloadStream = { stream },
+                    envelopeType = payload.envelopeType,
+                    payloadType = payload.payloadTypesHeader,
+                )
+            } ?: ExecutionResult.NotAttempted
+        } catch (t: Throwable) {
+            logger.trackInternalError(InternalErrorType.DeliverySchedulingFail, t)
+            ExecutionResult.Incomplete(exception = t, retry = false)
         }
     }
 
@@ -321,7 +343,9 @@ class SchedulingServiceImpl(
         this is ExecutionResult.Incomplete && (connectionBlockingExceptions.any { it.isInstance(exception) })
 
     private fun ExecutionResult.connectedToServer(): Boolean =
-        this !is ExecutionResult.NetworkNotReady && this !is ExecutionResult.NotAttempted
+        this !is ExecutionResult.NetworkNotReady &&
+            this !is ExecutionResult.NotAttempted &&
+            this !is ExecutionResult.PayloadTooLarge
 
     private data class RetryInstance(
         val failedAttempts: Int,

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageService.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageService.kt
@@ -32,6 +32,11 @@ interface PayloadStorageService {
     fun loadPayloadAsStream(metadata: StoredTelemetryMetadata): InputStream?
 
     /**
+     * The number of bytes the payload occupies on disk, or 0 if it is not stored or couldn't be read.
+     */
+    fun payloadSizeBytes(metadata: StoredTelemetryMetadata): Long
+
+    /**
      * Return stored payloads as a list sorted in priority order
      */
     fun getPayloadsByPriority(): List<StoredTelemetryMetadata>

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImpl.kt
@@ -59,6 +59,9 @@ class PayloadStorageServiceImpl(
         }
     }
 
+    override fun payloadSizeBytes(metadata: StoredTelemetryMetadata): Long =
+        fileStorageService.payloadSizeBytes(metadata)
+
     override fun getPayloadsByPriority(): List<StoredTelemetryMetadata> {
         return fileStorageService.getStoredPayloads().sortedWith(storedTelemetryComparator).apply {
             deliveryTracer?.onGetPayloadsByPriority(this)

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/scheduling/SchedulingServiceImplTest.kt
@@ -21,6 +21,7 @@ import io.embrace.android.embracesdk.internal.delivery.execution.ExecutionResult
 import io.embrace.android.embracesdk.internal.delivery.execution.ExecutionResult.Failure
 import io.embrace.android.embracesdk.internal.delivery.execution.ExecutionResult.Incomplete
 import io.embrace.android.embracesdk.internal.delivery.scheduling.SchedulingServiceImpl.Companion.INITIAL_DELAY_MS
+import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.payload.Envelope
 import io.embrace.android.embracesdk.internal.payload.Log
 import io.embrace.android.embracesdk.internal.payload.LogPayload
@@ -765,6 +766,47 @@ internal class SchedulingServiceImplTest {
         assertEquals(7, executionService.sendAttempts())
     }
 
+    @Test
+    fun `a payload larger than the maximum upload size is dropped without a request`() {
+        resetToSingleSessionPartPayload()
+        useMaxPayloadBytes(storedSizeOf(fakeSessionStoredTelemetryMetadata) - 1)
+        waitForResurrectionAndDeliveryAttempt()
+
+        assertEquals(0, executionService.sendAttempts())
+        assertEquals(0, storageService.storedPayloadCount())
+        assertEquals(1, logger.internalErrorMessages.size)
+        assertEquals(
+            InternalErrorType.PayloadDeliveryFail.toString(),
+            logger.internalErrorMessages.single().msg,
+        )
+    }
+
+    @Test
+    fun `a payload exactly at the maximum upload size is sent`() {
+        resetToSingleSessionPartPayload()
+        useMaxPayloadBytes(storedSizeOf(fakeSessionStoredTelemetryMetadata))
+        waitForResurrectionAndDeliveryAttempt()
+
+        assertEquals(1, executionService.sendAttempts())
+        assertEquals(0, storageService.storedPayloadCount())
+        assertTrue(logger.internalErrorMessages.isEmpty())
+    }
+
+    @Test
+    fun `an oversized payload does not block later payloads of the same type`() {
+        storageService.clearStorage()
+        val oversized = Envelope(data = SessionPartPayload(spans = List(50) { Span(name = "padding-span-" + it) }))
+        val deliverable = Envelope(data = SessionPartPayload(spans = listOf(Span(name = "s"))))
+        storageService.addPayload(fakeSessionStoredTelemetryMetadata, oversized)
+        storageService.addPayload(fakeSessionStoredTelemetryMetadata2, deliverable)
+        useMaxPayloadBytes(storedSizeOf(fakeSessionStoredTelemetryMetadata2))
+        waitForResurrectionAndDeliveryAttempt(2)
+
+        assertEquals(1, executionService.sendAttempts())
+        assertEquals(deliverable, executionService.getRequests<SessionPartPayload>().single())
+        assertEquals(0, storageService.storedPayloadCount())
+    }
+
     @Test(expected = RejectedExecutionException::class)
     fun `test shutdown`() {
         logger.throwOnInternalError = false
@@ -875,6 +917,26 @@ internal class SchedulingServiceImplTest {
     private fun resetToSingleSessionPartPayload() {
         storageService.clearStorage()
         storageService.addFakePayload(fakeSessionStoredTelemetryMetadata)
+    }
+
+    private fun storedSizeOf(metadata: StoredTelemetryMetadata): Long =
+        storageService.payloadSizeBytes(metadata)
+
+    private fun useMaxPayloadBytes(maxPayloadBytes: Long) {
+        logger.throwOnInternalError = false
+        networkConnectivityService.removeNetworkConnectivityListener(schedulingService)
+        schedulingService = SchedulingServiceImpl(
+            storageService = storageService,
+            executionService = executionService,
+            schedulingWorker = BackgroundWorker(schedulingExecutor),
+            deliveryWorker = BackgroundWorker(deliveryExecutor),
+            clock = clock,
+            logger = logger,
+            maxPayloadBytes = maxPayloadBytes,
+        )
+        networkConnectivityService.addNetworkConnectivityListener(schedulingService)
+        networkUpdateDispatchExecutor.awaitExecutionCompletion()
+        schedulingExecutor.awaitExecutionCompletion()
     }
 
     private fun allSendsSucceed() = setExecutionResult(ExecutionResult.Success)

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/PayloadStorageServiceImplTest.kt
@@ -72,6 +72,27 @@ class PayloadStorageServiceImplTest {
     }
 
     @Test
+    fun `payload size reports the gzipped bytes on disk`() {
+        val fileContents = "test".repeat(1000)
+        service.store(metadata) {
+            it.write(fileContents.toByteArray())
+        }
+        val file = outputDir.listFiles()?.single() ?: error("File not found")
+
+        val observed = service.payloadSizeBytes(metadata)
+        assertEquals(file.length(), observed)
+
+        // the payload is persisted gzipped, so the size reported is the compressed size
+        assertTrue(observed < fileContents.toByteArray().size)
+    }
+
+    @Test
+    fun `payload size is zero for a non existent file`() {
+        assertEquals(0L, service.payloadSizeBytes(metadata))
+        assertTrue(logger.internalErrorMessages.isEmpty())
+    }
+
+    @Test
     fun `delete non existent file`() {
         service.delete(metadata) // no exception thrown
         assertTrue(checkNotNull(outputDir.listFiles()).isEmpty())

--- a/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageService.kt
+++ b/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageService.kt
@@ -24,6 +24,12 @@ interface FileStorageService {
     fun loadPayloadAsStream(metadata: StoredTelemetryMetadata): InputStream?
 
     /**
+     * The number of bytes the payload occupies on disk, or 0 if it is not stored or its size
+     * could not be read.
+     */
+    fun payloadSizeBytes(metadata: StoredTelemetryMetadata): Long
+
+    /**
      * Return stored payloads as a list sorted in priority order
      */
     fun getStoredPayloads(): List<StoredTelemetryMetadata>

--- a/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImpl.kt
+++ b/embrace-android-telemetry-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImpl.kt
@@ -95,6 +95,9 @@ class FileStorageServiceImpl(
         }
     }
 
+    override fun payloadSizeBytes(metadata: StoredTelemetryMetadata): Long =
+        runCatching { index.fileFor(metadata).length() }.getOrDefault(0L)
+
     override fun getStoredPayloads(): List<StoredTelemetryMetadata> = index.storedEntries()
 }
 

--- a/embrace-android-telemetry-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImplTest.kt
+++ b/embrace-android-telemetry-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/storage/FileStorageServiceImplTest.kt
@@ -65,6 +65,21 @@ class FileStorageServiceImplTest {
     }
 
     @Test
+    fun `payload size reports the bytes on disk`() {
+        storeDummyFile(fakeSessionStoredTelemetryMetadata)
+        assertEquals(
+            DUMMY_CONTENT.toByteArray().size.toLong(),
+            service.payloadSizeBytes(fakeSessionStoredTelemetryMetadata),
+        )
+    }
+
+    @Test
+    fun `payload size is zero for a payload that was never stored`() {
+        assertEquals(0L, service.payloadSizeBytes(fakeSessionStoredTelemetryMetadata))
+        assertTrue(logger.internalErrorMessages.isEmpty())
+    }
+
+    @Test
     fun `load payload stream no file`() {
         assertNull(service.loadPayloadAsStream(fakeSessionStoredTelemetryMetadata))
         assertTrue(logger.internalErrorMessages.isEmpty())


### PR DESCRIPTION
## Goal

Drops any JSON payload file that has exceeded a backstop limit, to prevent memory exhaustion. This limit is set high and is unlikely to be met in practice.

## Testing

Added unit tests.
