### PR TITLE
Optimize write for completed spans

### DIFF
--- a/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
+++ b/embrace-android-core/src/main/kotlin/io/embrace/android/embracesdk/internal/session/orchestrator/SessionPartWriterImpl.kt
@@ -132,7 +132,7 @@ class SessionPartWriterImpl(
         writers.flushPendingWrites()
 
         worker.submit {
-            writers.sealed = true
+            writers.seal()
             writeTracker.markComplete(sessionPartId)
 
             if (!crashing && !processTerminating) {
@@ -385,5 +385,14 @@ class SessionPartWriterImpl(
         private val writeQueues = listOf(metadataWrites, sessionSpanWrites, spanSnapshotWrites)
 
         fun flushPendingWrites() = writeQueues.forEach(CoalescingWriteQueue::flush)
+
+        /**
+         * Marks this part as fully written and releases the file [completedSpans] holds open.
+         * This must run on the [worker] so that it cannot overlap a write still queued for the part.
+         */
+        fun seal() {
+            sealed = true
+            completedSpans.close()
+        }
     }
 }

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansWriter.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansWriter.kt
@@ -5,6 +5,7 @@ import io.embrace.android.embracesdk.internal.logging.InternalLogger
 import io.embrace.android.embracesdk.internal.payload.Span
 import io.embrace.android.embracesdk.internal.utils.SystemTrace
 import java.io.File
+import java.io.FileOutputStream
 import java.io.IOException
 
 /**
@@ -26,6 +27,8 @@ class CompletedSpansWriter(
     @Volatile
     private var reportedOverflow = false
 
+    private var spanFile: SpanFile? = null
+
     /**
      * Appends [spans] to the log for the active session part, leaving the spans already logged in
      * place. A session part in which nothing completed has no log at all, which reconstruction
@@ -35,33 +38,87 @@ class CompletedSpansWriter(
         try {
             writeImpl(spans)
         } catch (exc: Throwable) {
+            discardSpanFile()
             trackFailure(exc)
             false
         }
     }
 
+    /**
+     * Releases the file held open for the session part written to so far.
+     */
+    fun close() {
+        discardSpanFile()
+    }
+
     private fun writeImpl(spans: List<Span>): Boolean {
-        val directory = target.directory ?: return false
-        val partDir = target.partDir(directory, ::trackFailure) ?: return false
+        val spanFile = spanFile() ?: return false
 
         val records = CompletedSpans(spans = spans.map(Span::toProto))
         val bytes = CompletedSpans.ADAPTER.encode(records)
 
-        if (bytes.isNotEmpty() && !fits(partDir, bytes.size)) {
+        if (bytes.isNotEmpty() && spanFile.size + bytes.size > maxBytes) {
             if (!reportedOverflow) {
                 reportedOverflow = true
                 trackFailure(IOException(OVERSIZED_PART_FILE_MSG))
             }
             return false
         }
-        appendTo(partDir, COMPLETED_SPANS_FILE_NAME, bytes)
+        spanFile.append(bytes)
         return true
     }
 
-    private fun fits(partDir: File, byteCount: Int): Boolean =
-        File(partDir, COMPLETED_SPANS_FILE_NAME).length() + byteCount <= maxBytes
+    /**
+     * The file to append to, or null if the active session part has no directory on disk.
+     */
+    private fun spanFile(): SpanFile? {
+        val directory = target.directory ?: return null
+        spanFile?.let { open ->
+            if (open.directory == directory) {
+                return open
+            }
+            discardSpanFile()
+        }
+        val partDir = target.partDir(directory, ::trackFailure) ?: return null
+        return SpanFile(directory, File(partDir, COMPLETED_SPANS_FILE_NAME)).also { spanFile = it }
+    }
+
+    private fun discardSpanFile() {
+        val file = spanFile ?: return
+        spanFile = null
+        try {
+            file.close()
+        } catch (exc: IOException) {
+            trackFailure(exc)
+        }
+    }
 
     private fun trackFailure(exc: Throwable) {
         logger.trackInternalError(InternalErrorType.CompletedSpansWriteFail, exc)
+    }
+
+    /**
+     * The completed spans file for one session part, kept open across the appends made to it.
+     */
+    private class SpanFile(val directory: SessionPartDirectory, private val file: File) {
+
+        private var stream: FileOutputStream? = null
+
+        // assume file size doesn't change after first lookup
+        var size: Long = file.length()
+            private set
+
+        /**
+         * Appends [bytes] to the file, opening it if this is the first append.
+         */
+        fun append(bytes: ByteArray) {
+            val stream = stream ?: FileOutputStream(file, true).also { stream = it }
+            stream.write(bytes)
+            size += bytes.size
+        }
+
+        fun close() {
+            stream?.close()
+        }
     }
 }

--- a/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionPartFiles.kt
+++ b/embrace-android-session-persistence/src/main/kotlin/io/embrace/android/embracesdk/internal/session/persistence/SessionPartFiles.kt
@@ -2,7 +2,6 @@ package io.embrace.android.embracesdk.internal.session.persistence
 
 import io.embrace.android.embracesdk.internal.utils.SystemTrace
 import java.io.File
-import java.io.FileOutputStream
 import java.io.IOException
 import java.io.OutputStream
 
@@ -43,17 +42,6 @@ internal fun writeAtomically(partDir: File, fileName: String, maxBytes: Long, en
             }
         } finally {
             tmpFile.delete()
-        }
-    }
-}
-
-/**
- * Appends [bytes] to [fileName] in [partDir], creating the file if it is not there yet.
- */
-internal fun appendTo(partDir: File, fileName: String, bytes: ByteArray) {
-    SystemTrace.trace("mf-file-append") {
-        FileOutputStream(File(partDir, fileName), true).use { stream ->
-            stream.write(bytes)
         }
     }
 }

--- a/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansWriterTest.kt
+++ b/embrace-android-session-persistence/src/test/kotlin/io/embrace/android/embracesdk/internal/session/persistence/CompletedSpansWriterTest.kt
@@ -261,6 +261,49 @@ internal class CompletedSpansWriterTest {
         assertNoInternalErrors()
     }
 
+    @Test
+    fun `a write after the file is closed appends to it rather than replacing it`() {
+        assertTrue(write(spans = listOf(span("aaaaaaaaaaaaaaa1"))))
+        writer.close()
+        assertTrue(write(spans = listOf(span("aaaaaaaaaaaaaaa2"))))
+
+        assertEquals(listOf("aaaaaaaaaaaaaaa1", "aaaaaaaaaaaaaaa2"), readLog().map(SpanProto::span_id))
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `the size of a reopened file counts the spans written before it was closed`() {
+        writer = boundedWriter()
+        assertTrue(write(spans = listOf(span("aaaaaaaaaaaaaaa1"))))
+        writer.close()
+        assertTrue(write(spans = listOf(span("aaaaaaaaaaaaaaa2"))))
+        assertFalse(write(spans = listOf(span("aaaaaaaaaaaaaaa3"))))
+
+        assertEquals(twoSpanBudget, logFile().length())
+        assertWriteFailureTracked()
+    }
+
+    @Test
+    fun `closing a writer that has written nothing leaves no file behind`() {
+        writer.close()
+        assertEquals(emptyList<String>(), partDir().list()?.toList())
+        assertNoInternalErrors()
+    }
+
+    @Test
+    fun `the file is closed once the writer moves on to another session part`() {
+        val other = SessionPartDirectory(timestamp = TIMESTAMP + 1, uuid = UUID)
+        createPartDir(other)
+
+        assertTrue(write(spans = listOf(span("aaaaaaaaaaaaaaa1"))))
+        assertTrue(write(other, listOf(span("aaaaaaaaaaaaaaa2"))))
+        assertTrue(write(spans = listOf(span("aaaaaaaaaaaaaaa3"))))
+
+        assertEquals(listOf("aaaaaaaaaaaaaaa1", "aaaaaaaaaaaaaaa3"), readLog().map(SpanProto::span_id))
+        assertEquals(listOf("aaaaaaaaaaaaaaa2"), readLog(other).map(SpanProto::span_id))
+        assertNoInternalErrors()
+    }
+
     private fun boundedWriter(): CompletedSpansWriter =
         CompletedSpansWriter(target { activePart }, logger, twoSpanBudget)
 


### PR DESCRIPTION
## Goal

Improves performance for writing completed spans by keeping the file open for appends & tracking the file size ourselves.

## Testing

Added unit tests.
