### PR TITLE
Delete session part directory on successful store

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/SessionPartReader.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/resurrection/SessionPartReader.kt
@@ -22,7 +22,7 @@ import io.embrace.android.embracesdk.semconv.EmbSessionAttributes
 /**
  * Reads any session parts that were persisted on disk by the multi-file persistence layer,
  * reconstructs each one into an envelope, and hands it to the [IntakeService] for delivery. A
- * session part is deleted once intake has accepted it.
+ * session part is deleted once intake has stored it.
  */
 class SessionPartReader(
     private val directoryStore: SessionPartDirectoryStore,
@@ -60,18 +60,22 @@ class SessionPartReader(
     }
 
     /**
-     * Hands the session part's telemetry to the intake service, then removes it from disk. Session
-     * parts that cannot be reconstructed are deleted rather than retried.
+     * Hands the session part's telemetry to the intake service, and removes it from disk once intake
+     * has stored it. A part that intake drops or fails to store is left alone so that the next launch
+     * can retry it, as this is the only copy of the telemetry. Session parts that cannot be
+     * reconstructed are deleted rather than retried.
      */
     private fun deliver(directory: SessionPartDirectory) {
         val envelope = reconstructionService.reconstruct(directory)
-        if (envelope != null) {
-            intakeService.take(
-                intake = envelope,
-                metadata = directory.createMetadata(envelope),
-            )
+        if (envelope == null) {
+            directoryStore.delete(directory)
+            return
         }
-        directoryStore.delete(directory)
+        intakeService.take(
+            intake = envelope,
+            metadata = directory.createMetadata(envelope),
+            onStored = { directoryStore.delete(directory) },
+        )
     }
 
     private fun SessionPartDirectory.createMetadata(

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/PayloadResurrectionServiceImplTest.kt
@@ -799,6 +799,7 @@ class PayloadResurrectionServiceImplTest {
                 intake: Envelope<*>,
                 metadata: StoredTelemetryMetadata,
                 staleEntry: StoredTelemetryMetadata?,
+                onStored: (() -> Unit)?,
             ): Future<*> {
                 return object : Future<Unit> {
                     override fun cancel(mayInterruptIfRunning: Boolean) = false

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/SessionPartReaderTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/resurrection/SessionPartReaderTest.kt
@@ -168,6 +168,19 @@ internal class SessionPartReaderTest {
     }
 
     @Test
+    fun `a session part that intake does not store is left on disk`() {
+        persist(partDirectory)
+        intakeService.storeSucceeds = false
+
+        createReader().readPersistedSessionParts()
+
+        // the part reached intake but wasn't stored, so the only copy of the telemetry is retained
+        assertEquals(partDirectory.sessionPartId, intakeService.intakeList.single().metadata.sessionPartId)
+        assertEquals(setOf(partDirectory), directoryStore.storedDirectories().toSet())
+        assertEquals(setOf(partDirectory.dirName), sessionsDir.list()?.toSet() ?: emptySet<String>())
+    }
+
+    @Test
     fun `reading persisted session parts is a no-op when there is nothing on disk`() {
         createReader().readPersistedSessionParts()
 

--- a/embrace-android-delivery-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeIntakeService.kt
+++ b/embrace-android-delivery-fakes/src/main/kotlin/io/embrace/android/embracesdk/fakes/FakeIntakeService.kt
@@ -12,6 +12,12 @@ class FakeIntakeService : IntakeService {
     var intakeList: MutableList<FakePayloadIntake<*>> = mutableListOf()
     var cacheList: MutableList<FakePayloadIntake<*>> = mutableListOf()
 
+    /**
+     * Whether an intake is treated as stored. Set to false to simulate a payload that the intake
+     * service dropped or failed to persist, in which case the onStored callback is not invoked.
+     */
+    var storeSucceeds: Boolean = true
+
     @Suppress("UNCHECKED_CAST")
     inline fun <reified T : Any> getIntakes(complete: Boolean = true): List<FakePayloadIntake<T>> {
         val dst = when (complete) {
@@ -25,12 +31,20 @@ class FakeIntakeService : IntakeService {
         shutdownCount++
     }
 
-    override fun take(intake: Envelope<*>, metadata: StoredTelemetryMetadata, staleEntry: StoredTelemetryMetadata?): Future<*> {
+    override fun take(
+        intake: Envelope<*>,
+        metadata: StoredTelemetryMetadata,
+        staleEntry: StoredTelemetryMetadata?,
+        onStored: (() -> Unit)?,
+    ): Future<*> {
         val dst = when (metadata.complete) {
             true -> intakeList
             false -> cacheList
         }
         dst.add(FakePayloadIntake(intake, metadata))
+        if (storeSucceeds) {
+            onStored?.invoke()
+        }
         return fakeFuture
     }
 

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeService.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeService.kt
@@ -21,10 +21,15 @@ interface IntakeService : Shutdownable {
      * Stores the payload [intake] on disk as its JSON representation and associate it in the storage layer with [metadata].
      *
      * If [staleEntry] is non-null, the payload associated with it will be deleted once the new payload is successfully stored.
+     *
+     * [onStored] is invoked once [intake] has been written to disk, which typically happens on a worker thread. It is not invoked
+     * if the payload was dropped or could not be stored, so a caller that holds the only other copy of the telemetry can use it to
+     * find out when discarding that copy is safe.
      */
     fun take(
         intake: Envelope<*>,
         metadata: StoredTelemetryMetadata,
         staleEntry: StoredTelemetryMetadata? = null,
+        onStored: (() -> Unit)? = null,
     ): Future<*>
 }

--- a/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImpl.kt
+++ b/embrace-android-delivery/src/main/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImpl.kt
@@ -56,6 +56,7 @@ class IntakeServiceImpl(
         intake: Envelope<*>,
         metadata: StoredTelemetryMetadata,
         staleEntry: StoredTelemetryMetadata?,
+        onStored: (() -> Unit)?,
     ): Future<*> {
         deliveryTracer?.onTake(metadata)
 
@@ -66,7 +67,7 @@ class IntakeServiceImpl(
                 // non-blocking shutdown: reject subsequent submissions but defer the drain to
                 // payloadStore.handleCrash's later intakeService.shutdown() call
                 worker.shutdownAndWait(0)
-                processIntake(intake, metadata, staleEntry)
+                processIntake(intake, metadata, staleEntry, onStored)
                 return immediateFuture()
             }
             return immediateFuture()
@@ -75,7 +76,7 @@ class IntakeServiceImpl(
         // The worker is shut down once a crash is detected, so anything arriving before the service is sealed must be persisted
         // synchronously (like resurrected session parts) or be unrecoverably loss.
         if (state.get() == State.CRASH_RECEIVED) {
-            processIntake(intake, metadata, staleEntry)
+            processIntake(intake, metadata, staleEntry, onStored)
             // Only seal the service if the payload is the crashing session's last session part, after which we take in no more
             // telemetry and let the process die.
             if (metadata.isCrashingPartForCurrentProcess()) {
@@ -93,6 +94,7 @@ class IntakeServiceImpl(
                 intake = intake,
                 metadata = metadata,
                 staleEntry = staleEntry,
+                onStored = onStored,
             )
         }
 
@@ -112,6 +114,7 @@ class IntakeServiceImpl(
         intake: Envelope<*>,
         metadata: StoredTelemetryMetadata,
         staleEntry: StoredTelemetryMetadata?,
+        onStored: (() -> Unit)?,
     ) {
         try {
             val service = when {
@@ -131,6 +134,9 @@ class IntakeServiceImpl(
                     }
                 }
             }
+
+            // the payload is now on disk, so any other copy the caller holds is safe to discard
+            onStored?.invoke()
 
             /**
              * Determine which cache entry to clean up:

--- a/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImplTest.kt
+++ b/embrace-android-delivery/src/test/kotlin/io/embrace/android/embracesdk/internal/delivery/intake/IntakeServiceImplTest.kt
@@ -13,6 +13,7 @@ import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.BLO
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.CRASH
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.LOG
 import io.embrace.android.embracesdk.internal.delivery.SupportedEnvelopeType.SESSION
+import io.embrace.android.embracesdk.internal.delivery.storage.PayloadStorageServiceImpl
 import io.embrace.android.embracesdk.internal.delivery.storedTelemetryRunnableComparator
 import io.embrace.android.embracesdk.internal.logging.InternalErrorType
 import io.embrace.android.embracesdk.internal.payload.Envelope
@@ -32,10 +33,12 @@ import org.junit.Before
 import org.junit.Test
 import java.io.ByteArrayOutputStream
 import java.io.IOException
+import java.nio.file.Files
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
+import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
 
 class IntakeServiceImplTest {
@@ -55,6 +58,9 @@ class IntakeServiceImplTest {
     private val serializer = TestPlatformSerializer()
     private val sessionEnvelope = Envelope(
         data = SessionPartPayload(spans = listOf(Span(name = "session-span"))),
+    )
+    private val replacementSessionEnvelope = Envelope(
+        data = SessionPartPayload(spans = listOf(Span(name = "replacement-session-span"))),
     )
     private val logEnvelope = Envelope(
         data = LogPayload(logs = listOf(Log(body = "Log data"))),
@@ -787,6 +793,93 @@ class IntakeServiceImplTest {
         assertEquals(1, cacheStorageService.storedPayloadCount())
         assertFalse(f2.isCancelled)
         assertTrue(f2.isDone)
+    }
+
+    @Test
+    fun `onStored is invoked once the payload has been written to disk`() {
+        var storedCount = 0
+        intakeService.take(sessionEnvelope, sessionMetadata, onStored = { storedCount++ })
+
+        // the store is queued on the worker, so nothing is on disk yet
+        assertEquals(0, storedCount)
+
+        executorService.runCurrentlyBlocked()
+        assertEquals(1, payloadStorageService.storedPayloadCount())
+        assertEquals(1, storedCount)
+    }
+
+    @Test
+    fun `onStored is not invoked when the payload fails to store`() {
+        payloadStorageService.failStorage = true
+        var storedCount = 0
+        intakeService.take(sessionEnvelope, sessionMetadata, onStored = { storedCount++ })
+        executorService.runCurrentlyBlocked()
+
+        assertEquals(0, payloadStorageService.storedPayloadCount())
+        assertEquals(0, storedCount)
+        assertTrue(logger.internalErrorMessages.single().throwable is IOException)
+    }
+
+    @Test
+    fun `onStored is not invoked when the payload is dropped after sealing`() {
+        // a crash in the current process seals the intake service once its session part arrives
+        val jvmCrashMetadata = StoredTelemetryMetadata(
+            timestamp = clock.tick(),
+            uuid = "crash-uuid",
+            processIdentifier = PROCESS_ID,
+            envelopeType = CRASH,
+            complete = true,
+            payloadType = PayloadType.JVM_CRASH,
+        )
+        intakeService.take(logEnvelope, jvmCrashMetadata)
+        intakeService.take(sessionEnvelope, sessionMetadata)
+        assertEquals(2, payloadStorageService.storedPayloadCount())
+
+        var storedCount = 0
+        intakeService.take(
+            intake = sessionEnvelope,
+            metadata = sessionMetadata2,
+            onStored = { storedCount++ },
+        )
+
+        // the payload was dropped, so the caller is not told to discard its own copy
+        assertEquals(2, payloadStorageService.storedPayloadCount())
+        assertEquals(0, storedCount)
+    }
+
+    @Test
+    fun `taking a payload whose filename already exists overwrites the stored file`() {
+        val outputDir = Files.createTempDirectory("intake").toFile().apply { deleteRecursively() }
+        val fileStorageService = PayloadStorageServiceImpl(
+            outputDir = lazy { outputDir },
+            worker = PriorityWorker(BlockableExecutorService(blockingMode = false)),
+            processIdProvider = { PROCESS_ID },
+            logger = logger,
+            clock = clock,
+        )
+        intakeService = IntakeServiceImpl(
+            schedulingService,
+            fileStorageService,
+            cacheStorageService,
+            logger,
+            serializer,
+            PriorityWorker(executorService),
+        )
+
+        var storedCount = 0
+        intakeService.take(sessionEnvelope, sessionMetadata, onStored = { storedCount++ })
+        intakeService.take(replacementSessionEnvelope, sessionMetadata, onStored = { storedCount++ })
+        executorService.runCurrentlyBlocked()
+
+        val file = outputDir.listFiles()?.single() ?: error("File not found")
+        assertEquals(sessionMetadata.filename, file.name)
+        val observed = serializer.fromJson(GZIPInputStream(file.inputStream()), Envelope.sessionEnvelopeSerializer)
+        assertEquals("replacement-session-span", observed.data?.spans?.single()?.name)
+
+        assertEquals(2, storedCount)
+        assertEquals(listOf(sessionMetadata), fileStorageService.getPayloadsByPriority())
+        assertEquals(2, schedulingService.payloadIntakeCount)
+        assertTrue(logger.internalErrorMessages.isEmpty())
     }
 
     private fun assertIntakeRejected(envelope: Envelope<*>, metadata: StoredTelemetryMetadata) {


### PR DESCRIPTION
## Goal

Delete the session part directory when the `IntakeService` has successfully stored the envelope, to avoid potential data loss.

## Testing

Added unit tests.
