### PR TITLE
Remove unnecessary lock

### DIFF
--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansWriter.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansWriter.kt
@@ -23,8 +23,6 @@ class CompletedSpansWriter(
     private val maxBytes: Long = MAX_PART_FILE_BYTES,
 ) {
 
-    private val lock = Any()
-
     @Volatile
     private var reportedOverflow = false
 
@@ -34,13 +32,11 @@ class CompletedSpansWriter(
      * reads back as no completed spans.
      */
     fun write(spans: List<Span>): Boolean = SystemTrace.trace("mf-write-completed-spans") {
-        synchronized(lock) {
-            try {
-                writeImpl(spans)
-            } catch (exc: Throwable) {
-                trackFailure(exc)
-                false
-            }
+        try {
+            writeImpl(spans)
+        } catch (exc: Throwable) {
+            trackFailure(exc)
+            false
         }
     }
 

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionMetadataWriter.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionMetadataWriter.kt
@@ -19,19 +19,15 @@ class SessionMetadataWriter(
     private val logger: InternalLogger,
 ) {
 
-    private val lock = Any()
-
     /**
      * Writes the metadata for the active session part, replacing any metadata already on disk.
      */
     fun write(): Boolean = SystemTrace.trace("mf-write-metadata") {
-        synchronized(lock) {
-            try {
-                writeImpl()
-            } catch (exc: Throwable) {
-                trackFailure(exc)
-                false
-            }
+        try {
+            writeImpl()
+        } catch (exc: Throwable) {
+            trackFailure(exc)
+            false
         }
     }
 

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionSpanWriter.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionSpanWriter.kt
@@ -13,16 +13,12 @@ class SessionSpanWriter(
     private val logger: InternalLogger,
 ) {
 
-    private val lock = Any()
-
     fun write(span: Span): Boolean = SystemTrace.trace("mf-write-session-span") {
-        synchronized(lock) {
-            try {
-                writeImpl(span)
-            } catch (exc: Throwable) {
-                trackFailure(exc)
-                false
-            }
+        try {
+            writeImpl(span)
+        } catch (exc: Throwable) {
+            trackFailure(exc)
+            false
         }
     }
 

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SpanSnapshotsWriter.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SpanSnapshotsWriter.kt
@@ -17,19 +17,15 @@ class SpanSnapshotsWriter(
     private val logger: InternalLogger,
 ) {
 
-    private val lock = Any()
-
     /**
      * Writes the in-flight spans for the active session part, replacing any already on disk.
      */
     fun write(spans: List<Span>): Boolean = SystemTrace.trace("mf-write-span-snapshots") {
-        synchronized(lock) {
-            try {
-                writeImpl(spans)
-            } catch (exc: Throwable) {
-                trackFailure(exc)
-                false
-            }
+        try {
+            writeImpl(spans)
+        } catch (exc: Throwable) {
+            trackFailure(exc)
+            false
         }
     }
 

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansWriterTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansWriterTest.kt
@@ -13,7 +13,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
-import java.util.concurrent.CountDownLatch
 
 internal class CompletedSpansWriterTest {
 
@@ -209,32 +208,6 @@ internal class CompletedSpansWriterTest {
         assertFalse(writer.write(listOf(Span(attributes = ExplodingList()))))
         assertEquals(listOf(fullyPopulatedSpanProto), readLog())
         assertWriteFailureTracked()
-    }
-
-    @Test
-    fun `concurrent appends log every span exactly once`() {
-        val threadCount = 8
-        val writesPerThread = 25
-
-        val latch = CountDownLatch(1)
-        val threads = (0 until threadCount).map { thread ->
-            Thread {
-                latch.await()
-                repeat(writesPerThread) { attempt ->
-                    writer.write(listOf(span("aaaaaaaaaaaa$thread$attempt", name = "span-$thread-$attempt")))
-                }
-            }
-        }
-        threads.forEach(Thread::start)
-        latch.countDown()
-        threads.forEach(Thread::join)
-
-        val expected = (0 until threadCount).flatMap { thread ->
-            (0 until writesPerThread).map { attempt -> "span-$thread-$attempt" }
-        }
-        assertEquals(expected.sorted(), readLog().map { it.name }.sorted())
-        assertEquals(listOf(COMPLETED_SPANS_FILE_NAME), partDir().list()?.toList())
-        assertNoInternalErrors()
     }
 
     @Test

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionMetadataWriterTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionMetadataWriterTest.kt
@@ -12,7 +12,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
-import java.util.concurrent.CountDownLatch
 
 internal class SessionMetadataWriterTest {
 
@@ -297,32 +296,6 @@ internal class SessionMetadataWriterTest {
         assertEquals(fullyPopulatedMetadataProto, readMetadata())
         assertEquals(listOf(METADATA_FILE_NAME), partDir().list()?.toList())
         assertWriteFailureTracked()
-    }
-
-    @Test
-    fun `concurrent user info changes leave one valid metadata file`() {
-        val threadCount = 8
-        val writesPerThread = 25
-        write()
-
-        val userIds = (0 until threadCount).map { "userId$it" }
-        val latch = CountDownLatch(1)
-        val threads = userIds.map { userId ->
-            Thread {
-                latch.await()
-                repeat(writesPerThread) {
-                    metadataProvider = { fullyPopulatedMetadata.copy(userId = userId) }
-                    writer.write()
-                }
-            }
-        }
-        threads.forEach(Thread::start)
-        latch.countDown()
-        threads.forEach(Thread::join)
-
-        assertTrue(readMetadata().user_id in userIds)
-        assertEquals(listOf(METADATA_FILE_NAME), partDir().list()?.toList())
-        assertNoInternalErrors()
     }
 
     private fun target(source: () -> SessionPartDirectory?): SessionPartWriteTarget =

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionSpanWriterTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionSpanWriterTest.kt
@@ -11,7 +11,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
-import java.util.concurrent.CountDownLatch
 
 internal class SessionSpanWriterTest {
 
@@ -205,31 +204,6 @@ internal class SessionSpanWriterTest {
         assertEquals(fullyPopulatedSessionSpanProto, readSessionSpan())
         assertEquals(listOf(SESSION_SPAN_FILE_NAME), partDir().list()?.toList())
         assertWriteFailureTracked()
-    }
-
-    @Test
-    fun `concurrent session span writes leave one valid file`() {
-        val threadCount = 8
-        val writesPerThread = 25
-        write()
-
-        val spanIds = (0 until threadCount).map { "aaaaaaaaaaaaaaa$it" }
-        val latch = CountDownLatch(1)
-        val threads = spanIds.map { spanId ->
-            Thread {
-                latch.await()
-                repeat(writesPerThread) {
-                    writer.write(fullyPopulatedSpan.copy(spanId = spanId))
-                }
-            }
-        }
-        threads.forEach(Thread::start)
-        latch.countDown()
-        threads.forEach(Thread::join)
-
-        assertTrue(checkNotNull(readSessionSpan().span).span_id in spanIds)
-        assertEquals(listOf(SESSION_SPAN_FILE_NAME), partDir().list()?.toList())
-        assertNoInternalErrors()
     }
 
     private fun target(source: () -> SessionPartDirectory?): SessionPartWriteTarget =

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SpanSnapshotsWriterTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SpanSnapshotsWriterTest.kt
@@ -12,7 +12,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
-import java.util.concurrent.CountDownLatch
 
 internal class SpanSnapshotsWriterTest {
 
@@ -243,31 +242,6 @@ internal class SpanSnapshotsWriterTest {
         assertEquals(fullyPopulatedSpanSnapshotsProto, readSnapshots())
         assertEquals(listOf(SPAN_SNAPSHOTS_FILE_NAME), partDir().list()?.toList())
         assertWriteFailureTracked()
-    }
-
-    @Test
-    fun `concurrent span snapshot writes leave one valid file`() {
-        val threadCount = 8
-        val writesPerThread = 25
-        write()
-
-        val spanIds = (0 until threadCount).map { "aaaaaaaaaaaaaaa$it" }
-        val latch = CountDownLatch(1)
-        val threads = spanIds.map { spanId ->
-            Thread {
-                latch.await()
-                repeat(writesPerThread) {
-                    writer.write(listOf(fullyPopulatedSpan.copy(spanId = spanId)))
-                }
-            }
-        }
-        threads.forEach(Thread::start)
-        latch.countDown()
-        threads.forEach(Thread::join)
-
-        assertTrue(readSnapshots().spans.single().span_id in spanIds)
-        assertEquals(listOf(SPAN_SNAPSHOTS_FILE_NAME), partDir().list()?.toList())
-        assertNoInternalErrors()
     }
 
     private fun target(source: () -> SessionPartDirectory?): SessionPartWriteTarget =


### PR DESCRIPTION
## Goal

Removes unnecessary locks as the writes now all happen on a single-threaded executor.
