### PR TITLE
Avoid permanently delaying debounced task

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/CoalescingWriteQueue.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/CoalescingWriteQueue.kt
@@ -1,5 +1,6 @@
 package io.embrace.android.embracesdk.internal.session.orchestrator
 
+import io.embrace.android.embracesdk.internal.clock.Clock
 import io.embrace.android.embracesdk.internal.worker.BackgroundWorker
 import java.util.concurrent.Future
 import java.util.concurrent.FutureTask
@@ -12,14 +13,19 @@ import java.util.concurrent.atomic.AtomicReference
  * write that is superseded before it runs can be dropped. The intent behind this class
  * is that a burst of changes typically only cost one write, rather than one per change.
  *
- * A write is held as a [FutureTask] armed with a scheduled trigger that runs it
- * [delayMs] later. Cancelling that trigger does not cancel the [FutureTask] it wraps. This
- * lets [flush] force the task to run early rather than queueing the work twice.
+ * A write is held as a [FutureTask] armed with a scheduled trigger. Cancelling that trigger does
+ * not cancel the [FutureTask] it wraps. This lets [flush] force the task to run early rather than
+ * queueing the work twice.
+ *
+ * The wait is bounded: a write inherits the deadline of the armed write it supersedes, so a run of
+ * changes that never pauses for [delayMs] still reaches disk [delayMs] after the run started. The
+ * newest write always wins, it just cannot postpone the deadline set by the one before it.
  *
  * The first write submitted to a queue is not debounced.
  */
 internal class CoalescingWriteQueue(
     private val worker: BackgroundWorker,
+    private val clock: Clock,
     private val delayMs: Long,
 ) {
     private val pending = AtomicReference<PendingWrite?>(null)
@@ -31,16 +37,17 @@ internal class CoalescingWriteQueue(
     private val sequence = AtomicLong()
 
     /**
-     * Arms [runnable] to run once the delay from [delayFor] has elapsed, disarming whatever was
+     * Arms [runnable] to run once the delay from [deadlineFor] has elapsed, disarming whatever was
      * armed before it. In-progress writes are left to finish.
      */
     fun submit(runnable: Runnable) {
         val seq = sequence.incrementAndGet()
         val task = FutureTask(runnable, Unit)
+        val deadline = deadlineFor(seq)
         val trigger = runCatching {
-            worker.schedule<Unit>(task, delayFor(seq), TimeUnit.MILLISECONDS)
+            worker.schedule<Unit>(task, delayUntil(deadline), TimeUnit.MILLISECONDS)
         }.getOrNull()
-        val write = PendingWrite(seq, task, trigger)
+        val write = PendingWrite(seq, deadline, task, trigger)
 
         while (true) {
             val previous = pending.get()
@@ -67,13 +74,25 @@ internal class CoalescingWriteQueue(
     }
 
     /**
-     * How long the write numbered [seq] waits before it runs. The very first write for a session
-     * part is not debounced. All other writes wait for [delayMs].
+     * When the write numbered [seq] should run. The very first write for a session part is not
+     * debounced. A write that supersedes one which is still armed takes over its deadline, so that
+     * an unbroken run of changes cannot hold the file back indefinitely. Any other write waits for
+     * [delayMs].
      */
-    private fun delayFor(seq: Long): Long = if (seq == FIRST_WRITE_SEQ) NO_DELAY_MS else delayMs
+    private fun deadlineFor(seq: Long): Long {
+        val now = clock.now()
+        if (seq == FIRST_WRITE_SEQ) {
+            return now
+        }
+        val armed = pending.get()?.takeUnless { it.task.isDone }
+        return armed?.deadline ?: (now + delayMs)
+    }
+
+    private fun delayUntil(deadline: Long): Long = (deadline - clock.now()).coerceAtLeast(NO_DELAY_MS)
 
     private class PendingWrite(
         val seq: Long,
+        val deadline: Long,
         val task: FutureTask<Unit>,
         val trigger: Future<*>?,
     )

--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -378,9 +378,9 @@ class SessionPartWriterImpl(
         val completedSpans = CompletedSpansWriter(target, logger)
         val spanSnapshots = SpanSnapshotsWriter(target, logger)
 
-        val metadataWrites = CoalescingWriteQueue(worker, METADATA_WRITE_DELAY_MS)
-        val sessionSpanWrites = CoalescingWriteQueue(worker, SESSION_SPAN_WRITE_DELAY_MS)
-        val spanSnapshotWrites = CoalescingWriteQueue(worker, SPAN_SNAPSHOT_WRITE_DELAY_MS)
+        val metadataWrites = CoalescingWriteQueue(worker, clock, METADATA_WRITE_DELAY_MS)
+        val sessionSpanWrites = CoalescingWriteQueue(worker, clock, SESSION_SPAN_WRITE_DELAY_MS)
+        val spanSnapshotWrites = CoalescingWriteQueue(worker, clock, SPAN_SNAPSHOT_WRITE_DELAY_MS)
 
         private val writeQueues = listOf(metadataWrites, sessionSpanWrites, spanSnapshotWrites)
 

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/CoalescingWriteQueueTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/CoalescingWriteQueueTest.kt
@@ -16,6 +16,7 @@ internal class CoalescingWriteQueueTest {
         private const val DELAY_MS = 5000L
     }
 
+    private lateinit var clock: FakeClock
     private lateinit var executor: BlockingScheduledExecutorService
     private lateinit var queue: CoalescingWriteQueue
 
@@ -34,8 +35,9 @@ internal class CoalescingWriteQueueTest {
 
     @Before
     fun setUp() {
-        executor = BlockingScheduledExecutorService(FakeClock(), blockingMode = false)
-        queue = CoalescingWriteQueue(BackgroundWorker(executor), DELAY_MS)
+        clock = FakeClock()
+        executor = BlockingScheduledExecutorService(clock, blockingMode = false)
+        queue = CoalescingWriteQueue(BackgroundWorker(executor), clock, DELAY_MS)
         writes.clear()
     }
 
@@ -59,8 +61,9 @@ internal class CoalescingWriteQueueTest {
 
     @Test
     fun `the first write is queued on the worker rather than run inline`() {
-        val blockedExecutor = BlockingScheduledExecutorService(FakeClock(), blockingMode = true)
-        val blockedQueue = CoalescingWriteQueue(BackgroundWorker(blockedExecutor), DELAY_MS)
+        val blockedClock = FakeClock()
+        val blockedExecutor = BlockingScheduledExecutorService(blockedClock, blockingMode = true)
+        val blockedQueue = CoalescingWriteQueue(BackgroundWorker(blockedExecutor), blockedClock, DELAY_MS)
 
         blockedQueue.submit(write("first"))
         assertEquals(emptyList<String>(), writes)
@@ -116,6 +119,31 @@ internal class CoalescingWriteQueueTest {
         queue.submit(write("second"))
         executor.moveForwardAndRunBlocked(DELAY_MS)
 
+        assertEquals(listOf("first", "second"), writes)
+    }
+
+    @Test
+    fun `an unbroken run of writes cannot postpone the write past the delay`() {
+        primeQueue()
+        repeat(DELAY_MS.toInt()) { i ->
+            queue.submit(write("write-$i"))
+            executor.moveForwardAndRunBlocked(1)
+        }
+        assertEquals(listOf("write-${DELAY_MS - 1}"), writes)
+    }
+
+    @Test
+    fun `a write submitted once the deadline has passed waits out a fresh delay`() {
+        primeQueue()
+        queue.submit(write("first"))
+        executor.moveForwardAndRunBlocked(DELAY_MS)
+        assertEquals(listOf("first"), writes)
+
+        queue.submit(write("second"))
+        executor.moveForwardAndRunBlocked(DELAY_MS - 1)
+        assertEquals(listOf("first"), writes)
+
+        executor.moveForwardAndRunBlocked(1)
         assertEquals(listOf("first", "second"), writes)
     }
 
@@ -183,8 +211,9 @@ internal class CoalescingWriteQueueTest {
 
     @Test
     fun `flush does not wait for the write to run`() {
-        val blockedExecutor = BlockingScheduledExecutorService(FakeClock(), blockingMode = true)
-        val blockedQueue = CoalescingWriteQueue(BackgroundWorker(blockedExecutor), DELAY_MS)
+        val blockedClock = FakeClock()
+        val blockedExecutor = BlockingScheduledExecutorService(blockedClock, blockingMode = true)
+        val blockedQueue = CoalescingWriteQueue(BackgroundWorker(blockedExecutor), blockedClock, DELAY_MS)
 
         primeQueue(blockedQueue)
         blockedExecutor.runCurrentlyBlocked()
@@ -204,7 +233,7 @@ internal class CoalescingWriteQueueTest {
         val hookedExecutor = ScheduleHookExecutor(executor) {
             checkNotNull(queueRef).submit(write("second"))
         }
-        val reentrantQueue = CoalescingWriteQueue(BackgroundWorker(hookedExecutor), DELAY_MS)
+        val reentrantQueue = CoalescingWriteQueue(BackgroundWorker(hookedExecutor), clock, DELAY_MS)
         queueRef = reentrantQueue
 
         primeQueue(reentrantQueue)

--- a/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
+++ b/embrace-android-core/src/test/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImplTest.kt
@@ -439,6 +439,23 @@ internal class SessionPartWriterImplTest {
     }
 
     @Test
+    fun `an unbroken stream of session span changes still advances the heartbeat`() {
+        executor.blockingMode = false
+        val writer = createWriter()
+        val startedAt = clock.now()
+        writer.onSessionPartStarted(startedAt, USER_SESSION_ID, SESSION_PART_ID)
+        assertEquals(listOf(startedAt.millisToNanos().toString()), heartbeatsOnDisk(SESSION_PART_ID))
+
+        val step = SessionPartWriterImpl.SESSION_SPAN_WRITE_DELAY_MS / 2
+        repeat(4) {
+            writer.onSessionSpanChanged()
+            executor.moveForwardAndRunBlocked(step)
+        }
+        assertEquals(listOf(clock.now().millisToNanos().toString()), heartbeatsOnDisk(SESSION_PART_ID))
+        assertNoInternalErrors()
+    }
+
+    @Test
     fun `a heartbeat already on the session span is replaced rather than duplicated`() {
         sessionSpan.addSystemAttribute(EmbSessionAttributes.EMB_HEARTBEAT_TIME_UNIX_NANO, "1")
         executor.blockingMode = false


### PR DESCRIPTION
## Goal

Avoids permanently delaying debounced task by specifying a delay in the write queue, so that continuous bursts of updates don't stop a task from executing.

## Testing

Added unit tests.
