### PR TITLE
Drain spans on load

### DIFF
--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/DecodedSpans.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/DecodedSpans.kt
@@ -1,10 +1,28 @@
 package io.embrace.android.embracesdk.internal.session.persistence
 
+import io.embrace.android.embracesdk.internal.payload.Span
+
 /**
  * The spans read back from a completed spans file, including the first exception (if any) found when decoding
  */
 internal class DecodedSpans(
-    val spans: List<SpanProto>,
+    private val decoded: MutableList<SpanProto>,
     val corruption: Throwable?,
     val spanLimitReached: Boolean = false,
-)
+) {
+
+    val spans: List<SpanProto> get() = decoded
+
+    /**
+     * Maps every decoded span to its payload form, releasing each proto as it is mapped so that a
+     * whole log is never held in both representations at once. [spans] is left empty.
+     */
+    fun drainToPayload(): List<Span> {
+        val payload = ArrayList<Span>(decoded.size)
+        while (decoded.isNotEmpty()) {
+            payload.add(decoded.removeAt(decoded.lastIndex).toPayload())
+        }
+        payload.reverse()
+        return payload
+    }
+}

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionService.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionReconstructionService.kt
@@ -183,7 +183,7 @@ class SessionReconstructionService(
                 }
                 decoded.corruption?.let(::trackFailure)
                 budget.spend(decoded.spans.size, truncated = decoded.spanLimitReached)
-                SystemTrace.trace("mf-spans-proto-to-payload") { decoded.spans.map(SpanProto::toPayload) }
+                SystemTrace.trace("mf-spans-proto-to-payload") { decoded.drainToPayload() }
             } catch (exc: Throwable) {
                 trackFailure(exc)
                 null


### PR DESCRIPTION
## Goal

Drain spans when reading them back from persisted data so that they're only held in memory once, rather than twice per object layer.
