### PR TITLE
Avoid reporting unnecessary internal error

### DIFF
--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionService.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionService.kt
@@ -137,7 +137,7 @@ class SessionReconstructionService(
             val dedupedSpans = keepLatestPerSpanId(spans)
             val dedupedSnapshots = keepLatestPerSpanId(remainingSnapshots)
 
-            val duplicates = (spans.size - dedupedSpans.size) + (spanSnapshots.size - dedupedSnapshots.size)
+            val duplicates = (spans.size - dedupedSpans.size) + (remainingSnapshots.size - dedupedSnapshots.size)
             if (duplicates > 0) {
                 logger.trackInternalError(
                     InternalErrorType.DuplicateSpanIds,

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceDedupeTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionServiceDedupeTest.kt
@@ -92,7 +92,7 @@ internal class SessionReconstructionServiceDedupeTest {
         val payload = checkNotNull(service.reconstruct(partDirectory)?.data)
         assertEquals(listOf(earlySpan, fullyPopulatedSpan), payload.spans)
         assertEquals(emptyList<Span>(), payload.spanSnapshots)
-        assertDuplicatesTracked()
+        assertNoInternalErrors()
     }
 
     @Test
@@ -102,7 +102,7 @@ internal class SessionReconstructionServiceDedupeTest {
         val payload = checkNotNull(service.reconstruct(partDirectory)?.data)
         assertEquals(listOf(earlySpan, fullyPopulatedSpan), payload.spans)
         assertEquals(emptyList<Span>(), payload.spanSnapshots)
-        assertDuplicatesTracked()
+        assertNoInternalErrors()
     }
 
     @Test
@@ -119,6 +119,18 @@ internal class SessionReconstructionServiceDedupeTest {
 
         assertEquals(listOf(lateSpan), service.reconstruct(partDirectory)?.data?.spanSnapshots)
         assertDuplicatesTracked()
+    }
+
+    @Test
+    fun `a snapshot superseded by a completed span is not reported as a duplicate`() {
+        write(
+            spans = listOf(earlySpanProto, otherSpanProto),
+            snapshots = listOf(inFlightSpan, otherSnapshot),
+        )
+        val payload = checkNotNull(service.reconstruct(partDirectory)?.data)
+        assertEquals(listOf(earlySpan, otherSpan, fullyPopulatedSpan), payload.spans)
+        assertEquals(listOf(otherSnapshot), payload.spanSnapshots)
+        assertNoInternalErrors()
     }
 
     @Test


### PR DESCRIPTION
## Goal

Avoids reporting an unnecessary internal error when a span snapshot is superseded by a completed span.